### PR TITLE
fix(sync): allow self-data deletion in community mode

### DIFF
--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -254,13 +254,13 @@ class SyncState extends _$SyncState {
 
   /// Delete the user's account: wipe server data, sign out, clear local sync state.
   ///
-  /// Blocked in community mode to prevent accidental mass deletion
-  /// of the shared database. Users must disconnect first.
+  /// Works in every mode, including community (#3081). Every synced table's
+  /// RLS policy is `FOR ALL USING (user_id = auth.uid())`, so
+  /// [UserDataSync.deleteAll] can only ever remove the *caller's own* rows —
+  /// deleting your own data can never reach another community user's rows in
+  /// the shared database. The destructive UI action stays gated behind a
+  /// confirmation dialog before this runs.
   Future<void> deleteAccount() async {
-    if (state.mode == SyncMode.community) {
-      debugPrint('deleteAccount: blocked in community mode');
-      return;
-    }
     try {
       await UserDataSync.deleteAll();
       await TankSyncClient.signOut();

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'605d71cd1ee217cd0e8d7987fc5f52b03f42622a';
+String _$syncStateHash() => r'055ec0aecd6581ba5e8749f74ba58d43e91ca899';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -216,7 +216,6 @@ class DataTransparencyScreen extends ConsumerWidget {
                       const SizedBox(height: 16),
                       DataActionButtons(
                         loading: uiState.loading,
-                        mode: syncConfig.mode,
                         onSync: () => _forceSyncAndReload(context, ref),
                         onViewRawJson: () =>
                             _showRawJson(context, uiState.data!),

--- a/lib/features/sync/presentation/widgets/data_transparency_cards.dart
+++ b/lib/features/sync/presentation/widgets/data_transparency_cards.dart
@@ -96,7 +96,6 @@ class SyncedDataCard extends StatelessWidget {
 /// Data action buttons: sync, view JSON, export, delete, disconnect.
 class DataActionButtons extends StatelessWidget {
   final bool loading;
-  final SyncMode mode;
   final VoidCallback onSync;
   final VoidCallback onViewRawJson;
   final VoidCallback onExportJson;
@@ -107,7 +106,6 @@ class DataActionButtons extends StatelessWidget {
   const DataActionButtons({
     super.key,
     required this.loading,
-    required this.mode,
     required this.onSync,
     required this.onViewRawJson,
     required this.onExportJson,
@@ -141,58 +139,38 @@ class DataActionButtons extends StatelessWidget {
         ),
         const SizedBox(height: 24),
 
-        // Destructive actions -- disabled for community mode
-        if (mode == SyncMode.community) ...[
-          Card(
-            color: DarkModeColors.warningSurface(context),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                children: [
-                  Icon(Icons.info_outline, color: DarkModeColors.warning(context)),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      l?.dataDeletionNotAvailableCommunity ??
-                          'Data deletion is not available in community '
-                              'mode. Disconnect first, or use a private database.',
-                      style: const TextStyle(fontSize: 13),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+        // Destructive actions. Available in every mode, including community
+        // (#3081): each synced table's RLS is `FOR ALL USING (user_id =
+        // auth.uid())`, so a user can only ever delete their *own* rows —
+        // deleting your private data never touches the shared community DB's
+        // other users. A confirmation dialog still gates each action.
+        FilledButton.icon(
+          style: FilledButton.styleFrom(
+            backgroundColor: DarkModeColors.error(context),
           ),
-          const SizedBox(height: 8),
-        ] else ...[
-          FilledButton.icon(
-            style: FilledButton.styleFrom(
-              backgroundColor: DarkModeColors.error(context),
-            ),
-            onPressed: onDeleteAll,
-            icon: const Icon(Icons.delete_forever),
-            label: Text(l?.deleteAllServerData ?? 'Delete all server data'),
+          onPressed: onDeleteAll,
+          icon: const Icon(Icons.delete_forever),
+          label: Text(l?.deleteAllServerData ?? 'Delete all server data'),
+        ),
+        const SizedBox(height: 8),
+        // #1541 — narrower destructive action: wipes only the
+        // synced trip history (both `trip_summaries` and
+        // `trip_details`) without touching the user's other
+        // server-side data. Outlined rather than filled so it
+        // visually defers to the broader "Delete all server data"
+        // above it.
+        OutlinedButton.icon(
+          key: const Key('forget_all_synced_trips_button'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: DarkModeColors.error(context),
           ),
-          const SizedBox(height: 8),
-          // #1541 — narrower destructive action: wipes only the
-          // synced trip history (both `trip_summaries` and
-          // `trip_details`) without touching the user's other
-          // server-side data. Outlined rather than filled so it
-          // visually defers to the broader "Delete all server data"
-          // above it.
-          OutlinedButton.icon(
-            key: const Key('forget_all_synced_trips_button'),
-            style: OutlinedButton.styleFrom(
-              foregroundColor: DarkModeColors.error(context),
-            ),
-            onPressed: onForgetAllTrips,
-            icon: const Icon(Icons.history_toggle_off),
-            label: Text(
-              l?.forgetAllSyncedTripsButton ?? 'Forget all synced trips',
-            ),
+          onPressed: onForgetAllTrips,
+          icon: const Icon(Icons.history_toggle_off),
+          label: Text(
+            l?.forgetAllSyncedTripsButton ?? 'Forget all synced trips',
           ),
-          const SizedBox(height: 8),
-        ],
+        ),
+        const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onDisconnect,
           icon: const Icon(Icons.link_off),

--- a/test/core/sync/sync_provider_auth_transition_test.dart
+++ b/test/core/sync/sync_provider_auth_transition_test.dart
@@ -15,7 +15,8 @@ import '../../fakes/fake_hive_storage.dart';
 /// - Anonymous → Email sign-up
 /// - Anonymous → Email sign-in (existing account)
 /// - Connected → Disconnect → Reconnect
-/// - Community mode → Delete account (blocked)
+/// - Community mode → Delete account (now allowed, #3081 — RLS scopes
+///   the wipe to the caller's own rows)
 ///
 /// The tests use a [FakeHiveStorage] to simulate local state and verify
 /// state changes via fake-state inspection (no mocktail needed for
@@ -103,7 +104,12 @@ void main() {
       expect(state.userId, isNull);
     });
 
-    test('deleteAccount is blocked in community mode', () async {
+    test('deleteAccount proceeds in community mode (#3081)', () async {
+      // Pre-seed local data — deleteAccount wipes *server* rows then
+      // disconnects; local data is untouched (only the sync config is
+      // cleared).
+      await fakeStorage.setFavoriteIds(['s1', 's2']);
+
       final container = createContainer(
         initialConfig: const SyncConfig(
           enabled: true,
@@ -117,12 +123,21 @@ void main() {
       container.read(syncStateProvider);
       await container.read(syncStateProvider.notifier).deleteAccount();
 
-      // In community mode, disconnect should NOT be called
-      // (deleteAccount returns early)
+      // The community early-return is gone: deleteAccount now reaches the
+      // delete + disconnect path. RLS (`FOR ALL USING (user_id =
+      // auth.uid())`) scopes the server wipe to the caller's own rows, so
+      // this can never touch other community users' data. With no live
+      // Supabase session in tests, the server calls are graceful no-ops
+      // and the path falls through to disconnect(), which clears the
+      // sync config.
+      expect(fakeStorage.getSetting('sync_enabled'), false,
+          reason: 'Community mode must no longer block deleteAccount');
       final state = container.read(syncStateProvider);
-      expect(state.enabled, isTrue,
-          reason: 'Community mode should block deleteAccount');
-      expect(state.mode, SyncMode.community);
+      expect(state.enabled, isFalse);
+      expect(state.userId, isNull);
+      expect(state.mode, SyncMode.none);
+      // Local data is preserved — only server data + sync config go.
+      expect(fakeStorage.getFavoriteIds(), ['s1', 's2']);
     });
 
     test('deleteAccount works in private mode', () async {

--- a/test/features/sync/presentation/widgets/data_transparency_cards_test.dart
+++ b/test/features/sync/presentation/widgets/data_transparency_cards_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/data_transparency_cards.dart';
@@ -38,6 +39,43 @@ void main() {
       expect(find.text('Account'), findsOneWidget);
       expect(find.text('test-uuid-123'), findsOneWidget);
       expect(find.text('https://test.supabase.co'), findsOneWidget);
+    });
+  });
+
+  group('DataActionButtons', () {
+    // #3081 — destructive actions used to be hidden behind a "data
+    // deletion is not available in community mode" warning Card. RLS
+    // scopes every delete to the caller's own rows (`FOR ALL USING
+    // (user_id = auth.uid())`), so the block was over-broad. The actions
+    // must now render unconditionally (the widget no longer takes a
+    // `mode` param) and the community warning text must be absent.
+    Widget buildButtons() => DataActionButtons(
+          loading: false,
+          onSync: () {},
+          onViewRawJson: () {},
+          onExportJson: () {},
+          onDeleteAll: () {},
+          onForgetAllTrips: () {},
+          onDisconnect: () {},
+        );
+
+    testWidgets('shows destructive actions and no community warning',
+        (tester) async {
+      await pumpApp(tester, buildButtons());
+
+      // The broad + narrow destructive actions are both present.
+      expect(find.text('Delete all server data'), findsOneWidget);
+      expect(
+        find.byKey(const Key('forget_all_synced_trips_button')),
+        findsOneWidget,
+      );
+      expect(find.text('Forget all synced trips'), findsOneWidget);
+
+      // The former community-mode warning must be gone entirely.
+      expect(
+        find.textContaining('Data deletion is not available in community'),
+        findsNothing,
+      );
     });
   });
 


### PR DESCRIPTION
## Why

TankSync blocked **all** data deletion in Community mode. That was over-broad: every synced table's RLS policy is `FOR ALL USING (user_id = auth.uid())`, so a connected user can **only ever delete their own rows** — wiping your own favorites/trips can never reach the shared community DB's other users. A user reported being unable to delete their private data (favorites, trips) while on the community database.

## What

1. **`SyncState.deleteAccount`** (`lib/core/sync/sync_provider.dart`) — removed the `if (state.mode == SyncMode.community) { ...; return; }` early-return so full account deletion (`UserDataSync.deleteAll` + sign-out + `disconnect`, all RLS-scoped to the caller's own rows) now runs in community mode too. Stale "Blocked in community mode" dartdoc updated to explain the RLS scoping.
2. **`DataActionButtons`** (`lib/features/sync/presentation/widgets/data_transparency_cards.dart`) — dropped the community special-case so the "Delete all server data" and "Forget all synced trips" destructive actions render in **every** mode. The `mode` param became dead and was removed, along with its only caller wiring in `data_transparency_screen.dart`.
3. The unused `dataDeletionNotAvailableCommunity` ARB key is left in place (unused keys are allowed; removing it would require the 23-locale fan-out for no benefit). No new strings added.

## Safety

- **The confirmation dialogs are retained.** `onDeleteAll` still routes through `DataTransparencyScreen._deleteAllData`, which shows a confirm dialog before `deleteAllData()`; "Forget all synced trips" keeps its own confirm dialog too.
- RLS guarantees the wipe is scoped to `auth.uid()`, so a user deleting their own data can never affect another community user.

## Tests

- **Widget:** `DataActionButtons` now renders "Delete all server data" + the `forget_all_synced_trips_button` and the former community-warning text is absent.
- **Unit:** `deleteAccount` no longer early-returns in community mode — it reaches the delete + disconnect path (sync config cleared, local data preserved). The old "blocked in community mode" expectation was inverted.

`flutter analyze` clean (one pre-existing, unrelated `anonKey` deprecation in `supabase_client.dart`). `flutter test test/core/sync/ test/features/sync/` green (505 tests).

Closes #3081
Part of Epic #3075

🤖 Generated with [Claude Code](https://claude.com/claude-code)
