### PR TITLE
fix(shell): open search criteria after the lazy Search-branch nav mounts

### DIFF
--- a/lib/app/shell/search_fab_tap.dart
+++ b/lib/app/shell/search_fab_tap.dart
@@ -22,46 +22,75 @@ import '../routes/shell_branches.dart';
 /// root push covered the shell + bottom bar and hid the FAB mid-flow (#2131).
 /// Switches to the Search branch first so the modal lands on the visible
 /// branch.
+/// Test seam (#3098) — the real criteria push, overridable in tests. The
+/// production push builds [SearchCriteriaScreen], which needs Hive; a widget
+/// test injects a no-op recorder to verify the post-frame retry wiring without
+/// standing up Hive. Null in production.
+@visibleForTesting
+void Function(NavigatorState nav)? debugPushSearchCriteriaOverride;
+
 void openSearchCriteriaOnBranch({
   required int slot,
   required int currentIndex,
   required ValueChanged<int> onTap,
 }) {
-  if (slot != currentIndex) onTap(slot);
+  final switched = slot != currentIndex;
+  if (switched) onTap(slot);
   final searchNav = searchBranchNavigatorKey.currentState;
-  if (searchNav == null) {
-    // #2811 — branch nav unmounted (early frame / unwired test). Do NOT
-    // root-push here: from the bar's context `Navigator.of(context)` is the
-    // ROOT navigator, and a fullscreen route there covers the whole shell —
-    // bar included — stranding it until restart if orphaned. Degrade to a
-    // branch jump, and trace it (a missing nav on a user tap is abnormal).
-    unawaited(errorLogger.log(
-      ErrorLayer.ui,
-      'search branch navigator not mounted on FAB tap — degraded to '
-          'branch jump (no root push)',
-      StackTrace.current,
-      context: {'source': 'openCriteriaOnSearchBranch', 'branch': slot},
-    ));
-    onTap(slot);
+  if (searchNav != null) {
+    _pushSearchCriteria(searchNav, slot);
     return;
   }
+  // #3098 — the Search branch's nested Navigator mounts LAZILY (go_router
+  // `StatefulShellRoute.indexedStack`, preload off), so on the FIRST switch to
+  // Search from another branch its key has no `currentState` THIS frame. The
+  // old code degraded to a bare branch jump and the criteria modal never
+  // opened. Instead: ensure we've switched, then push the modal once the
+  // branch's navigator mounts on the NEXT frame. NEVER root-push from here —
+  // `Navigator.of(the bar)` is the ROOT and a fullscreen route there covers
+  // the whole shell incl. the bar (#2811).
+  if (!switched) onTap(slot);
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final nav = searchBranchNavigatorKey.currentState;
+    if (nav == null) {
+      // Still unmounted a frame after the switch — genuinely abnormal; trace
+      // and bail (no root push).
+      unawaited(errorLogger.log(
+        ErrorLayer.ui,
+        'search branch navigator still not mounted a frame after FAB switch '
+            '— criteria not opened',
+        StackTrace.current,
+        context: {'source': 'openCriteriaOnSearchBranch', 'branch': slot},
+      ));
+      return;
+    }
+    _pushSearchCriteria(nav, slot);
+  });
+}
+
+/// Push the criteria modal onto the (mounted) Search-branch [nav], guarding
+/// against stacking a duplicate (#2810).
+void _pushSearchCriteria(NavigatorState nav, int slot) {
   // #2810 — refuse to stack a duplicate criteria modal: the FAB stays visible
   // while it is open (branch-push keeps the shell mounted), so a repeat tap
   // would push a second copy ("search just re-opens the same form again and
   // again"). Bail if it is already current.
-  if (searchCriteriaRouteIsCurrent(searchNav)) {
+  if (searchCriteriaRouteIsCurrent(nav)) {
     // #2874 — re-tapping the FAB while the criteria sheet is already open is an
-    // EXPECTED no-op, not a fault: spooling it at [ErrorLayer.ui] surfaced it
-    // in the user-facing error log (error-log #21). Keep the #2810 diagnostic
-    // trail as a breadcrumb so it attaches to any LATER genuine trace instead
-    // of standing alone as a phantom ERROR.
+    // EXPECTED no-op, not a fault: a breadcrumb (not an ErrorLayer.ui trace)
+    // so it attaches to any LATER genuine trace instead of standing alone.
     BreadcrumbCollector.add(
       'search criteria re-open suppressed (already current)',
       detail: 'openCriteriaOnSearchBranch branch=$slot',
     );
     return;
   }
-  searchNav.push<void>(
+  final override = debugPushSearchCriteriaOverride;
+  if (override != null) {
+    override(nav);
+    return;
+  }
+  nav.push<void>(
     MaterialPageRoute<void>(
       builder: (_) => const SearchCriteriaScreen(),
       fullscreenDialog: true,

--- a/test/app/shell/search_fab_tap_test.dart
+++ b/test/app/shell/search_fab_tap_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/routes/shell_branches.dart';
+import 'package:tankstellen/app/shell/search_fab_tap.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+/// #3098 — tapping the centre search FAB from another branch must OPEN the
+/// search-criteria modal, not degrade to a bare branch jump. The Search
+/// branch's nested Navigator mounts LAZILY (go_router indexedStack), so the
+/// push has to wait until the branch navigator appears on the next frame.
+void main() {
+  silenceErrorLoggerSpool();
+
+  tearDown(() => debugPushSearchCriteriaOverride = null);
+
+  testWidgets(
+      'pushes the criteria once the lazily-mounted Search-branch nav appears '
+      'on the next frame (no degrade)', (tester) async {
+    NavigatorState? pushedOn;
+    // The real push builds SearchCriteriaScreen (needs Hive) — record instead.
+    debugPushSearchCriteriaOverride = (nav) => pushedOn = nav;
+
+    // Frame 1: the Search-branch Navigator is NOT mounted yet (its key has no
+    // currentState) — exactly the lazy-branch state before its first visit.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    expect(searchBranchNavigatorKey.currentState, isNull);
+
+    // Tap the FAB from another branch (slot 0 = Search; currentIndex 2 = e.g.
+    // Favorites). The nav is null THIS frame → the push must be DEFERRED.
+    openSearchCriteriaOnBranch(slot: 0, currentIndex: 2, onTap: (_) {});
+    expect(pushedOn, isNull, reason: 'push is deferred to post-frame, not sync');
+
+    // The branch navigator mounts on the next frame (the switch took effect).
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Navigator(
+          key: searchBranchNavigatorKey,
+          onGenerateRoute: (_) =>
+              MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(pushedOn, isNotNull,
+        reason: 'criteria must push once the branch nav mounts — the old code '
+            'degraded to a branch jump and never opened it');
+    expect(pushedOn, same(searchBranchNavigatorKey.currentState));
+  });
+
+  testWidgets('pushes synchronously when the Search-branch nav is already '
+      'mounted', (tester) async {
+    NavigatorState? pushedOn;
+    debugPushSearchCriteriaOverride = (nav) => pushedOn = nav;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Navigator(
+          key: searchBranchNavigatorKey,
+          onGenerateRoute: (_) =>
+              MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+        ),
+      ),
+    );
+
+    openSearchCriteriaOnBranch(slot: 0, currentIndex: 2, onTap: (_) {});
+    // Mounted nav → no post-frame wait needed.
+    expect(pushedOn, isNotNull);
+    expect(pushedOn, same(searchBranchNavigatorKey.currentState));
+  });
+}


### PR DESCRIPTION
## Bug (production, error-log)
Tapping the centre **search FAB from another tab** logged `search branch navigator not mounted on FAB tap — degraded to branch jump` and just switched to the Search tab without opening the search-criteria modal.

## Root cause
`openSearchCriteriaOnBranch` switched branches then **synchronously** read `searchBranchNavigatorKey.currentState`. go_router's `StatefulShellRoute.indexedStack` mounts a branch's nested Navigator **lazily**, so on the first switch to Search the key is still null that frame → degrade, criteria never opens.

## Fix
When the branch nav isn't mounted yet, switch + push the criteria on the **next frame** (`addPostFrameCallback`) once it mounts; only trace if it's STILL unmounted a frame later. Never root-pushes (#2811); keeps the #2810 duplicate-modal guard. The push is extracted behind a `@visibleForTesting` override so the post-frame retry is unit-testable without the Hive-dependent `SearchCriteriaScreen` — 2 new tests (post-frame retry + synchronous-when-mounted); existing degrade/dedup tests still pass.

Closes #3098

🤖 Generated with [Claude Code](https://claude.com/claude-code)