### PR TITLE
fix(search): clear empty-state for a zero-result radar scan (#3058)

### DIFF
--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -63,6 +63,16 @@ class SearchResultsContent extends ConsumerWidget {
       // Settings path for denied location permission).
       return radar.stations.when(
         data: (stations) {
+          // #3058 — a genuinely-empty radar result is its OWN state, visually
+          // distinct from the loading shimmer and the error banner, so the
+          // user knows the scan FINISHED and found nothing — not that it's
+          // still searching (the old bare "0 stations" + blank was ambiguous).
+          if (stations.isEmpty) {
+            return _RadarEmptyState(
+              onRetry: () =>
+                  ref.read(radarSearchProvider.notifier).runRadar(),
+            );
+          }
           final radarResult = ServiceResult<List<SearchResultItem>>(
             data: [for (final s in stations) FuelStationResult(s)],
             source: ServiceSource.cache,
@@ -122,6 +132,54 @@ class SearchResultsContent extends ConsumerWidget {
             stackTrace: stackTrace,
             searchContext: 'Station search (${ref.read(selectedFuelTypeProvider).apiValue})',
           ),
+    );
+  }
+}
+
+/// #3058 — the radar's "scan finished, found nothing" state. Visually distinct
+/// from the loading shimmer (still searching) and the error banner (failed), so
+/// the user never has to guess which one they're looking at. Reuses the generic
+/// no-results strings — no new ARB keys.
+class _RadarEmptyState extends StatelessWidget {
+  const _RadarEmptyState({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.radar, size: 56, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 16),
+            Text(
+              l10n?.noResults ?? 'No stations found.',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n?.errorHintNoStations ??
+                  'Try increasing the search radius or search a different location.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: Text(l10n?.retry ?? 'Try again'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/features/search/presentation/widgets/search_results_content_test.dart
+++ b/test/features/search/presentation/widgets/search_results_content_test.dart
@@ -11,6 +11,7 @@ import 'package:tankstellen/features/search/domain/entities/search_result_item.d
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
@@ -99,7 +100,41 @@ void main() {
       expect(find.byType(SearchResultsList), findsOneWidget);
     });
 
+    testWidgets(
+        '#3058 — an empty radar result shows a clear empty-state (not a blank '
+        'SearchResultsList) so the user knows the scan finished', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        SearchResultsContent(onGpsRetry: noopRetry),
+        overrides: [
+          ...test.overrides,
+          radarSearchProvider.overrideWith(() => _EmptyRadarSearch()),
+        ].cast(),
+      );
+
+      // The radar owns the panel and found nothing → the dedicated empty-state
+      // (no-results message + radar icon + Try-again), NOT a blank list.
+      expect(find.text('No stations found.'), findsOneWidget);
+      expect(find.text('Try again'), findsOneWidget);
+      expect(find.byIcon(Icons.radar), findsOneWidget);
+      expect(find.byType(SearchResultsList), findsNothing);
+    });
   });
+}
+
+/// Radar active + zero stations — drives the #3058 empty-state branch.
+class _EmptyRadarSearch extends RadarSearch {
+  @override
+  RadarSearchState build() => const RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(<Station>[]),
+      );
+
+  @override
+  Future<void> runRadar() async {/* no-op so a Try-again tap is inert */}
 }
 
 class _LoadingSearchState extends SearchState {


### PR DESCRIPTION
## What

While the radar fetches, #3047 already shows a loading **shimmer** and routes failures to an actionable **error banner**. But a scan that genuinely finds nothing (`AsyncData([])`) still rendered an empty `SearchResultsList` — a bare **"0 stations" + blank** area that's indistinguishable from "still searching" (your screenshot).

## Fix

Give the zero-result case its **own** state: radar icon + *"No stations found."* + *"Try increasing the search radius…"* + a **Try again** button. The four radar states are now visually distinct so the user never has to guess:

| State | UI |
|---|---|
| Searching | shimmer (5 skeleton cards) |
| Failed | actionable error banner (Retry / Open Settings) |
| **Found zero** | **radar-icon empty-state + Try again** ← this PR |
| Results | the station list |

Reuses existing strings (`noResults`, `errorHintNoStations`, `retry`) — **no ARB fan-out**. Widget test added.

Closes #3058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)