### PR TITLE
fix(obd2): unfiltered BLE scan + discovery-transport resolve so iPhone finds name-only ELM327 adapters

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -33,10 +33,11 @@ enum Obd2AdapterCompatibility {
   untested,
 }
 
-/// Thin value-object describing one BLE scan result. Kept
+/// Thin value-object describing one scan result. Kept
 /// flutter_blue_plus-free so the registry can be unit-tested without
 /// the platform plugin (the real connection service converts
-/// `ScanResult` into this shape at the edge). Step 1 of #733.
+/// `ScanResult` / a bonded-device entry into this shape at the edge).
+/// Step 1 of #733.
 class Obd2AdapterCandidate {
   /// Platform device id (MAC address on Android, UUID on iOS).
   final String deviceId;
@@ -53,11 +54,24 @@ class Obd2AdapterCandidate {
   /// values closer to 0 (e.g. -50 is stronger than -90).
   final int rssi;
 
+  /// Which transport actually discovered this candidate (#3097). The BLE
+  /// facade stamps [BluetoothTransport.ble]; the Classic (bonded-device)
+  /// facade stamps [BluetoothTransport.classic]. [resolve] reads it to
+  /// disambiguate a generic name (e.g. `OBDII`) that matches BOTH a BLE and
+  /// a Classic profile: a BLE-discovered hit must resolve to a BLE profile
+  /// (so it connects over BLE — the only transport iOS can use for a
+  /// non-MFi adapter), and a Classic-discovered hit on Android must still
+  /// resolve to Classic. Defaults to [BluetoothTransport.ble] — the
+  /// dominant over-the-air scan transport, and the historical assumption of
+  /// this BLE-first value object.
+  final BluetoothTransport discoveryTransport;
+
   Obd2AdapterCandidate({
     required this.deviceId,
     required this.deviceName,
     required Iterable<String> advertisedServiceUuids,
     required this.rssi,
+    this.discoveryTransport = BluetoothTransport.ble,
   }) : advertisedServiceUuids = advertisedServiceUuids
             .map((u) => u.trim().toLowerCase())
             .toSet();
@@ -160,11 +174,17 @@ class Obd2AdapterRegistry {
   factory Obd2AdapterRegistry.defaults() =>
       const Obd2AdapterRegistry(profiles: _defaultProfiles);
 
-  /// All BLE service UUIDs the registry knows about. Handed to
-  /// `FlutterBluePlus.startScan(withServices: ...)` so the scan
-  /// filters out consumer BLE noise (fitness trackers, headphones).
-  /// Classic profiles are excluded — SPP uses a single universal
-  /// UUID and Classic discovery doesn't filter by service anyway.
+  /// All BLE service UUIDs the registry knows about. Classic profiles are
+  /// excluded — SPP uses a single universal UUID and Classic discovery
+  /// doesn't filter by service anyway.
+  ///
+  /// #3097 — this is **no longer** handed to `startScan(withServices:)`. The
+  /// scan now runs UNFILTERED: on iOS, CoreBluetooth only returns peripherals
+  /// that ADVERTISE one of these UUIDs, but most ELM327 BLE clones advertise a
+  /// NAME and no service UUID, so a service-filtered scan returned nothing on
+  /// iPhone. [resolve] already drops non-adapter noise (returns null → the
+  /// picker hides it), so the scan-level filter was both redundant and
+  /// iOS-starving. Retained only for reference / tests.
   Set<String> get allServiceUuids => profiles
       .where((p) => p.transport == BluetoothTransport.ble)
       .map((p) => p.serviceUuid.toLowerCase())
@@ -176,8 +196,30 @@ class Obd2AdapterRegistry {
   Obd2AdapterProfile? resolve(Obd2AdapterCandidate candidate) {
     // Pass 1: named match. A named profile wins over a generic one
     // if the advertised name carries its signature.
-    for (final p in profiles) {
-      if (p.matchesName(candidate.deviceName)) return p;
+    //
+    // #3097 — when a name matches profiles of MORE THAN ONE transport (e.g. a
+    // generic `OBDII` matches both `generic-ble` and `generic-classic`, or a
+    // `SmartOBD` matches both `smartobd-ble` and `smartobd-classic`), prefer
+    // the profile whose transport == the candidate's discovery transport. A
+    // BLE-discovered generic adapter must resolve to a BLE profile so it
+    // connects over BLE (the only transport iOS can use for a non-MFi
+    // adapter); a Classic-discovered one on Android must still resolve to
+    // Classic (no regression). A single-transport name match is unaffected:
+    // the first matcher in catalog order wins, exactly as before.
+    final named = [
+      for (final p in profiles)
+        if (p.matchesName(candidate.deviceName)) p,
+    ];
+    if (named.isNotEmpty) {
+      final transports = named.map((p) => p.transport).toSet();
+      if (transports.length > 1) {
+        for (final p in named) {
+          if (p.transport == candidate.discoveryTransport) return p;
+        }
+      }
+      // Single transport, or no profile matched the discovery transport
+      // (defensive) — keep the historical first-in-catalog-order winner.
+      return named.first;
     }
     // Pass 2: service UUID match, but only against generic/nameless
     // profiles. Named profiles require their name to be seen —
@@ -540,6 +582,20 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
   ),
+  // Generic ELM327 BLE fallback by NAME (#3097). A clone that advertises a
+  // generic name (`OBDII`, `ELM327 v1.5`, …) but NO service UUID — the iOS
+  // case: CoreBluetooth surfaces it by name only. Listed BEFORE the
+  // generic-classic entry so a BLE-discovered generic name resolves to a BLE
+  // profile (resolve() prefers the discovery transport for this BLE+Classic
+  // name pair). NO pinned service UUID — the channel's dynamic GATT discovery
+  // (#3014, see elm_gatt_profiles.dart) finds the ELM service post-connect
+  // among FFE0/FFF0/18F0/Nordic-UART by characteristic property, so a
+  // name-only adapter still connects.
+  Obd2AdapterProfile(
+    id: 'generic-ble',
+    displayName: 'Generic ELM327 (BLE)',
+    nameMatchers: _genericElmNameMatchers,
+  ),
   // Generic ELM327 Classic SPP fallback (#761). Matches any bonded
   // device whose name contains "obd" or "elm327" — the common ones
   // on Amazon / AliExpress that predate BLE. Classic can't be
@@ -549,8 +605,21 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     id: 'generic-classic',
     displayName: 'Generic ELM327 (Classic)',
     transport: BluetoothTransport.classic,
-    nameMatchers: ['obdii', 'obd-ii', 'obd ii', 'obd2', 'elm327'],
+    nameMatchers: _genericElmNameMatchers,
   ),
+];
+
+/// Shared generic-ELM327 name signature used by BOTH the `generic-ble` and
+/// `generic-classic` fallback profiles (#3097). One source of truth so the two
+/// transports always match the same set of names; [Obd2AdapterRegistry.resolve]
+/// disambiguates which transport a given hit lands on via its discovery
+/// transport.
+const List<String> _genericElmNameMatchers = [
+  'obdii',
+  'obd-ii',
+  'obd ii',
+  'obd2',
+  'elm327',
 ];
 
 /// Re-export so callers can still reach the protocol types via the

--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -97,6 +97,11 @@ class PluginBluetoothFacade implements BluetoothFacade {
             advertisedServiceUuids:
                 r.advertisementData.serviceUuids.map((g) => g.str).toList(),
             rssi: r.rssi,
+            // #3097 — this facade IS the BLE transport, so every hit it
+            // surfaces was discovered over BLE. resolve() uses this to send a
+            // generic-named clone to a BLE profile (which connects on iOS),
+            // not the Classic-only generic fallback.
+            discoveryTransport: BluetoothTransport.ble,
           );
           accumulated[candidate.deviceId] = candidate;
         }

--- a/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
@@ -52,6 +52,10 @@ class PluginClassicBluetoothFacade implements ClassicBluetoothFacade {
                 deviceName: d.name,
                 advertisedServiceUuids: const [],
                 rssi: 0,
+                // #3097 — bonded-device enumeration is the Classic transport,
+                // so resolve() keeps a generic-named clone on the Classic
+                // profile here (Android-only; this facade is null on iOS).
+                discoveryTransport: BluetoothTransport.classic,
               ))
           .toList();
     } on Exception catch (e, st) {

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -145,10 +145,9 @@ class Obd2ConnectionService {
     var sawAny = false;
     final accumulated = <String, Obd2AdapterCandidate>{};
 
-    final bleStream = bluetooth.scan(
-      serviceUuids: registry.allServiceUuids,
-      timeout: timeout,
-    );
+    // #3097 — scan UNFILTERED: a withServices filter starves iOS of name-only
+    // ELM327 clones; registry.rank still drops non-adapter noise post-scan.
+    final bleStream = bluetooth.scan(serviceUuids: const {}, timeout: timeout);
     final classicStream = classicBluetooth?.scan(timeout: timeout) ??
         const Stream<List<Obd2AdapterCandidate>>.empty();
 

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -55,17 +55,57 @@ void main() {
       expect(registry.resolve(hit)?.id, 'generic-fff0');
     });
 
-    test('Classic clone named "OBDII" → generic-classic fallback (#761)',
-        () {
+    test(
+        'Classic-discovered clone named "OBDII" → generic-classic fallback '
+        '(#761, #3097)', () {
       // Amazon's generic Classic-SPP dongles report themselves with
       // no FFF0 service (Classic has no advertised services) and a
-      // name like "OBDII" / "ELM327 v1.5". Must land on the
-      // generic-classic profile, not null.
-      final hit = _candidate(name: 'OBDII', services: []);
+      // name like "OBDII" / "ELM327 v1.5". A Classic-discovered hit
+      // (the Android bonded-device path) must land on the
+      // generic-classic profile, not null — and NOT be hijacked by
+      // the new generic-ble entry that shares the same matchers (#3097).
+      final hit = _candidate(
+        name: 'OBDII',
+        services: [],
+        discoveryTransport: BluetoothTransport.classic,
+      );
       final profile = registry.resolve(hit);
       expect(profile, isNotNull);
       expect(profile!.id, 'generic-classic');
       expect(profile.transport, BluetoothTransport.classic);
+    });
+
+    test(
+        'BLE-discovered clone named "OBDII" → generic-ble (NOT classic) '
+        '(#3097)', () {
+      // The iPhone bug: a generic ELM327 BLE adapter advertises a name
+      // ("OBDII", "ELM327 v1.5") and NO service UUID, so CoreBluetooth
+      // surfaces it over BLE with no advertised services. Before #3097
+      // the only generic name matchers lived on the Classic profile, so
+      // it resolved to generic-classic → a Classic connect iOS cannot
+      // make (no MFi). With the discovery transport stamped `ble`, it
+      // must resolve to a BLE profile so the BLE + dynamic-GATT path runs.
+      final hit = _candidate(
+        name: 'OBDII',
+        services: [],
+        discoveryTransport: BluetoothTransport.ble,
+      );
+      final profile = registry.resolve(hit);
+      expect(profile, isNotNull);
+      expect(profile!.id, 'generic-ble');
+      expect(profile.transport, BluetoothTransport.ble,
+          reason: 'a BLE-discovered generic ELM327 must resolve to a BLE '
+              'profile so it connects on iPhone (#3097)');
+    });
+
+    test('a name-only ELM327 v1.5 over BLE resolves to generic-ble (#3097)',
+        () {
+      final hit = _candidate(
+        name: 'ELM327 v1.5',
+        services: [],
+        discoveryTransport: BluetoothTransport.ble,
+      );
+      expect(registry.resolve(hit)?.id, 'generic-ble');
     });
 
     test('unknown name and unrelated service → null (hide from picker)',
@@ -245,8 +285,13 @@ void main() {
         '#949 additions', () {
       // Guard on the "last entry is the catch-all" contract. A
       // name that carries an OBD signature but matches none of the
-      // named profiles must land on the generic-classic fallback.
-      final hit = _candidate(name: 'OBD-II Random Clone', services: []);
+      // named profiles must land on the generic-classic fallback when
+      // discovered over Classic (the Android bonded path) (#3097).
+      final hit = _candidate(
+        name: 'OBD-II Random Clone',
+        services: [],
+        discoveryTransport: BluetoothTransport.classic,
+      );
       final profile = registry.resolve(hit);
       expect(profile, isNotNull);
       expect(profile!.id, 'generic-classic');
@@ -455,12 +500,33 @@ void main() {
 
     test('every BLE profile defines all three GATT UUIDs', () {
       for (final p in registry.profiles
-          .where((p) => p.transport == BluetoothTransport.ble)) {
+          .where((p) => p.transport == BluetoothTransport.ble)
+          // #3097 — the name-only generic-ble fallback INTENTIONALLY pins no
+          // service UUID: it connects via dynamic GATT discovery (#3014), which
+          // finds the ELM service post-connect among FFE0/FFF0/18F0/Nordic-UART
+          // by characteristic property. Every OTHER BLE profile keeps its exact
+          // UUIDs as the known-good hint.
+          .where((p) => p.id != 'generic-ble')) {
         expect(p.serviceUuid, isNotEmpty, reason: '${p.id} serviceUuid');
         expect(p.writeCharUuid, isNotEmpty, reason: '${p.id} writeCharUuid');
         expect(p.notifyCharUuid, isNotEmpty,
             reason: '${p.id} notifyCharUuid');
       }
+    });
+
+    test('generic-ble fallback pins NO service UUID — dynamic GATT (#3097)',
+        () {
+      final g = registry.profiles.firstWhere((p) => p.id == 'generic-ble');
+      expect(g.transport, BluetoothTransport.ble);
+      expect(g.serviceUuid, isEmpty,
+          reason: 'generic-ble relies on dynamic GATT discovery so it can '
+              'connect to a name-only adapter that advertises no service');
+      expect(g.adapter, isA<GenericElm327Adapter>());
+      // Shares the generic-classic name signature so the same generic names
+      // are recognised on both transports; resolve() splits them by the
+      // candidate discovery transport.
+      final c = registry.profiles.firstWhere((p) => p.id == 'generic-classic');
+      expect(g.nameMatchers, c.nameMatchers);
     });
 
     test('the #1641 best-seller additions resolve by name', () {
@@ -552,10 +618,12 @@ Obd2AdapterCandidate _candidate({
   required String name,
   required Iterable<String> services,
   int rssi = -60,
+  BluetoothTransport discoveryTransport = BluetoothTransport.ble,
 }) =>
     Obd2AdapterCandidate(
       deviceId: 'aa:bb:cc:dd:ee:ff',
       deviceName: name,
       advertisedServiceUuids: services,
       rssi: rssi,
+      discoveryTransport: discoveryTransport,
     );

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -136,6 +136,55 @@ void main() {
       expect(emitted.last.first.profile.id, 'obdlink-mx',
           reason: 'strongest RSSI must rank first');
     });
+
+    test(
+        'requests an UNFILTERED BLE scan (empty serviceUuids) so iOS sees '
+        'name-only ELM327 adapters (#3097)', () async {
+      // A service-UUID filter becomes startScan(withServices:), and on iOS
+      // CoreBluetooth only returns peripherals that ADVERTISE one of those
+      // UUIDs — but most ELM327 BLE clones advertise a NAME and no service,
+      // so the filtered scan returned nothing on iPhone. The service must
+      // request an empty (unfiltered) set; resolve()/rank still drop noise.
+      final fake = _FakeFacade(batches: const [[]]);
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+      // The empty batch yields no known adapter, so scan throws ScanTimeout;
+      // we only care that the facade was driven with an empty filter.
+      await expectLater(svc.scan().toList(), throwsA(isA<Obd2ScanTimeout>()));
+      expect(fake.lastScanServiceUuids, isNotNull,
+          reason: 'the BLE facade scan must have been invoked');
+      expect(fake.lastScanServiceUuids, isEmpty,
+          reason: 'the BLE scan must be UNFILTERED (#3097) — a non-empty '
+              'withServices filter starves iOS of name-only adapters');
+    });
+
+    test(
+        'a BLE-discovered generic "OBDII" resolves to a BLE profile, not '
+        'Classic (#3097)', () async {
+      // End-to-end through the real registry: a generic ELM327 advertising a
+      // name and NO service over BLE must rank as a BLE profile so it connects
+      // on iPhone (a Classic profile cannot — no MFi). Would FAIL on master:
+      // pre-#3097 the only generic matchers lived on generic-classic.
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'ios-uuid-1',
+              deviceName: 'OBDII',
+              advertisedServiceUuids: const [],
+              rssi: -50,
+              discoveryTransport: BluetoothTransport.ble,
+            ),
+          ],
+        ]),
+      );
+      final emitted = await svc.scan().toList();
+      final resolved = emitted.single.single;
+      expect(resolved.profile.id, 'generic-ble');
+      expect(resolved.profile.transport, BluetoothTransport.ble,
+          reason: 'a BLE-discovered generic ELM327 must resolve to a BLE '
+              'profile so the BLE connect path runs on iPhone (#3097)');
+    });
   });
 
   group('Obd2ConnectionService.connect (#741)', () {
@@ -1099,6 +1148,11 @@ class _FakeFacade implements BluetoothFacade {
   /// happy-path test assert NO scan occurred.
   bool scanInvoked = false;
 
+  /// #3097 — captures the `serviceUuids` the connection service requested on
+  /// the most recent [scan] call, so a test can assert the scan is UNFILTERED
+  /// (empty set). A non-empty filter starved iOS of name-only ELM327 adapters.
+  Set<String>? lastScanServiceUuids;
+
   /// Args captured from the most recent [channelForDirect] call.
   String? directMac;
   Duration? directTimeout;
@@ -1118,6 +1172,7 @@ class _FakeFacade implements BluetoothFacade {
     Duration timeout = const Duration(seconds: 8),
   }) async* {
     scanInvoked = true;
+    lastScanServiceUuids = serviceUuids;
     for (final batch in batches) {
       yield batch;
     }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -108,7 +108,15 @@ void main() {
     // (`transportsForName` + `disambiguateTransport`) — when a name matches BOTH
     // a BLE and Classic profile (SmartOBD / vLinker), prefer bonded-Classic when
     // bonded else BLE — plus dartdoc. Two pure lookup methods on the catalog.
-    'lib/features/consumption/data/obd2/adapter_registry.dart': 556,
+    // #3097 — re-grandfathered 556 → 625: the iOS-BLE-scan fix adds (1) a
+    // `discoveryTransport` field on Obd2AdapterCandidate + its dartdoc, (2)
+    // resolve() now prefers the discovery transport when a name matches both a
+    // BLE and a Classic profile (so a BLE-discovered `OBDII` resolves to a BLE
+    // profile, the only transport iOS can use), and (3) a `generic-ble`
+    // fallback profile mirroring `generic-classic`'s matchers (shared const)
+    // that connects via dynamic GATT discovery. Pure data + lookup growth on
+    // the existing catalog class; decomposition tracked by #2190.
+    'lib/features/consumption/data/obd2/adapter_registry.dart': 625,
     // #2969 — grandfathered at 563 (was 389, under-cap before). The #2969
     // connect-trace instrumentation opens/finalises a trace at the FIVE public
     // connect entry points (the single virtual-dispatch chokepoint every live


### PR DESCRIPTION
## Problem
On iPhone, the OBD2 picker's Bluetooth scan finds **no adapter** for most ELM327 BLE dongles, even when powered, advertising, and in range. Two compounding bugs in the scan/resolve path.

### Bug 1 — service-UUID-filtered BLE scan starves iOS
`Obd2ConnectionService.scan()` passed `registry.allServiceUuids` → `FlutterBluePlus.startScan(withServices: …)`. On iOS, CoreBluetooth returns **only** peripherals that ADVERTISE one of those UUIDs — but most ELM327 BLE clones advertise a **name** and **no service UUID**, so the filtered scan returned nothing on iPhone. The filter was also redundant: `Obd2AdapterRegistry.resolve()` already drops non-adapter noise (returns `null` → the picker hides it).

### Bug 2 — generic ELM327 name matchers were Classic-only
The generic matchers (`obdii`, `obd-ii`, `obd ii`, `obd2`, `elm327`) lived **only** on the `generic-classic` profile (`transport: classic`). There was no generic **BLE** profile, so a generic-named adapter resolved to Classic — which iOS cannot connect to (Apple restricts Bluetooth Classic SPP to MFi hardware; the Classic facade is null on iOS). The candidate didn't record which transport discovered it, so `resolve()` couldn't disambiguate.

## Fix
- **Scan unfiltered** — `Obd2ConnectionService.scan()` now passes `serviceUuids: const {}` so `startScan` sweeps all BLE peripherals. `registry.rank` still drops non-adapter noise, just after the scan instead of at the radio. `allServiceUuids` is retained (with an updated comment) for reference/tests only.
- **Tag candidates with their discovery transport** — `Obd2AdapterCandidate` gains `BluetoothTransport discoveryTransport`. The BLE facade stamps `ble`; the Classic (bonded-device) facade stamps `classic`. On iOS the Classic facade is null, so every iOS candidate is `ble`.
- **`resolve()` prefers the discovery transport** — when a name matches profiles of **more than one** transport (a generic `OBDII` matching both `generic-ble` and `generic-classic`, or a `SmartOBD` matching both `smartobd-ble`/`smartobd-classic`), it picks the profile whose `transport == candidate.discoveryTransport`. A BLE-discovered `OBDII` → a BLE profile (connects on iPhone); a Classic-discovered `OBDII` on Android → Classic (no regression). A single-transport name match is unchanged (first-in-catalog winner), and the #3014 stored/reconnect `disambiguateTransport` path is untouched.
- **New `generic-ble` profile** — mirrors `generic-classic`'s matchers (shared `_genericElmNameMatchers` const) but `transport: ble` with **no pinned service UUID**, so it connects via the #3014 dynamic GATT discovery path (the ELM service is found post-connect among FFE0/FFF0/18F0/Nordic-UART by characteristic property — a name-only adapter still connects). Listed before `generic-classic`. `connect()` already dispatches on the resolved profile's transport, so the BLE path runs.

## Tests (RED on master)
- A BLE-discovered candidate named `OBDII` (no advertised service, `discoveryTransport: ble`) resolves to `generic-ble` — **RED on master** (resolved to `generic-classic`).
- A Classic-discovered `OBDII` (`discoveryTransport: classic`) still resolves to `generic-classic` (no Android regression).
- `Obd2ConnectionService.scan()` requests an **unfiltered** scan (empty `serviceUuids`), asserted via the fake `BluetoothFacade` — **RED on master** (master passes a non-empty service set).
- `generic-ble` pins no service UUID and shares `generic-classic`'s matchers; existing adapter_registry + connection_service tests kept/adjusted.

`flutter analyze` clean; `flutter test test/features/consumption/data/obd2/` + the lint suite green (1600 obd2 tests). No freezed/riverpod/part change → no codegen. file_length snapshot for `adapter_registry.dart` bumped 556 → 625 (pure data + lookup growth on the catalog class; `obd2_connection_service.dart` kept net-neutral against its snapshot).

## NOTE — iOS hardware limitation (not a software bug)
This fix covers BLE adapters that advertise a **name but no service UUID**. A **Bluetooth-Classic-ONLY (Bluetooth 3.0 / SPP) adapter cannot work on iPhone at all** — Apple restricts Classic SPP to MFi-certified hardware — so a non-BLE adapter on iOS is a hardware limitation, not something this (or any) software change can fix.

Closes #3097

🤖 Generated with [Claude Code](https://claude.com/claude-code)