### PR TITLE
fix(settings): add a top-left back arrow to the Settings screen (#3061)

### DIFF
--- a/lib/app/shell/settings_app_bar_action.dart
+++ b/lib/app/shell/settings_app_bar_action.dart
@@ -2,9 +2,39 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../current_shell_branch_provider.dart';
 import '../../l10n/app_localizations.dart';
+
+part 'settings_app_bar_action.g.dart';
+
+/// The route each shell-branch index returns to, mirroring the branch order in
+/// `shell_branches.dart` (#3061). Used to send the Settings back arrow to the
+/// branch the user came from. Branch 4 is Settings itself, so it is never an
+/// origin; anything unmapped falls back to home (`/`).
+String routeForShellBranch(int branch) => switch (branch) {
+      1 => '/map',
+      2 => '/favorites',
+      3 => '/consumption-tab',
+      5 => '/trajets-tab',
+      _ => '/', // 0 = Search / home
+    };
+
+/// Where the Settings (Profile) branch returns to when its top-left back arrow
+/// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
+/// branch tracker the moment the gear is tapped, so `ProfileScreen`'s back
+/// button is a TRUE "back" to wherever the user came from. Defaults to home
+/// (`/`).
+@riverpod
+class SettingsReturnLocation extends _$SettingsReturnLocation {
+  @override
+  String build() => '/';
+
+  void update(String location) => state = location;
+}
 
 /// Top-right app-bar action that opens the Settings (profile) screen
 /// (#1874).
@@ -15,16 +45,24 @@ import '../../l10n/app_localizations.dart';
 /// of the reference design. Tapping it routes to branch 4 (`/profile`)
 /// of the shell, so the screen's state is preserved across visits and
 /// the bottom bar stays visible for navigating back out.
-class SettingsAppBarAction extends StatelessWidget {
+class SettingsAppBarAction extends ConsumerWidget {
   const SettingsAppBarAction({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     return IconButton(
       icon: const Icon(Icons.settings_outlined),
       tooltip: l10n?.settings ?? 'Settings',
-      onPressed: () => context.go('/profile'),
+      onPressed: () {
+        // #3061 — record the branch the user is on (the shell keeps this
+        // current) BEFORE switching to Settings, so the Settings back arrow
+        // returns there instead of always dumping the user on home. The
+        // branch switch below has no back-stack of its own.
+        final from = routeForShellBranch(ref.read(currentShellBranchProvider));
+        ref.read(settingsReturnLocationProvider.notifier).update(from);
+        context.go('/profile');
+      },
     );
   }
 }

--- a/lib/app/shell/settings_app_bar_action.g.dart
+++ b/lib/app/shell/settings_app_bar_action.g.dart
@@ -1,0 +1,84 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settings_app_bar_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Where the Settings (Profile) branch returns to when its top-left back arrow
+/// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
+/// branch tracker the moment the gear is tapped, so `ProfileScreen`'s back
+/// button is a TRUE "back" to wherever the user came from. Defaults to home
+/// (`/`).
+
+@ProviderFor(SettingsReturnLocation)
+final settingsReturnLocationProvider = SettingsReturnLocationProvider._();
+
+/// Where the Settings (Profile) branch returns to when its top-left back arrow
+/// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
+/// branch tracker the moment the gear is tapped, so `ProfileScreen`'s back
+/// button is a TRUE "back" to wherever the user came from. Defaults to home
+/// (`/`).
+final class SettingsReturnLocationProvider
+    extends $NotifierProvider<SettingsReturnLocation, String> {
+  /// Where the Settings (Profile) branch returns to when its top-left back arrow
+  /// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
+  /// branch tracker the moment the gear is tapped, so `ProfileScreen`'s back
+  /// button is a TRUE "back" to wherever the user came from. Defaults to home
+  /// (`/`).
+  SettingsReturnLocationProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settingsReturnLocationProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settingsReturnLocationHash();
+
+  @$internal
+  @override
+  SettingsReturnLocation create() => SettingsReturnLocation();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<String>(value),
+    );
+  }
+}
+
+String _$settingsReturnLocationHash() =>
+    r'465f0edabba12b0c501f6142feb4c5a1c88fec58';
+
+/// Where the Settings (Profile) branch returns to when its top-left back arrow
+/// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
+/// branch tracker the moment the gear is tapped, so `ProfileScreen`'s back
+/// button is a TRUE "back" to wherever the user came from. Defaults to home
+/// (`/`).
+
+abstract class _$SettingsReturnLocation extends $Notifier<String> {
+  String build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<String, String>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<String, String>,
+              String,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../app/shell/settings_app_bar_action.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/theme/theme_mode_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -73,6 +74,12 @@ class ProfileScreen extends ConsumerWidget {
 
     return PageScaffold(
       title: l?.settings ?? 'Settings',
+      // #3061 — Settings is a shell branch (no back-stack) → explicit back arrow.
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+        onPressed: () => context.go(ref.read(settingsReturnLocationProvider)),
+      ),
       // #530 — compact vertical spacing. Was `EdgeInsets.all(16)` plus
       // `SizedBox(height: 32)` between every major section, which ate
       // ~180 dp of whitespace on a single screen. Tightened to 8 dp

--- a/test/app/shell/settings_app_bar_action_test.dart
+++ b/test/app/shell/settings_app_bar_action_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tankstellen/app/shell/settings_app_bar_action.dart';
@@ -13,12 +14,14 @@ void main() {
   testWidgets('renders a settings gear icon with a localized tooltip',
       (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        locale: Locale('en'),
-        home: Scaffold(
-          appBar: _ActionBar(),
+      const ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: Locale('en'),
+          home: Scaffold(
+            appBar: _ActionBar(),
+          ),
         ),
       ),
     );
@@ -45,11 +48,13 @@ void main() {
     );
 
     await tester.pumpWidget(
-      MaterialApp.router(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        locale: const Locale('en'),
-        routerConfig: router,
+      ProviderScope(
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
       ),
     );
 
@@ -57,6 +62,32 @@ void main() {
     await tester.tap(find.byIcon(Icons.settings_outlined));
     await tester.pumpAndSettle();
     expect(find.text('PROFILE'), findsOneWidget);
+  });
+
+  // #3061 — the gear records where the user came from (their shell branch,
+  // mapped to its route) so `ProfileScreen`'s back arrow returns there. The
+  // two halves of that logic are unit-tested deterministically below; the
+  // on-tap wiring (`routeForShellBranch(ref.read(currentShellBranchProvider))`)
+  // is exercised end-to-end in the running app.
+  test('routeForShellBranch maps each shell branch index to its route', () {
+    expect(routeForShellBranch(0), '/'); // Search / home
+    expect(routeForShellBranch(1), '/map');
+    expect(routeForShellBranch(2), '/favorites');
+    expect(routeForShellBranch(3), '/consumption-tab');
+    expect(routeForShellBranch(4), '/'); // Settings itself → home fallback
+    expect(routeForShellBranch(5), '/trajets-tab');
+  });
+
+  test('SettingsReturnLocation defaults to home and records an updated route',
+      () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(settingsReturnLocationProvider), '/');
+    container
+        .read(settingsReturnLocationProvider.notifier)
+        .update('/favorites');
+    expect(container.read(settingsReturnLocationProvider), '/favorites');
   });
 }
 


### PR DESCRIPTION
## What

The Settings (Paramètres) screen had **no top-left back button** — it's a StatefulShellRoute *branch* reached from the global gear (`context.go('/profile')`, a branch switch with no back-stack), so there was nothing to pop and no automatic leading. Users could only leave via the bottom nav. Reported with a screenshot.

## Fix

- The gear records the branch the user is on (from the app's reliable `currentShellBranchProvider`), mapped to its route, into `settingsReturnLocationProvider` **before** switching to Settings.
- `ProfileScreen` gets an explicit back arrow (`PageScaffold` already supports `leading`) that `context.go`s back to that location — a **true "back"** to wherever the user came from (Search / Map / Favorites / Carburant / Trajets), defaulting to home (`/`).
- Tooltip from `MaterialLocalizations.backButtonTooltip` (no new ARB).
- Tests: the branch→route map + the return-location notifier. (The on-tap wiring is exercised in-app; go_router + provider-scope interplay makes the full tap-capture brittle to unit-test.)

Closes #3061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)