### PR TITLE
test(network): bounded retry for the nightly live-API suite (#3096)

### DIFF
--- a/test/core/services/api_connectivity_test.dart
+++ b/test/core/services/api_connectivity_test.dart
@@ -6,6 +6,7 @@ library;
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/network_retry.dart';
 import '../../helpers/silence_error_logger.dart';
 
 /// Integration tests that verify each country's fuel price API is reachable
@@ -24,7 +25,7 @@ void main() {
   late Dio dio;
 
   setUp(() {
-    dio = Dio(BaseOptions(
+    dio = retryingDio(BaseOptions(
       connectTimeout: const Duration(seconds: 15),
       receiveTimeout: const Duration(seconds: 30),
       headers: {'User-Agent': 'de.tankstellen.app/1.0.0'},
@@ -150,7 +151,7 @@ void main() {
     });
 
     test('Italy — MIMIT station CSV is reachable and parseable', () async {
-      final csvDio = Dio(BaseOptions(
+      final csvDio = retryingDio(BaseOptions(
         connectTimeout: const Duration(seconds: 15),
         receiveTimeout: const Duration(seconds: 60),
         headers: {'User-Agent': 'de.tankstellen.app/1.0.0'},
@@ -183,7 +184,7 @@ void main() {
     });
 
     test('Italy — MIMIT price CSV is reachable and parseable', () async {
-      final csvDio = Dio(BaseOptions(
+      final csvDio = retryingDio(BaseOptions(
         connectTimeout: const Duration(seconds: 15),
         receiveTimeout: const Duration(seconds: 60),
         headers: {'User-Agent': 'de.tankstellen.app/1.0.0'},
@@ -244,7 +245,7 @@ void main() {
     });
 
     test('Argentina — Energía CSV is reachable and has coordinates', () async {
-      final csvDio = Dio(BaseOptions(
+      final csvDio = retryingDio(BaseOptions(
         connectTimeout: const Duration(seconds: 20),
         receiveTimeout: const Duration(seconds: 60),
         headers: {'User-Agent': 'de.tankstellen.app/1.0.0'},

--- a/test/core/services/italy_search_live_test.dart
+++ b/test/core/services/italy_search_live_test.dart
@@ -9,6 +9,8 @@ import 'package:tankstellen/features/station_services/italy/mise_station_service
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
+import '../../helpers/network_retry.dart';
+
 /// #695 — live end-to-end search against the Italian MISE provider.
 /// Hits `mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv`
 /// + the price CSV, asserts >0 stations for Rome and Milan.
@@ -21,13 +23,16 @@ void main() {
     'MISE returns stations within 10km of Rome (Roma Centro)',
     () async {
       final service = MiseStationService();
-      // Via del Corso, Roma (Piazza Venezia area)
-      final result = await service.searchStations(
-        const SearchParams(
-          lat: 41.8967,
-          lng: 12.4822,
-          radiusKm: 10,
-          fuelType: FuelType.e10,
+      // Via del Corso, Roma (Piazza Venezia area). #3096 — retry the live
+      // upstream fetch so a transient MIMIT timeout self-heals.
+      final result = await retryNetwork(
+        () => service.searchStations(
+          const SearchParams(
+            lat: 41.8967,
+            lng: 12.4822,
+            radiusKm: 10,
+            fuelType: FuelType.e10,
+          ),
         ),
       );
       expect(result.data, isNotEmpty,
@@ -49,12 +54,14 @@ void main() {
     'MISE returns stations within 5km of Milan (Duomo)',
     () async {
       final service = MiseStationService();
-      final result = await service.searchStations(
-        const SearchParams(
-          lat: 45.4642,
-          lng: 9.1900,
-          radiusKm: 5,
-          fuelType: FuelType.diesel,
+      final result = await retryNetwork(
+        () => service.searchStations(
+          const SearchParams(
+            lat: 45.4642,
+            lng: 9.1900,
+            radiusKm: 5,
+            fuelType: FuelType.diesel,
+          ),
         ),
       );
       expect(result.data, isNotEmpty,

--- a/test/helpers/network_retry.dart
+++ b/test/helpers/network_retry.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart' show TestFailure;
+
+/// Bounded retry for the `network`-tagged nightly suite (#3096).
+///
+/// The live API-connectivity / search tests hit real upstream endpoints
+/// (Italy MIMIT, Denmark OK, …) which intermittently TIME OUT or return a
+/// transient 5xx. Those blips filed a `nightly-flaky` issue every few nights
+/// even though nothing in the app or the upstream contract was broken. These
+/// helpers retry ONLY transient transport failures a couple of times, so a
+/// blip self-heals — while a GENUINE, persistent breakage (every attempt
+/// fails, or the upstream contract changed → an assertion fails) still fails
+/// hard, preserving the whole point of the live suite.
+
+bool _isTransient(DioException e) =>
+    e.type == DioExceptionType.connectionTimeout ||
+    e.type == DioExceptionType.receiveTimeout ||
+    e.type == DioExceptionType.sendTimeout ||
+    e.type == DioExceptionType.connectionError ||
+    (e.response?.statusCode != null && e.response!.statusCode! >= 500);
+
+class _RetryInterceptor extends Interceptor {
+  _RetryInterceptor(this._dio, {this.maxRetries = 2});
+
+  static const _baseDelay = Duration(seconds: 2);
+
+  final Dio _dio;
+  final int maxRetries;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    final attempt = (err.requestOptions.extra['retry_attempt'] as int?) ?? 0;
+    if (_isTransient(err) && attempt < maxRetries) {
+      await Future<void>.delayed(_baseDelay * (attempt + 1));
+      final opts = err.requestOptions..extra['retry_attempt'] = attempt + 1;
+      try {
+        return handler.resolve(await _dio.fetch<dynamic>(opts));
+      } catch (_) {
+        return handler.next(err);
+      }
+    }
+    return handler.next(err);
+  }
+}
+
+/// A [Dio] that transparently retries transient transport failures (#3096).
+/// Drop-in for `Dio(BaseOptions(...))` in the live network tests.
+Dio retryingDio(BaseOptions options, {int maxRetries = 2}) {
+  final dio = Dio(options);
+  dio.interceptors.add(_RetryInterceptor(dio, maxRetries: maxRetries));
+  return dio;
+}
+
+/// Retry [body] up to [attempts] times on a transient [DioException] (#3096),
+/// for live tests that go through a SERVICE (which owns its own Dio) rather
+/// than a raw [Dio]. A [TestFailure] (a real assertion) is NEVER retried — it
+/// rethrows immediately so a genuine contract break fails fast.
+Future<T> retryNetwork<T>(
+  Future<T> Function() body, {
+  int attempts = 3,
+  Duration baseDelay = const Duration(seconds: 2),
+}) async {
+  Object? lastError;
+  StackTrace? lastStack;
+  for (var i = 0; i < attempts; i++) {
+    try {
+      return await body();
+    } on TestFailure {
+      rethrow;
+    } catch (e, st) {
+      if (e is DioException && !_isTransient(e)) rethrow;
+      lastError = e;
+      lastStack = st;
+      if (i < attempts - 1) await Future<void>.delayed(baseDelay * (i + 1));
+    }
+  }
+  Error.throwWithStackTrace(lastError!, lastStack!);
+}


### PR DESCRIPTION
The `network`-tagged nightly suite hits real upstream APIs (Italy MIMIT, Denmark OK, …) that intermittently time out / return a transient 5xx, filing a `nightly-flaky failed <date>` issue every few nights with nothing actually broken (3 failures in 4 days).

## Fix
A bounded retry that masks **only transient transport failures** (connect/receive/send timeout, connection error, 5xx — a couple of attempts with backoff) while still **failing hard** on a genuine, persistent breakage or a contract change (a `TestFailure`/assertion is never retried — it rethrows immediately, so the suite still catches real upstream breakage).

- New `test/helpers/network_retry.dart`: a `retryingDio()` factory (retry interceptor) for raw-Dio tests + a `retryNetwork()` wrapper for service-based tests.
- `api_connectivity_test.dart`: all 4 Dio instances → `retryingDio` (covers DE/FR/AT/ES/IT/DK/AR/Nominatim).
- `italy_search_live_test.dart`: the live MISE search calls wrapped in `retryNetwork`.

Test-only; no lib/ARB/codegen. Excluded from PR CI (the `network` tag); runs in the nightly-flaky workflow.

Closes #3096

🤖 Generated with [Claude Code](https://claude.com/claude-code)