### PR TITLE
fix(location): faster first GPS fix so search+radar work on older iPhones (#3116)

### DIFF
--- a/lib/core/location/location_service.dart
+++ b/lib/core/location/location_service.dart
@@ -47,9 +47,16 @@ class LocationService {
     }
 
     final position = await _geolocator.getCurrentPosition(
+      // #3116 — a cold high-accuracy GPS lock on older hardware (iPhone 8 / A11)
+      // routinely exceeds 10s — it waits for a satellite fix — so search AND
+      // radar (both route through here) timed out and died on the 8 while the
+      // A15 iPhone 13 cleared it in 5-8s. Use `medium` so the FIRST fix is
+      // cell/wifi-assisted and locks near-instantly on every device (~100m is
+      // ample for km-scale station search + road-snapped route starts), and
+      // give a genuinely slow lock a 30s safety net instead of 10s.
       locationSettings: const LocationSettings(
-        accuracy: LocationAccuracy.high,
-        timeLimit: Duration(seconds: 10),
+        accuracy: LocationAccuracy.medium,
+        timeLimit: Duration(seconds: 30),
       ),
     );
 

--- a/test/core/location/location_service_test.dart
+++ b/test/core/location/location_service_test.dart
@@ -25,10 +25,14 @@ class _FakeGeolocator extends GeolocatorWrapper {
   Future<LocationPermission> requestPermission() async =>
       requestResult ?? permission;
 
+  /// #3116 — captured so the test can assert the acquisition profile.
+  LocationSettings? lastLocationSettings;
+
   @override
   Future<Position> getCurrentPosition({
     LocationSettings? locationSettings,
   }) async {
+    lastLocationSettings = locationSettings;
     if (positionToReturn != null) return positionToReturn!;
     return Position(
       latitude: 52.52,
@@ -58,6 +62,17 @@ void main() {
     setUp(() {
       fakeGeolocator = _FakeGeolocator();
       service = LocationService(fakeGeolocator);
+    });
+
+    test(
+        '#3116 — first fix uses medium accuracy + a 30s safety net (a cold '
+        'high-accuracy A11/iPhone-8 lock blew the old 10s window, killing '
+        'search + radar)', () async {
+      await service.getCurrentPosition();
+      final settings = fakeGeolocator.lastLocationSettings;
+      expect(settings, isNotNull);
+      expect(settings!.accuracy, LocationAccuracy.medium);
+      expect(settings.timeLimit, const Duration(seconds: 30));
     });
 
     test('returns position when permission granted', () async {


### PR DESCRIPTION
## Symptom
Search **and** radar both fail completely on an **iPhone 8 (A11)** while working on an **iPhone 13 (A15)** — same build.

## Root cause (one shared chokepoint)
Both features get the user position via `LocationService.getCurrentPosition()`, which requested `LocationSettings(accuracy: high, timeLimit: 10s)`. A **cold high-accuracy GPS lock on older hardware waits for a satellite fix and routinely exceeds 10s**, so the one-shot times out → both die. The A15 clears it in 5–8s. Hardware-sensitive in exactly the 8-vs-13 direction; predates today's work.

## Fix
First fix now uses **`medium` accuracy** (cell/wifi-assisted, near-instant cold lock on every device; ~100 m is ample for km-scale station search + road-snapped route starts) with a **30 s** safety-net timeout instead of 10 s.

## #3112 exonerated
That change only touches the separate in-trip `ApproachDetector` stream; search and the search-radar use this one-shot `getCurrentPosition`, never `approachLocationSettings`. Confirmed by call-graph in the investigation — the timing was coincidental.

## Test
`location_service_test` now asserts the first fix uses `medium` + 30 s (fake captures the settings). analyze clean; no codegen/ARB.

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)