### PR TITLE
feat(ios): receipt + pump OCR via Apple Vision; Android stays on ML Kit (#3052)

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,6 +3,7 @@
 
 import Flutter
 import UIKit
+import Vision
 import workmanager_apple
 
 @main
@@ -71,6 +72,11 @@ import workmanager_apple
     // and immediately scan for a cold-launch share the extension left behind.
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "ShareIntentBridge") {
       shareIntent.register(messenger: registrar.messenger())
+    }
+    // #3052 — native Apple Vision text OCR for receipt + pump-display scans
+    // (replaces Google ML Kit on iOS; Android keeps ML Kit).
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "VisionOcrBridge") {
+      VisionOcrBridge.shared.register(messenger: registrar.messenger())
     }
   }
 
@@ -177,5 +183,117 @@ final class ShareIntentBridge: NSObject, FlutterStreamHandler {
       let items = json["items"] as? [Any], !items.isEmpty
     else { return nil }
     return json
+  }
+}
+
+/// #3052 — native Apple **Vision** text OCR, serving the `tankstellen/vision_ocr`
+/// MethodChannel. Replaces Google ML Kit on iOS (on-device, no Google
+/// dependency, builds on the simulator). Returns the flat text plus per-line
+/// boxes in source-image PIXEL coordinates with a TOP-LEFT origin — matching
+/// the `OcrBox` shape Android's ML Kit adapter produces — so the #2478
+/// label-anchored receipt/pump extractor stays engine-agnostic.
+///
+/// Inline in AppDelegate.swift (not a separate file) on purpose: a new file
+/// under ios/Runner/ is not in the Runner target's compile sources without a
+/// project.pbxproj edit (see the ShareIntentBridge note above), so defining it
+/// here keeps the build green with zero pbxproj change.
+final class VisionOcrBridge {
+  static let shared = VisionOcrBridge()
+  private static let channelName = "tankstellen/vision_ocr"
+
+  func register(messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "recognizeText":
+        guard
+          let args = call.arguments as? [String: Any],
+          let path = args["path"] as? String
+        else {
+          result(nil)
+          return
+        }
+        let languageCorrection = args["languageCorrection"] as? Bool ?? true
+        let languages = args["languages"] as? [String] ?? []
+        Self.recognize(
+          path: path,
+          languageCorrection: languageCorrection,
+          languages: languages,
+          result: result
+        )
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  /// Runs `VNRecognizeTextRequest` on the image at [path] off the main thread
+  /// and returns `{ text: String, blocks: [{text,left,top,right,bottom}] }`
+  /// (pixel, top-left). Any failure resolves to nil so the Dart caller degrades
+  /// exactly as the ML Kit path did. `languageCorrection` is off for 7-segment
+  /// pump displays (digits, not prose).
+  private static func recognize(
+    path: String,
+    languageCorrection: Bool,
+    languages: [String],
+    result: @escaping FlutterResult
+  ) {
+    guard
+      let image = UIImage(contentsOfFile: path),
+      let cgImage = image.cgImage
+    else {
+      result(nil)
+      return
+    }
+    let width = CGFloat(cgImage.width)
+    let height = CGFloat(cgImage.height)
+
+    let request = VNRecognizeTextRequest { request, error in
+      func finish(_ value: Any?) {
+        DispatchQueue.main.async { result(value) }
+      }
+      if error != nil {
+        finish(nil)
+        return
+      }
+      let observations = request.results as? [VNRecognizedTextObservation] ?? []
+      var blocks: [[String: Any]] = []
+      var lines: [String] = []
+      for observation in observations {
+        guard let candidate = observation.topCandidates(1).first else { continue }
+        let text = candidate.string
+        if text.isEmpty { continue }
+        lines.append(text)
+        // Vision boundingBox: normalized [0,1], origin BOTTOM-LEFT. Convert to
+        // source-image PIXELS with a TOP-LEFT origin (flip Y) to match OcrBox.
+        let box = observation.boundingBox
+        let left = box.minX * width
+        let right = box.maxX * width
+        let top = (1.0 - box.maxY) * height
+        let bottom = (1.0 - box.minY) * height
+        blocks.append([
+          "text": text,
+          "left": Double(left),
+          "top": Double(top),
+          "right": Double(right),
+          "bottom": Double(bottom),
+        ])
+      }
+      finish(["text": lines.joined(separator: "\n"), "blocks": blocks])
+    }
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = languageCorrection
+    if !languages.isEmpty {
+      request.recognitionLanguages = languages
+    }
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+      do {
+        try handler.perform([request])
+      } catch {
+        DispatchQueue.main.async { result(nil) }
+      }
+    }
   }
 }

--- a/lib/features/consumption/data/ocr/impl/ocr_engine_factory.dart
+++ b/lib/features/consumption/data/ocr/impl/ocr_engine_factory.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import '../mlkit_ocr_text_engine.dart';
+import '../ocr_text_engine.dart';
+
+/// Picks the platform's text-OCR backend (#3052): Apple **Vision** on iOS
+/// (native, no Google, simulator-buildable), Google **ML Kit** everywhere
+/// else (Android production — unchanged).
+///
+/// Lives in `impl/` so the `Platform.isIOS` branch stays out of shared code
+/// (enforced by `test/lint/no_inline_platform_check_test.dart`).
+OcrTextEngine createDefaultOcrTextEngine() =>
+    Platform.isIOS ? VisionOcrTextEngine() : MlKitOcrTextEngine();

--- a/lib/features/consumption/data/ocr/mlkit_ocr_text_engine.dart
+++ b/lib/features/consumption/data/ocr/mlkit_ocr_text_engine.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+import 'ocr_text_engine.dart';
+import 'recognized_text_adapter.dart';
+
+/// Google ML Kit text-OCR engine — the **Android** (and test-host) backend
+/// (#3052). This is the exact recognition path the app shipped before the
+/// engine seam existed: `TextRecognizer.processImage` + the #2478
+/// `mapRecognizedText` block-geometry adapter. Android is in production and
+/// its behaviour is unchanged — only its location moved out of
+/// `ReceiptScanService`.
+///
+/// ML Kit ignores [languageCorrection] / [languages] (it auto-detects); they
+/// exist only so the [OcrTextEngine] contract is uniform with the iOS Vision
+/// engine, which honours them.
+class MlKitOcrTextEngine implements OcrTextEngine {
+  MlKitOcrTextEngine({TextRecognizer? recognizer})
+      : _recognizer = recognizer ?? TextRecognizer();
+
+  final TextRecognizer _recognizer;
+
+  @override
+  Future<OcrTextResult?> recognize(
+    String imagePath, {
+    bool languageCorrection = true,
+    List<String> languages = const [],
+  }) async {
+    final recognized =
+        await _recognizer.processImage(InputImage.fromFilePath(imagePath));
+    return (text: recognized.text, blocks: mapRecognizedText(recognized));
+  }
+
+  @override
+  void dispose() => _recognizer.close();
+}

--- a/lib/features/consumption/data/ocr/ocr_text_engine.dart
+++ b/lib/features/consumption/data/ocr/ocr_text_engine.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+
+import 'recognized_text_block.dart';
+
+/// The recognized text from one OCR pass: the flat string (legacy fallback
+/// parsers) plus the per-line geometry the #2478 label-anchored extractor
+/// needs. Mirrors the tuple `ReceiptScanService` already passes around.
+typedef OcrTextResult = ({String text, List<RecognizedTextBlock> blocks});
+
+/// Pluggable on-device text-OCR backend (#3052).
+///
+/// Lets iOS use Apple's native **Vision** framework while Android keeps Google
+/// ML Kit unchanged (Android is in production — its path is untouched). The
+/// result type is the app's PURE [RecognizedTextBlock] list, so everything
+/// downstream (the receipt + pump-display parsers) is engine-agnostic.
+abstract class OcrTextEngine {
+  /// Runs OCR on the (already EXIF-upright / preprocessed) image at
+  /// [imagePath]. Returns null on any recognize error so the caller degrades
+  /// exactly as before. [languageCorrection] is off for 7-segment pump
+  /// displays (digits, not prose). [languages] is an optional priority list of
+  /// BCP-47 codes (e.g. `fr-FR`); empty lets the engine auto-detect.
+  Future<OcrTextResult?> recognize(
+    String imagePath, {
+    bool languageCorrection = true,
+    List<String> languages = const [],
+  });
+
+  /// Releases native resources (ML Kit holds a recognizer; Vision is
+  /// stateless). Default no-op so stateless engines need not override.
+  void dispose() {}
+}
+
+/// iOS engine backed by Apple Vision (`VNRecognizeTextRequest`) over the
+/// `tankstellen/vision_ocr` MethodChannel handled by `VisionOcrBridge` in
+/// `ios/Runner/AppDelegate.swift`. The Swift side already converts Vision's
+/// normalized, bottom-left boxes into pixel, top-left coordinates so the
+/// [OcrBox] geometry matches what the ML Kit adapter produces.
+class VisionOcrTextEngine implements OcrTextEngine {
+  VisionOcrTextEngine({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel('tankstellen/vision_ocr');
+
+  final MethodChannel _channel;
+
+  @override
+  Future<OcrTextResult?> recognize(
+    String imagePath, {
+    bool languageCorrection = true,
+    List<String> languages = const [],
+  }) async {
+    final res = await _channel.invokeMapMethod<String, dynamic>(
+      'recognizeText',
+      {
+        'path': imagePath,
+        'languageCorrection': languageCorrection,
+        'languages': languages,
+      },
+    );
+    if (res == null) return null;
+    final text = (res['text'] as String?) ?? '';
+    final rawBlocks = (res['blocks'] as List?) ?? const [];
+    final blocks = <RecognizedTextBlock>[];
+    for (final entry in rawBlocks) {
+      final m = (entry as Map).cast<String, dynamic>();
+      final boxText = (m['text'] as String?) ?? '';
+      if (boxText.isEmpty) continue;
+      blocks.add(
+        RecognizedTextBlock(
+          text: boxText,
+          box: OcrBox(
+            left: (m['left'] as num).toDouble(),
+            top: (m['top'] as num).toDouble(),
+            right: (m['right'] as num).toDouble(),
+            bottom: (m['bottom'] as num).toDouble(),
+          ),
+        ),
+      );
+    }
+    return (text: text, blocks: blocks);
+  }
+
+  @override
+  void dispose() {/* Vision is stateless — nothing to release. */}
+}

--- a/lib/features/consumption/data/ocr/pump_glare_check.dart
+++ b/lib/features/consumption/data/ocr/pump_glare_check.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+
+import '../../../../core/logging/error_logger.dart';
+import 'ocr_image_preprocessor.dart';
+import 'ocr_trace_recorder.dart';
+
+/// #2275 — `true` when the [roi] of the pump-display photo at [path] is
+/// over-glared per [GlarePolicy.standard], so the caller can prompt a re-angle
+/// BEFORE OCR rather than show a generic failure. Best-effort: a decode error
+/// returns `false` so a quirky image still reaches OCR.
+///
+/// Extracted from `ReceiptScanService` (#3052) to keep that file decomposed.
+Future<bool> isPumpFrameOverGlared(
+  String path,
+  OcrNormalizedRect? roi,
+  OcrImagePreprocessor preprocessor, {
+  OcrTraceRecorder? trace,
+}) async {
+  try {
+    final bytes = await File(path).readAsBytes();
+    final decoded = img.decodeJpg(bytes);
+    if (decoded == null) return false;
+    final upright = img.bakeOrientation(decoded);
+    final region = roi != null ? preprocessor.cropToRoi(upright, roi) : upright;
+    final fraction = preprocessor.glareFraction(region);
+    final threshold = GlarePolicy.standard.rejectAbove;
+    final rejected = fraction > threshold;
+    trace?.glare(fraction: fraction, threshold: threshold, rejected: rejected);
+    return rejected;
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+        context: const {'where': 'pump glare check failed'}));
+    return false;
+  }
+}

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
-import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
 
 import 'ocr/image_orientation.dart';
@@ -17,7 +16,10 @@ import 'ocr/pump_display_orchestrator.dart';
 import 'ocr/pump_ocr_config.dart';
 import 'ocr/pump_recognizer_source.dart';
 import 'ocr/pump_validation_gate.dart';
-import 'ocr/recognized_text_adapter.dart';
+import 'ocr/impl/ocr_engine_factory.dart';
+import 'ocr/mlkit_ocr_text_engine.dart';
+import 'ocr/ocr_text_engine.dart';
+import 'ocr/pump_glare_check.dart';
 import 'ocr/recognized_text_block.dart';
 import 'pump_display_parser.dart';
 import 'receipt_parser.dart';
@@ -47,7 +49,12 @@ export 'receipt_scan_outcomes.dart'
 ///     itself (Betrag / Abgabe / Preis/Liter).
 class ReceiptScanService {
   final ImagePicker _picker;
-  final TextRecognizer _recognizer;
+
+  /// #3052 — the OCR backend. iOS → Apple Vision, Android/host → ML Kit
+  /// (selected by [createDefaultOcrTextEngine]). Tests inject `recognizer:`
+  /// (wrapped in [MlKitOcrTextEngine]) so the ML Kit path stays covered.
+  final OcrTextEngine _engine;
+
   final ReceiptParser _parser;
   final PumpDisplayParser _pumpParser;
   final PumpValidationGate _pumpGate;
@@ -57,13 +64,19 @@ class ReceiptScanService {
   ReceiptScanService({
     ImagePicker? picker,
     TextRecognizer? recognizer,
+    OcrTextEngine? engine,
     ReceiptParser? parser,
     PumpDisplayParser? pumpParser,
     PumpValidationGate? pumpGate,
     PumpOcrConfig? ocrConfig,
     OcrImagePreprocessor? preprocessor,
   })  : _picker = picker ?? ImagePicker(),
-        _recognizer = recognizer ?? TextRecognizer(),
+        // An explicit [engine] wins; a legacy `recognizer:` (tests) keeps the
+        // ML Kit path; otherwise the platform default (iOS Vision / else ML Kit).
+        _engine = engine ??
+            (recognizer != null
+                ? MlKitOcrTextEngine(recognizer: recognizer)
+                : createDefaultOcrTextEngine()),
         _parser = parser ?? const ReceiptParser(),
         _pumpParser = pumpParser ?? const PumpDisplayParser(),
         _pumpGate = pumpGate ?? const PumpValidationGate(),
@@ -192,7 +205,7 @@ class ReceiptScanService {
     );
     // #2275 — auto-reject an over-glared frame BEFORE OCR so the caller
     // can prompt a re-angle rather than show a generic failure.
-    if (await _isOverGlared(path, roi, trace: trace)) {
+    if (await isPumpFrameOverGlared(path, roi, _preprocessor, trace: trace)) {
       return PumpDisplayScanOutcome(
         parse: const PumpDisplayParseResult(),
         ocrText: '',
@@ -248,34 +261,6 @@ class ReceiptScanService {
     );
   }
 
-  /// Decodes [path], crops to [roi], and returns `true` when the ROI is
-  /// over-glared per [GlarePolicy.standard]. Best-effort: a decode error
-  /// returns `false` so a quirky image still reaches OCR (#2275).
-  Future<bool> _isOverGlared(
-    String path,
-    OcrNormalizedRect? roi, {
-    OcrTraceRecorder? trace,
-  }) async {
-    try {
-      final bytes = await File(path).readAsBytes();
-      final decoded = img.decodeJpg(bytes);
-      if (decoded == null) return false;
-      final upright = img.bakeOrientation(decoded);
-      final region =
-          roi != null ? _preprocessor.cropToRoi(upright, roi) : upright;
-      final fraction = _preprocessor.glareFraction(region);
-      final threshold = GlarePolicy.standard.rejectAbove;
-      final rejected = fraction > threshold;
-      trace?.glare(
-          fraction: fraction, threshold: threshold, rejected: rejected);
-      return rejected;
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
-          context: const {'where': 'pump glare check failed'}));
-      return false;
-    }
-  }
-
   Future<String?> _capture() async {
     final image = await _picker.pickImage(
       source: ImageSource.camera,
@@ -297,22 +282,21 @@ class ReceiptScanService {
   /// #1860 — when [enhanceContrast] is set (the pump-display path) the
   /// temp copy also gets a grayscale + histogram-normalise + contrast
   /// pass so 7-segment LCDs and washed-out displays become readable.
-  Future<({String text, List<RecognizedTextBlock> blocks})?> _recognise(
+  Future<OcrTextResult?> _recognise(
     String path, {
     bool enhanceContrast = false,
     OcrNormalizedRect? roi,
     OcrTraceRecorder? trace,
   }) async {
-    final recognized =
+    final recognised =
         await _recogniseRaw(path, enhanceContrast: enhanceContrast, roi: roi);
-    if (recognized == null) return null;
-    final text = recognized.text;
-    debugPrint('OCR text (${text.length} chars):\n$text');
-    // #2848 — keep ML Kit's block geometry so the receipt path can route a
-    // fuel-station receipt to the label-anchored extractor (was trace-only).
-    final blocks = mapRecognizedText(recognized);
-    trace?.blocks(text, blocks);
-    return (text: text, blocks: blocks);
+    if (recognised == null) return null;
+    debugPrint('OCR text (${recognised.text.length} chars):\n${recognised.text}');
+    // #2848 — the engine already carries the per-line block geometry so the
+    // receipt path can route a fuel-station receipt to the label-anchored
+    // extractor (ML Kit via mapRecognizedText, Vision via the channel).
+    trace?.blocks(recognised.text, recognised.blocks);
+    return recognised;
   }
 
   /// Runs ML Kit on the pump-display crop and returns BOTH the flat text
@@ -320,17 +304,22 @@ class ReceiptScanService {
   /// boxes to anchor the unit price to its label. Same EXIF-upright +
   /// #2275 Sauvola preprocessing as [_recognise]; the flat text is kept
   /// for the legacy fallback parser. Returns null when OCR reads nothing.
-  Future<({String text, List<RecognizedTextBlock> blocks})?> _recognisePump(
+  Future<OcrTextResult?> _recognisePump(
     String path, {
     OcrNormalizedRect? roi,
     bool binarize = true,
   }) async {
-    final recognized = await _recogniseRaw(path,
-        enhanceContrast: true, roi: roi, binarize: binarize);
-    if (recognized == null) return null;
-    final blocks = mapRecognizedText(recognized);
-    debugPrint('Pump OCR: ${recognized.text.length} chars, ${blocks.length} blocks');
-    return (text: recognized.text, blocks: blocks);
+    // #3052 — pump readouts are 7-segment digits, not prose: disable language
+    // correction so Vision/ML Kit don't "auto-correct" the numbers.
+    final recognised = await _recogniseRaw(path,
+        enhanceContrast: true,
+        roi: roi,
+        binarize: binarize,
+        languageCorrection: false);
+    if (recognised == null) return null;
+    debugPrint(
+        'Pump OCR: ${recognised.text.length} chars, ${recognised.blocks.length} blocks');
+    return recognised;
   }
 
   /// Core ML Kit pass shared by [_recognise] and [_recognisePump]: writes
@@ -338,18 +327,22 @@ class ReceiptScanService {
   /// the recognizer, and returns the raw [RecognizedText] so each caller
   /// can keep just the flat text or the full block geometry. Returns null
   /// on any decode/recognize error (logged).
-  Future<RecognizedText?> _recogniseRaw(
+  Future<OcrTextResult?> _recogniseRaw(
     String path, {
     bool enhanceContrast = false,
     OcrNormalizedRect? roi,
     bool binarize = true,
+    bool languageCorrection = true,
   }) async {
     String? uprightTemp;
     try {
       uprightTemp = await _writeUprightCopy(path,
           enhanceContrast: enhanceContrast, roi: roi, binarize: binarize);
-      final inputImage = InputImage.fromFilePath(uprightTemp ?? path);
-      return await _recognizer.processImage(inputImage);
+      // #3052 — recognition is delegated to the platform engine (iOS Vision /
+      // Android ML Kit); the EXIF-upright + Sauvola/ROI preprocessing above is
+      // engine-agnostic.
+      return await _engine.recognize(uprightTemp ?? path,
+          languageCorrection: languageCorrection);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
           context: const {'where': 'OCR scan failed'}));
@@ -406,6 +399,6 @@ class ReceiptScanService {
   Future<void> deleteCapturedImage(String path) => _tryDelete(path);
 
   void dispose() {
-    _recognizer.close();
+    _engine.dispose();
   }
 }

--- a/test/features/consumption/data/ocr/ocr_text_engine_test.dart
+++ b/test/features/consumption/data/ocr/ocr_text_engine_test.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ocr/ocr_text_engine.dart';
+
+/// #3052 — the iOS [VisionOcrTextEngine] is a thin bridge over the
+/// `tankstellen/vision_ocr` MethodChannel (Apple Vision in AppDelegate.swift).
+/// These tests pin the channel CONTRACT it relies on: the args it forwards and
+/// the decode of the `{text, blocks:[{text,left,top,right,bottom}]}` payload
+/// into the pure [RecognizedTextBlock]/[OcrBox] geometry the receipt + pump
+/// extractors consume. The Swift side (coordinate flip, VNRecognizeTextRequest)
+/// is verified on the maintainer's iOS build — the sim build is ML-Kit-blocked.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('tankstellen/vision_ocr');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('forwards args and maps the response into text + box geometry',
+      () async {
+    Map<Object?, Object?>? received;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      received = call.arguments as Map<Object?, Object?>;
+      return <String, Object?>{
+        'text': 'PRIX\n1,859',
+        'blocks': <Object?>[
+          <String, Object?>{
+            'text': 'PRIX',
+            'left': 10.0,
+            'top': 20.0,
+            'right': 60.0,
+            'bottom': 40.0,
+          },
+          <String, Object?>{
+            'text': '1,859',
+            'left': 70.0,
+            'top': 22.0,
+            'right': 140.0,
+            'bottom': 41.0,
+          },
+          // Empty-text fragment must be dropped (matches ML Kit-side behaviour).
+          <String, Object?>{
+            'text': '',
+            'left': 0.0,
+            'top': 0.0,
+            'right': 0.0,
+            'bottom': 0.0,
+          },
+        ],
+      };
+    });
+
+    final engine = VisionOcrTextEngine();
+    final result = await engine.recognize(
+      '/tmp/pump.jpg',
+      languageCorrection: false,
+      languages: const ['fr-FR'],
+    );
+
+    // Args forwarded verbatim to the Swift handler.
+    expect(received?['path'], '/tmp/pump.jpg');
+    expect(received?['languageCorrection'], false);
+    expect(received?['languages'], ['fr-FR']);
+
+    // Flat text preserved; empty fragment dropped; geometry mapped 1:1.
+    expect(result, isNotNull);
+    expect(result!.text, 'PRIX\n1,859');
+    expect(result.blocks, hasLength(2));
+    expect(result.blocks[0].text, 'PRIX');
+    expect(result.blocks[0].box.left, 10.0);
+    expect(result.blocks[0].box.bottom, 40.0);
+    expect(result.blocks[1].text, '1,859');
+    expect(result.blocks[1].box.right, 140.0);
+    expect(result.blocks[1].box.cx, (70.0 + 140.0) / 2);
+  });
+
+  test('null channel response → null so the caller degrades like ML Kit',
+      () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    final engine = VisionOcrTextEngine();
+    expect(await engine.recognize('/tmp/x.jpg'), isNull);
+  });
+
+  test('integer coordinates from the platform are coerced to double', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return <String, Object?>{
+        'text': 'A',
+        'blocks': <Object?>[
+          // Platform may send whole numbers as int — must not throw.
+          <String, Object?>{
+            'text': 'A',
+            'left': 1,
+            'top': 2,
+            'right': 3,
+            'bottom': 4,
+          },
+        ],
+      };
+    });
+    final engine = VisionOcrTextEngine();
+    final result = await engine.recognize('/tmp/x.jpg');
+    expect(result!.blocks.single.box.right, 3.0);
+  });
+}


### PR DESCRIPTION
## What

iOS OCR (receipt + pump-display) now runs on **Apple Vision** instead of Google ML Kit — the correct native implementation: on-device, no Google dependency, simulator-buildable, and aligned with the privacy-first positioning. **Android is untouched** (production) — it keeps the exact ML Kit path at runtime.

## How

- **`OcrTextEngine` seam** (`ocr/ocr_text_engine.dart`) returning the app's pure `RecognizedTextBlock`/`OcrBox` geometry, so the #2478 label-anchored receipt/pump extractor is engine-agnostic.
- **iOS** → `VisionOcrTextEngine` (`tankstellen/vision_ocr` MethodChannel) backed by `VisionOcrBridge` in `AppDelegate.swift` (inline, per the `ShareIntentBridge` convention — a new Swift file isn't in the Runner target without a pbxproj edit). Converts Vision's normalized **bottom-left** boxes → pixel **top-left** `OcrBox` (Y-flip).
- **Android / test host** → `MlKitOcrTextEngine` (the existing `TextRecognizer` + `mapRecognizedText` path, relocated verbatim). Platform selection lives in `ocr/impl/ocr_engine_factory.dart` (keeps `Platform.isIOS` out of shared code per `no_inline_platform_check`).
- Receipt mode: `.accurate` + language correction. Pump 7-seg: language correction off; existing Sauvola/ROI preprocessing still runs first.
- Extracted the glare check into `ocr/pump_glare_check.dart` (keeps `receipt_scan_service.dart` decomposed, ≤ its file-length snapshot).

## Tests

- New `ocr_text_engine_test.dart` — channel contract: arg forwarding, payload→geometry mapping, empty-fragment drop, int→double coercion, null-degrades.
- **All existing OCR tests pass** (service, screens, share handlers) — the ML Kit path is unchanged.
- Swift verified on the maintainer's next iOS build (the simulator build is otherwise ML-Kit-blocked).

Note: fully evicting the ML Kit *pod* from the iOS binary additionally needs `mobile_scanner` (barcode) moved off ML Kit + a Podfile exclusion — tracked separately.

Closes #3052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)