### PR TITLE
fix(sync): persist the server∪local merge so TankSync actually pulls (#3076)

### DIFF
--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -19,6 +19,13 @@ import '../../core/logging/error_logger.dart';
 
 part 'sync_provider.g.dart';
 
+/// Signature for a sync-merge that takes the device's local ids and
+/// returns the union (server ∪ local) — exactly the shape of
+/// [FavoritesSync.merge] / [IgnoredStationsSync.merge]. Injected as a
+/// seam so the pull-persist wiring (#3076) is unit-testable without a
+/// live Supabase session.
+typedef IdMergeFn = Future<List<String>> Function(List<String> localIds);
+
 /// Manages the cloud sync connection state.
 ///
 /// ## Reusability
@@ -209,18 +216,41 @@ class SyncState extends _$SyncState {
   void _performInitialSync(StorageRepository storage) {
     Future.microtask(() async {
       try {
-        final favIds = storage.getFavoriteIds();
-        if (favIds.isNotEmpty) await FavoritesSync.merge(favIds);
-        final ignoredIds = storage.getIgnoredIds();
-        if (ignoredIds.isNotEmpty) await IgnoredStationsSync.merge(ignoredIds);
+        await syncAndPersistIds(storage);
         // #2319 — batch every local rating into one upsert round-trip
-        // instead of N serial calls on connect.
+        // instead of N serial calls on connect. (Ratings pull is #3077.)
         await RatingsSync.upsertAll(storage.getRatings());
         debugPrint('InitialSync: complete');
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));
       }
     });
+  }
+
+  /// Bidirectionally sync favorites + ignored stations and **persist the
+  /// union back to local storage** (#3076).
+  ///
+  /// Previously the [FavoritesSync.merge] / [IgnoredStationsSync.merge]
+  /// return values (server ∪ local) were discarded, so a device only
+  /// ever uploaded — server-side rows added on another device never
+  /// reached this one. We now write the merged superset back via
+  /// [StorageRepository.setFavoriteIds] / [StorageRepository.setIgnoredIds].
+  ///
+  /// The merges run unconditionally (no `isNotEmpty` guard): a fresh
+  /// device with no local favorites must still *pull* the server's set.
+  ///
+  /// [mergeFavorites] / [mergeIgnored] default to the real syncs and are
+  /// injectable so the pull-persist wiring is unit-testable without a
+  /// live Supabase session (the real merges return the input unchanged
+  /// when unauthenticated, masking the wiring under test).
+  @visibleForTesting
+  Future<void> syncAndPersistIds(
+    StorageRepository storage, {
+    IdMergeFn mergeFavorites = FavoritesSync.merge,
+    IdMergeFn mergeIgnored = IgnoredStationsSync.merge,
+  }) async {
+    await storage.setFavoriteIds(await mergeFavorites(storage.getFavoriteIds()));
+    await storage.setIgnoredIds(await mergeIgnored(storage.getIgnoredIds()));
   }
 
   static SyncMode _parseMode(String? value) => switch (value) {

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'd1ae9a241e0fb9e2a31cfd87ad87bc6b3bd96ad3';
+String _$syncStateHash() => r'24eb9fca5ddd15d1b5a085af6ef72670237259d5';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/supabase_client.dart';
 import '../../../core/sync/sync_provider.dart';
 import '../../../core/sync/alerts_sync.dart';
@@ -123,10 +124,18 @@ class DataTransparencyController extends _$DataTransparencyController {
         }
       }
 
-      await FavoritesSync.merge(favoriteIds);
+      // #3076 — persist the union (server ∪ local) back to local storage
+      // instead of discarding the merge result, so favorites added on
+      // another device are pulled down here. Then invalidate the favorites
+      // provider so the in-session UI reflects the newly-pulled ids; the
+      // `Favorites` notifier re-reads storage on rebuild.
+      final storage = ref.read(storageRepositoryProvider);
+      await storage.setFavoriteIds(await FavoritesSync.merge(favoriteIds));
+      ref.invalidate(favoritesProvider);
 
       final alerts = ref.read(alertProvider);
       debugPrint('DataTransparency: syncing ${alerts.length} local alerts');
+      // Alerts pull is #3077 — leave merge as upload-only for now.
       await AlertsSync.merge(alerts);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'DataTransparency: force sync failed'}));

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -44,7 +44,7 @@ final class DataTransparencyControllerProvider
 }
 
 String _$dataTransparencyControllerHash() =>
-    r'8add90fb3c7995cb3329ff02695c1a968fa9b9dc';
+    r'674e5a5c9f4e8b0bb00e85f6b86abb5c4333d412';
 
 abstract class _$DataTransparencyController
     extends $Notifier<DataTransparencyState> {

--- a/test/core/sync/sync_pull_persist_test.dart
+++ b/test/core/sync/sync_pull_persist_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/core/sync/sync_provider.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+
+/// Regression tests for #3076 — TankSync was upload-only.
+///
+/// [FavoritesSync.merge] / [IgnoredStationsSync.merge] each return the
+/// union (server ∪ local), but `_performInitialSync` discarded the
+/// return value — so server-side rows added on another device never
+/// reached this device. It also skipped the merge entirely when the
+/// local set was empty, so a fresh install never pulled the server set.
+///
+/// These tests drive the [SyncState.syncAndPersistIds] seam with an
+/// injected fake merge that simulates server rows, and assert the union
+/// is **persisted back to local storage**. They FAIL against the
+/// pre-fix code (discarded return + `isNotEmpty` guard) and PASS after.
+void main() {
+  late FakeHiveStorage fakeStorage;
+
+  setUp(() {
+    fakeStorage = FakeHiveStorage();
+  });
+
+  ProviderContainer createContainer() {
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(fakeStorage),
+      syncStateProvider.overrideWith(() => _FakeSyncState(const SyncConfig(
+            enabled: true,
+            supabaseUrl: 'https://test.supabase.co',
+            supabaseAnonKey: 'key',
+            userId: 'user-123',
+            mode: SyncMode.community,
+          ))),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Builds a fake merge that simulates the server returning [serverIds]
+  /// in addition to whatever the device sends up — the real merge's
+  /// "return local ∪ server" contract.
+  IdMergeFn fakeMergeWithServer(List<String> serverIds) {
+    return (localIds) async => {...localIds, ...serverIds}.toList();
+  }
+
+  group('SyncState.syncAndPersistIds (#3076 pull-persist)', () {
+    test('persists a server-only favorite into LOCAL storage', () async {
+      await fakeStorage.setFavoriteIds(['local-1']);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      await notifier.syncAndPersistIds(
+        fakeStorage,
+        mergeFavorites: fakeMergeWithServer(['server-only-id']),
+        mergeIgnored: fakeMergeWithServer(const []),
+      );
+
+      // The discarded-return bug would leave this as just ['local-1'].
+      expect(
+        fakeStorage.getFavoriteIds(),
+        containsAll(<String>['local-1', 'server-only-id']),
+        reason: 'server-only favorite must be written to local storage',
+      );
+    });
+
+    test('persists a server-only ignored station into LOCAL storage',
+        () async {
+      await fakeStorage.setIgnoredIds(['ignored-local']);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      await notifier.syncAndPersistIds(
+        fakeStorage,
+        mergeFavorites: fakeMergeWithServer(const []),
+        mergeIgnored: fakeMergeWithServer(['ignored-server']),
+      );
+
+      expect(
+        fakeStorage.getIgnoredIds(),
+        containsAll(<String>['ignored-local', 'ignored-server']),
+        reason: 'server-only ignored id must be written to local storage',
+      );
+    });
+
+    test('empty local + server rows → local gets the server rows', () async {
+      // No local favorites/ignored at all — proves the removed
+      // `isNotEmpty` guard: an empty device must still PULL the server set.
+      expect(fakeStorage.getFavoriteIds(), isEmpty);
+      expect(fakeStorage.getIgnoredIds(), isEmpty);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      await notifier.syncAndPersistIds(
+        fakeStorage,
+        mergeFavorites: fakeMergeWithServer(['srv-fav-a', 'srv-fav-b']),
+        mergeIgnored: fakeMergeWithServer(['srv-ign-a']),
+      );
+
+      expect(
+        fakeStorage.getFavoriteIds(),
+        containsAll(<String>['srv-fav-a', 'srv-fav-b']),
+        reason: 'empty device must pull server favorites',
+      );
+      expect(
+        fakeStorage.getIgnoredIds(),
+        contains('srv-ign-a'),
+        reason: 'empty device must pull server ignored stations',
+      );
+    });
+
+    test('no-op merge leaves local storage unchanged', () async {
+      await fakeStorage.setFavoriteIds(['keep-1', 'keep-2']);
+      await fakeStorage.setIgnoredIds(['keep-ign']);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      // identity merge — simulates an unauthenticated/empty server.
+      await notifier.syncAndPersistIds(
+        fakeStorage,
+        mergeFavorites: (ids) async => ids,
+        mergeIgnored: (ids) async => ids,
+      );
+
+      expect(fakeStorage.getFavoriteIds(), ['keep-1', 'keep-2']);
+      expect(fakeStorage.getIgnoredIds(), ['keep-ign']);
+    });
+  });
+}
+
+/// Fake [SyncState] that returns a fixed [SyncConfig] without touching
+/// Supabase — the seam under test (`syncAndPersistIds`) is inherited.
+class _FakeSyncState extends SyncState {
+  final SyncConfig _config;
+  _FakeSyncState(this._config);
+
+  @override
+  SyncConfig build() => _config;
+}


### PR DESCRIPTION
## What

TankSync was **upload-only**. `FavoritesSync.merge(localIds)` and
`IgnoredStationsSync.merge(localIds)` each return the union (server ∪
local), but every caller **discarded the return** — so a device only
ever *uploaded* its own favorites/ignored stations and never wrote down
rows added on another device. `_performInitialSync` additionally
**skipped the merge entirely when the local set was empty**, so a fresh
install never pulled the server's set at all.

Net effect: a second device (or a reinstall) never saw the favorites /
ignored stations synced from the first device. This is the foundational
"server→client never persists" bug for Epic #3075.

## Fix

- **`lib/core/sync/sync_provider.dart`** — `_performInitialSync` now
  delegates to a new injectable `syncAndPersistIds` seam that runs both
  merges **unconditionally** (the `isNotEmpty` guards are gone) and
  writes the returned union **back to local storage** via
  `setFavoriteIds` / `setIgnoredIds`.
- **`lib/features/sync/providers/data_transparency_provider.dart`** —
  `forceSyncAndReload` persists the favorites union back to storage and
  invalidates `favoritesProvider` so the in-session UI reflects the
  newly-pulled ids.
- `RatingsSync.upsertAll` and `AlertsSync.merge` are deliberately left
  **upload-only** — their pull is scoped to **#3077**.

### Layering

`sync_provider.dart` lives in `core/` and must not depend on `features/`
providers. The initial-sync path therefore only persists to storage and
relies on `Favorites` / `IgnoredStations` re-reading storage on their
next build/launch — correctness on next build over a fragile cross-layer
invalidate. The in-session `ref.invalidate(favoritesProvider)` lives only
in the **features-layer** `data_transparency_provider.dart` (verified: no
import cycle — neither favorites nor ignored providers import data
transparency).

## Test

New `test/core/sync/sync_pull_persist_test.dart` drives the
`syncAndPersistIds` seam with a fake merge that simulates server rows and
asserts a **server-only id lands in local storage**, including the
empty-local case that proves the removed guard.

The seam exists precisely because the real merges return their input
unchanged when unauthenticated — which is exactly why the original wiring
bug (a discarded return value) was untestable and escaped review. The
test **fails against the pre-fix behaviour** (`Actual: ['local-1']` /
`Actual: []`) and **passes after**.

Part of Epic #3075.

Closes #3076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
