### PR TITLE
fix(approach): recompute in-radius distance live from GPS (frozen between polls)

### DIFF
--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -11,52 +11,12 @@ import '../logging/error_logger.dart';
 import '../utils/geo_utils.dart' as geo;
 import '../utils/num_extensions.dart';
 import '../utils/station_extensions.dart';
+import 'approach_state.dart';
 
-/// State emitted by [ApproachDetector] (#2085 / ADR 0011).
-///
-/// Sealed hierarchy — the consumer (the PiP overlay in #2084) picks
-/// its UI on the runtime subtype:
-///
-/// - [ApproachIdle] — no GPS fix yet, or detector not running.
-/// - [ApproachPolling] — GPS available, no station in radius. The
-///   overlay shows the default "huge L/100 km" view from #2068.
-/// - [ApproachInRadius] — driver is inside the configured radius of
-///   a target station. The overlay flips to the huge-price view.
-/// - [ApproachLeaving] — radius exit was detected, but the 5 s
-///   grace window is still open. The overlay keeps showing the
-///   price until the grace expires or the radius is re-entered.
-sealed class ApproachState {
-  const ApproachState();
-}
-
-/// No GPS fix / detector not yet receiving samples.
-class ApproachIdle extends ApproachState {
-  const ApproachIdle();
-}
-
-/// GPS is producing samples but no station is in the radius right now.
-class ApproachPolling extends ApproachState {
-  final Position gps;
-  final Duration nextPollIn;
-  const ApproachPolling({required this.gps, required this.nextPollIn});
-}
-
-/// A target station is in the configured radius.
-class ApproachInRadius extends ApproachState {
-  final Station station;
-  final double distanceMeters;
-  const ApproachInRadius({
-    required this.station,
-    required this.distanceMeters,
-  });
-}
-
-/// Grace period after exit — the overlay keeps the price visible for
-/// [ApproachDetector.exitGrace] before falling back to [ApproachPolling].
-class ApproachLeaving extends ApproachState {
-  final Station lastStation;
-  const ApproachLeaving({required this.lastStation});
-}
+// The [ApproachState] sealed hierarchy lives in `approach_state.dart` (#3092
+// keeps this file under the line cap); re-export it so callers that import
+// `approach_detector.dart` still get ApproachIdle/Polling/InRadius/Leaving.
+export 'approach_state.dart';
 
 /// Which station the detector targets when more than one is inside
 /// the radius (#2067 profile setting drives this — see ADR 0011).
@@ -226,10 +186,11 @@ class ApproachDetector {
     final speedMps = p.speed.isFinite && p.speed >= 0 ? p.speed : 0.0;
     _recentSpeeds.add(speedMps);
     if (_recentSpeeds.length > 3) _recentSpeeds.removeAt(0);
+    final cur = _state;
     // First emit on first sample — fire a Polling state immediately
     // so the consumer doesn't sit on Idle through the first poll
     // window.
-    if (_state is ApproachIdle) {
+    if (cur is ApproachIdle) {
       _emit(ApproachPolling(
         gps: p,
         nextPollIn: computePollInterval(
@@ -239,6 +200,22 @@ class ApproachDetector {
         ),
       ));
       _schedulePoll();
+    } else if (cur is ApproachInRadius) {
+      // #3092 — LIVE, GPS-driven distance. While a station is in radius,
+      // recompute the distance to the ALREADY-targeted station on every GPS
+      // fix and re-emit, so the overlay's distance ticks down smoothly as the
+      // driver approaches — WITHOUT a data-service poll. The poll keeps doing
+      // enter/leave detection + cheapest re-evaluation at its own, slower
+      // cadence; this only refreshes the distance of the locked target.
+      _emit(ApproachInRadius(
+        station: cur.station,
+        distanceMeters: distanceMeters(
+          p.latitude,
+          p.longitude,
+          cur.station.lat,
+          cur.station.lng,
+        ),
+      ));
     }
   }
 

--- a/lib/core/services/approach_state.dart
+++ b/lib/core/services/approach_state.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:geolocator/geolocator.dart';
+
+import '../../features/search/domain/entities/station.dart';
+
+/// State emitted by [ApproachDetector] (#2085 / ADR 0011) — split out of
+/// `approach_detector.dart` so the state hierarchy lives apart from the
+/// detector's logic (#3092). Re-exported by `approach_detector.dart`, so
+/// existing imports of that file still see these types.
+///
+/// Sealed hierarchy — the consumer (the PiP overlay in #2084) picks
+/// its UI on the runtime subtype:
+///
+/// - [ApproachIdle] — no GPS fix yet, or detector not running.
+/// - [ApproachPolling] — GPS available, no station in radius. The
+///   overlay shows the default "huge L/100 km" view from #2068.
+/// - [ApproachInRadius] — driver is inside the configured radius of
+///   a target station. The overlay flips to the huge-price view.
+/// - [ApproachLeaving] — radius exit was detected, but the 5 s
+///   grace window is still open. The overlay keeps showing the
+///   price until the grace expires or the radius is re-entered.
+sealed class ApproachState {
+  const ApproachState();
+}
+
+/// No GPS fix / detector not yet receiving samples.
+class ApproachIdle extends ApproachState {
+  const ApproachIdle();
+}
+
+/// GPS is producing samples but no station is in the radius right now.
+class ApproachPolling extends ApproachState {
+  final Position gps;
+  final Duration nextPollIn;
+  const ApproachPolling({required this.gps, required this.nextPollIn});
+}
+
+/// A target station is in the configured radius.
+class ApproachInRadius extends ApproachState {
+  final Station station;
+  final double distanceMeters;
+  const ApproachInRadius({
+    required this.station,
+    required this.distanceMeters,
+  });
+}
+
+/// Grace period after exit — the overlay keeps the price visible for
+/// [ApproachDetector.exitGrace] before falling back to [ApproachPolling].
+class ApproachLeaving extends ApproachState {
+  final Station lastStation;
+  const ApproachLeaving({required this.lastStation});
+}

--- a/test/core/services/approach_detector_test.dart
+++ b/test/core/services/approach_detector_test.dart
@@ -352,4 +352,65 @@ void main() {
       });
     });
   });
+
+  // #3092 — the in-radius distance must update LIVE off each GPS fix, NOT
+  // only on the (slower) data-service poll. The detector recomputes the
+  // distance to the already-locked station on every sample, with no extra
+  // fetch, so the overlay's distance ticks down smoothly as the driver nears.
+  group('ApproachDetector live GPS distance (#3092)', () {
+    test('in-radius distance ticks down on each GPS fix without re-polling',
+        () {
+      fakeAsync((async) {
+        var fetchCount = 0;
+        // Station ~500 m due north of the start (0.0045° lat ≈ 500 m).
+        final station = _station(id: 'A', lat: 48.0045, lng: 2.0, e10: 1.699);
+        final gps = StreamController<Position>.broadcast();
+        final det = ApproachDetector(
+          gpsStream: gps.stream,
+          fetchStations: (_, _, _, _) async {
+            fetchCount++;
+            return [station];
+          },
+          config: const ApproachDetectorConfig(
+            radiusMeters: 1000,
+            priceMode: ApproachPriceMode.nearest,
+            minPollSeconds: 5,
+            fuelTypeApiValue: 'e10',
+          ),
+        );
+        final emitted = <ApproachState>[];
+        final sub = det.state.listen(emitted.add);
+
+        // First fix → Polling; advance past the poll → fetch → InRadius (~500 m).
+        gps.add(_pos(48.0, 2.0, speedMps: 10));
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        final initial = emitted.whereType<ApproachInRadius>().toList();
+        expect(initial, isNotEmpty,
+            reason: 'the poll must have produced an in-radius emit');
+        final dStart = initial.last.distanceMeters;
+        expect(dStart, closeTo(500, 60));
+        final fetchesAfterPoll = fetchCount;
+
+        // A CLOSER fix (~250 m from the station), WITHOUT advancing the poll
+        // timer: the live recompute must tick the distance down with NO fetch.
+        gps.add(_pos(48.00225, 2.0, speedMps: 10));
+        async.flushMicrotasks();
+
+        final after = emitted.whereType<ApproachInRadius>().last;
+        expect(after.station.id, 'A');
+        expect(after.distanceMeters, lessThan(dStart),
+            reason: 'distance must update LIVE (tick down) from the GPS fix');
+        expect(after.distanceMeters, closeTo(250, 60));
+        expect(fetchCount, fetchesAfterPoll,
+            reason: 'the live recompute must NOT poll the data service');
+
+        sub.cancel();
+        det.dispose();
+        gps.close();
+      });
+    });
+  });
 }


### PR DESCRIPTION
## Bug (reported)
When approaching a fuel station the overlay distance doesn't change. `ApproachDetector` set `ApproachInRadius.distanceMeters` **only** in `_poll()` (the data-service/corridor fetch cadence); `_onPosition` never recomputed it. At driving speed the poll cadence is short so it looked live; slower/stationary it appears frozen.

## Fix (matches the intended GPS-driven design)
`_onPosition` now, while a station is in radius, recomputes the distance to the **already-locked station** from each GPS fix and re-emits `ApproachInRadius` — **zero data-service calls**. The poll keeps doing enter/leave detection + cheapest re-evaluation at its own cadence. The detector already receives a live `sharedPositionStream`, so the distance ticks down smoothly.

Adds a RED-on-master test (a closer fix between polls must tick the distance down with no extra fetch). The `ApproachState` sealed hierarchy moved to `approach_state.dart` (re-exported) to keep the file under the 400-line cap.

Android overlay bug fix → reaches beta + TestFlight; production on the next manual promotion.

Closes #3092

🤖 Generated with [Claude Code](https://claude.com/claude-code)