### PR TITLE
fix(ios): wire Darwin notification init + details so alerts show on iPhone

### DIFF
--- a/lib/core/notifications/local_notification_service.dart
+++ b/lib/core/notifications/local_notification_service.dart
@@ -13,8 +13,11 @@ import '../../core/logging/error_logger.dart';
 /// `flutter_local_notifications`.
 ///
 /// Uses the Android `price_alerts` channel for high-priority price drop
-/// notifications. On iOS the same plugin handles the UNUserNotificationCenter
-/// setup (not yet active — iOS build is disabled).
+/// notifications. On iOS (#3094) the Darwin init installs the
+/// UNUserNotificationCenter delegate (foreground presentation + tap routing)
+/// and each `show()` carries [DarwinNotificationDetails] so the banner
+/// actually surfaces — including in the foreground, which iOS otherwise
+/// suppresses.
 class LocalNotificationService implements NotificationService {
   /// Visible for testing — allows injecting a fake plugin.
   final FlutterLocalNotificationsPlugin plugin;
@@ -41,7 +44,21 @@ class LocalNotificationService implements NotificationService {
   Future<void> initialize() async {
     const androidSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');
-    const initSettings = InitializationSettings(android: androidSettings);
+    // #3094 — iOS (Darwin) init is REQUIRED for notifications on iPhone: it
+    // installs the UNUserNotificationCenter delegate that presents alerts in
+    // the foreground and routes taps. Permission is NOT requested here
+    // (request*Permission: false) — the app asks explicitly via
+    // [requestPermission] when the user creates an alert, so there is no
+    // double-prompt at launch.
+    const darwinSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: darwinSettings,
+    );
     // #1012 phase 3 — register the tap callback so the launch listener
     // (wired in lib/app/app.dart) can resolve payloads to deep-link
     // targets. The static dispatcher fans out so any number of warm
@@ -140,6 +157,14 @@ class LocalNotificationService implements NotificationService {
         importance: Importance.high,
         priority: Priority.high,
       ),
+      // #3094 — without DarwinNotificationDetails the alert never surfaces on
+      // iPhone (and iOS suppresses it entirely in the foreground). present*
+      // shows the banner/badge/sound like Android's high-importance channel.
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
+      ),
     );
     await plugin.show(
       id: id,
@@ -163,6 +188,12 @@ class LocalNotificationService implements NotificationService {
         channelDescription: _serviceChannelDescription,
         importance: Importance.defaultImportance,
         priority: Priority.defaultPriority,
+      ),
+      // #3094 — iOS presentation so service reminders surface on iPhone too.
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
       ),
     );
     await plugin.show(

--- a/test/core/notifications/local_notification_service_test.dart
+++ b/test/core/notifications/local_notification_service_test.dart
@@ -137,6 +137,19 @@ void main() {
       expect(android.priority, Priority.high);
     });
 
+    test('#3094 — carries iOS (Darwin) details so it surfaces on iPhone',
+        () async {
+      await service.showPriceAlert(id: 1, title: 't', body: 'b');
+
+      final ios = fakePlugin.showCalls.single.details?.iOS;
+      expect(ios, isNotNull,
+          reason: 'without DarwinNotificationDetails iOS shows nothing');
+      expect(ios!.presentAlert, isTrue,
+          reason: 'must present the banner (incl. foreground) on iOS');
+      expect(ios.presentBadge, isTrue);
+      expect(ios.presentSound, isTrue);
+    });
+
     test('payload defaults to null when caller omits it', () async {
       await service.showPriceAlert(id: 7, title: 't', body: 'b');
 


### PR DESCRIPTION
## Bug
Price alerts fire on Android but never on iPhone. `LocalNotificationService` was **Android-only**:
- `initialize()` passed no `iOS: DarwinInitializationSettings` → the iOS UNUserNotificationCenter delegate (foreground presentation + tap routing) was never installed.
- `showPriceAlert`/`showServiceReminder` passed no `iOS: DarwinNotificationDetails` → no iOS presentation; iOS shows nothing (and suppresses entirely in the foreground).

The class comment still said 'iOS build is disabled' — never wired for iOS, now live on TestFlight.

## Fix
- `DarwinInitializationSettings` in `initialize()` (`request*Permission:false` — the app requests explicitly via `requestPermission` when an alert is created → no double-prompt).
- `iOS: DarwinNotificationDetails(presentAlert/Badge/Sound: true)` on both `show()` calls → banner surfaces on iPhone, including foreground.
- Cross-platform config (no inline Platform check). Test asserts the iOS details are present.

Fixes notification **display** (the in-app Test-alert, foreground, and background-when-the-scan-runs). iOS background-scan cadence (BGTask opportunism) remains the separate, known Tier-2-push item.

Closes #3094

🤖 Generated with [Claude Code](https://claude.com/claude-code)