### PR TITLE
fix(sync): pull server→local for ratings, alerts, fill-ups, vehicles (#3077)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -25,22 +25,26 @@ import '../core/telemetry/storage/trace_storage.dart';
 import '../core/telemetry/trace_recorder.dart';
 import '../core/logging/error_logger.dart';
 import '../core/notifications/local_notification_service.dart';
+import '../core/data/storage_repository.dart';
 import '../core/perf/startup_timer.dart';
 import '../core/services/country_service_registry.dart';
 import '../core/storage/hive_boxes.dart';
 import '../core/storage/hive_storage.dart';
 import '../core/sync/community_config.dart';
 import '../core/sync/supabase_client.dart';
+import '../core/sync/sync_provider.dart';
 import '../core/sync/trips_sync.dart';
 import '../core/sync/trips_sync_enabled_provider.dart';
 import '../core/telemetry/pii_scrubber.dart';
 import '../core/utils/edge_to_edge.dart';
+import '../features/alerts/providers/alert_provider.dart';
 import '../features/consumption/data/obd2/active_trip_recovery_service.dart';
 import '../features/consumption/data/obd2/active_trip_repository.dart';
 import '../features/consumption/data/obd2/paused_trip_recovery_service.dart';
 import '../features/consumption/data/obd2/paused_trip_repository.dart';
 import '../features/consumption/data/trip_history_repository.dart';
 import '../features/consumption/providers/auto_record_orchestrator.dart';
+import '../features/consumption/providers/consumption_providers.dart';
 import '../features/consumption/providers/obd2_comm_diagnostics_gate_provider.dart';
 import '../features/consumption/providers/obd2_debug_logging_provider.dart';
 import '../features/consumption/providers/trip_recording_provider.dart';
@@ -52,6 +56,7 @@ import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import '../features/vehicle/data/vehicle_profile_migrator.dart';
 import '../features/vehicle/providers/vehicle_aggregate_updater_provider.dart';
+import '../features/vehicle/providers/vehicle_providers.dart';
 import '../features/widget/data/home_widget_service.dart';
 import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 import '../features/widget/providers/pending_widget_uri_provider.dart';
@@ -169,6 +174,11 @@ class AppInitializer {
       // once TankSync is up. No-ops cleanly when the user is signed
       // out or when the trip-history Hive box isn't open.
       await _runTripsSyncMerge(container);
+      // #3077 — pull the remaining server→local entities (ratings,
+      // alerts, fill-ups, vehicles) once TankSync is up, mirroring the
+      // trips merge above. No-ops cleanly when sync is off / unauthenticated
+      // and respects each entity's consent gate.
+      await _runEntitySyncMerge(container, storage);
     });
 
     // Cache runtime version so AppConstants.appVersion is accurate (#570).
@@ -584,6 +594,60 @@ class AppInitializer {
       await TripsSync.pruneOldDetails();
     } catch (e, st) {
       debugPrint('AppInitializer._runTripsSyncMerge failed: $e\n$st');
+    }
+  }
+
+  /// #3077 — on app launch, pull the remaining server→local entities into
+  /// local storage so cross-device rows land without a manual sync gesture,
+  /// mirroring [_runTripsSyncMerge]. TankSync was upload-only for these:
+  /// the download branch existed in each `*_sync.dart` but had no
+  /// connect/launch caller (fill-ups + vehicles), or its return was
+  /// discarded (ratings), or it only fired on a local edit (alerts). The
+  /// per-entity pull-persist seams (`*.pullFromServer` /
+  /// `syncAndPersistRatings`) are the unit-tested units; this method is
+  /// the launch-time glue, mirroring the untested `_runTripsSyncMerge`.
+  ///
+  /// Consent gates (conservative — never pull data the user hasn't
+  /// consented to):
+  /// - **ratings / alerts** ride the master TankSync consent — they pull
+  ///   whenever `sync_enabled` is set (the same gate the existing
+  ///   favorites/ignored pull and the alert-mutation pull already use).
+  /// - **fill-ups / vehicles** are trip-data adjacent (fill-ups carry
+  ///   linked trajet ids + OBD2-derived consumption; a vehicle profile is
+  ///   the anchor trips attach to), so they ride the stricter trip-sync
+  ///   gate (`tripsSyncEnabledProvider` = email ∧ cloudSync ∧ syncTrips).
+  ///
+  /// No-ops cleanly when TankSync isn't initialised or the user is signed
+  /// out (each `*Sync` method short-circuits on a null user id, returning
+  /// the input unchanged). Each entity is independently error-protected so
+  /// one failing pull never blocks the others.
+  static Future<void> _runEntitySyncMerge(
+    ProviderContainer container,
+    StorageRepository storage,
+  ) async {
+    if (TankSyncClient.client == null) return;
+    if (!container.read(syncStateProvider).enabled) return;
+
+    // ratings + alerts ride the master consent; fill-ups + vehicles are
+    // trip-data adjacent and ride the stricter trip-sync gate.
+    final tripData = container.read(tripsSyncEnabledProvider);
+    final pulls = <String, Future<void> Function()>{
+      'ratings': () =>
+          container.read(syncStateProvider.notifier).syncAndPersistRatings(storage),
+      'alerts': () => container.read(alertProvider.notifier).pullFromServer(),
+      if (tripData)
+        'vehicles': () =>
+            container.read(vehicleProfileListProvider.notifier).pullFromServer(),
+      if (tripData)
+        'fillUps': () => container.read(fillUpListProvider.notifier).pullFromServer(),
+    };
+    for (final entry in pulls.entries) {
+      try {
+        await entry.value();
+      } catch (e, st) {
+        debugPrint(
+            'AppInitializer._runEntitySyncMerge ${entry.key} failed: $e\n$st');
+      }
     }
   }
 

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -26,6 +26,13 @@ part 'sync_provider.g.dart';
 /// live Supabase session.
 typedef IdMergeFn = Future<List<String>> Function(List<String> localIds);
 
+/// Signature for a ratings fetch returning the server's
+/// `stationId → rating` map — the shape of [RatingsSync.fetchAll].
+/// Injected as a seam so the ratings pull-persist wiring (#3077) is
+/// unit-testable without a live Supabase session (the real fetch
+/// returns an empty map when unauthenticated, masking the wiring).
+typedef RatingsFetchFn = Future<Map<String, int>> Function();
+
 /// Signature for an email auth call (sign-up / sign-in / anonymous-upgrade)
 /// returning the resulting user id (or `null`). Mirrors the static
 /// `TankSyncClient.*` methods so the auth-branch selection in
@@ -293,8 +300,12 @@ class SyncState extends _$SyncState {
       try {
         await syncAndPersistIds(storage);
         // #2319 — batch every local rating into one upsert round-trip
-        // instead of N serial calls on connect. (Ratings pull is #3077.)
+        // instead of N serial calls on connect.
         await RatingsSync.upsertAll(storage.getRatings());
+        // #3077 — pull server-only ratings down too. The upsertAll above
+        // is upload-only; without this a rating created on another device
+        // never reached this one.
+        await syncAndPersistRatings(storage);
         debugPrint('InitialSync: complete');
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));
@@ -326,6 +337,41 @@ class SyncState extends _$SyncState {
   }) async {
     await storage.setFavoriteIds(await mergeFavorites(storage.getFavoriteIds()));
     await storage.setIgnoredIds(await mergeIgnored(storage.getIgnoredIds()));
+  }
+
+  /// Pull the user's server ratings and **persist the server-only ones
+  /// back to local storage** (#3077).
+  ///
+  /// [RatingsSync.fetchAll] returns every `stationId → rating` the
+  /// authenticated user owns. Previously the return was never consumed —
+  /// `_performInitialSync` only ever *uploaded* via [RatingsSync.upsertAll],
+  /// so a rating made on another device never reached this one. We now
+  /// write any server station the device doesn't already rate locally via
+  /// [RatingStorage.setRating].
+  ///
+  /// Union-merge semantics: **local wins on id collision** — a station the
+  /// device already rates is left untouched (its in-flight edit may not yet
+  /// have reached the server). Only server-only stations are added. The
+  /// `station_rating_provider` re-reads storage on rebuild, so the in-session
+  /// UI reflects the pulled ratings.
+  ///
+  /// Called on the connect / "sync now" / app-launch triggers (see
+  /// `data_transparency_provider` + `AppInitializer`). [fetchRatings]
+  /// defaults to the real [RatingsSync.fetchAll] and is injectable so the
+  /// pull-persist wiring is unit-testable without a live Supabase session
+  /// (the real fetch returns an empty map when unauthenticated, masking the
+  /// wiring under test).
+  Future<void> syncAndPersistRatings(
+    StorageRepository storage, {
+    RatingsFetchFn fetchRatings = RatingsSync.fetchAll,
+  }) async {
+    final serverRatings = await fetchRatings();
+    if (serverRatings.isEmpty) return;
+    final localRatings = storage.getRatings();
+    for (final entry in serverRatings.entries) {
+      if (localRatings.containsKey(entry.key)) continue;
+      await storage.setRating(entry.key, entry.value);
+    }
   }
 
   static SyncMode _parseMode(String? value) => switch (value) {

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'055ec0aecd6581ba5e8749f74ba58d43e91ca899';
+String _$syncStateHash() => r'a16a129ea3aeedbb1a32e98f1d07228a57f4c55d';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/alerts/providers/alert_provider.dart
+++ b/lib/features/alerts/providers/alert_provider.dart
@@ -81,26 +81,39 @@ class AlertNotifier extends _$AlertNotifier {
     await BackgroundService.reconcile();
   }
 
+  /// Explicitly upload local alerts AND pull server-only alerts into local
+  /// storage (#3077). Used by the connect / app-launch / "sync now"
+  /// triggers — the mutation hooks ([addAlert] / [toggleAlert]) already
+  /// pull on every edit, but a device that never edits an alert (a fresh
+  /// install signing in on a second device) needs an explicit pull pass to
+  /// see alerts created elsewhere. Returns the count of newly-persisted
+  /// (downloaded) alerts. No-op when TankSync is disabled.
+  Future<int> pullFromServer() =>
+      _syncAlertsIfConnected(applyDownloads: true);
+
   /// Push local alerts to the backend and, unless [applyDownloads] is
-  /// false, pull server-only alerts back into local storage.
+  /// false, pull server-only alerts back into local storage. Returns the
+  /// count of server-only alerts persisted this pass (0 when downloads are
+  /// suppressed, TankSync is off, or nothing new came down).
   ///
   /// #2246 — [AlertsSync.merge] returns the merged superset
   /// (`[local, ...server-only downloaded]`). The result used to be
   /// discarded, so an alert created on another device never reached this
   /// one. We now persist the server-only rows via [_applyMergedAlerts].
-  Future<void> _syncAlertsIfConnected({bool applyDownloads = true}) async {
+  Future<int> _syncAlertsIfConnected({bool applyDownloads = true}) async {
     try {
       final syncState = ref.read(syncStateProvider);
       if (syncState.enabled) {
         final merge = ref.read(alertsMergeFnProvider);
         final merged = await merge(state);
         if (applyDownloads) {
-          await _applyMergedAlerts(merged);
+          return _applyMergedAlerts(merged);
         }
       }
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'AlertProvider: sync failed'}));
     }
+    return 0;
   }
 
   /// Persist any [merged] alert whose id isn't already in local storage,

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -132,7 +132,7 @@ final class AlertNotifierProvider
   }
 }
 
-String _$alertNotifierHash() => r'a31007c9f66874972bd29d7d3eab99faca8dfc7c';
+String _$alertNotifierHash() => r'0f5704e93402174bd6244293687986dc85d1f8b8';
 
 abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
   List<PriceAlert> build();

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -11,6 +11,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/data/storage_repository.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_providers.dart';
+import '../../../core/sync/fill_ups_sync.dart';
 import '../../vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../../vehicle/data/ve_learner.dart';
 import '../../vehicle/data/vehicle_profile_catalog_matcher.dart';
@@ -200,6 +201,12 @@ class LastVeLearnResult extends _$LastVeLearnResult {
     state = result;
   }
 }
+
+/// Signature of the bidirectional fill-ups merge. Defaults to
+/// [FillUpsSync.merge]; injectable so the #3077 pull-persist wiring is
+/// unit-testable without a live Supabase session (the real merge returns
+/// the input unchanged when unauthenticated, masking the wiring under test).
+typedef FillUpsMergeFn = Future<List<FillUp>> Function(List<FillUp> local);
 
 /// Mutable list of all fill-ups, newest first.
 @Riverpod(keepAlive: true)
@@ -912,6 +919,29 @@ class FillUpList extends _$FillUpList {
     }
     state = repo.getAll();
     return added;
+  }
+
+  /// Pull the user's server fill-ups and **persist the server-only ones
+  /// into local storage** (#3077).
+  ///
+  /// [FillUpsSync.merge] uploads local-only rows AND returns the union
+  /// (`[...local, ...downloaded]`). Previously the only caller was the
+  /// manual device-link flow, so a fill-up logged on another device never
+  /// reached this one on connect / launch. We now keep only the server-only
+  /// entries (local wins on id collision — an in-flight local edit is never
+  /// clobbered) and add them via [mergeFrom]. Returns the count of
+  /// newly-persisted (downloaded) fill-ups.
+  ///
+  /// The caller owns the consent gate — this is invoked behind the
+  /// trip-data sync gate (fill-ups are trip-data adjacent). [mergeFn]
+  /// defaults to the real sync and is injectable for unit tests.
+  Future<int> pullFromServer({FillUpsMergeFn mergeFn = FillUpsSync.merge}) async {
+    final repo = ref.read(fillUpRepositoryProvider);
+    final localIds = repo.getAll().map((f) => f.id).toSet();
+    final merged = await mergeFn(repo.getAll());
+    final serverOnly = merged.where((f) => !localIds.contains(f.id)).toList();
+    if (serverOnly.isEmpty) return 0;
+    return mergeFrom(serverOnly);
   }
 }
 

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -467,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'9005145b421427b5230e301550eb3f00a92aae7c';
+String _$fillUpListHash() => r'a812fbb2887bf218957b08aa8f5e76ebc6956dcf';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -9,11 +9,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/supabase_client.dart';
 import '../../../core/sync/sync_provider.dart';
-import '../../../core/sync/alerts_sync.dart';
 import '../../../core/sync/favorites_sync.dart';
+import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../../core/sync/user_data_sync.dart';
 import '../../alerts/providers/alert_provider.dart';
+import '../../consumption/providers/consumption_providers.dart';
 import '../../favorites/providers/favorites_provider.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
 import '../../../core/logging/error_logger.dart';
 
 part 'data_transparency_provider.g.dart';
@@ -133,10 +135,25 @@ class DataTransparencyController extends _$DataTransparencyController {
       await storage.setFavoriteIds(await FavoritesSync.merge(favoriteIds));
       ref.invalidate(favoritesProvider);
 
+      // #3077 — pull server-only ratings into local storage (local wins on
+      // collision). The station_rating provider re-reads storage on rebuild.
+      await ref.read(syncStateProvider.notifier).syncAndPersistRatings(storage);
+
+      // #3077 — alerts: an explicit upload + download pass. The
+      // add/toggle hooks already pull on every edit, but the "sync now"
+      // gesture must also pull alerts created on another device for a
+      // device that never edits one locally.
       final alerts = ref.read(alertProvider);
       debugPrint('DataTransparency: syncing ${alerts.length} local alerts');
-      // Alerts pull is #3077 — leave merge as upload-only for now.
-      await AlertsSync.merge(alerts);
+      await ref.read(alertProvider.notifier).pullFromServer();
+
+      // #3077 — fill-ups + vehicles are trip-data adjacent, so they ride
+      // the same trip-sync consent gate (cloudSync ∧ syncTrips ∧ email).
+      // Off → upload-only stays the contract, nothing is pulled.
+      if (ref.read(tripsSyncEnabledProvider)) {
+        await ref.read(vehicleProfileListProvider.notifier).pullFromServer();
+        await ref.read(fillUpListProvider.notifier).pullFromServer();
+      }
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'DataTransparency: force sync failed'}));
     }

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -44,7 +44,7 @@ final class DataTransparencyControllerProvider
 }
 
 String _$dataTransparencyControllerHash() =>
-    r'674e5a5c9f4e8b0bb00e85f6b86abb5c4333d412';
+    r'6f7412b55b4b699795210784a8d93fc316b9c835';
 
 abstract class _$DataTransparencyController
     extends $Notifier<DataTransparencyState> {

--- a/lib/features/vehicle/providers/vehicle_providers.dart
+++ b/lib/features/vehicle/providers/vehicle_providers.dart
@@ -4,10 +4,18 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/storage_providers.dart';
+import '../../../core/sync/vehicles_sync.dart';
 import '../data/repositories/vehicle_profile_repository.dart';
 import '../domain/entities/vehicle_profile.dart';
 
 part 'vehicle_providers.g.dart';
+
+/// Signature of the bidirectional vehicles merge. Defaults to
+/// [VehiclesSync.merge]; injectable so the #3077 pull-persist wiring is
+/// unit-testable without a live Supabase session (the real merge returns
+/// the input unchanged when unauthenticated, masking the wiring under test).
+typedef VehiclesMergeFn = Future<List<VehicleProfile>> Function(
+    List<VehicleProfile> local);
 
 /// Repository for reading/writing [VehicleProfile] entries.
 @Riverpod(keepAlive: true)
@@ -67,6 +75,31 @@ class VehicleProfileList extends _$VehicleProfileList {
     state = repo.getAll();
     ref.invalidate(activeVehicleProfileProvider);
     return added;
+  }
+
+  /// Pull the user's server vehicle profiles and **persist the server-only
+  /// ones into local storage** (#3077).
+  ///
+  /// [VehiclesSync.merge] uploads local-only profiles AND returns the union
+  /// (`[...local, ...downloaded]`). Previously the only caller was the
+  /// manual device-link flow, so a vehicle added on another device never
+  /// reached this one on connect / launch. We keep only the server-only
+  /// entries (local wins on id collision — an in-flight local edit is never
+  /// clobbered) and add them via [mergeFrom]. Returns the count of
+  /// newly-persisted (downloaded) profiles.
+  ///
+  /// The caller owns the consent gate — this is invoked behind the
+  /// trip-data sync gate (a vehicle profile is the anchor its trips +
+  /// fill-ups attach to). [mergeFn] defaults to the real sync and is
+  /// injectable for unit tests.
+  Future<int> pullFromServer(
+      {VehiclesMergeFn mergeFn = VehiclesSync.merge}) async {
+    final repo = ref.read(vehicleProfileRepositoryProvider);
+    final localIds = repo.getAll().map((v) => v.id).toSet();
+    final merged = await mergeFn(repo.getAll());
+    final serverOnly = merged.where((v) => !localIds.contains(v.id)).toList();
+    if (serverOnly.isEmpty) return 0;
+    return mergeFrom(serverOnly);
   }
 }
 

--- a/lib/features/vehicle/providers/vehicle_providers.g.dart
+++ b/lib/features/vehicle/providers/vehicle_providers.g.dart
@@ -98,7 +98,7 @@ final class VehicleProfileListProvider
 }
 
 String _$vehicleProfileListHash() =>
-    r'073721ba48e664fcee7e78ce62c637c875ce0563';
+    r'9fd49bbc7559187c79f3f5a7b60b7214557b908e';
 
 /// Full list of stored vehicle profiles.
 

--- a/test/core/sync/sync_pull_persist_test.dart
+++ b/test/core/sync/sync_pull_persist_test.dart
@@ -136,6 +136,61 @@ void main() {
       expect(fakeStorage.getIgnoredIds(), ['keep-ign']);
     });
   });
+
+  // #3077 — ratings were upload-only: `_performInitialSync` called
+  // `RatingsSync.upsertAll` (push) but never consumed `RatingsSync.fetchAll`,
+  // so a rating made on another device never reached this one. These drive
+  // the new `syncAndPersistRatings` seam and assert the server-only rating
+  // is written to LOCAL storage. They FAIL on master (the method doesn't
+  // exist / nothing persisted the fetch) and PASS after.
+  group('SyncState.syncAndPersistRatings (#3077 ratings pull-persist)', () {
+    test('persists a server-only rating into LOCAL storage', () async {
+      await fakeStorage.setRating('st-local', 4);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      await notifier.syncAndPersistRatings(
+        fakeStorage,
+        fetchRatings: () async => {'st-local': 4, 'st-server': 5},
+      );
+
+      expect(fakeStorage.getRating('st-server'), 5,
+          reason: 'server-only rating must be written to local storage');
+      expect(fakeStorage.getRating('st-local'), 4);
+    });
+
+    test('local wins on id collision (in-flight edit not clobbered)',
+        () async {
+      await fakeStorage.setRating('st-1', 5); // local edit: 5 stars
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      // server still has the stale 2-star value for the same station.
+      await notifier.syncAndPersistRatings(
+        fakeStorage,
+        fetchRatings: () async => {'st-1': 2},
+      );
+
+      expect(fakeStorage.getRating('st-1'), 5,
+          reason: 'local rating must win — server value must not overwrite it');
+    });
+
+    test('empty server fetch leaves local ratings unchanged', () async {
+      await fakeStorage.setRating('keep', 3);
+
+      final container = createContainer();
+      final notifier = container.read(syncStateProvider.notifier);
+
+      await notifier.syncAndPersistRatings(
+        fakeStorage,
+        fetchRatings: () async => const <String, int>{},
+      );
+
+      expect(fakeStorage.getRatings(), {'keep': 3});
+    });
+  });
 }
 
 /// Fake [SyncState] that returns a fixed [SyncConfig] without touching

--- a/test/features/alerts/providers/alert_provider_test.dart
+++ b/test/features/alerts/providers/alert_provider_test.dart
@@ -460,5 +460,28 @@ void main() {
       expect(stored, equals({'keep'}),
           reason: 'remove must not resurrect the deleted alert');
     });
+
+    // #3077 — before this, alerts only pulled on a LOCAL mutation
+    // (add/toggle). A device that signs in but never edits an alert
+    // (a fresh second device) needs an explicit pull on connect / launch /
+    // "sync now". `pullFromServer` is that trigger. This FAILS on master
+    // (no such method) and PASSES after.
+    test('pullFromServer applies a server-only alert WITHOUT a local edit',
+        () async {
+      final serverOnly = _makeAlert(id: 'server-only', stationId: 's-server');
+      // No local alert exists; the merge surfaces the server-only row.
+      mergeReturn = [serverOnly];
+
+      final added =
+          await container.read(alertProvider.notifier).pullFromServer();
+
+      expect(added, 1);
+      final stored = fakeStorage.getAlerts().map((a) => a['id']).toSet();
+      expect(stored, contains('server-only'),
+          reason: 'explicit pull must persist the server-only alert');
+      expect(container.read(alertProvider).map((a) => a.id),
+          contains('server-only'));
+      expect(mergeCalls, 1);
+    });
   });
 }

--- a/test/features/consumption/fill_ups_pull_persist_test.dart
+++ b/test/features/consumption/fill_ups_pull_persist_test.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/consumption/data/repositories/fill_up_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+import '../../helpers/silence_error_logger.dart';
+
+/// Regression tests for #3077 — TankSync was upload-only for fill-ups.
+///
+/// [FillUpsSync.merge] returns the union (`[...local, ...downloaded]`) but
+/// the only caller was the manual device-link flow, so a fill-up logged on
+/// another device never reached this one on connect / launch. These drive
+/// the new `FillUpList.pullFromServer` seam with an injected fake merge that
+/// simulates server rows, and assert the server-only fill-up is **persisted
+/// to LOCAL storage** (the `consumptionLog` settings key the repository
+/// reads). They FAIL on master (the method doesn't exist / nothing wired the
+/// merge to a connect-or-launch trigger) and PASS after.
+void main() {
+  silenceErrorLoggerSpool();
+  late FakeHiveStorage fakeStorage;
+
+  setUp(() {
+    fakeStorage = FakeHiveStorage();
+  });
+
+  ProviderContainer createContainer() {
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(fakeStorage),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  FillUp makeFillUp(String id) => FillUp(
+        id: id,
+        vehicleId: 'veh-1',
+        date: DateTime(2026, 4, 22),
+        liters: 40.0,
+        totalCost: 70.0,
+        odometerKm: 123456,
+        fuelType: FuelType.e10,
+      );
+
+  /// A fake merge that echoes the device's local list plus [serverOnly] —
+  /// the real [FillUpsSync.merge] "return local ∪ downloaded" contract.
+  FillUpsMergeFn fakeMergeWithServer(List<FillUp> serverOnly) {
+    return (local) async => [...local, ...serverOnly];
+  }
+
+  group('FillUpList.pullFromServer (#3077 pull-persist)', () {
+    test('persists a server-only fill-up into LOCAL storage', () async {
+      final container = createContainer();
+      final notifier = container.read(fillUpListProvider.notifier);
+      await notifier.add(makeFillUp('local-1'));
+
+      final added = await notifier.pullFromServer(
+        mergeFn: fakeMergeWithServer([makeFillUp('server-1')]),
+      );
+
+      expect(added, 1);
+      // The repository re-reads from `consumptionLog` settings — assert the
+      // downloaded id landed there, not just in provider state.
+      final storedIds = FillUpRepository(fakeStorage).getAll().map((f) => f.id);
+      expect(storedIds, containsAll(<String>['local-1', 'server-1']),
+          reason: 'server-only fill-up must be written to local storage');
+      // And reflected in provider state.
+      expect(container.read(fillUpListProvider).map((f) => f.id),
+          containsAll(<String>['local-1', 'server-1']));
+    });
+
+    test('empty local + server rows → local gets the server fill-up',
+        () async {
+      final container = createContainer();
+      final notifier = container.read(fillUpListProvider.notifier);
+      expect(container.read(fillUpListProvider), isEmpty);
+
+      final added = await notifier.pullFromServer(
+        mergeFn: fakeMergeWithServer([makeFillUp('srv-only')]),
+      );
+
+      expect(added, 1);
+      expect(FillUpRepository(fakeStorage).getAll().map((f) => f.id),
+          contains('srv-only'),
+          reason: 'a fresh device must pull the server fill-up set');
+    });
+
+    test('no-op merge (unauthenticated server) leaves local unchanged',
+        () async {
+      final container = createContainer();
+      final notifier = container.read(fillUpListProvider.notifier);
+      await notifier.add(makeFillUp('keep-1'));
+
+      // identity merge — what the real merge returns when unauthenticated.
+      final added = await notifier.pullFromServer(mergeFn: (local) async => local);
+
+      expect(added, 0);
+      expect(FillUpRepository(fakeStorage).getAll().map((f) => f.id),
+          ['keep-1']);
+    });
+  });
+}

--- a/test/features/vehicle/vehicles_pull_persist_test.dart
+++ b/test/features/vehicle/vehicles_pull_persist_test.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+import '../../helpers/silence_error_logger.dart';
+
+/// Regression tests for #3077 — TankSync was upload-only for vehicles.
+///
+/// [VehiclesSync.merge] returns the union (`[...local, ...downloaded]`) but
+/// the only caller was the manual device-link flow, so a vehicle profile
+/// added on another device never reached this one on connect / launch.
+/// These drive the new `VehicleProfileList.pullFromServer` seam with an
+/// injected fake merge that simulates server rows, and assert the
+/// server-only profile is **persisted to LOCAL storage** (the
+/// `vehicleProfiles` settings key the repository reads). They FAIL on master
+/// (the method doesn't exist / nothing wired the merge to a trigger) and
+/// PASS after.
+void main() {
+  silenceErrorLoggerSpool();
+  late FakeHiveStorage fakeStorage;
+
+  setUp(() {
+    fakeStorage = FakeHiveStorage();
+  });
+
+  ProviderContainer createContainer() {
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(fakeStorage),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  VehicleProfile vehicle(String id, String name) =>
+      VehicleProfile(id: id, name: name);
+
+  /// A fake merge that echoes the device's local list plus [serverOnly] —
+  /// the real [VehiclesSync.merge] "return local ∪ downloaded" contract.
+  VehiclesMergeFn fakeMergeWithServer(List<VehicleProfile> serverOnly) {
+    return (local) async => [...local, ...serverOnly];
+  }
+
+  group('VehicleProfileList.pullFromServer (#3077 pull-persist)', () {
+    test('persists a server-only vehicle into LOCAL storage', () async {
+      final container = createContainer();
+      final notifier = container.read(vehicleProfileListProvider.notifier);
+      await notifier.save(vehicle('local-1', 'Peugeot 107'));
+
+      final added = await notifier.pullFromServer(
+        mergeFn: fakeMergeWithServer([vehicle('server-1', 'Renault Clio')]),
+      );
+
+      expect(added, 1);
+      final storedIds =
+          VehicleProfileRepository(fakeStorage).getAll().map((v) => v.id);
+      expect(storedIds, containsAll(<String>['local-1', 'server-1']),
+          reason: 'server-only vehicle must be written to local storage');
+      expect(container.read(vehicleProfileListProvider).map((v) => v.id),
+          containsAll(<String>['local-1', 'server-1']));
+    });
+
+    test('empty local + server rows → local gets the server vehicle',
+        () async {
+      final container = createContainer();
+      final notifier = container.read(vehicleProfileListProvider.notifier);
+      expect(container.read(vehicleProfileListProvider), isEmpty);
+
+      final added = await notifier.pullFromServer(
+        mergeFn: fakeMergeWithServer([vehicle('srv-only', 'VW Polo')]),
+      );
+
+      expect(added, 1);
+      expect(VehicleProfileRepository(fakeStorage).getAll().map((v) => v.id),
+          contains('srv-only'),
+          reason: 'a fresh device must pull the server vehicle set');
+    });
+
+    test('no-op merge (unauthenticated server) leaves local unchanged',
+        () async {
+      final container = createContainer();
+      final notifier = container.read(vehicleProfileListProvider.notifier);
+      await notifier.save(vehicle('keep-1', 'Fiat 500'));
+
+      final added =
+          await notifier.pullFromServer(mergeFn: (local) async => local);
+
+      expect(added, 0);
+      expect(VehicleProfileRepository(fakeStorage).getAll().map((v) => v.id),
+          ['keep-1']);
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -53,7 +53,14 @@ void main() {
     // #2978 — 961 → 964: `initializeDateFormatting()` + its import + comment,
     // so `intl` locale date-symbols are loaded once at startup and the
     // localized price-prediction weekday renders for non-`en_US` locales.
-    'lib/app/app_initializer.dart': 964,
+    // #3077 — re-grandfathered 964 → 1028: the launch-time
+    // `_runEntitySyncMerge` (+ its post-`_runTripsSyncMerge` call site +
+    // 5 provider imports) pulls the remaining server→local entities
+    // (ratings/alerts/fill-ups/vehicles) on cold start, mirroring the
+    // adjacent trips merge. The unit-tested logic lives in the per-entity
+    // provider seams; this is the (compacted) launch glue. Decomposition
+    // of this god-file is tracked separately.
+    'lib/app/app_initializer.dart': 1028,
     // #2415 — background_service.dart graduated: the scan body moved into
     // BackgroundAlertScanCoordinator + BackgroundScanRunners +
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246
@@ -517,7 +524,12 @@ void main() {
     // drops a still-unresolved deferred gap (the decision is never lost).
     // Lives on `FillUpList` because it reads + mutates the pending-gap
     // provider in the same save path. Decomposition tracked #2187/#2188.
-    'lib/features/consumption/providers/consumption_providers.dart': 975,
+    // #3077 — re-grandfathered 975 → 1005: `FillUpList.pullFromServer`
+    // (the unit-tested server→local fill-ups pull-persist seam, local wins
+    // on id collision) + the `FillUpsMergeFn` typedef + the fill_ups_sync
+    // import. Sibling of the existing device-link `mergeFrom`. Decomposition
+    // of this god-class is tracked #2187/#2188.
+    'lib/features/consumption/providers/consumption_providers.dart': 1005,
     // #2509 — re-grandfathered 1180 → 1217: the persist guard in
     // `_saveToHistory` was tightened from the buggy disjunction
     // (`startedAt == null || distance < 0.01`, which silently discarded a


### PR DESCRIPTION
## What & why

TankSync was upload-only for several entities. Each `lib/core/sync/*_sync.dart` has a working **download** branch (`merge()` returns the server∪local union, `fetchAll()` returns server rows), but the result was discarded, had no connect/launch caller, or only fired on a local edit — so a row created on another device never reached this one. This is the server→client half of Epic #3075 (continuing #3076 for favorites/ignored).

## Audit

| Entity | Was it broken? | What was wrong | What we wired |
| --- | --- | --- | --- |
| **fill_ups** | ❌ **Broken** | `FillUpsSync.merge`'s only caller was the manual device-link flow → never synced up *or* down on connect/launch | `FillUpList.pullFromServer` (server-only rows added via existing `mergeFrom`, local wins). Wired: launch (`AppInitializer`) + "sync now". |
| **vehicles** | ❌ **Broken** | Same — `VehiclesSync.merge` only had the device-link caller | `VehicleProfileList.pullFromServer`. Wired: launch + "sync now". |
| **ratings** | ❌ **Broken** | `RatingsSync.fetchAll` had **no caller anywhere**; `_performInitialSync` was upload-only (`upsertAll`) | `SyncState.syncAndPersistRatings` (persist via `setRating`, local wins). Wired: connect (`_performInitialSync`) + "sync now" + launch. |
| **alerts** | ⚠️ **Partial** | Pulled only on add/toggle (`_syncAlertsIfConnected`); the connect/launch/"sync now" paths never pulled — `data_transparency.forceSyncAndReload` discarded the merge return | `AlertNotifier.pullFromServer`. Wired: launch + "sync now". |
| **itineraries** | ✅ **Already working** | `ItineraryNotifier._loadAndMerge` pulls `fetchAll`, persists server-only via `storage.addItinerary`, updates state — runs on provider `build()` | Left untouched. |

## Design

Mirrors the #3076 favorites template and the `AppInitializer._runTripsSyncMerge` trips template:

- **Per-entity pull-persist seams** (the unit-tested units): `syncAndPersistRatings` (core/sync), `FillUpList.pullFromServer`, `VehicleProfileList.pullFromServer`, `AlertNotifier.pullFromServer`. Each takes an injectable merge/fetch fn (default = the real sync) so the wiring is testable without a live Supabase session.
- **Union-merge semantics**: local wins on id collision (an in-flight local edit is never clobbered); only server-only rows are added. Reuses the existing `mergeFrom` for fill-ups/vehicles.
- **Triggers**: launch via a compact `AppInitializer._runEntitySyncMerge` (post-frame, after `_runTripsSyncMerge`); connect via `_performInitialSync` (ratings); "sync now" via `data_transparency.forceSyncAndReload` (which previously discarded the alerts merge return).

### Consent gates (respected, conservative)

- **ratings / alerts** ride the master TankSync consent (`sync_enabled`) — the same gate the existing favorites/ignored pull and the alert-mutation pull already use.
- **fill-ups / vehicles** are trip-data adjacent (fill-ups carry linked trajet ids + OBD2-derived consumption; a vehicle profile is the anchor trips attach to), so they ride the **stricter** `tripsSyncEnabledProvider` gate (`email ∧ cloudSync ∧ syncTrips`) — the same gate the trips pull uses. Nothing is pulled for a user who hasn't consented to trip-data sync.

### Out of scope

Deletion tombstones are #3078 — not implemented here; the union-merge "resurrect on next sync" caveat is known/accepted.

## Tests (RED on master → GREEN after)

All four wiring methods are **net-new** (confirmed absent on `origin/master`), so each test fails to compile/run against master:

- `test/core/sync/sync_pull_persist_test.dart` — +3 ratings cases (server-only persisted; local wins on collision; empty fetch no-op).
- `test/features/consumption/fill_ups_pull_persist_test.dart` — new (server-only persisted to the `consumptionLog` store; empty-device pull; no-op merge).
- `test/features/vehicle/vehicles_pull_persist_test.dart` — new (same shape, `vehicleProfiles` store).
- `test/features/alerts/providers/alert_provider_test.dart` — +1 case: `pullFromServer` persists a server-only alert **without** a local edit.

Each drives the injected-seam fake (server returns a row the device didn't send) and asserts it lands in **local** storage. `flutter test test/core/sync/ test/features/sync/ test/features/consumption/ test/features/vehicle/` → 5807 pass. `flutter analyze` clean (only the pre-existing `anonKey` deprecation info). `file_length` re-grandfathered (#3077 comments) for the two already-over-cap god-files touched.

Closes #3077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
