### PR TITLE
fix(obd2): a Classic enumeration failure must not kill BLE discovery

### DIFF
--- a/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
@@ -3,12 +3,11 @@
 
 import 'dart:async';
 
-
+import '../../../../core/logging/error_logger.dart';
 import 'adapter_registry.dart';
 import 'classic_elm_channel.dart';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
-import '../../../../core/logging/error_logger.dart';
 
 /// Facade over the Classic Bluetooth transport for OBD2 adapters
 /// (#761 abstraction, #763 real impl).
@@ -58,8 +57,19 @@ class PluginClassicBluetoothFacade implements ClassicBluetoothFacade {
                 discoveryTransport: BluetoothTransport.classic,
               ))
           .toList();
-    } on Exception catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PluginClassicBluetoothFacade: bondedDevices failed'}));
+    } catch (e, st) {
+      // #3106 — catch ALL throwables, not just `Exception`. This stream is
+      // StreamGroup-merged with the BLE scan in Obd2ConnectionService, so an
+      // uncaught `Error` here (e.g. a platform `MissingPluginException` is an
+      // Error, or an OOM during bonded enumeration) would tear down the MERGED
+      // stream and take BLE discovery down with it — the user would find NO
+      // adapters at all, on Android, because the Classic side blipped. Degrade
+      // gracefully to "no Classic candidates" (log it; never yield a stream
+      // error that aborts the BLE results) so BLE discovery always survives.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'PluginClassicBluetoothFacade: bondedDevices failed — '
+            'degraded to no Classic candidates (BLE scan unaffected)',
+      }));
     }
   }
 

--- a/test/features/consumption/data/obd2/classic_bluetooth_facade_test.dart
+++ b/test/features/consumption/data/obd2/classic_bluetooth_facade_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'classic_bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'classic_method_channel.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3106 — a Classic bonded-enumeration failure must DEGRADE gracefully, never
+/// tear down the scan. The facade's stream is StreamGroup-merged with the BLE
+/// scan in Obd2ConnectionService, so an UNCAUGHT throwable here would abort the
+/// merged stream and take BLE discovery down with it — the user would find NO
+/// adapters on Android because the Classic side blipped.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('PluginClassicBluetoothFacade.scan fault tolerance (#3106)', () {
+    test('an Exception from bondedDevices degrades to no candidates', () async {
+      final facade = PluginClassicBluetoothFacade(
+        plugin: _ThrowingPlugin(const FormatException('boom')),
+      );
+      await expectLater(facade.scan().toList(), completion(isEmpty));
+    });
+
+    test(
+        'an ERROR from bondedDevices is ALSO caught (the old `on Exception` let '
+        'it escape and abort the merged BLE stream)', () async {
+      final facade = PluginClassicBluetoothFacade(
+        plugin: _ThrowingPlugin(StateError('platform Error')),
+      );
+      // Completes empty instead of propagating — BLE discovery is unaffected.
+      await expectLater(facade.scan().toList(), completion(isEmpty));
+    });
+  });
+}
+
+/// A method-channel stand-in whose [bondedDevices] always throws the given
+/// [error] (an Exception or an Error), to exercise the facade's catch path.
+class _ThrowingPlugin extends Obd2ClassicMethodChannel {
+  _ThrowingPlugin(this.error);
+
+  final Object error;
+
+  @override
+  Future<List<ClassicBondedDevice>> bondedDevices() async => throw error;
+}


### PR DESCRIPTION
Epic #3103, child C (#3106).

`PluginClassicBluetoothFacade.scan` caught only `on Exception`. Its stream is **StreamGroup-merged with the BLE scan** in `Obd2ConnectionService`, so an uncaught **Error** (a platform `MissingPluginException` is an `Error`; an OOM during bonded enumeration) tore down the **merged** stream and took **BLE discovery down with it** — on Android the user would find **no adapters at all** because the Classic side blipped.

## Fix
Catch **all** throwables and degrade to "no Classic candidates" (logged; never a stream error that aborts the BLE results), so BLE discovery always survives a Classic-side failure.

## Test
Fault-injection test: an `Error` from `bondedDevices()` now completes empty instead of propagating — **RED on master** (the old `on Exception` let it escape), green with the fix. Also covers the `Exception` path.

Disjoint from #3107 (A+B); touches only `classic_bluetooth_facade.dart` + its new test.

Closes #3106

🤖 Generated with [Claude Code](https://claude.com/claude-code)