### PR TITLE
fix(ios): radar no longer freezes + BLE cold-connect gets a 7s budget

### DIFF
--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -73,6 +73,29 @@ final bool kGpsRecordingForegroundServiceEnabled = false;
 /// cancels on the last), so the wakelock + 1 s cadence apply only while a
 /// trip is actively recording. The interval is a self-bounded 1000 ms with
 /// `distanceFilter: 0` — never geolocator's unbounded "fastest".
+///
+/// #3112 — [approachLocationSettings] is the radar/approach-detector sibling:
+/// not foreground-service-promoted and no l10n, but it MUST still pass iOS the
+/// `pauseLocationUpdatesAutomatically: false` flag — a bare `LocationSettings`
+/// lets iOS CoreLocation auto-pause the stream when it thinks the user stopped
+/// (red light / fuel stop), freezing the radar after its first scan ("radar
+/// stuck on iPhone"). Android's bare high-accuracy stream does not auto-pause,
+/// so it is left unchanged. `automotiveNavigation` + `allowBackgroundLocationUpdates`
+/// mirror the recorder so the #2065 PiP approach keeps receiving fixes.
+LocationSettings approachLocationSettings({TargetPlatform? platform}) {
+  switch (platform ?? defaultTargetPlatform) {
+    case TargetPlatform.iOS:
+      return AppleSettings(
+        accuracy: LocationAccuracy.high,
+        activityType: ActivityType.automotiveNavigation,
+        allowBackgroundLocationUpdates: true,
+        pauseLocationUpdatesAutomatically: false,
+      );
+    default:
+      return const LocationSettings(accuracy: LocationAccuracy.high);
+  }
+}
+
 LocationSettings recordingLocationSettings({
   required AppLocalizations l10n,
   TargetPlatform? platform,

--- a/lib/features/approach/providers/approach_state_provider.dart
+++ b/lib/features/approach/providers/approach_state_provider.dart
@@ -3,10 +3,11 @@
 
 import 'dart:async';
 
-import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/location/recording_location_settings.dart'
+    show approachLocationSettings;
 import '../../../core/logging/error_logger.dart';
 import '../../../core/services/approach_detector.dart';
 import '../../consumption/providers/trip_recording_provider.dart';
@@ -77,9 +78,11 @@ Stream<ApproachState> approachState(Ref ref) {
     // detector already treats its input as a hot/late-join stream — the shared
     // source replays the latest fix to late joiners, so no detector change.
     gpsStream: geo.sharedPositionStream(
-      locationSettings: const LocationSettings(
-        accuracy: LocationAccuracy.high,
-      ),
+      // #3112 — iOS needs AppleSettings(pauseLocationUpdatesAutomatically:
+      // false) or CoreLocation auto-pauses the stream when it thinks the user
+      // stopped, freezing the radar after its first scan. Android keeps the
+      // bare high-accuracy settings (unchanged).
+      locationSettings: approachLocationSettings(),
     ),
     fetchStations: (lat, lng, radiusKm, fuelTypeApiValue) async {
       try {

--- a/lib/features/approach/providers/approach_state_provider.g.dart
+++ b/lib/features/approach/providers/approach_state_provider.g.dart
@@ -116,4 +116,4 @@ final class ApproachStateProvider
   }
 }
 
-String _$approachStateHash() => r'f52e878832ee20a86c94a924541ab83226f1d55b';
+String _$approachStateHash() => r'792a385d710be2573628d53ad43690689eb5ec05';

--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -39,9 +39,19 @@ part of 'obd2_connection_service.dart';
 Future<Obd2Service?> _connectByMacDirect(
   Obd2ConnectionService svc,
   String mac, {
-  Duration timeout = const Duration(seconds: 4),
+  Duration? timeout,
   bool fallbackToScan = true,
 }) async {
+  // #3113 — a cold iOS CoreBluetooth GATT connect to an ELM clone (OBDLink CX)
+  // routinely exceeds Android's 4s, so a live adapter was clipped mid-connect
+  // ("Timed out after 4s"). Give iOS a 7s budget; Android keeps the
+  // LOAD-BEARING 4s (#2242: autoConnect:false blocks ~35s on a sleeping
+  // adapter, so the bound must stay tight there). The scan-resolved path
+  // already uses 10s — only this direct path was too tight.
+  final connectTimeout = timeout ??
+      (defaultTargetPlatform == TargetPlatform.iOS
+          ? const Duration(seconds: 7)
+          : const Duration(seconds: 4));
   // #2906 — stop any active scan + settle before the direct GATT open. An
   // in-trip reconnect can reach here while the scanner's last active scan is
   // still winding down on the radio; an unstopped scan racing this connect()
@@ -60,7 +70,8 @@ Future<Obd2Service?> _connectByMacDirect(
   // wrong-transport attempt (a BLE direct connect against a Classic adapter)
   // shows resolvedTransport:ble in the trace.
   Obd2ConnectTraceLog.active?.setResolvedTransport(Obd2ConnectTransport.ble);
-  final channel = svc.bluetooth.channelForDirect(mac, connectTimeout: timeout);
+  final channel =
+      svc.bluetooth.channelForDirect(mac, connectTimeout: connectTimeout);
   svc._lastDirectChannel = channel;
   try {
     return await svc._openAndInit(

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -511,7 +511,10 @@ class Obd2ConnectionService {
   /// any scan fallback (first-wins).
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    // #3113 — null ⇒ the platform-aware cold-connect budget computed in
+    // [_connectByMacDirect] (iOS 7s / Android 4s). A caller may still pin an
+    // explicit timeout.
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) =>

--- a/test/core/location/recording_location_settings_test.dart
+++ b/test/core/location/recording_location_settings_test.dart
@@ -89,4 +89,37 @@ void main() {
       expect(settings.accuracy, LocationAccuracy.high);
     });
   });
+
+  group('approachLocationSettings (#3112) — radar / approach detector', () {
+    test('iOS → AppleSettings with pauseLocationUpdatesAutomatically:false '
+        '(or CoreLocation auto-pauses and the radar freezes)', () {
+      final settings = approachLocationSettings(platform: TargetPlatform.iOS);
+      expect(settings, isA<AppleSettings>());
+      final apple = settings as AppleSettings;
+      expect(apple.accuracy, LocationAccuracy.high);
+      expect(apple.activityType, ActivityType.automotiveNavigation);
+      expect(apple.pauseLocationUpdatesAutomatically, isFalse,
+          reason: 'the load-bearing flag: a fuel stop / red light must not '
+              'auto-pause the radar GPS stream on iPhone');
+      expect(apple.allowBackgroundLocationUpdates, isTrue);
+    });
+
+    test('Android → plain high-accuracy LocationSettings, UNCHANGED (no '
+        'AppleSettings, no prod-Android behaviour change)', () {
+      final settings =
+          approachLocationSettings(platform: TargetPlatform.android);
+      expect(settings, isA<LocationSettings>());
+      expect(settings, isNot(isA<AppleSettings>()));
+      expect(settings, isNot(isA<AndroidSettings>()));
+      expect(settings.accuracy, LocationAccuracy.high);
+    });
+
+    test('selection follows debugDefaultTargetPlatformOverride', () {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(approachLocationSettings(), isA<AppleSettings>());
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(approachLocationSettings(), isNot(isA<AppleSettings>()));
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/obd2_connect_by_mac_transport_aware_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connect_by_mac_transport_aware_test.dart
@@ -224,7 +224,7 @@ class _RecordingConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/consumption/data/obd2/obd2_connect_transient_denoise_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connect_transient_denoise_test.dart
@@ -170,7 +170,7 @@ class _ThrowingConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -4,6 +4,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
@@ -369,8 +371,10 @@ void main() {
       await ready.disconnect();
     });
 
-    test('passes a 4 s connect timeout to the facade by default',
+    test('Android → a 4 s cold direct-connect timeout (LOAD-BEARING, #2242)',
         () async {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final fake = _FakeFacade(
         batches: const [[]],
         directChannel: _FakeChannel(respondTo: _elmOkResponses()),
@@ -379,6 +383,21 @@ void main() {
 
       final ready = await svc.connectByMacDirect('aa:bb');
       expect(fake.directTimeout, const Duration(seconds: 4));
+      await ready!.disconnect();
+    });
+
+    test('#3113 — iOS → a 7 s cold direct-connect timeout (a cold CoreBluetooth '
+        'GATT connect to an ELM clone exceeds 4s)', () async {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final fake = _FakeFacade(
+        batches: const [[]],
+        directChannel: _FakeChannel(respondTo: _elmOkResponses()),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+      expect(fake.directTimeout, const Duration(seconds: 7));
       await ready!.disconnect();
     });
 

--- a/test/features/consumption/data/obd2/obd2_self_test_driver_test.dart
+++ b/test/features/consumption/data/obd2/obd2_self_test_driver_test.dart
@@ -505,7 +505,7 @@ class _FakeConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
@@ -916,7 +916,7 @@ class _ReconnectingFakeConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -142,7 +142,7 @@ class _RecordingFakeConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/consumption/providers/obd2_self_test_controller_test.dart
+++ b/test/features/consumption/providers/obd2_self_test_controller_test.dart
@@ -245,7 +245,7 @@ class _FakeConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) async {

--- a/test/features/profile/presentation/screens/developer_tools/obd2_self_test_screen_test.dart
+++ b/test/features/profile/presentation/screens/developer_tools/obd2_self_test_screen_test.dart
@@ -235,7 +235,7 @@ class _FakeConnection extends Obd2ConnectionService {
   @override
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
-    Duration timeout = const Duration(seconds: 4),
+    Duration? timeout,
     bool fallbackToScan = true,
     String? adapterName,
   }) {

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -170,8 +170,10 @@ void main() {
     // guard. Decomposition still tracked under #2187/#2188.
     // #3103 — 674 → 694: the `supportsClassicDiscovery` getter + the
     // Android-only Classic-facade platform gate at the provider seam (+ their
-    // rationale comments). Decomposition still tracked under #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 694,
+    // rationale comments). #3113 — 694 → 697: connectByMacDirect's timeout made
+    // nullable so iOS gets a 7s cold-connect budget (+ rationale comment).
+    // Decomposition still tracked under #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 697,
     // #2969 — grandfathered at 419 (was ~399, right at the cap on master). The
     // scan-path BLE `connect()` timeout bound (FBP could otherwise block ~35 s
     // on a vanished candidate) + the channel-open connect-trace stamp (the one


### PR DESCRIPTION
Two iOS-only platform-divergence fixes from the field report (radar stuck on iPhone + Bluetooth not connecting). Both leave **Android byte-identical** (no production-Android risk).

## #3112 — radar 'stuck on iPhone'
Answering the user's question directly: the radar is **NOT a redundant implementation** — it's one shared `ApproachDetector`. The bug is the GPS layer: the detector opened the stream with a bare `LocationSettings(accuracy:high)`, which iOS CoreLocation **auto-pauses** when it thinks the user stopped (red light / fuel stop) → the radar finds stations once then freezes. New `approachLocationSettings()`: iOS → `AppleSettings(pauseLocationUpdatesAutomatically:false + automotiveNavigation + background updates)` (the same recipe the trip recorder already uses); Android → the current bare settings, unchanged.

## #3113 — OBDLink CX BLE `gattTimeout`
The OBDLink CX is a **BLE** adapter (iOS-capable), but the direct-by-MAC connect hardcoded a **4s** timeout; a cold iOS CoreBluetooth GATT connect to an ELM clone routinely exceeds 4s → `FlutterBluePlusException 'Timed out after 4s'`. Made the cold direct-connect budget platform-aware: **iOS 7s / Android 4s** (Android keeps the LOAD-BEARING tight bound — #2242). The scan-resolved path already used 10s; only the direct path was too tight.

## Not in this PR (stale build / deferred)
- The `[storage] MissingPluginException` spam is the Classic-facade-on-iOS already gated by **#3107** — the user just needs the latest beta.
- A deeper iOS BLE identity nuance (CoreBluetooth UUID vs MAC at `bluetooth_facade.dart:267`) is **deferred pending on-device verification** — it touches production-Android identity storage, so the right order is: ship this timeout bump, retest the OBDLink CX, and only do the identity change if it still fails.

## Tests
`approachLocationSettings` (iOS AppleSettings/no-auto-pause; Android unchanged; override-driven); `connectByMacDirect` iOS→7s / Android→4s (the existing 4s test made platform-deterministic). Updated 7 fake `Obd2ConnectionService` overrides for the nullable timeout. analyze clean, file-length snapshot bumped, codegen drift committed.

Closes #3112
Closes #3113

🤖 Generated with [Claude Code](https://claude.com/claude-code)