### PR TITLE
feat(site): marketing landing page + launch-copy kit + editorial nomination

### DIFF
--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -115,22 +115,24 @@ jobs:
           cd fdroid && fdroid update --create-metadata --pretty
 
       # --- Assemble the COMBINED Pages site ----------------------------------
-      # Privacy policy + index.html at the site root, and the F-Droid repo
-      # index served directly at /fdroid (so the repo_url
-      # https://…/tankstellen/fdroid resolves /fdroid/index-v1.jar). Same
-      # layout pages.yml stages, so whichever workflow deploys last is
-      # consistent.
+      # Marketing landing page at the site root, privacy policy at
+      # /privacy-policy/, and the F-Droid repo index served directly at /fdroid
+      # (so the repo_url https://…/tankstellen/fdroid resolves
+      # /fdroid/index-v1.jar). Same layout pages.yml stages, so whichever
+      # workflow deploys last is consistent (#3066).
       - name: Assemble _site
         run: |
           rm -rf _site
           mkdir -p _site/fdroid
-          # Privacy policy (its own index.html) IS the deployed site root.
-          cp -R docs/privacy-policy/. _site/
-          # Also serve it at /privacy-policy/ so the legacy URL the Play
-          # listing links to keeps resolving after the legacy->Actions Pages
-          # migration (root alone would 404 that path).
+          # Marketing landing page IS the deployed site root (#3066).
+          cp -R docs/landing/. _site/
+          # Privacy policy at its canonical /privacy-policy/ URL (the landing
+          # page took the root; store listings now cite this path).
           mkdir -p _site/privacy-policy && cp -R docs/privacy-policy/. _site/privacy-policy/
+          # Landing-page assets at the root paths index.html references.
           cp -f docs/icon.png _site/icon.png 2>/dev/null || true
+          cp -f docs/play-store/metadata/android/en-US/images/featureGraphic.png _site/featureGraphic.png 2>/dev/null || true
+          mkdir -p _site/screenshots && cp -R docs/screenshots/. _site/screenshots/ 2>/dev/null || true
           # F-Droid repo index served at /fdroid/repo (fdroidserver requires
           # repo_url to end in /repo).
           mkdir -p _site/fdroid/repo && cp -R fdroid/repo/. _site/fdroid/repo/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,19 +1,24 @@
 # Copyright (c) 2026 Florian DITTGEN
 # SPDX-License-Identifier: MIT
 
-name: Deploy site (privacy policy + F-Droid repo) to GitHub Pages
+name: Deploy site (landing page + privacy policy + F-Droid repo) to GitHub Pages
 
-# Single Pages site (#2576): the privacy policy (its own index.html) is the
-# site root, the self-hosted F-Droid repo index is served at /fdroid. A push
-# that changes the privacy policy OR the committed F-Droid repo index redeploys
-# the combined site. (fdroid-publish.yml deploys the SAME combined layout on a
-# version tag, after rebuilding + re-signing the APK; both share the `pages`
-# concurrency group so they never race the single site.)
+# Single Pages site (#2576, #3066): the marketing landing page (docs/landing/
+# index.html) is the site root, the privacy policy is served at /privacy-policy/,
+# and the self-hosted F-Droid repo index is served at /fdroid. A push that
+# changes the landing page, its screenshots/feature graphic, the privacy policy
+# OR the committed F-Droid repo index redeploys the combined site.
+# (fdroid-publish.yml deploys the SAME combined layout on a version tag, after
+# rebuilding + re-signing the APK; both share the `pages` concurrency group so
+# they never race the single site.)
 
 on:
   push:
     branches: [master]
     paths:
+      - 'docs/landing/**'
+      - 'docs/screenshots/**'
+      - 'docs/play-store/metadata/android/en-US/images/featureGraphic.png'
       - 'docs/privacy-policy/**'
       - 'docs/icon.png'
       - 'fdroid/repo/**'
@@ -36,19 +41,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Combine: privacy policy at the root, the committed F-Droid repo index
-      # served directly at /fdroid (so the repo_url
-      # https://…/tankstellen/fdroid resolves /fdroid/index-v1.jar).
+      # Combine: marketing landing page at the root, privacy policy at
+      # /privacy-policy/, the committed F-Droid repo index served directly at
+      # /fdroid (so the repo_url https://…/tankstellen/fdroid resolves
+      # /fdroid/index-v1.jar).
       - name: Assemble _site
         run: |
           rm -rf _site
           mkdir -p _site/fdroid
-          cp -R docs/privacy-policy/. _site/
-          # Also serve the policy at /privacy-policy/ so the legacy URL the
-          # Play listing links to keeps resolving after the legacy->Actions
-          # Pages migration (root alone would 404 that path).
+          # Marketing landing page IS the deployed site root (#3066).
+          cp -R docs/landing/. _site/
+          # Privacy policy at its canonical /privacy-policy/ URL (the landing
+          # page took the root; store listings now cite this path).
           mkdir -p _site/privacy-policy && cp -R docs/privacy-policy/. _site/privacy-policy/
+          # Landing-page assets at the root paths index.html references.
           cp -f docs/icon.png _site/icon.png 2>/dev/null || true
+          cp -f docs/play-store/metadata/android/en-US/images/featureGraphic.png _site/featureGraphic.png 2>/dev/null || true
+          mkdir -p _site/screenshots && cp -R docs/screenshots/. _site/screenshots/ 2>/dev/null || true
           if [ -d fdroid/repo ]; then
             mkdir -p _site/fdroid/repo && cp -R fdroid/repo/. _site/fdroid/repo/
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ docs/*
 !docs/design/
 !docs/security/
 !docs/feature-concepts/
+!docs/landing/
+!docs/marketing/
 # Quality / process audit reports — pattern-allowlisted (live at docs root,
 # not inside docs/decisions/ which is reserved for ADRs).
 !docs/test-audit-*.md

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sparkilo — Free fuel-price &amp; EV-charging comparison, 17 countries</title>
+  <meta name="description" content="Sparkilo: free, ad-free, open-source app for real-time official fuel prices, cheapest petrol/diesel/gas &amp; EV charging across 17 countries. Route to the cheapest station, price alerts, consumption tracker — privacy-first, no account." />
+  <meta name="theme-color" content="#2E7D32" />
+  <link rel="icon" href="./icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="./icon.png" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Sparkilo — Free fuel-price &amp; EV-charging comparison" />
+  <meta property="og:description" content="Real-time official fuel prices &amp; EV charging across 17 countries. Route to the cheapest station, price alerts, consumption tracker. Free, ad-free, open-source, privacy-first." />
+  <meta property="og:image" content="./featureGraphic.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Sparkilo — Free fuel-price &amp; EV-charging comparison" />
+  <meta name="twitter:description" content="Real-time official fuel prices &amp; EV charging across 17 countries. Free, ad-free, open-source, privacy-first." />
+  <meta name="twitter:image" content="./featureGraphic.png" />
+
+  <style>
+    :root {
+      --green: #2E7D32;
+      --green-dark: #1B5E20;
+      --green-light: #4CAF50;
+      --green-soft: #E8F5E9;
+      --ink: #14201a;
+      --body: #38463f;
+      --muted: #6b7a72;
+      --bg: #ffffff;
+      --surface: #ffffff;
+      --surface-2: #f5f8f6;
+      --border: #e2e9e4;
+      --shadow: 0 4px 14px rgba(20, 50, 30, 0.08);
+      --shadow-lg: 0 18px 50px rgba(20, 50, 30, 0.16);
+      --radius: 18px;
+      --maxw: 1120px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --green: #5BBF61;
+        --green-dark: #3a9a41;
+        --green-light: #7ed884;
+        --green-soft: #16291b;
+        --ink: #eef5ef;
+        --body: #c3d0c8;
+        --muted: #8fa298;
+        --bg: #0e1512;
+        --surface: #15201b;
+        --surface-2: #111a15;
+        --border: #243329;
+        --shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 18px 50px rgba(0, 0, 0, 0.5);
+      }
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif;
+      color: var(--body);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    a { color: var(--green); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    img { max-width: 100%; display: block; }
+
+    h1, h2, h3 { color: var(--ink); line-height: 1.15; margin: 0 0 0.4em; letter-spacing: -0.02em; }
+
+    .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 20px; }
+
+    .skip-link {
+      position: absolute; left: -999px; top: 0;
+      background: var(--green); color: #fff; padding: 10px 16px; z-index: 1000; border-radius: 0 0 8px 0;
+    }
+    .skip-link:focus { left: 0; }
+
+    /* ---------- Header ---------- */
+    header.site {
+      position: sticky; top: 0; z-index: 50;
+      backdrop-filter: saturate(1.4) blur(12px);
+      -webkit-backdrop-filter: saturate(1.4) blur(12px);
+      background: color-mix(in srgb, var(--bg) 82%, transparent);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+    .brand { display: flex; align-items: center; gap: 10px; font-weight: 700; color: var(--ink); font-size: 1.15rem; letter-spacing: -0.02em; }
+    .brand img { width: 32px; height: 32px; border-radius: 8px; }
+    .nav-links { display: flex; gap: 26px; align-items: center; }
+    .nav-links a { color: var(--body); font-weight: 500; font-size: 0.95rem; }
+    .nav-links a:hover { color: var(--green); text-decoration: none; }
+    .nav-cta {
+      background: var(--green); color: #fff !important; padding: 8px 16px; border-radius: 999px;
+      font-weight: 600; font-size: 0.9rem;
+    }
+    .nav-cta:hover { background: var(--green-dark); text-decoration: none; }
+    @media (max-width: 720px) { .nav-links a:not(.nav-cta) { display: none; } }
+
+    /* ---------- Hero ---------- */
+    .hero {
+      position: relative;
+      background:
+        radial-gradient(1100px 500px at 75% -10%, color-mix(in srgb, var(--green) 26%, transparent), transparent 60%),
+        linear-gradient(160deg, var(--surface-2) 0%, var(--bg) 70%);
+      border-bottom: 1px solid var(--border);
+      overflow: hidden;
+    }
+    .hero-inner { padding: 64px 20px 56px; text-align: center; }
+    .hero-logo { display: inline-flex; align-items: center; gap: 14px; margin-bottom: 26px; }
+    .hero-logo img { width: 76px; height: 76px; border-radius: 20px; box-shadow: var(--shadow-lg); }
+    .hero-logo .word { font-size: 2.4rem; font-weight: 800; color: var(--ink); letter-spacing: -0.03em; }
+    .hero h1 {
+      font-size: clamp(2rem, 5.5vw, 3.4rem);
+      max-width: 16ch; margin: 0 auto 0.5em;
+      background: linear-gradient(120deg, var(--ink), var(--green) 130%);
+      -webkit-background-clip: text; background-clip: text;
+    }
+    .hero .tagline { font-size: clamp(1.05rem, 2.4vw, 1.3rem); color: var(--body); max-width: 56ch; margin: 0 auto 8px; }
+    .hero .pill-row { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 22px auto 4px; }
+    .pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: var(--green-soft); color: var(--green-dark);
+      border: 1px solid color-mix(in srgb, var(--green) 30%, transparent);
+      padding: 6px 14px; border-radius: 999px; font-size: 0.85rem; font-weight: 600;
+    }
+    @media (prefers-color-scheme: dark) { .pill { color: var(--green-light); } }
+
+    .feature-graphic { max-width: 760px; margin: 36px auto 0; }
+    .feature-graphic img { border-radius: var(--radius); box-shadow: var(--shadow-lg); border: 1px solid var(--border); width: 100%; }
+
+    /* ---------- Store buttons ---------- */
+    .stores { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; align-items: center; margin: 34px auto 6px; }
+    .store-badge img { height: 56px; width: auto; border-radius: 10px; }
+    .store-btn {
+      display: inline-flex; align-items: center; gap: 10px;
+      height: 56px; padding: 0 20px; border-radius: 10px;
+      background: var(--ink); color: var(--bg) !important; font-weight: 600;
+      border: 1px solid transparent; line-height: 1.1;
+    }
+    .store-btn:hover { text-decoration: none; opacity: 0.92; }
+    .store-btn small { display: block; font-size: 0.66rem; font-weight: 500; opacity: 0.8; letter-spacing: 0.02em; }
+    .store-btn strong { font-size: 1.05rem; font-weight: 700; }
+    .store-btn .ic { font-size: 1.5rem; line-height: 1; }
+    .store-btn.fdroid { background: var(--green); color: #fff !important; }
+    .store-btn.disabled { background: var(--surface-2); color: var(--muted) !important; border: 1px solid var(--border); cursor: not-allowed; }
+    .store-btn.disabled:hover { opacity: 1; }
+    .ghost-link {
+      display: inline-flex; align-items: center; gap: 8px; margin-top: 14px;
+      color: var(--body); font-weight: 600; font-size: 0.95rem;
+    }
+
+    /* ---------- Trust strip ---------- */
+    .trust { background: var(--green); color: #fff; }
+    .trust .wrap { display: flex; flex-wrap: wrap; justify-content: center; gap: 18px 48px; padding: 30px 20px; text-align: center; }
+    .trust .stat { min-width: 130px; }
+    .trust .num { font-size: 2rem; font-weight: 800; display: block; letter-spacing: -0.02em; }
+    .trust .lbl { font-size: 0.9rem; opacity: 0.92; }
+    @media (prefers-color-scheme: dark) { .trust { background: var(--green-dark); } }
+
+    /* ---------- Sections ---------- */
+    section { padding: 72px 0; }
+    .section-head { text-align: center; max-width: 64ch; margin: 0 auto 48px; }
+    .section-head h2 { font-size: clamp(1.7rem, 4vw, 2.4rem); }
+    .section-head p { color: var(--muted); font-size: 1.08rem; margin: 0; }
+    .eyebrow { color: var(--green); font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.8rem; display: block; margin-bottom: 10px; }
+
+    /* ---------- Differentiators ---------- */
+    .diffs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+    .diff {
+      background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 28px; box-shadow: var(--shadow); position: relative; overflow: hidden;
+    }
+    .diff::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 4px; background: linear-gradient(90deg, var(--green), var(--green-light)); }
+    .diff .ic { font-size: 2rem; margin-bottom: 12px; }
+    .diff h3 { font-size: 1.2rem; }
+    .diff p { margin: 0; color: var(--body); }
+    @media (max-width: 860px) { .diffs { grid-template-columns: 1fr; } }
+
+    /* ---------- Feature grid ---------- */
+    .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+    .feature {
+      background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 26px; transition: transform .18s ease, box-shadow .18s ease;
+    }
+    .feature:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); }
+    .feature .badge {
+      width: 46px; height: 46px; border-radius: 12px; display: grid; place-items: center;
+      background: var(--green-soft); font-size: 1.4rem; margin-bottom: 14px;
+    }
+    .feature h3 { font-size: 1.15rem; }
+    .feature p { margin: 0; color: var(--body); font-size: 0.98rem; }
+    @media (max-width: 900px) { .features { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 600px) { .features { grid-template-columns: 1fr; } }
+
+    /* ---------- Screenshots ---------- */
+    #screenshots { background: var(--surface-2); }
+    .shots {
+      display: flex; gap: 22px; overflow-x: auto; padding: 8px 20px 24px;
+      scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin; scrollbar-color: var(--green) transparent;
+    }
+    .shots::-webkit-scrollbar { height: 8px; }
+    .shots::-webkit-scrollbar-thumb { background: var(--green); border-radius: 999px; }
+    .shot { flex: 0 0 auto; width: 240px; scroll-snap-align: center; text-align: center; }
+    .shot img {
+      width: 100%; aspect-ratio: 9 / 16; object-fit: cover;
+      border-radius: 22px; border: 1px solid var(--border); box-shadow: var(--shadow-lg); background: var(--surface);
+    }
+    .shot figcaption { margin-top: 12px; font-size: 0.92rem; color: var(--body); font-weight: 600; }
+    .shots-hint { text-align: center; color: var(--muted); font-size: 0.85rem; margin-top: 4px; }
+
+    /* ---------- CTA band ---------- */
+    .cta-band { text-align: center; }
+    .cta-band .box {
+      background: linear-gradient(150deg, var(--green-dark), var(--green));
+      color: #fff; border-radius: 26px; padding: 54px 28px; box-shadow: var(--shadow-lg);
+    }
+    .cta-band h2 { color: #fff; font-size: clamp(1.6rem, 4vw, 2.3rem); }
+    .cta-band p { color: rgba(255,255,255,0.92); max-width: 50ch; margin: 0 auto 26px; font-size: 1.08rem; }
+
+    /* ---------- Countries ---------- */
+    .countries { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; max-width: 920px; margin: 0 auto; }
+    .country {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 999px;
+      padding: 7px 16px; font-size: 0.9rem; font-weight: 500; color: var(--body);
+    }
+
+    /* ---------- Footer ---------- */
+    footer.site { background: var(--surface-2); border-top: 1px solid var(--border); padding: 48px 0 40px; }
+    .foot-grid { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 28px; }
+    .foot-brand { display: flex; align-items: center; gap: 10px; font-weight: 700; color: var(--ink); }
+    .foot-brand img { width: 34px; height: 34px; border-radius: 9px; }
+    .foot-links { display: flex; flex-wrap: wrap; gap: 22px; align-items: center; }
+    .foot-links a { color: var(--body); font-weight: 500; font-size: 0.95rem; }
+    .foot-note { margin-top: 28px; color: var(--muted); font-size: 0.88rem; text-align: center; }
+
+    .center { text-align: center; }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site">
+    <div class="wrap nav">
+      <a class="brand" href="#top" aria-label="Sparkilo home">
+        <img src="./icon.png" alt="Sparkilo logo: a white droplet inside a shield on green" width="32" height="32" />
+        <span>Sparkilo</span>
+      </a>
+      <nav class="nav-links" aria-label="Primary">
+        <a href="#features">Features</a>
+        <a href="#screenshots">Screenshots</a>
+        <a href="#countries">Countries</a>
+        <a href="https://github.com/fdittgen-png/tankstellen" rel="noopener">Source</a>
+        <a class="nav-cta" href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices" rel="noopener">Get the app</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- HERO -->
+    <section class="hero" id="top" aria-labelledby="hero-title">
+      <div class="hero-inner">
+        <div class="hero-logo">
+          <img src="./icon.png" alt="Sparkilo logo: a white droplet inside a shield on green" width="76" height="76" />
+          <span class="word">Sparkilo</span>
+        </div>
+
+        <h1 id="hero-title">Always pay the cheapest price for fuel &amp; charging</h1>
+        <p class="tagline">
+          Real-time <strong>official</strong> fuel prices and EV charging across 17 countries.
+          Free, ad-free, open-source — and everything stays on your device.
+        </p>
+
+        <div class="pill-row" aria-hidden="false">
+          <span class="pill">100% free &amp; ad-free</span>
+          <span class="pill">Official data, not crowdsourced</span>
+          <span class="pill">Privacy-first · no account</span>
+        </div>
+
+        <!-- STORE BUTTONS -->
+        <div class="stores">
+          <a class="store-badge" href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices" rel="noopener">
+            <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_us/get_it_on_google_play.png" alt="Get it on Google Play" />
+          </a>
+
+          <a class="store-btn fdroid" href="https://fdittgen-png.github.io/tankstellen/fdroid" rel="noopener">
+            <span class="ic" aria-hidden="true">&#129505;</span>
+            <span><small>Libre build on</small><strong>F-Droid</strong></span>
+          </a>
+
+          <span class="store-btn disabled" role="note" aria-label="App Store coming soon">
+            <span class="ic" aria-hidden="true">&#63743;</span>
+            <span><small>Coming soon to the</small><strong>App&nbsp;Store</strong></span>
+          </span>
+        </div>
+
+        <div class="center">
+          <a class="ghost-link" href="https://github.com/fdittgen-png/tankstellen" rel="noopener">
+            <span aria-hidden="true">&#128279;</span> View source on GitHub
+          </a>
+        </div>
+
+        <!-- FEATURE GRAPHIC -->
+        <figure class="feature-graphic">
+          <img src="./featureGraphic.png" alt="Sparkilo app showing a map of nearby fuel stations with prices coloured cheapest to priciest" width="1024" height="500" loading="lazy" />
+        </figure>
+      </div>
+    </section>
+
+    <!-- TRUST STRIP -->
+    <div class="trust" aria-label="Coverage at a glance">
+      <div class="wrap">
+        <div class="stat"><span class="num">17</span><span class="lbl">countries with official prices</span></div>
+        <div class="stat"><span class="num">23</span><span class="lbl">UI languages</span></div>
+        <div class="stat"><span class="num">6</span><span class="lbl">fuel types + EV charging</span></div>
+        <div class="stat"><span class="num">€0</span><span class="lbl">forever · no ads, no account</span></div>
+      </div>
+    </div>
+
+    <!-- DIFFERENTIATORS -->
+    <section aria-labelledby="why-title">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Why Sparkilo</span>
+          <h2 id="why-title">Three things that make it different</h2>
+          <p>Not another crowdsourced, ad-funded tracker. Sparkilo is built on trustworthy data and on respect for your privacy.</p>
+        </div>
+        <div class="diffs">
+          <article class="diff">
+            <div class="ic" aria-hidden="true">&#9989;</div>
+            <h3>Official data, not guesses</h3>
+            <p>Prices come straight from government and open-data feeds — never crowdsourced. What you see is what stations are legally posting right now.</p>
+          </article>
+          <article class="diff">
+            <div class="ic" aria-hidden="true">&#127873;</div>
+            <h3>Free, ad-free, open-source</h3>
+            <p>No ads, no upsells, no premium tier. The full source is public under the MIT licence, with a libre build on F-Droid.</p>
+          </article>
+          <article class="diff">
+            <div class="ic" aria-hidden="true">&#128274;</div>
+            <h3>Privacy by design</h3>
+            <p>Your GPS location and API keys never leave the phone. No tracking, no analytics, no account required. Sync across devices only if you choose to.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- FEATURE GRID -->
+    <section id="features" aria-labelledby="feat-title">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Everything you need at the pump</span>
+          <h2 id="feat-title">Features</h2>
+          <p>From finding the cheapest litre to coaching your driving — all in one app.</p>
+        </div>
+        <div class="features">
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#9981;</div>
+            <h3>Cheapest-station search</h3>
+            <p>Find the lowest price nearby for petrol, diesel, LPG, CNG, E85 or electric. Pins are coloured cheapest to priciest, and the Fuel Station Radar live-scans around you.</p>
+          </article>
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#128506;</div>
+            <h3>Search along your route</h3>
+            <p>Heading somewhere? Sparkilo finds the best-value stations in your driving corridor. Filter by fuel type, radius, open-now, amenities or highway-only.</p>
+          </article>
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#128276;</div>
+            <h3>Smart price alerts</h3>
+            <p>Set on-device alerts that fire only when a great price is genuinely nearby. Keep favourites and open the full station detail — brand, hours, payment, amenities.</p>
+          </article>
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#128203;</div>
+            <h3>Consumption tracker + OCR</h3>
+            <p>Log fill-ups by snapping the pump display or receipt. Track L/100&nbsp;km, cost per km and history, with a built-in fuel-cost calculator and CO&#8322; dashboard.</p>
+          </article>
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#127942;</div>
+            <h3>Trip logbook + eco-coaching</h3>
+            <p>Record trips via OBD2 (ELM327) or GPS-only and see each route coloured by efficiency. Get an approach live-price overlay, a home-screen widget and voice announcements.</p>
+          </article>
+          <article class="feature">
+            <div class="badge" aria-hidden="true">&#9889;</div>
+            <h3>EV charging worldwide</h3>
+            <p>Compare charging points anywhere via Open Charge Map, right alongside fuel stations — perfect for mixed and electric fleets.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- SCREENSHOTS -->
+    <section id="screenshots" aria-labelledby="shots-title">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">See it in action</span>
+          <h2 id="shots-title">Screenshots</h2>
+          <p>Swipe through Sparkilo on a real phone.</p>
+        </div>
+      </div>
+      <div class="shots" role="list" aria-label="App screenshots, scrollable">
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/02-search-results.jpg" alt="Search results listing the cheapest fuel stations near the user" loading="lazy" />
+          <figcaption>Cheapest stations near you</figcaption>
+        </figure>
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/04-map-route-corridor.jpg" alt="Map showing price pins along a planned driving route corridor" loading="lazy" />
+          <figcaption>Price map + route</figcaption>
+        </figure>
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/06-price-alerts.jpg" alt="Price alert settings for nearby fuel deals" loading="lazy" />
+          <figcaption>Price alerts</figcaption>
+        </figure>
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/05-favorites-fuel-and-ev.jpg" alt="Favourites list mixing fuel stations and EV charging points" loading="lazy" />
+          <figcaption>Favourites: fuel + EV</figcaption>
+        </figure>
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/08-fuel-stats.jpg" alt="Consumption tracker statistics with litres per 100 km and cost per km" loading="lazy" />
+          <figcaption>Consumption tracker</figcaption>
+        </figure>
+        <figure class="shot" role="listitem">
+          <img src="./screenshots/10-trip-detail-gps-route.jpg" alt="Trip detail with a GPS route coloured by driving efficiency" loading="lazy" />
+          <figcaption>Trip eco-route</figcaption>
+        </figure>
+      </div>
+      <p class="shots-hint">Swipe or scroll to see more &rarr;</p>
+    </section>
+
+    <!-- COUNTRIES -->
+    <section id="countries" aria-labelledby="countries-title">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Coverage</span>
+          <h2 id="countries-title">Official prices in 17 countries</h2>
+          <p>Real-time government and open-data fuel prices — plus EV charging worldwide via Open Charge Map.</p>
+        </div>
+        <div class="countries">
+          <span class="country">Austria</span>
+          <span class="country">Argentina</span>
+          <span class="country">Australia</span>
+          <span class="country">Chile</span>
+          <span class="country">Denmark</span>
+          <span class="country">France</span>
+          <span class="country">Germany</span>
+          <span class="country">Greece</span>
+          <span class="country">Italy</span>
+          <span class="country">Luxembourg</span>
+          <span class="country">Mexico</span>
+          <span class="country">Portugal</span>
+          <span class="country">Romania</span>
+          <span class="country">Slovenia</span>
+          <span class="country">South Korea</span>
+          <span class="country">Spain</span>
+          <span class="country">United Kingdom</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA BAND -->
+    <section class="cta-band" aria-labelledby="cta-title">
+      <div class="wrap">
+        <div class="box">
+          <h2 id="cta-title">Start saving on every fill-up</h2>
+          <p>Download Sparkilo today — free, ad-free and open-source. No account, no tracking, no catch.</p>
+          <div class="stores" style="margin-bottom:0;">
+            <a class="store-badge" href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices" rel="noopener">
+              <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_us/get_it_on_google_play.png" alt="Get it on Google Play" />
+            </a>
+            <a class="store-btn fdroid" href="https://fdittgen-png.github.io/tankstellen/fdroid" rel="noopener" style="background:#fff;color:var(--green-dark)!important;">
+              <span class="ic" aria-hidden="true">&#129505;</span>
+              <span><small>Libre build on</small><strong>F-Droid</strong></span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="site">
+    <div class="wrap">
+      <div class="foot-grid">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" aria-hidden="true" width="34" height="34" />
+          <span>Sparkilo</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="https://github.com/fdittgen-png/tankstellen" rel="noopener">GitHub</a>
+          <a href="./privacy-policy/">Privacy policy</a>
+          <a href="mailto:fdittgen@gmail.com">Contact</a>
+          <a href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices" rel="noopener">Google Play</a>
+          <a href="https://fdittgen-png.github.io/tankstellen/fdroid" rel="noopener">F-Droid</a>
+        </nav>
+      </div>
+      <p class="foot-note">© 2026 Florian DITTGEN · Released under the MIT licence · Made with care, no ads, no tracking.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/marketing/launch-copy.md
+++ b/docs/marketing/launch-copy.md
@@ -1,0 +1,479 @@
+# Sparkilo — Launch Copy Kit
+
+Ready-to-paste posts for launch day. Each block is self-contained. Don't fire them all at once — see **Posting tips** at the bottom for cadence.
+
+---
+
+## 1. Hacker News — Show HN
+
+**Title** (copy this line):
+
+```
+Show HN: Sparkilo – open-source, ad-free fuel-price and EV-charging app (17 countries)
+```
+
+**Body**:
+
+```
+Hi HN,
+
+I'm a solo developer and this is my first real launch, so I'd genuinely
+appreciate honest feedback.
+
+Sparkilo compares fuel prices and EV-charging across 17 countries (Austria,
+Argentina, Australia, Chile, Denmark, France, Germany, Greece, Italy,
+Luxembourg, Mexico, Portugal, Romania, Slovenia, South Korea, Spain, UK).
+It routes you to the cheapest nearby station — or the cheapest one along a
+route you're about to drive — for petrol, diesel, LPG, CNG, E85 or electric.
+
+The thing that bugged me about existing apps, and the reason I built this:
+
+- The prices are OFFICIAL. They come from government / open-data feeds, not
+  crowdsourced guesses. (EV charging is via Open Charge Map.)
+- No ads, no tracking, no account, no analytics SDK. Your GPS location and
+  the API keys you enter never leave the device.
+- It's free and MIT-licensed.
+
+Other bits: on-device price alerts that only fire when you're actually near
+the station, a fuel-station "radar" live scan, a consumption tracker with OCR
+of the pump display and receipts, a fuel-cost calculator, a CO2 dashboard, a
+trip logbook with eco-coaching (OBD2 ELM327 or GPS-only), a home-screen
+widget and voice announcements.
+
+Tech: Flutter (one codebase, Android + iOS), Riverpod + freezed, Hive for
+local storage. Each country is a pluggable service that talks to that
+country's official open-data API and normalises into a common model, with
+fallback chains when a feed is flaky. 23 UI languages. There's a libre
+F-Droid build with no proprietary bits, and an optional self-hosted Supabase
+("TankSync") if you want cross-device sync you control — it's off by default
+and the app ships you the SQL to paste into your own project.
+
+Honest caveats: it's new, I'm one person, and coverage quality varies by
+country because every government publishes data differently. If your country's
+data looks wrong I'd love a bug report. iOS is in TestFlight right now; the
+App Store listing is in progress.
+
+Source: https://github.com/fdittgen-png/tankstellen
+Google Play: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid (libre build): https://fdittgen-png.github.io/tankstellen/fdroid
+
+Happy to answer anything about the data sources, the privacy model, or the
+Flutter side.
+```
+
+---
+
+## 2. Product Hunt
+
+**Product name**:
+
+```
+Sparkilo
+```
+
+**Tagline** (≤60 chars):
+
+```
+Free, ad-free fuel & EV-charging prices, 17 countries
+```
+
+**Description** (≤260 chars):
+
+```
+Compare official, real-time fuel prices and EV-charging across 17 countries.
+Routes you to the cheapest station nearby or along your route. No ads, no
+tracking, no account — GPS and keys stay on-device. Free, open-source (MIT).
+```
+
+**Maker's first comment**:
+
+```
+Hey Product Hunt 👋
+
+I'm the solo developer behind Sparkilo. I built it because the fuel apps I
+was using were full of ads, wanted an account, and showed prices that other
+users had typed in — sometimes days out of date.
+
+Sparkilo is different in three ways I care about:
+
+1. The prices are OFFICIAL — pulled straight from government / open-data feeds
+   in each of the 17 countries (EV charging via Open Charge Map), not
+   crowdsourced.
+2. It's privacy-first by design — no ads, no tracking, no account. Your
+   location and any API keys never leave your phone.
+3. It's free and open-source (MIT). There's even a libre F-Droid build.
+
+Beyond price comparison it does along-the-route search, on-device price alerts
+that only fire when you're nearby, a fuel-station radar, a consumption tracker
+with OCR of the pump/receipt, a CO2 dashboard, and a trip logbook with
+eco-coaching (OBD2 or GPS-only). 23 UI languages.
+
+It's on Google Play and F-Droid now; iOS is in TestFlight with the App Store
+listing on the way.
+
+I'm one person, so the roadmap and the next countries are wide open — I'd love
+to hear what you'd want. Thanks for taking a look!
+```
+
+**Topics / tags**:
+
+```
+Android · Open Source · Privacy · Travel
+```
+
+---
+
+## 3. Reddit
+
+> Localise nothing further — the FR/DE/ES/PT blocks below are already written in-language. Post each to its own subreddit on a different day. Read each sub's self-promo rules first; some require a flair.
+
+### r/france
+
+**Title**:
+
+```
+J'ai créé une appli open-source et gratuite pour comparer les prix des carburants (prix officiels, sans pub ni traçage)
+```
+
+**Body**:
+
+```
+Salut r/france,
+
+Développeur solo, je viens de sortir Sparkilo. Ça compare les prix des
+carburants à partir des données OFFICIELLES (prix.carburants / open data du
+gouvernement en France), pas des prix saisis par les utilisateurs. Ça vous
+guide vers la station la moins chère à proximité — ou la moins chère sur votre
+trajet — pour SP95, gazole, GPL, E85, etc. Recharge électrique aussi (via Open
+Charge Map).
+
+Ce à quoi je tiens : pas de pub, pas de traçage, pas de compte. Votre position
+GPS ne quitte jamais le téléphone. C'est gratuit et open-source (MIT).
+
+Il y a aussi des alertes de prix locales, un suivi de consommation avec OCR du
+ticket, un calculateur de coût et un carnet de trajets. 17 pays au total.
+
+Play Store : https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid : https://fdittgen-png.github.io/tankstellen/fdroid
+Code source : https://github.com/fdittgen-png/tankstellen
+
+C'est tout récent et je suis seul dessus, donc tout retour (ou bug sur les
+données françaises) m'intéresse beaucoup. Merci !
+```
+
+### r/de  *(German)*
+
+**Title**:
+
+```
+Ich habe eine kostenlose, quelloffene App für Spritpreise gebaut — offizielle Daten, keine Werbung, kein Tracking
+```
+
+**Body**:
+
+```
+Hallo r/de,
+
+ich entwickle allein und habe gerade Sparkilo veröffentlicht. Die App
+vergleicht Spritpreise auf Basis OFFIZIELLER Daten (in Deutschland über die
+Markttransparenzstelle für Kraftstoffe), nicht über von Nutzern eingetragene
+Preise. Sie lotst euch zur günstigsten Tankstelle in der Nähe — oder zur
+günstigsten entlang eurer Route — für Benzin, Diesel, LPG, CNG, E85. Auch
+E-Laden ist dabei (über Open Charge Map).
+
+Was mir wichtig ist: keine Werbung, kein Tracking, kein Konto. Euer GPS-Standort
+verlässt das Gerät nie. Kostenlos und Open Source (MIT).
+
+Dazu gibt es lokale Preisalarme (lösen nur aus, wenn ihr in der Nähe seid),
+einen Verbrauchstracker mit OCR des Kassenbons, einen Kostenrechner und ein
+Fahrtenbuch. Insgesamt 17 Länder, 23 Sprachen.
+
+Play Store: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid: https://fdittgen-png.github.io/tankstellen/fdroid
+Quellcode: https://github.com/fdittgen-png/tankstellen
+
+Ist noch ganz frisch und ich bin allein dran — über Feedback oder Bug-Reports
+(gerade zu den deutschen Daten) freue ich mich sehr. Danke!
+```
+
+### r/italy  *(Italian)*
+
+**Title**:
+
+```
+Ho creato un'app gratuita e open-source per confrontare i prezzi dei carburanti — dati ufficiali, niente pubblicità né tracciamento
+```
+
+**Body**:
+
+```
+Ciao r/italy,
+
+sviluppatore solitario, ho appena pubblicato Sparkilo. Confronta i prezzi dei
+carburanti usando i dati UFFICIALI (in Italia l'Osservaprezzi Carburanti del
+MIMIT), non prezzi inseriti dagli utenti. Ti porta al distributore più
+economico nelle vicinanze — o a quello più conveniente lungo il tuo percorso —
+per benzina, diesel, GPL, metano, E85. C'è anche la ricarica elettrica (via
+Open Charge Map).
+
+Ciò che mi sta a cuore: niente pubblicità, niente tracciamento, niente account.
+La tua posizione GPS non lascia mai il telefono. Gratuita e open-source (MIT).
+
+Ci sono anche avvisi di prezzo locali, un registro dei consumi con OCR dello
+scontrino, un calcolatore di costi e un diario di viaggio. In totale 17 paesi.
+
+Play Store: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid: https://fdittgen-png.github.io/tankstellen/fdroid
+Codice sorgente: https://github.com/fdittgen-png/tankstellen
+
+È appena nata e ci lavoro da solo, quindi ogni feedback (o segnalazione di bug
+sui dati italiani) è molto gradito. Grazie!
+```
+
+### r/es  *(Spanish)*
+
+**Title**:
+
+```
+He creado una app gratuita y de código abierto para comparar precios de carburantes — datos oficiales, sin anuncios ni rastreo
+```
+
+**Body**:
+
+```
+Hola r/es,
+
+soy desarrollador en solitario y acabo de publicar Sparkilo. Compara los
+precios de los carburantes usando datos OFICIALES (en España, los del
+Ministerio / Geoportal de Hidrocarburos), no precios introducidos por los
+usuarios. Te lleva a la gasolinera más barata cercana — o a la más barata en tu
+ruta — para gasolina, diésel, GLP, GNC, E85. También carga eléctrica (vía Open
+Charge Map).
+
+Lo que me importa: sin anuncios, sin rastreo, sin cuenta. Tu ubicación GPS
+nunca sale del teléfono. Gratis y de código abierto (MIT).
+
+También tiene alertas de precio locales, un registro de consumo con OCR del
+ticket, una calculadora de costes y un diario de viajes. En total 17 países.
+
+Play Store: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid: https://fdittgen-png.github.io/tankstellen/fdroid
+Código fuente: https://github.com/fdittgen-png/tankstellen
+
+Es muy reciente y lo llevo yo solo, así que cualquier comentario (o aviso de
+fallo en los datos de España) lo agradezco mucho. ¡Gracias!
+```
+
+### r/portugal  *(Portuguese)*
+
+**Title**:
+
+```
+Criei uma app gratuita e de código aberto para comparar preços de combustíveis — dados oficiais, sem anúncios nem rastreamento
+```
+
+**Body**:
+
+```
+Olá r/portugal,
+
+sou um programador a solo e acabei de lançar a Sparkilo. Compara os preços dos
+combustíveis com base em dados OFICIAIS (em Portugal, os da DGEG / Preços
+Combustíveis), não em preços introduzidos pelos utilizadores. Leva-te ao posto
+mais barato nas proximidades — ou ao mais barato ao longo do teu trajeto — para
+gasolina, gasóleo, GPL, GNC, E85. Também tem carregamento elétrico (via Open
+Charge Map).
+
+O que me importa: sem anúncios, sem rastreamento, sem conta. A tua localização
+GPS nunca sai do telemóvel. Gratuita e de código aberto (MIT).
+
+Tem ainda alertas de preço locais, um registo de consumos com OCR do talão, uma
+calculadora de custos e um diário de viagens. No total, 17 países.
+
+Play Store: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid: https://fdittgen-png.github.io/tankstellen/fdroid
+Código-fonte: https://github.com/fdittgen-png/tankstellen
+
+É muito recente e sou só eu a trabalhar nela, por isso qualquer comentário (ou
+relato de erro nos dados de Portugal) é muito bem-vindo. Obrigado!
+```
+
+### r/androidapps
+
+**Title**:
+
+```
+[App] Sparkilo — free, ad-free fuel-price & EV-charging comparison using official data (17 countries, open-source)
+```
+
+**Body**:
+
+```
+Solo dev here. Sparkilo compares fuel prices across 17 countries (AT, AR, AU,
+CL, DK, FR, DE, GR, IT, LU, MX, PT, RO, SI, KR, ES, UK) using OFFICIAL
+government / open-data feeds — not crowdsourced prices. EV charging is via Open
+Charge Map. It routes you to the cheapest station nearby or along your route for
+petrol, diesel, LPG, CNG, E85 or electric.
+
+No ads, no tracking, no account, and your GPS + API keys never leave the device.
+Free and MIT-licensed.
+
+Other features: on-device price alerts (only fire when you're nearby), a
+fuel-station radar, consumption tracker with OCR of the pump/receipt, fuel-cost
+calculator, CO2 dashboard, home-screen widget, trip logbook with eco-coaching
+(OBD2 or GPS-only). 23 UI languages.
+
+Play Store: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+F-Droid: https://fdittgen-png.github.io/tankstellen/fdroid
+Source: https://github.com/fdittgen-png/tankstellen
+
+It's brand new and I'm one person — feedback and bug reports very welcome,
+especially on data quality in your country. iOS is in TestFlight, App Store
+listing coming soon.
+```
+
+### r/fossdroid
+
+**Title**:
+
+```
+Sparkilo — fuel-price & EV-charging comparison (17 countries), MIT-licensed, libre F-Droid build, no tracking
+```
+
+**Body**:
+
+```
+I built Sparkilo, a fuel-price + EV-charging comparison app, and it now has a
+self-hosted libre F-Droid repo (no proprietary dependencies in that build):
+
+https://fdittgen-png.github.io/tankstellen/fdroid
+
+It uses OFFICIAL open-data fuel feeds across 17 countries (EV charging via Open
+Charge Map), routes you to the cheapest station nearby or along a route, and is
+genuinely privacy-first: no ads, no tracking, no account, and your GPS + any API
+keys never leave the device. MIT-licensed.
+
+Optional cross-device sync ("TankSync") is off by default and uses a Supabase
+project YOU self-host — the app generates the SQL to paste into your own
+instance, so even sync stays under your control.
+
+Source: https://github.com/fdittgen-png/tankstellen
+
+Solo dev, just launched — happy to take feedback on the libre build, the data
+sources, or anything that should change to make it a cleaner FOSS citizen.
+```
+
+### r/degoogle
+
+**Title**:
+
+```
+Sparkilo — a fuel-price app with no Google dependency: official data, no tracking, no account, libre F-Droid build
+```
+
+**Body**:
+
+```
+Most fuel-price apps are ad-and-tracker monsters that want an account. I built
+Sparkilo as the opposite:
+
+- No ads, no tracking, no analytics SDK, no account.
+- Your GPS location and any API keys NEVER leave the device.
+- Available as a libre F-Droid build (no proprietary bits):
+  https://fdittgen-png.github.io/tankstellen/fdroid
+- Open-source, MIT-licensed: https://github.com/fdittgen-png/tankstellen
+
+It compares OFFICIAL government / open-data fuel prices across 17 countries (EV
+charging via Open Charge Map) and routes you to the cheapest station nearby or
+along your route. Optional sync is self-hosted on a Supabase project you control
+(off by default), so there's nothing of yours sitting on my servers — I don't
+run any.
+
+Solo dev, just launched. If you spot anything that phones home that shouldn't,
+tell me — that's exactly the kind of report I want.
+```
+
+### r/opensource
+
+**Title**:
+
+```
+Sparkilo — MIT-licensed Flutter app comparing official fuel prices across 17 countries (no ads/tracking/account)
+```
+
+**Body**:
+
+```
+Sharing a project I just launched: Sparkilo, an MIT-licensed fuel-price and
+EV-charging comparison app.
+
+What it does: pulls OFFICIAL government / open-data fuel feeds across 17
+countries (EV charging via Open Charge Map) and routes you to the cheapest
+station nearby or along a route. Privacy-first — no ads, no tracking, no account,
+GPS + keys stay on-device.
+
+How it's built: Flutter, one codebase for Android + iOS, Riverpod + freezed,
+Hive local storage. Each country is a pluggable service that normalises its
+national feed into a shared model, with fallback chains for flaky feeds. 23 UI
+languages. Optional sync is self-hosted Supabase, off by default.
+
+Source: https://github.com/fdittgen-png/tankstellen
+F-Droid (libre): https://fdittgen-png.github.io/tankstellen/fdroid
+
+I'm a solo maintainer and this is an early launch. Contributions, issues, and
+especially new-country data adapters are very welcome — the per-country service
+pattern is designed to make adding a country a fairly contained PR.
+```
+
+---
+
+## 4. Lobsters / r/flutterdev
+
+**Title**:
+
+```
+Sparkilo — a cross-platform fuel-price app in Flutter: 23 locales, OBD2, on-device OCR (Apple Vision / ML Kit)
+```
+
+**Body**:
+
+```
+Sharing the dev side of Sparkilo, an open-source (MIT) fuel-price + EV-charging
+app I just launched on Android and F-Droid (iOS in TestFlight).
+
+Stack and the bits that were interesting to build:
+
+- Flutter, single codebase for Android + iOS. Riverpod (with codegen) + freezed
+  models, Hive for local persistence.
+- 17 countries, each a pluggable service that talks to a national open-data fuel
+  API and normalises into one shared station model, with fallback chains so a
+  flaky feed degrades gracefully instead of blanking the map.
+- 23 UI languages via ARB. New strings fan out to every locale through a build
+  step + a coverage gate, so en-only additions can't slip through.
+- On-device OCR for the pump display and fuel receipts — Apple Vision on iOS,
+  ML Kit on Android — behind a platform-plugin seam so the shared code never
+  branches on Platform.is*.
+- Trip logbook + eco-coaching from either an OBD2 ELM327 adapter (BLE) or
+  GPS-only, with the per-trip route coloured by efficiency.
+- Privacy by construction: no analytics, no account, GPS + API keys never leave
+  the device. Optional cross-device sync is a self-hosted Supabase the user
+  controls.
+
+Source: https://github.com/fdittgen-png/tankstellen
+
+Solo project, early days — happy to talk about the per-country service pattern,
+the BLE/OBD2 layer, the OCR plumbing, or the ARB fan-out if anyone's curious.
+```
+
+---
+
+## 5. Posting tips
+
+- **One subreddit per day**, max. Cross-posting the same link to many subs on the same day is the fastest way to get auto-flagged as spam and shadow-removed.
+- **Read each sub's rules first.** Some (e.g. r/androidapps) require a `[App]`/self-promo flair or have a dedicated self-promo thread/day; r/france and others restrict promo. A removed post for a rules violation burns the launch.
+- **Don't paste identical text across subs.** The blocks above are deliberately different per community (the localized ones, the FOSS/degoogle angles). Reddit's filters and humans both notice copy-paste.
+- **Be a person, not an ad** on Reddit and HN: lead with "I built this / here's why," stay in the comments, answer every reply for the first few hours, and take criticism gracefully — engagement in the first hour drives ranking on both HN and Reddit.
+- **Best timing:** HN Show HN lands best weekday mornings US Eastern (Tue–Thu, ~8–10am ET). Product Hunt launches at 12:01am PT and runs a 24h cycle — pick a Tue–Thu and be online all day. Reddit posts do well weekday mid-morning in the sub's own timezone (post the localized ones at local morning, not US time).
+- **Stagger the launch over ~2 weeks**, not one day: e.g. HN + Product Hunt on day 1, then one Reddit sub per day after, localized subs on weekday mornings in their region. Spreading it out also keeps you sane in the comments.
+- **Disclose you're the maker** every time (PH requires it; HN and Reddit expect it). It builds trust and it's the norm for solo-dev launches.
+- **Have screenshots / a short screen-recording ready** for Product Hunt and r/androidapps — those communities expect visuals, and a 15-30s clip of "search → cheapest pin → route" converts far better than text.

--- a/docs/marketing/play-editorial-nomination.md
+++ b/docs/marketing/play-editorial-nomination.md
@@ -1,0 +1,70 @@
+This is a content-writing task; no codebase exploration is needed. The brief is fully specified. I'll produce the Markdown directly.
+
+# Google Play — Editorial Feature Nomination
+
+**App name:** Sparkilo
+
+**Package name:** `de.tankstellen.fuelprices`
+
+**Primary category (recommended):** **Maps & Navigation**
+> Rationale: Sparkilo's core loop is location-driven — route to the cheapest station nearby or *along your route*, live "Fuel Station Radar" scanning, an approach live-price overlay, and per-trip GPS routes. That is navigation-first behaviour, and the category is where curators look for polished mapping experiences. (Auto & Vehicles is the natural secondary tag — the consumption tracker, OBD2 trip logbook and CO2 dashboard fit it — but the day-to-day job-to-be-done is "navigate me to the best price," so Maps & Navigation is the stronger primary.)
+
+**Single most compelling reason to feature it:**
+> A genuinely **free, ad-free, no-account, open-source (MIT)** comparison app that uses **official government / open-data fuel prices** — not crowdsourced guesses — across **17 countries**, with **GPS and API keys that never leave the device**. It's the rare utility that's both delightful and principled: privacy-by-design, no monetisation dark patterns, and source you can audit on GitHub.
+
+**What's new / innovative:**
+- **Official price data, not crowdsourced.** Prices come from national government feeds and official open-data sources, so they're authoritative rather than user-submitted and stale.
+- **Search *along your route*, not just nearby.** Plan a trip and Sparkilo finds the cheapest detour-light station on the way, with pins coloured cheapest→priciest.
+- **Fuel Station Radar** live scan and an **approach live-price overlay** that surfaces the price as you near a station.
+- **One app for combustion *and* EV** — petrol, diesel, LPG, CNG, E85, plus EV charging worldwide via Open Charge Map.
+- **On-device price alerts** that fire only when you're actually near a qualifying station — useful, not spammy.
+- **Eco-coaching trip logbook** via OBD2 (ELM327) *or* GPS-only, with each trip's route coloured by efficiency, plus OCR of the pump display and receipts into a consumption tracker (L/100km, cost/km, CO2 dashboard).
+
+**Target audience:**
+> Daily drivers, commuters, fleet and gig drivers, EV and hybrid owners, road-trippers, and privacy-conscious users across Europe, Latin America, Asia-Pacific and beyond who want to spend less on fuel without handing over their data.
+
+**Key launch markets:**
+> Germany, France, United Kingdom, Spain, Italy, Austria, Portugal, Greece, Denmark, Luxembourg, Romania, Slovenia, South Korea, Australia, Argentina, Chile, Mexico. (EV charging is worldwide.)
+
+**Quality & design highlights:**
+- Clean **Material 3** interface with a calm forest-green identity (#2E7D32) and a clear cheapest→priciest price-pin colour scale.
+- Thoughtful utility surface: home-screen widget, voice announcements, favourites, full station detail (brand, opening hours, payment methods, amenities), filters (fuel type, radius, open-now, amenities, highway-only), and a built-in fuel-cost calculator.
+- **Privacy-by-design architecture:** no ads, no tracking SDKs, no account required; location and API keys stay on-device. Optional, opt-in **TankSync** cross-device sync only if the user wants it.
+- **Open-source and verifiable:** MIT-licensed, with a libre F-Droid build alongside Play.
+
+**Accessibility & localisation:**
+> **23 UI languages**, covering all 17 supported markets and more. Material 3 components inherit platform accessibility (scalable text, screen-reader labels, high-contrast-friendly colour roles); voice announcements add a hands-free, eyes-free mode for use while driving.
+
+---
+
+**Elevator pitch (reusable by curators):**
+> Sparkilo is a free, ad-free, open-source app that routes you to the cheapest fuel — petrol, diesel, LPG, CNG, E85 or EV charging — using *official* government price data across 17 countries. It searches nearby or along your route, alerts you on-device when prices drop near you, and tracks your consumption and CO2 — all without ads, tracking, or an account, with your location never leaving your phone.
+
+**Links:**
+- Google Play: https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices
+- GitHub (source, MIT): https://github.com/fdittgen-png/tankstellen
+- F-Droid (libre build): https://fdittgen-png.github.io/tankstellen/fdroid
+
+---
+
+# Apple App Store — Featuring / "Apps We Love" Pitch
+
+> *iOS is coming soon to the App Store (currently in TestFlight / internal testing).*
+
+**App name:** Sparkilo — Fuel & EV Price Compare
+
+**The pitch:**
+> Sparkilo finds you the cheapest place to fill up — petrol, diesel, LPG, CNG, E85, or an EV charger — using **official government price data** across **17 countries**, not crowdsourced guesses. Search nearby or **along your route**, watch pins shade from cheapest to priciest, and get an on-device alert the moment a good price appears near you. It then closes the loop with a consumption tracker, eco-coaching trip logbook, and a CO2 dashboard.
+
+**Why it deserves a Story / feature:**
+- **Principled by design.** Free, no ads, no tracking, no account — and **open-source (MIT)**. Your location and API keys never leave your iPhone.
+- **Authoritative, not crowdsourced.** Real-time official price feeds make it trustworthy in a category full of stale, user-submitted data.
+- **Beautifully focused utility.** A calm, modern interface, a home-screen widget, voice announcements for hands-free driving, an approach live-price overlay, and live Fuel Station Radar — saving money made genuinely pleasant to use.
+- **Global from day one.** 17 countries, worldwide EV charging via Open Charge Map, and **23 languages** — a localisation story that travels.
+
+**One-line hook:**
+> The free, private, open-source way to never overpay for fuel — official prices, on your route, in 23 languages.
+
+**Links:**
+- iOS: coming soon to the App Store (TestFlight / internal testing now)
+- Source (MIT): https://github.com/fdittgen-png/tankstellen

--- a/docs/play-store/DATA_SAFETY.md
+++ b/docs/play-store/DATA_SAFETY.md
@@ -13,7 +13,7 @@
 - **App collects or shares user data?** Yes
 - **All data encrypted in transit?** Yes (all network calls use HTTPS/TLS)
 - **Users can request data deletion?** Yes (local: Settings > Delete all data; server: TankSync > Data Transparency > Delete everything)
-- **Privacy policy URL:** https://fdittgen-png.github.io/tankstellen/
+- **Privacy policy URL:** https://fdittgen-png.github.io/tankstellen/privacy-policy/
 
 ---
 
@@ -130,4 +130,4 @@ After deletion, the anonymous account is removed and cannot be recovered.
 4. All other data categories: select **"Not collected"**
 5. Confirm data is encrypted in transit
 6. Confirm users can request deletion
-7. Provide privacy policy URL: `https://fdittgen-png.github.io/tankstellen/`
+7. Provide privacy policy URL: `https://fdittgen-png.github.io/tankstellen/privacy-policy/`

--- a/ios/fastlane/metadata/de-DE/privacy_url.txt
+++ b/ios/fastlane/metadata/de-DE/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/

--- a/ios/fastlane/metadata/en-US/privacy_url.txt
+++ b/ios/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/

--- a/ios/fastlane/metadata/es-ES/privacy_url.txt
+++ b/ios/fastlane/metadata/es-ES/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/

--- a/ios/fastlane/metadata/fr-FR/privacy_url.txt
+++ b/ios/fastlane/metadata/fr-FR/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/

--- a/ios/fastlane/metadata/it/privacy_url.txt
+++ b/ios/fastlane/metadata/it/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/

--- a/ios/fastlane/metadata/pt-PT/privacy_url.txt
+++ b/ios/fastlane/metadata/pt-PT/privacy_url.txt
@@ -1,1 +1,1 @@
-https://fdittgen-png.github.io/tankstellen/
+https://fdittgen-png.github.io/tankstellen/privacy-policy/


### PR DESCRIPTION
Launch growth kit (docs + Pages only — no app code).

## Landing page (#3066)
A real marketing landing page now lives at the Pages root `fdittgen-png.github.io/tankstellen/` — branded hero with the new feature graphic, store badges (Play + F-Droid + 'App Store coming soon'), differentiators (official data / free+open-source / privacy), feature grid, scrollable screenshot gallery, 17-country + 23-language trust strip, MIT/privacy footer. Responsive, dark-mode, OG/Twitter cards, zero trackers.

**Privacy-URL migration:** the root previously served the privacy policy, so it moves to its canonical `/privacy-policy/` (already served there). `pages.yml` + `fdroid-publish.yml` updated to stage the landing page at root + copy assets; the 6 iOS `privacy_url.txt` + Data-Safety doc are updated.
> ⚠️ **Maintainer action:** update the Play Console privacy-policy URL field (App content → Privacy policy) to `https://fdittgen-png.github.io/tankstellen/privacy-policy/`. The policy stays live there throughout.

## Marketing kit (#3067)
`docs/marketing/launch-copy.md` (Show HN · Product Hunt · per-country Reddit, FR/DE/ES/PT localized · Lobsters/r/flutterdev · cadence tips) and `docs/marketing/play-editorial-nomination.md` (Play nomination form draft + Apple featuring pitch).

Merging redeploys Pages with the landing page at root.

Closes #3066
Closes #3067

🤖 Generated with [Claude Code](https://claude.com/claude-code)