### PR TITLE
feat(sync): deletion tombstones so a delete doesn't resurrect across devices

### DIFF
--- a/lib/core/sync/baselines_sync.dart
+++ b/lib/core/sync/baselines_sync.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 
 import '../../features/consumption/data/baseline_sync.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
 import '../../core/logging/error_logger.dart';
 
@@ -46,6 +47,16 @@ class BaselinesSync {
     }
 
     try {
+      // #3078 — a baseline the user "forgot" on another device must not be
+      // re-uploaded here. If this vehicle's baseline is tombstoned, leave the
+      // local copy untouched and don't push it back to the server.
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds('obd2_baselines');
+      if (tombstoned.contains(vehicleId)) {
+        debugPrint('BaselinesSync.merge: $vehicleId tombstoned — skipping');
+        return localJson;
+      }
+
       final serverRow = await client
           .from('obd2_baselines')
           .select('data')
@@ -99,6 +110,7 @@ class BaselinesSync {
           .delete()
           .eq('user_id', userId)
           .eq('vehicle_id', vehicleId);
+      await DeletionsSync.record('obd2_baselines', vehicleId); // #3078
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'BaselinesSync.delete FAILED'}));
     }

--- a/lib/core/sync/deletions_sync.dart
+++ b/lib/core/sync/deletions_sync.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../utils/json_extensions.dart';
+import 'supabase_client.dart';
+import '../../core/logging/error_logger.dart';
+
+/// Deletion tombstones (#3078, Epic #3075).
+///
+/// TankSync merges synced entities as `server ∪ local` then upserts. So when
+/// device A deletes a favorite, device B's next sync re-adds it (the union
+/// re-includes the still-local row) and the delete **resurrects**. A tombstone
+/// is the durable "this id was deliberately deleted" record that lets every
+/// device's merge filter the resurrected row out for good.
+///
+/// One `deletions` row per `(user_id, table_name, record_id)` (idempotent via
+/// that unique key). On a synced delete the owning sync class additionally
+/// [record]s a tombstone; before each union it [fetchTombstonedIds] and runs
+/// the server rows through `SyncHelper.removeTombstoned`.
+class DeletionsSync {
+  DeletionsSync._();
+
+  /// The Supabase table name. Exposed so the schema completeness drift-guard
+  /// and the sync classes reference the same literal.
+  static const table = 'deletions';
+
+  /// Record a tombstone for [recordId] in [tableName]. Idempotent — a repeat
+  /// delete of the same id just refreshes `deleted_at`. No-op + silent when
+  /// unauthenticated or on a transient failure (the local delete already
+  /// happened; sync must never throw back into the caller).
+  static Future<void> record(String tableName, String recordId) =>
+      recordAll(tableName, [recordId]);
+
+  /// Batch analogue of [record] — one round-trip for many ids of the same
+  /// [tableName]. No-op when the id list is empty or unauthenticated.
+  static Future<void> recordAll(
+    String tableName,
+    Iterable<String> recordIds,
+  ) async {
+    final ids = recordIds.toList();
+    if (ids.isEmpty) return;
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+
+    final now = DateTime.now().toIso8601String();
+    final rows = ids
+        .map((id) => {
+              'user_id': userId,
+              'table_name': tableName,
+              'record_id': id,
+              'deleted_at': now,
+            })
+        .toList();
+    try {
+      await client.from(table).upsert(
+            rows,
+            onConflict: 'user_id,table_name,record_id',
+          );
+      debugPrint('DeletionsSync.record: ${ids.length} tombstone(s) '
+          'for "$tableName"');
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'DeletionsSync.record FAILED'}));
+    }
+  }
+
+  /// Fetch the set of record ids the current user has tombstoned for
+  /// [tableName]. Returns an empty set when unauthenticated or on failure —
+  /// the caller then simply skips the tombstone filter (degrades to the old
+  /// union behaviour rather than dropping rows it shouldn't).
+  static Future<Set<String>> fetchTombstonedIds(String tableName) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return {};
+    try {
+      final rows = await client
+          .from(table)
+          .select('record_id')
+          .eq('user_id', userId)
+          .eq('table_name', tableName);
+      return rows
+          .map((r) => r.getString('record_id'))
+          .whereType<String>()
+          .toSet();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'DeletionsSync.fetchTombstonedIds FAILED'}));
+      return {};
+    }
+  }
+}

--- a/lib/core/sync/favorites_sync.dart
+++ b/lib/core/sync/favorites_sync.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Favorites sync with Supabase, pulled out of [SyncService] (#727).
@@ -36,11 +38,16 @@ class FavoritesSync {
           .from('favorites')
           .select('station_id')
           .eq('user_id', userId);
-      final serverIds = serverRows
-          .map((r) => r.getString('station_id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = localFavoriteIds.toSet();
+      // #3078 — drop tombstoned ids from the server set so a delete on
+      // another device can't resurrect through the union below.
+      final tombstoned = await DeletionsSync.fetchTombstonedIds('favorites');
+      final serverIds = SyncHelper.removeTombstoned(
+        serverRows.map((r) => r.getString('station_id')),
+        tombstoned,
+        key: (id) => id,
+      ).whereType<String>().toSet();
+      final localIds =
+          localFavoriteIds.where((id) => !tombstoned.contains(id)).toSet();
 
       debugPrint('FavoritesSync.merge: local=${localIds.length}, '
           'server=${serverIds.length}, userId=$userId');
@@ -79,6 +86,8 @@ class FavoritesSync {
           .delete()
           .eq('user_id', userId)
           .eq('station_id', stationId);
+      // #3078 — tombstone the id so other devices' merge never re-adds it.
+      await DeletionsSync.record('favorites', stationId);
       debugPrint('FavoritesSync.delete: $stationId removed from server');
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FavoritesSync.delete FAILED'}));

--- a/lib/core/sync/fill_ups_sync.dart
+++ b/lib/core/sync/fill_ups_sync.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 
 import '../../features/consumption/domain/entities/fill_up.dart';
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Per-fill-up consumption-log sync with Supabase (#713), pulled out
@@ -34,23 +36,34 @@ class FillUpsSync {
     }
 
     try {
-      final serverRows = await client
+      final serverRowsRaw = await client
           .from('fill_ups')
           .select('id, data')
           .eq('user_id', userId);
+
+      // #3078 — drop tombstoned rows from BOTH sides so a delete on another
+      // device can't resurrect through the union/re-upload below.
+      final tombstoned = await DeletionsSync.fetchTombstonedIds('fill_ups');
+      final serverRows = SyncHelper.removeTombstoned(
+        serverRowsRaw,
+        tombstoned,
+        key: (r) => r.getString('id'),
+      ).toList();
+      final liveLocal =
+          localFillUps.where((f) => !tombstoned.contains(f.id)).toList();
 
       final serverIds = serverRows
           .map((r) => r.getString('id'))
           .whereType<String>()
           .toSet();
-      final localIds = localFillUps.map((f) => f.id).toSet();
+      final localIds = liveLocal.map((f) => f.id).toSet();
 
       debugPrint('FillUpsSync.merge: local=${localIds.length}, '
           'server=${serverIds.length}');
 
       // Upload local-only fill-ups.
       final localOnly =
-          localFillUps.where((f) => !serverIds.contains(f.id)).toList();
+          liveLocal.where((f) => !serverIds.contains(f.id)).toList();
       if (localOnly.isNotEmpty) {
         final rows = localOnly
             .map((f) => {
@@ -85,7 +98,7 @@ class FillUpsSync {
         return null;
       }).whereType<FillUp>().toList();
 
-      return [...localFillUps, ...downloaded];
+      return [...liveLocal, ...downloaded];
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FillUpsSync.merge FAILED'}));
       return localFillUps;
@@ -104,6 +117,7 @@ class FillUpsSync {
           .delete()
           .eq('user_id', userId)
           .eq('id', fillUpId);
+      await DeletionsSync.record('fill_ups', fillUpId); // #3078
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FillUpsSync.delete FAILED'}));
     }

--- a/lib/core/sync/ignored_stations_sync.dart
+++ b/lib/core/sync/ignored_stations_sync.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Ignored-stations sync with Supabase, pulled out of [SyncService] (#727).
@@ -34,11 +36,17 @@ class IgnoredStationsSync {
           .from('ignored_stations')
           .select('station_id')
           .eq('user_id', userId);
-      final serverIds = serverRows
-          .map((r) => r.getString('station_id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = localIgnoredIds.toSet();
+      // #3078 — drop tombstoned ids so an un-ignore on another device
+      // doesn't resurrect through the union below.
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds('ignored_stations');
+      final serverIds = SyncHelper.removeTombstoned(
+        serverRows.map((r) => r.getString('station_id')),
+        tombstoned,
+        key: (id) => id,
+      ).whereType<String>().toSet();
+      final localIds =
+          localIgnoredIds.where((id) => !tombstoned.contains(id)).toSet();
 
       debugPrint('IgnoredStationsSync.merge: local=${localIds.length}, '
           'server=${serverIds.length}');
@@ -60,6 +68,27 @@ class IgnoredStationsSync {
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'IgnoredStationsSync.merge FAILED'}));
       return localIgnoredIds;
+    }
+  }
+
+  /// Un-ignore a single station on the server (#3078). Before this existed
+  /// the un-ignore path only re-ran [merge], whose union re-added the still-
+  /// server row, so the station never actually un-hid. Now the server row is
+  /// deleted AND tombstoned, so neither side resurrects it. Silent on failure.
+  static Future<void> delete(String stationId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('ignored_stations')
+          .delete()
+          .eq('user_id', userId)
+          .eq('station_id', stationId);
+      await DeletionsSync.record('ignored_stations', stationId);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'IgnoredStationsSync.delete FAILED'}));
     }
   }
 }

--- a/lib/core/sync/itineraries_sync.dart
+++ b/lib/core/sync/itineraries_sync.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Saved-itinerary sync with Supabase, pulled out of [SyncService]
@@ -67,7 +69,13 @@ class ItinerariesSync {
           .eq('user_id', userId)
           .order('updated_at', ascending: false);
 
-      return rows.map((r) {
+      // #3078 — never re-hydrate an itinerary deleted on another device.
+      final tombstoned = await DeletionsSync.fetchTombstonedIds('itineraries');
+      return SyncHelper.removeTombstoned(
+        rows,
+        tombstoned,
+        key: (r) => r.getString('id'),
+      ).map((r) {
         final createdAtStr = r.getString('created_at');
         final updatedAtStr = r.getString('updated_at');
         return SavedItinerary(
@@ -106,6 +114,7 @@ class ItinerariesSync {
           .delete()
           .eq('id', itineraryId)
           .eq('user_id', userId);
+      await DeletionsSync.record('itineraries', itineraryId); // #3078
       return true;
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ItinerariesSync.delete FAILED'}));

--- a/lib/core/sync/ratings_sync.dart
+++ b/lib/core/sync/ratings_sync.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
 import '../../core/logging/error_logger.dart';
 
@@ -103,6 +104,9 @@ class RatingsSync {
           .delete()
           .eq('user_id', userId)
           .eq('station_id', stationId);
+      // #3078 — tombstone so another device's re-upload / fetch can't
+      // resurrect the deleted rating.
+      await DeletionsSync.record('station_ratings', stationId);
       debugPrint('RatingsSync.delete: $stationId removed');
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.delete FAILED'}));
@@ -122,11 +126,16 @@ class RatingsSync {
           .from('station_ratings')
           .select('station_id, rating')
           .eq('user_id', userId);
+      // #3078 — never re-hydrate a rating the user deleted on another device.
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds('station_ratings');
       final result = <String, int>{};
       for (final r in rows) {
         final stationId = r.getString('station_id');
         final rating = r.getInt('rating');
-        if (stationId != null && rating != null) {
+        if (stationId != null &&
+            rating != null &&
+            !tombstoned.contains(stationId)) {
           result[stationId] = rating;
         }
       }

--- a/lib/core/sync/schema_sql.dart
+++ b/lib/core/sync/schema_sql.dart
@@ -25,7 +25,7 @@ import 'schema_sql_policies.dart';
 /// and warns when a self-hoster's recorded version is older — turning what
 /// used to be silent per-table breakage into a clear "re-run the setup SQL"
 /// signal. See `SchemaVerifier.checkSchemaVersion`.
-const int kSupabaseSchemaVersion = 2;
+const int kSupabaseSchemaVersion = 3;
 
 /// The metadata table that records the applied schema version. Readable by
 /// anyone (it carries no user data — only the schema version the verifier
@@ -243,6 +243,22 @@ CREATE INDEX IF NOT EXISTS trip_shares_recipient_idx
   ON public.trip_shares(shared_with_id);
 CREATE INDEX IF NOT EXISTS trip_shares_trip_recipient_idx
   ON public.trip_shares(trip_id, shared_with_id);
+''',
+  // #3078 — deletion tombstones. One row per deleted record so a delete on
+  // one device doesn't resurrect from another's still-local copy through the
+  // union merge. The owning sync class records a tombstone on delete and
+  // filters server rows against these ids before the union.
+  'deletions': '''
+CREATE TABLE IF NOT EXISTS public.deletions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  table_name TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, table_name, record_id)
+);
+CREATE INDEX IF NOT EXISTS deletions_user_table_idx
+  ON public.deletions(user_id, table_name);
 ''',
 };
 

--- a/lib/core/sync/schema_sql_policies.dart
+++ b/lib/core/sync/schema_sql_policies.dart
@@ -28,6 +28,7 @@ ALTER TABLE public.obd2_baselines ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.trip_summaries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.trip_details ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.trip_shares ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.deletions ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS users_own ON public.users;
 CREATE POLICY users_own ON public.users FOR ALL USING (id = auth.uid());
@@ -134,6 +135,11 @@ CREATE POLICY trip_details_shared_read ON public.trip_details
         AND s.shared_with_id = auth.uid()
     )
   );
+
+-- Deletion tombstones (#3078): a user only ever sees / writes their own.
+DROP POLICY IF EXISTS deletions_own ON public.deletions;
+CREATE POLICY deletions_own ON public.deletions
+  FOR ALL USING (user_id = auth.uid());
 ''';
 
 /// SECURITY DEFINER RPCs the trip-sharing sync code calls

--- a/lib/core/sync/schema_verifier.dart
+++ b/lib/core/sync/schema_verifier.dart
@@ -47,6 +47,7 @@ class SchemaVerifier {
     'trip_summaries',
     'trip_details',
     'trip_shares',
+    'deletions',
   ];
 
   /// Every table the wizard SQL creates / the verifier probes.

--- a/lib/core/sync/sync_helper.dart
+++ b/lib/core/sync/sync_helper.dart
@@ -62,4 +62,26 @@ class SyncHelper {
     String context,
     Future<void> Function() syncFn,
   ) => syncIfEnabled(ref, context, syncFn);
+
+  /// Drop every element of [serverRows] whose key is in [tombstoned] (#3078).
+  ///
+  /// The shared tombstone-filter seam for the union-merge sync classes. A
+  /// union merge re-adds any server row, so a record one device deleted comes
+  /// back from another device's still-local copy — the delete "resurrects".
+  /// Each sync class fetches its deletion tombstones
+  /// (`DeletionsSync.fetchTombstonedIds`) and runs the **server** rows through
+  /// this filter BEFORE the local ∪ server union, so a tombstoned id is never
+  /// re-included no matter which side still holds it.
+  ///
+  /// [key] extracts the record id from each row (identity for a `List<String>`
+  /// of ids). Pure + side-effect-free so it is the unit-testable seam the
+  /// resurrection regression test pins.
+  static Iterable<T> removeTombstoned<T>(
+    Iterable<T> serverRows,
+    Set<String> tombstoned, {
+    required String? Function(T) key,
+  }) {
+    if (tombstoned.isEmpty) return serverRows;
+    return serverRows.where((row) => !tombstoned.contains(key(row)));
+  }
 }

--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../features/consumption/data/trip_history_repository.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
 import 'trips_sync_json.dart';
 import '../../core/logging/error_logger.dart';
@@ -158,6 +159,7 @@ class TripsSync {
           .delete()
           .eq('user_id', userId)
           .eq('id', tripId);
+      await DeletionsSync.record('trip_summaries', tripId); // #3078
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.deleteSummary FAILED for $tripId'}));
     }
@@ -192,26 +194,32 @@ class TripsSync {
           .select('id, data')
           .eq('user_id', userId);
 
+      // #3078 — a trip deleted on another device must not resurrect. Drop
+      // tombstoned ids from BOTH the re-upload set and the downloaded union.
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds('trip_summaries');
+      final liveLocal =
+          localEntries.where((e) => !tombstoned.contains(e.id)).toList();
       final serverIds = <String>{};
       for (final r in serverRows) {
         final id = r['id'];
-        if (id is String) serverIds.add(id);
+        if (id is String && !tombstoned.contains(id)) serverIds.add(id);
       }
 
       // Upload local-only entries (heals a missing server row from a
       // previous offline save). #2319 — batch the Nx2 round-trips into
       // one upsert each instead of a serial per-entry loop.
       final localOnly =
-          localEntries.where((e) => !serverIds.contains(e.id)).toList();
+          liveLocal.where((e) => !serverIds.contains(e.id)).toList();
       await _uploadBatch(client, userId, localOnly);
 
       // Decode server-only rows and return the union — the superset the
       // app-launch caller persists back to Hive (see
       // `AppInitializer._runTripsSyncMerge`; #2239 pins this seam).
-      final merged = mergeRows(localEntries, serverRows);
-      debugPrint('TripsSync.merge: local=${localEntries.length} '
+      final merged = mergeRows(liveLocal, serverRows, tombstoned: tombstoned);
+      debugPrint('TripsSync.merge: local=${liveLocal.length} '
           'server=${serverIds.length} '
-          'downloaded=${merged.length - localEntries.length}');
+          'downloaded=${merged.length - liveLocal.length}');
       return merged;
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.merge FAILED'}));
@@ -381,13 +389,19 @@ class TripsSync {
   @visibleForTesting
   static List<TripHistoryEntry> mergeRows(
     List<TripHistoryEntry> localEntries,
-    List<Map<String, dynamic>> serverRows,
-  ) {
+    List<Map<String, dynamic>> serverRows, {
+    Set<String> tombstoned = const {},
+  }) {
     final localIds = localEntries.map((e) => e.id).toSet();
     final downloaded = <TripHistoryEntry>[];
     for (final r in serverRows) {
       final id = r['id'];
-      if (id is! String || localIds.contains(id)) continue;
+      // #3078 — also skip a server row the user deleted on another device.
+      if (id is! String ||
+          localIds.contains(id) ||
+          tombstoned.contains(id)) {
+        continue;
+      }
       final data = r['data'];
       if (data is! Map) continue;
       try {

--- a/lib/core/sync/user_data_sync.dart
+++ b/lib/core/sync/user_data_sync.dart
@@ -102,6 +102,7 @@ class UserDataSync {
     'itineraries': 'user_id',
     'obd2_baselines': 'user_id',
     'station_ratings': 'user_id',
+    'deletions': 'user_id', // #3078 — wipe the user's tombstones too
   };
 
   /// Delete every row the user owns across every sync table (GDPR

--- a/lib/core/sync/vehicles_sync.dart
+++ b/lib/core/sync/vehicles_sync.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 
 import '../../features/vehicle/domain/entities/vehicle_profile.dart';
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Per-vehicle profile sync with Supabase (#713), pulled out of
@@ -39,23 +41,34 @@ class VehiclesSync {
     }
 
     try {
-      final serverRows = await client
+      final serverRowsRaw = await client
           .from('vehicles')
           .select('id, data')
           .eq('user_id', userId);
+
+      // #3078 — drop tombstoned rows from BOTH sides so a delete on another
+      // device can't resurrect through the union/re-upload below.
+      final tombstoned = await DeletionsSync.fetchTombstonedIds('vehicles');
+      final serverRows = SyncHelper.removeTombstoned(
+        serverRowsRaw,
+        tombstoned,
+        key: (r) => r.getString('id'),
+      ).toList();
+      final liveLocal =
+          localVehicles.where((v) => !tombstoned.contains(v.id)).toList();
 
       final serverIds = serverRows
           .map((r) => r.getString('id'))
           .whereType<String>()
           .toSet();
-      final localIds = localVehicles.map((v) => v.id).toSet();
+      final localIds = liveLocal.map((v) => v.id).toSet();
 
       debugPrint('VehiclesSync.merge: local=${localIds.length}, '
           'server=${serverIds.length}');
 
       // Upload local-only vehicles.
       final localOnly =
-          localVehicles.where((v) => !serverIds.contains(v.id)).toList();
+          liveLocal.where((v) => !serverIds.contains(v.id)).toList();
       if (localOnly.isNotEmpty) {
         final rows = localOnly
             .map((v) => {
@@ -88,7 +101,7 @@ class VehiclesSync {
         return null;
       }).whereType<VehicleProfile>().toList();
 
-      return [...localVehicles, ...downloaded];
+      return [...liveLocal, ...downloaded];
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'VehiclesSync.merge FAILED'}));
       return localVehicles;
@@ -109,6 +122,7 @@ class VehiclesSync {
           .delete()
           .eq('user_id', userId)
           .eq('id', vehicleId);
+      await DeletionsSync.record('vehicles', vehicleId); // #3078
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'VehiclesSync.delete FAILED'}));
     }

--- a/lib/features/search/providers/ignored_stations_provider.dart
+++ b/lib/features/search/providers/ignored_stations_provider.dart
@@ -41,8 +41,11 @@ class IgnoredStations extends _$IgnoredStations {
     await storage.removeIgnored(stationId);
     state = storage.getIgnoredIds();
 
+    // #3078 — delete (+ tombstone) the server row instead of re-running the
+    // union merge, which used to re-add the still-server id so the station
+    // never actually un-hid across devices.
     await SyncHelper.syncIfEnabled(ref, 'IgnoredStations.remove',
-      () => IgnoredStationsSync.merge(state),
+      () => IgnoredStationsSync.delete(stationId),
     );
   }
 

--- a/lib/features/search/providers/ignored_stations_provider.g.dart
+++ b/lib/features/search/providers/ignored_stations_provider.g.dart
@@ -65,7 +65,7 @@ final class IgnoredStationsProvider
   }
 }
 
-String _$ignoredStationsHash() => r'7f656b4ccdb9b582c0306f0441bf2a97acb67676';
+String _$ignoredStationsHash() => r'81bbc345f0ba18ac669d5001b4def2a4e98bbca7';
 
 /// Manages the user's list of ignored (hidden) station IDs.
 ///

--- a/supabase/migrations/20260609000001_deletion_tombstones.sql
+++ b/supabase/migrations/20260609000001_deletion_tombstones.sql
@@ -1,0 +1,39 @@
+-- #3078 (Epic #3075) — deletion tombstones.
+--
+-- TankSync merges synced entities as `server ∪ local` then upserts. So when
+-- device A deletes a favorite, device B's next sync re-adds it (the union
+-- re-includes the still-local row) and the delete RESURRECTS. A tombstone is
+-- the durable "this id was deliberately deleted" record: on a synced delete
+-- the app inserts a `deletions` row, and before each union the merge filters
+-- the server rows against the user's tombstones — so a deleted id never comes
+-- back, no matter which device still holds a local copy.
+--
+-- Mirrors the wizard SQL (lib/core/sync/schema_sql.dart +
+-- schema_sql_policies.dart). Bumps the recorded schema version to 3 so a
+-- self-hoster who has not re-applied the setup SQL is flagged as outdated
+-- (see SchemaVerifier.isSchemaOutdated). Every statement is idempotent.
+
+CREATE TABLE IF NOT EXISTS public.deletions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  table_name TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, table_name, record_id)
+);
+
+CREATE INDEX IF NOT EXISTS deletions_user_table_idx
+  ON public.deletions(user_id, table_name);
+
+ALTER TABLE public.deletions ENABLE ROW LEVEL SECURITY;
+
+-- A user only ever sees / writes their own tombstones.
+DROP POLICY IF EXISTS deletions_own ON public.deletions;
+CREATE POLICY deletions_own ON public.deletions
+  FOR ALL USING (user_id = auth.uid());
+
+-- Record the new schema version so the verifier can flag outdated self-hosts.
+INSERT INTO public.tanksync_meta (key, value, updated_at)
+  VALUES ('schema_version', '3', now())
+  ON CONFLICT (key)
+  DO UPDATE SET value = EXCLUDED.value, updated_at = now();

--- a/test/core/sync/deletion_tombstones_test.dart
+++ b/test/core/sync/deletion_tombstones_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/schema_sql.dart';
+import 'package:tankstellen/core/sync/schema_sql_policies.dart';
+import 'package:tankstellen/core/sync/schema_verifier.dart';
+import 'package:tankstellen/core/sync/sync_helper.dart';
+
+/// #3078 (Epic #3075) — deletion tombstones so a delete doesn't resurrect.
+///
+/// The union merge re-adds any server row, so a record device A deleted comes
+/// back from device B's still-local copy. The fix is a `deletions` tombstone
+/// table + a shared tombstone-filter that drops the resurrected id from the
+/// **server** set BEFORE the union. These tests pin both the bug-proving merge
+/// seam and the self-host schema parity (HARD RULE #5).
+void main() {
+  group('SyncHelper.removeTombstoned — resurrection prevention (#3078)', () {
+    test('Device A deleted X → Device B merge does NOT re-include X', () {
+      // Device B still holds X locally; the server also still returns X
+      // (the union would re-add it). X is tombstoned (Device A deleted it).
+      const local = ['st-1', 'st-X', 'st-3'];
+      const serverIds = ['st-1', 'st-X', 'st-3'];
+      final tombstoned = {'st-X'};
+
+      // The fix: filter the SERVER rows through the tombstone seam before
+      // the union, so the deleted id can never be re-included.
+      final liveServer = SyncHelper.removeTombstoned(
+        serverIds,
+        tombstoned,
+        key: (id) => id,
+      ).toSet();
+      final merged = {...local.where((id) => !tombstoned.contains(id)),
+                      ...liveServer};
+
+      expect(merged, isNot(contains('st-X')),
+          reason: 'the tombstoned id resurrected through the union merge');
+      expect(merged, containsAll(<String>['st-1', 'st-3']));
+    });
+
+    test('an empty tombstone set is a pass-through (no behaviour change)', () {
+      const serverIds = ['a', 'b', 'c'];
+      final result =
+          SyncHelper.removeTombstoned(serverIds, <String>{}, key: (id) => id)
+              .toList();
+      expect(result, equals(serverIds));
+    });
+
+    test('filters keyed objects, not just bare id strings', () {
+      final rows = [
+        {'id': 'keep'},
+        {'id': 'gone'},
+      ];
+      final result = SyncHelper.removeTombstoned(
+        rows,
+        {'gone'},
+        key: (r) => r['id'],
+      ).toList();
+      expect(result, hasLength(1));
+      expect(result.single['id'], 'keep');
+    });
+  });
+
+  group('deletions table self-host schema parity (HARD RULE #5)', () {
+    test('the deletions table is a probed (optional) verifier table', () {
+      expect(SchemaVerifier.allTables, contains('deletions'));
+    });
+
+    test('schema_sql.tableSql defines an idempotent deletions table', () {
+      expect(tableSql.keys, contains('deletions'));
+      final block = tableSql['deletions']!;
+      expect(block, contains('CREATE TABLE IF NOT EXISTS public.deletions'));
+      expect(block, contains('table_name'));
+      expect(block, contains('record_id'));
+      expect(block, contains('UNIQUE(user_id, table_name, record_id)'));
+    });
+
+    test('wizard SQL creates the table, enables RLS and an own-row policy', () {
+      final sql = SchemaVerifier.getMigrationSql(const {});
+      expect(sql, contains('CREATE TABLE IF NOT EXISTS public.deletions'));
+      expect(
+          sql, contains('ALTER TABLE public.deletions ENABLE ROW LEVEL SECURITY'));
+      expect(rlsSql, contains('CREATE POLICY deletions_own ON public.deletions'));
+      expect(rlsSql, contains('USING (user_id = auth.uid())'));
+    });
+
+    test('the schema version was bumped past the pre-#3078 value', () {
+      // The deletions table is a new schema object self-hosters must re-apply.
+      expect(kSupabaseSchemaVersion, greaterThanOrEqualTo(3));
+    });
+  });
+}

--- a/test/core/sync/deletions_sync_test.dart
+++ b/test/core/sync/deletions_sync_test.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/deletions_sync.dart';
+
+/// Fault-path contract for [DeletionsSync] (#3078).
+///
+/// `DeletionsSync.record` documents "sync must never throw back into the
+/// caller" — the local delete already happened, so a sync hiccup must be
+/// swallowed silently. With no Supabase client initialised, every method takes
+/// the fault path (no auth / no client); these assertions pin that it returns
+/// normally rather than throwing, satisfying the #2349 never-throws ratchet.
+void main() {
+  group('DeletionsSync never-throws fault path (#3078)', () {
+    test('record completes silently when the client is uninitialised', () {
+      expectLater(DeletionsSync.record('favorites', 'st-X'), completes);
+    });
+
+    test('recordAll completes silently on the fault path', () {
+      expectLater(
+        DeletionsSync.recordAll('fill_ups', const ['a', 'b']),
+        completes,
+      );
+    });
+
+    test('recordAll on an empty list returns normally (no round-trip)', () {
+      expect(
+        () => DeletionsSync.recordAll('vehicles', const <String>[]),
+        returnsNormally,
+      );
+    });
+
+    test('fetchTombstonedIds returns an empty set instead of throwing', () async {
+      expect(await DeletionsSync.fetchTombstonedIds('itineraries'), isEmpty);
+    });
+  });
+}

--- a/test/core/sync/schema_verifier_completeness_test.dart
+++ b/test/core/sync/schema_verifier_completeness_test.dart
@@ -44,6 +44,7 @@ void main() {
     'trip_summaries',
     'trip_details',
     'trip_shares',
+    'deletions',
   };
 
   // Tables read only by server-side SQL (functions / triggers / RPCs), never

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -61,6 +61,13 @@ void main() {
     // provider seams; this is the (compacted) launch glue. Decomposition
     // of this god-file is tracked separately.
     'lib/app/app_initializer.dart': 1028,
+    // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
+    // deletion-tombstone fix threads a tombstoned-id set through `merge` and
+    // `mergeRows` (fetch + dual-side filter so a delete on another device
+    // doesn't resurrect) plus the `deleteSummary` tombstone write — a real
+    // fix, not boilerplate. Decomposition of this near-cap file is its own
+    // future task.
+    'lib/core/sync/trips_sync.dart': 414,
     // #2415 — background_service.dart graduated: the scan body moved into
     // BackgroundAlertScanCoordinator + BackgroundScanRunners +
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246


### PR DESCRIPTION
## What & why

Closes #3078 (part of Epic #3075).

TankSync merges synced entities as `server ∪ local` then upserts, so a record
one device deleted came back from another device's still-local copy through the
union — the delete **resurrected**. This adds a `deletions` tombstone table plus
a shared tombstone-filter seam so a deleted id is never re-included again.

## Changes

- **`DeletionsSync`** (new) — `record` / `recordAll` / `fetchTombstonedIds` over
  the new `deletions` table (one row per `(user_id, table_name, record_id)`,
  idempotent upsert).
- **`SyncHelper.removeTombstoned`** (new) — a pure, unit-testable seam that every
  union-merge runs its **server** rows through before the union.
- Wired tombstone-write on each synced delete and tombstone-filter on each merge
  / fetch (dropping tombstoned ids from **both** sides): `favorites`,
  `ignored_stations`, `station_ratings`, `fill_ups`, `vehicles`,
  `obd2_baselines`, `itineraries`, `trip_summaries`.
  - `ignored_stations` additionally gained a real server `delete()` — the
    un-ignore path used to only re-run the resurrecting union merge, so an
    un-ignored station never actually un-hid across devices.
  - The GDPR "forget me" wipe also clears the user's tombstones.

## HARD RULE #5 — self-host (TankSync) schema parity

The `deletions` table is added to `schema_sql.dart`, `schema_sql_policies.dart`
(own-row RLS `user_id = auth.uid()`), `schema_verifier.dart` (`optionalTables`),
a new timestamped migration (`supabase/migrations/20260609000001_deletion_tombstones.sql`),
and **`kSupabaseSchemaVersion` bumped 2 → 3** so an outdated self-host schema is
flagged. The #2929 completeness drift-guard stays green.

## Tests

- `deletion_tombstones_test.dart` reproduces the resurrection bug at the merge
  seam (RED on master — the symbols + schema don't exist) and pins the self-host
  schema parity.
- `deletions_sync_test.dart` — fault-path / never-throws contract (#2349).
- `trips_sync.dart` grandfathered 400 → 414 (the dual-side tombstone threading
  through `merge` / `mergeRows`).

`flutter analyze` clean; full `test/core/sync` + lint + l10n gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
