### PR TITLE
fix(consumption): app-bar check action to save Add-fill-up above the iOS keyboard

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -571,11 +571,22 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
         tooltip: l?.tooltipBack ?? 'Back',
         onPressed: () => Navigator.maybePop(context),
       ),
+      // #3073 — app-bar save stays above the iOS keyboard, which covers the
+      // bottom save bar and has no system dismiss. Bottom bar kept otherwise.
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.check),
+          tooltip: l?.save ?? 'Save',
+          onPressed: _save,
+        ),
+      ],
       bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
         autovalidateMode: AutovalidateMode.onUserInteraction,
         child: ListView(
+          // #3073 — drag-to-dismiss the keyboard (iOS lacks a system dismiss).
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           padding: EdgeInsets.fromLTRB(
             16,
             16,

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_restyle_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_restyle_test.dart
@@ -154,6 +154,29 @@ void main() {
       expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
     });
 
+    testWidgets(
+        '#3073 — exposes a check action in the app bar (reachable above the '
+        'iOS keyboard) alongside the pinned bottom Save', (tester) async {
+      await _pumpWithTallView(
+        tester,
+        const AddFillUpScreen(),
+        overrides: _withVehicle,
+      );
+
+      // The app-bar ✓ action stays visible above the keyboard, so the form
+      // is submittable on iOS where the keyboard covers the bottom save bar.
+      final checkAction = find.byWidgetPredicate(
+        (w) =>
+            w is IconButton &&
+            w.icon is Icon &&
+            (w.icon as Icon).icon == Icons.check &&
+            w.tooltip == 'Save',
+      );
+      expect(checkAction, findsOneWidget);
+      // The pinned bottom Save bar stays for the keyboard-closed case.
+      expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
+    });
+
     testWidgets('every ARB label referenced in the form still renders',
         (tester) async {
       await _pumpWithTallView(

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -432,8 +432,11 @@ void main() {
     // callback wiring. The dialog + parse-and-prefill body live in the
     // extracted handler file; only the thin delegation lands here.
     // Decomposition stays tracked under #2187.
+    // #3073 — +11 → 649: app-bar check action (save above the iOS keyboard,
+    // which covers the bottom save bar and has no system dismiss) + onDrag
+    // keyboard dismissal. Small iOS bug fix; decomposition still tracked (#2187).
     'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
-        638,
+        649,
     // #2380 — +5: closest-station radar card at the top of the
     // recording column + a SingleChildScrollView wrap so the longer
     // column (radar + 5 metric cards + coaching card) scrolls instead


### PR DESCRIPTION
## Bug (iPhone)
On the **Add fill-up** form, the Save button lives in a bottom `FillUpPinnedSaveBar` that the iOS keyboard covers — and iOS has no system keyboard-dismiss (unlike Android's back gesture). Result: focus a field → keyboard hides Save → the form can't be saved and the keyboard can't be closed.

## Fix
- **App-bar check (✓) action** (`PageScaffold.actions`) wired to the same `_save()`. The app bar stays above the keyboard, so the form is always submittable. Tooltip reuses the existing `save` ARB string — no l10n fan-out.
- **`keyboardDismissBehavior: onDrag`** on the form `ListView` so dragging dismisses the keyboard too.
- The bottom Save bar stays for the keyboard-closed case (both platforms).

Cross-platform Material pattern; iOS/TestFlight + Android-beta bound (Android production stays a manual decision). Added a structural test for the new action; bumped the grandfathered file-length snapshot (638→649) with justification — decomposition still tracked under #2187.

Closes #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)