### PR TITLE
fix(android): make Downloads export collision-proof (Failed to build unique file)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/PublicFileExporterChannel.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/PublicFileExporterChannel.kt
@@ -3,6 +3,8 @@
 
 package de.tankstellen.tankstellen
 
+import android.content.ContentUris
+import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
 import android.os.Build
@@ -65,20 +67,19 @@ object PublicFileExporterChannel {
     ): String {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val resolver = context.contentResolver
-            val values = ContentValues().apply {
-                put(MediaStore.Downloads.DISPLAY_NAME, fileName)
-                put(MediaStore.Downloads.MIME_TYPE, mimeType)
-                put(MediaStore.Downloads.IS_PENDING, 1)
+            // #3084 — a prior export interrupted between insert and the
+            // IS_PENDING=0 finalize leaves an orphaned MediaStore row
+            // (_size=null) that makes a same-name re-insert fail with
+            // "Failed to build unique file". Clear any app-owned stale row for
+            // this name first (best-effort), then insert; on ANY collision /
+            // failure, fall back to a timestamped unique name so the export
+            // never hard-fails on the user.
+            deleteExistingDownloads(resolver, fileName)
+            return try {
+                insertIntoDownloads(resolver, fileName, mimeType, bytes)
+            } catch (e: Exception) {
+                insertIntoDownloads(resolver, uniqueName(fileName), mimeType, bytes)
             }
-            val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
-            val uri = resolver.insert(collection, values)
-                ?: throw IllegalStateException("MediaStore.insert returned null")
-            resolver.openOutputStream(uri)?.use { it.write(bytes) }
-                ?: throw IllegalStateException("openOutputStream returned null")
-            values.clear()
-            values.put(MediaStore.Downloads.IS_PENDING, 0)
-            resolver.update(uri, values, null, null)
-            return uri.toString()
         }
         val downloads = Environment.getExternalStoragePublicDirectory(
             Environment.DIRECTORY_DOWNLOADS,
@@ -87,5 +88,71 @@ object PublicFileExporterChannel {
         val file = File(downloads, fileName)
         file.writeBytes(bytes)
         return file.absolutePath
+    }
+
+    /** Insert [bytes] into MediaStore.Downloads under [displayName] (API 29+). */
+    private fun insertIntoDownloads(
+        resolver: ContentResolver,
+        displayName: String,
+        mimeType: String,
+        bytes: ByteArray,
+    ): String {
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, displayName)
+            put(MediaStore.Downloads.MIME_TYPE, mimeType)
+            put(MediaStore.Downloads.IS_PENDING, 1)
+        }
+        val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+        val uri = resolver.insert(collection, values)
+            ?: throw IllegalStateException("MediaStore.insert returned null")
+        resolver.openOutputStream(uri)?.use { it.write(bytes) }
+            ?: throw IllegalStateException("openOutputStream returned null")
+        values.clear()
+        values.put(MediaStore.Downloads.IS_PENDING, 0)
+        resolver.update(uri, values, null, null)
+        return uri.toString()
+    }
+
+    /**
+     * Best-effort: delete any app-owned Downloads row whose display name is
+     * exactly [fileName], clearing a stale/orphaned entry that would block a
+     * same-name insert. Failures are swallowed — the caller's unique-name
+     * fallback still guarantees the export succeeds.
+     */
+    private fun deleteExistingDownloads(resolver: ContentResolver, fileName: String) {
+        try {
+            val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+            resolver.query(
+                collection,
+                arrayOf(MediaStore.Downloads._ID),
+                "${MediaStore.Downloads.DISPLAY_NAME} = ?",
+                arrayOf(fileName),
+                null,
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID)
+                while (cursor.moveToNext()) {
+                    val itemUri =
+                        ContentUris.withAppendedId(collection, cursor.getLong(idColumn))
+                    try {
+                        resolver.delete(itemUri, null, null)
+                    } catch (_: Exception) {
+                        // Not ours / already gone — leave it; the fallback name handles it.
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Query unavailable — fall through to the insert + unique-name fallback.
+        }
+    }
+
+    /** Insert a millisecond stamp before the extension: `name-<ts>.ext`. */
+    private fun uniqueName(fileName: String): String {
+        val stamp = System.currentTimeMillis()
+        val dot = fileName.lastIndexOf('.')
+        return if (dot > 0) {
+            "${fileName.substring(0, dot)}-$stamp${fileName.substring(dot)}"
+        } else {
+            "$fileName-$stamp"
+        }
     }
 }


### PR DESCRIPTION
## Bug (production 6.0.0+2026061271)
Error-log export to Downloads threw `PlatformException(WRITE_FAILED, Failed to build unique file: …/Download/tankstellen-error-log.json … _size=null)` at `PublicFileExporterChannel.saveBytes`.

## Root cause
`saveBytes` (API 29+) inserts a FIXED `DISPLAY_NAME` with `IS_PENDING=1`. A prior export interrupted between `insert` and the `IS_PENDING=0` finalize leaves an **orphaned MediaStore row** (`_size=null`), and the next same-name insert fails with "Failed to build unique file".

## Fix
Before inserting, best-effort delete any app-owned Downloads row with that display name (clears the orphan); then insert; on any exception fall back to a **timestamped unique name** so the export always succeeds. Insert extracted to `insertIntoDownloads`; pre-Q `File.writeBytes` path (already overwrites) unchanged. Native-only (no Dart/ARB change); `build-android` CI validates compilation.

Android bug fix → reaches the beta channel; production on the next manual promotion.

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)