### PR TITLE
fix(shell): compact wide-layout NavigationRail — stop wasting horizontal space (#3056)

### DIFF
--- a/lib/app/shell/shell_nav_rail.dart
+++ b/lib/app/shell/shell_nav_rail.dart
@@ -7,8 +7,9 @@ import 'shell_nav_item.dart';
 
 /// NavigationRail for medium and expanded screen sizes.
 ///
-/// Shows labels and a wider rail on expanded screens (>= 840dp).
-/// Shows an icons-only rail on medium screens (600-840dp).
+/// A compact rail with each label UNDER its icon ([NavigationRailLabelType.all])
+/// at both sizes (#3056) — the old `extended` horizontal-label rail wasted
+/// ~100px of width the results column + map needed on wide/tablet layouts.
 ///
 /// Companion to [ShellBottomBar] — both consume the same
 /// `(items, branchForSlot, currentIndex, iconControllers)` quad so the
@@ -27,7 +28,6 @@ class ShellNavRail extends StatelessWidget {
   /// slot (the Settings/profile branch, reached from the app bar).
   final int? currentIndex;
   final List<AnimationController> iconControllers;
-  final bool extended;
   final ValueChanged<int> onTap;
 
   const ShellNavRail({
@@ -36,7 +36,6 @@ class ShellNavRail extends StatelessWidget {
     required this.branchForSlot,
     required this.currentIndex,
     required this.iconControllers,
-    required this.extended,
     required this.onTap,
   });
 
@@ -47,12 +46,12 @@ class ShellNavRail extends StatelessWidget {
     return NavigationRail(
       selectedIndex: currentIndex,
       onDestinationSelected: onTap,
-      extended: extended,
-      minWidth: 56,
-      minExtendedWidth: 180,
-      labelType: extended
-          ? NavigationRailLabelType.none
-          : NavigationRailLabelType.selected,
+      // #3056 — a COMPACT rail (every label UNDER its icon) on every wide
+      // layout, instead of the old `extended` horizontal-label rail (~180px)
+      // that wasted ~100px the results column + map needed. Keeps all labels
+      // (discoverable) at roughly half the width.
+      minWidth: 80,
+      labelType: NavigationRailLabelType.all,
       selectedIconTheme: IconThemeData(color: theme.colorScheme.primary),
       unselectedIconTheme: IconThemeData(
         color: theme.colorScheme.onSurfaceVariant,

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -357,7 +357,6 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
               // reached from the app bar) — no rail item highlighted.
               currentIndex: selectedSlot < 0 ? null : selectedSlot,
               iconControllers: _iconControllers,
-              extended: screenSize == ScreenSize.expanded,
               onTap: onSlotTap,
             ),
             const VerticalDivider(width: 1, thickness: 1),

--- a/test/app/shell/shell_nav_rail_test.dart
+++ b/test/app/shell/shell_nav_rail_test.dart
@@ -12,8 +12,8 @@ import 'package:tankstellen/app/shell/shell_nav_rail.dart';
 /// builds one [NavigationRailDestination] per `items[]` entry. Tests
 /// focus on the wiring rather than the rail's internal layout:
 ///   * one destination per item;
-///   * `extended: true` -> [NavigationRailLabelType.none];
-///   * `extended: false` -> [NavigationRailLabelType.selected];
+///   * a COMPACT rail: not extended, [NavigationRailLabelType.all] (label
+///     under every icon) — the #3056 width fix;
 ///   * tapping a destination fires `onTap(i)`;
 ///   * the selected slot uses the `filledIcon`, others use
 ///     `outlinedIcon`;
@@ -55,7 +55,6 @@ void main() {
     required List<int> branchForSlot,
     required int currentIndex,
     required List<AnimationController> iconControllers,
-    required bool extended,
     required ValueChanged<int> onTap,
   }) {
     return tester.pumpWidget(
@@ -68,7 +67,6 @@ void main() {
                 branchForSlot: branchForSlot,
                 currentIndex: currentIndex,
                 iconControllers: iconControllers,
-                extended: extended,
                 onTap: onTap,
               ),
               const Expanded(child: SizedBox.shrink()),
@@ -100,7 +98,6 @@ void main() {
         branchForSlot: const [0, 1, 2],
         currentIndex: 0,
         iconControllers: controllers,
-        extended: false,
         onTap: (_) {},
       );
 
@@ -123,7 +120,6 @@ void main() {
         branchForSlot: const [0, 1, 2],
         currentIndex: 1, // Search is selected
         iconControllers: controllers,
-        extended: false,
         onTap: (_) {},
       );
 
@@ -141,8 +137,9 @@ void main() {
     });
   });
 
-  group('ShellNavRail labelType', () {
-    testWidgets('extended: true -> labelType.none', (tester) async {
+  group('ShellNavRail labelType (#3056 compact rail)', () {
+    testWidgets('is a compact rail (not extended) with a label under every icon',
+        (tester) async {
       final controllers = [
         newController(),
         newController(),
@@ -155,35 +152,15 @@ void main() {
         branchForSlot: const [0, 1, 2],
         currentIndex: 0,
         iconControllers: controllers,
-        extended: true,
         onTap: (_) {},
       );
 
       final rail = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(rail.extended, isTrue);
-      expect(rail.labelType, NavigationRailLabelType.none);
-    });
-
-    testWidgets('extended: false -> labelType.selected', (tester) async {
-      final controllers = [
-        newController(),
-        newController(),
-        newController(),
-      ];
-
-      await pumpRail(
-        tester,
-        items: items,
-        branchForSlot: const [0, 1, 2],
-        currentIndex: 0,
-        iconControllers: controllers,
-        extended: false,
-        onTap: (_) {},
-      );
-
-      final rail = tester.widget<NavigationRail>(find.byType(NavigationRail));
-      expect(rail.extended, isFalse);
-      expect(rail.labelType, NavigationRailLabelType.selected);
+      expect(rail.extended, isFalse,
+          reason: 'compact rail — the extended horizontal-label rail wasted '
+              'width the results column + map needed');
+      expect(rail.labelType, NavigationRailLabelType.all,
+          reason: 'every destination keeps its label, under the icon');
     });
   });
 
@@ -202,7 +179,6 @@ void main() {
         branchForSlot: const [0, 1, 2],
         currentIndex: 0,
         iconControllers: controllers,
-        extended: false,
         onTap: taps.add,
       );
 
@@ -237,7 +213,6 @@ void main() {
           branchForSlot: const [0, 2, 4],
           currentIndex: 0,
           iconControllers: controllers,
-          extended: false,
           onTap: (_) {},
         );
 


### PR DESCRIPTION
## What

On wide/landscape/tablet layouts the left `NavigationRail` used `extended: true` (~180px, icon + horizontal label), eating space the search-results column and map need (reported with a screenshot).

## Fix

Switch to a **compact** rail with each label **under** its icon (`NavigationRailLabelType.all`, `minWidth: 80`) at every wide size — keeps all labels (discoverable) at roughly **half the width**, returning ~100px to the content. The now-unused `extended` flag is removed from `ShellNavRail` + `shell_screen.dart`. Widget tests updated to assert the compact rail.

Closes #3056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)