### PR TITLE
fix(obd2): start recording on a transient bus probe, not just busAnswered

### DIFF
--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -153,9 +153,21 @@ class RecordingStartCoordinator {
       // "start the engine" message ([Obd2EngineOff]), NOT the old
       // adapter-blaming [Obd2AdapterUnresponsive] ("the adapter did not
       // respond" — but it DID respond; only the engine is off). Roll the
-      // connecting phase back and tear down the dead link. Gated STRICTLY on
-      // the no-answer signal so it never trips when discovery found PIDs.
-      if (!service.busAnswered) {
+      // connecting phase back and tear down the dead link.
+      //
+      // #3101 — gate on the FINER [Obd2Service.busProbe] tri-state, NOT the
+      // coarse `busAnswered`. #3035 fixed this same false-engine-off in the
+      // CONNECTION layer but this start gate was never migrated: on a
+      // cache-miss first connect (post reset / reinstall) to a LIVE-but-slow
+      // car, the `0100` probe merely TIMES OUT during the ELM protocol search
+      // → no protocol digit, no PIDs → `busAnswered == false` though the
+      // engine is ON. The old gate then bailed with engine-off and the trip
+      // "won't start at all". Block ONLY a confirmed engine-off
+      // ([Obd2BusProbeResult.probedSilent] — the ECU stayed silent through
+      // EVERY retry); a `transient` / `answered` / `notProbed` (warm
+      // cache-hit) connect starts and lets the scheduler pick up PIDs once the
+      // protocol search converges.
+      if (service.busProbe == Obd2BusProbeResult.probedSilent) {
         notifier.cancelConnecting();
         onConnectionError(const Obd2EngineOff());
         unawaited(service.disconnect());

--- a/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
@@ -54,9 +54,16 @@ void main() {
   }
 
   testWidgets(
-      'a silent-bus connect surfaces Obd2EngineOff, disconnects, '
-      'and never calls notifier.start (#2892, #3009)', (tester) async {
-    final service = _FakeObd2Service(busAnswered: false);
+      'a CONFIRMED engine-off connect (probedSilent) surfaces Obd2EngineOff, '
+      'disconnects, and never calls notifier.start (#2892, #3009, #3101)',
+      (tester) async {
+    // #3101 — only a `probedSilent` probe (ECU silent through every retry) is
+    // a genuine engine-off. `busAnswered` is false here too, but the gate now
+    // keys off the finer tri-state, not the coarse boolean.
+    final service = _FakeObd2Service(
+      busAnswered: false,
+      busProbe: Obd2BusProbeResult.probedSilent,
+    );
     final coordinator = RecordingStartCoordinator();
     final errors = <Object>[];
     late _SpyTripRecording recording;
@@ -94,7 +101,10 @@ void main() {
   testWidgets(
       'a connect whose bus answered starts the trip as normal (#2892)',
       (tester) async {
-    final service = _FakeObd2Service(busAnswered: true);
+    final service = _FakeObd2Service(
+      busAnswered: true,
+      busProbe: Obd2BusProbeResult.answered,
+    );
     final coordinator = RecordingStartCoordinator();
     final errors = <Object>[];
     late _SpyTripRecording recording;
@@ -119,6 +129,74 @@ void main() {
     expect(recording.lastStartedService, same(service));
     expect(service.disconnectCallCount, 0,
         reason: 'the live recording now owns the link');
+  });
+
+  testWidgets(
+      '#3101 — a TRANSIENT probe (live-but-slow car, 0100 timed out: '
+      'busAnswered=false but NOT engine-off) STARTS the trip, not bails',
+      (tester) async {
+    // The regression: a cache-miss first connect to a LIVE car whose `0100`
+    // merely timed out during the protocol search. `busAnswered` is false
+    // (no protocol digit, no PIDs yet) but `busProbe` is `transient`, NOT
+    // `probedSilent`. The old gate bailed with Obd2EngineOff → "recording
+    // won't start at all". The trip must start and the recording must own the
+    // link so the scheduler picks up PIDs once the search converges.
+    final service = _FakeObd2Service(
+      busAnswered: false,
+      busProbe: Obd2BusProbeResult.transient,
+    );
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        openPicker: () async => service,
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    expect(errors, isEmpty,
+        reason: 'a transient probe is NOT engine-off — no error');
+    expect(recording.startCallCount, 1,
+        reason: 'a live-but-slow car must start the trip (#3101)');
+    expect(recording.lastStartedService, same(service));
+    expect(service.disconnectCallCount, 0,
+        reason: 'the live recording now owns the link — do not tear it down');
+  });
+
+  testWidgets(
+      '#3101 — a warm cache-hit (notProbed, busAnswered=true) starts normally',
+      (tester) async {
+    // A pinned/paired adapter cache-hit skips discovery: `busProbe` is
+    // `notProbed` and `busAnswered` trips on the cached protocol/PID set.
+    final service = _FakeObd2Service(
+      busAnswered: true,
+      busProbe: Obd2BusProbeResult.notProbed,
+    );
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        openPicker: () async => service,
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    expect(errors, isEmpty);
+    expect(recording.startCallCount, 1);
   });
 }
 
@@ -151,17 +229,24 @@ class _SpyTripRecording extends TripRecording {
   }
 }
 
-/// Fake [Obd2Service] whose `busAnswered` is fixed by the test and whose
-/// `disconnect` is counted. Everything else is unreachable in these tests.
+/// Fake [Obd2Service] whose `busAnswered` + `busProbe` are fixed by the test
+/// and whose `disconnect` is counted. Everything else is unreachable here.
 class _FakeObd2Service implements Obd2Service {
-  _FakeObd2Service({required bool busAnswered})
-      : busAnsweredValue = busAnswered;
+  _FakeObd2Service({
+    required bool busAnswered,
+    required Obd2BusProbeResult busProbe,
+  })  : busAnsweredValue = busAnswered,
+        busProbeValue = busProbe;
 
   final bool busAnsweredValue;
+  final Obd2BusProbeResult busProbeValue;
   int disconnectCallCount = 0;
 
   @override
   bool get busAnswered => busAnsweredValue;
+
+  @override
+  Obd2BusProbeResult get busProbe => busProbeValue;
 
   @override
   Future<void> disconnect() async {

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -205,14 +205,19 @@ class _EmptyBluetoothFacade implements BluetoothFacade {
 }
 
 class _NoopObd2Service implements Obd2Service {
-  // #2892 — the recording coordinator gates on `busAnswered` before starting:
-  // a connected service whose vehicle bus never answered surfaces the
-  // "turn the ignition on" condition instead of starting a degraded trip.
-  // These tests exercise the healthy start/pre-warm flow, so the fake reports
-  // a live bus (the silent-bus gate has its own dedicated coverage in
+  // #2892 / #3101 — the recording coordinator gates on the vehicle-bus signal
+  // before starting: a connected service whose bus is confirmed silent
+  // (engine off) surfaces the "turn the ignition on" condition instead of
+  // starting a degraded trip. These tests exercise the healthy start/pre-warm
+  // flow, so the fake reports a live bus — #3101 the gate now keys off the
+  // finer `busProbe` tri-state (answered), not just the coarse `busAnswered`
+  // (the silent-bus / transient gate has its own dedicated coverage in
   // recording_start_coordinator_bus_silent_test.dart).
   @override
   bool get busAnswered => true;
+
+  @override
+  Obd2BusProbeResult get busProbe => Obd2BusProbeResult.answered;
 
   @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);


### PR DESCRIPTION
## Symptom (field report — both iOS + Android)
Adapter connects, **self-test passes**, but tapping **Start** to record never enters the live recording screen — it errors / spins back to idle. "OBD2 initialization when recording does not work."

## Root cause (regression from #3035)
`RecordingStartCoordinator.connectAndStart` gated trip-start on the **coarse** `service.busAnswered` (`= cachedProtocolDigit != null || supportedPids.isNotEmpty`). On a **cache-miss first connect** (post phone-reset / reinstall) to a **live-but-slow** car, the `0100` supported-PID probe merely **times out** during the ELM327 protocol search → no protocol digit, no PIDs → `busAnswered == false` **even though the engine is on** → the gate bailed with `Obd2EngineOff` and returned to idle.

#3035 already fixed this exact false-engine-off in the **connection layer** by introducing the finer `Obd2BusProbeResult` tri-state (classify engine-off **only** on `probedSilent`; `transient` keeps the connect usable) — but the **recording start gate was never migrated**. The self-test path doesn't probe the bus (chip-only ATZ…ATI), which is why it "looks fine."

## Fix
Gate the start on the finer signal: bail **only** when `service.busProbe == Obd2BusProbeResult.probedSilent` (ECU silent through every retry = genuine engine-off). A `transient` / `answered` / `notProbed` (warm cache-hit) connect starts and lets the PID scheduler converge once the protocol search completes. Cross-platform (shared Dart); no codegen / no ARB.

## Test
Updated `recording_start_coordinator_bus_silent_test.dart` to drive `busProbe`; the engine-off case now uses `probedSilent`, plus a **RED-first regression** (`transient` ⇒ trip starts, link not torn down) and a cache-hit (`notProbed`) case. **RED verified on master** (transient wrongly bailed); green with the fix. Broader OBD2 suite (0100-search + connection-service) green.

Closes #3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)