### PR TITLE
fix(ios): widen post-connect setNotify/discover timeouts so the OBDLink CX connects (#3118)

### DIFF
--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -63,11 +63,33 @@ class FlutterBluePlusElmChannel
   /// 15 s; a hung discovery (a clone whose GATT table never resolves) used to
   /// freeze the whole open for 15 s and read as a hang. A miss now fails in
   /// ~5 s with a distinct `gattTimeout` outcome.
-  static const Duration _discoverTimeout = Duration(seconds: 5);
+  /// #3118 — iOS-aware. iOS CoreBluetooth's `discoverServices` is slower than
+  /// Android's, so the OBDLink CX's GATT-table resolution can blow Android's
+  /// tight 5 s on a cold iPhone connect. Android keeps 5 s (byte-identical).
+  static Duration get _discoverTimeout =>
+      defaultTargetPlatform == TargetPlatform.iOS
+          ? const Duration(seconds: 8)
+          : const Duration(seconds: 5);
 
   /// #3014 — bound `setNotifyValue`, for the same reason: a clone that accepts
   /// the descriptor write but never ACKs would otherwise block 15 s.
-  static const Duration _setNotifyTimeout = Duration(seconds: 4);
+  ///
+  /// #3118 — iOS-aware. THIS is the OBDLink CX failure on iPhone
+  /// (`TimeoutException after 0:00:04 — Future not completed`): the post-connect
+  /// CCCD descriptor write (enabling notifications) is slower over iOS
+  /// CoreBluetooth than Android's 4 s. #3113 only widened the `connect()` budget
+  /// (iOS 7 s); this very next step still clipped at 4 s. iOS gets 7 s; Android
+  /// keeps 4 s (byte-identical — the #2242/#3014 tight bound stays load-bearing).
+  static Duration get _setNotifyTimeout =>
+      defaultTargetPlatform == TargetPlatform.iOS
+          ? const Duration(seconds: 7)
+          : const Duration(seconds: 4);
+
+  /// #3118 — test seams to lock the iOS-aware post-connect budgets.
+  @visibleForTesting
+  static Duration get debugDiscoverTimeout => _discoverTimeout;
+  @visibleForTesting
+  static Duration get debugSetNotifyTimeout => _setNotifyTimeout;
 
   /// #3014 — best-effort MTU asked for during the bounded-connect path. Clones
   /// often reject it; the post-discovery `requestMtu` in [tuneForRecording]

--- a/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
@@ -158,6 +160,27 @@ void main() {
       expect(ch.refreshGattCache(), completes,
           reason: 'a throwing clearGattCache must be swallowed so the '
               'GATT-133 retry proceeds and the real error is preserved');
+    });
+  });
+
+  group('#3118 — post-connect timeouts are iOS-aware', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('iOS gets longer setNotify + discover budgets (slow CoreBluetooth) — '
+        'the OBDLink CX 4s setNotify TimeoutException fix', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(FlutterBluePlusElmChannel.debugSetNotifyTimeout,
+          const Duration(seconds: 7));
+      expect(FlutterBluePlusElmChannel.debugDiscoverTimeout,
+          const Duration(seconds: 8));
+    });
+
+    test('Android keeps the tight load-bearing budgets (#2242/#3014)', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(FlutterBluePlusElmChannel.debugSetNotifyTimeout,
+          const Duration(seconds: 4));
+      expect(FlutterBluePlusElmChannel.debugDiscoverTimeout,
+          const Duration(seconds: 5));
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -200,7 +200,11 @@ void main() {
     // rather than waiting for the next failed command. The drop edge already
     // lives here (it cannot leave this cohesive channel body), so the signal is
     // a few additive lines on it, not a new file.
-    'lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart': 678,
+    // #3118 — 678 → 700: the post-connect discover + setNotify timeouts made
+    // iOS-aware (const → platform-branching getters + dartdoc) so a slow iOS
+    // CoreBluetooth CCCD write no longer clips the OBDLink CX at 4s, plus two
+    // @visibleForTesting accessors to lock the budgets. Android byte-identical.
+    'lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart': 700,
     // #2953 — grandfathered at 405 (5 over): the _probeSafely / _connectSafely
     // catches were rerouted from a raw `errorLogger.log` ERROR spool to the
     // shared `recordObd2ConnectTransient` de-noiser (a parked-car engine-off


### PR DESCRIPTION
## Symptom (iOS, OBDLink CX — a BLE adapter)
OBD2 fails on both self-test and route recording with `TimeoutException after 0:00:04.000000 — Future not completed`; recording stalls at 'Connecting to OBD2 adapter…'.

## Root cause
Scan finds the CX and resolves it correctly (profile UUIDs are right). The failure is the **post-connect CCCD write** that enables notifications — `flutter_blue_plus_elm_channel.dart:435` `setNotifyValue(true).timeout(_setNotifyTimeout)` bounded by a hardcoded **4s** (line 70). iOS CoreBluetooth's descriptor write to the CX is slower than 4s → that exact Dart `TimeoutException`. **#3113 only widened `device.connect()` (iOS 7s); this very next step still clipped at 4s.**

## Fix
`_setNotifyTimeout` → iOS 7s / Android 4s, and `_discoverTimeout` → iOS 8s / Android 5s (belt-and-braces; CoreBluetooth's discover is also slower). Android **byte-identical** (the `TargetPlatform.iOS` guard keeps the #2242/#3014 tight load-bearing bounds). Test seams lock both platform budgets.

Closes #3118

🤖 Generated with [Claude Code](https://claude.com/claude-code)