### PR TITLE
fix(obd2): connection-reliability root-cause wave 1 — zombie retry channel, poweredOn gate, native timeouts, CX profile, Classic drop visibility

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -107,6 +107,11 @@ object Obd2ClassicPlugin {
                     disconnect()
                     result.success(true)
                 }
+                // #3183 — the Dart-side permission flow needs the REAL SDK
+                // level (it hard-coded 33 before, making the <31 legacy
+                // location-permission branch unreachable). Reuse this channel
+                // instead of pulling in device_info_plus.
+                "sdkInt" -> result.success(android.os.Build.VERSION.SDK_INT)
                 else -> result.notImplemented()
             }
         } catch (e: Exception) {
@@ -261,23 +266,51 @@ object Obd2ClassicPlugin {
         readerThread = thread(name = "obd2-classic-read") {
             val s = socket ?: return@thread
             val buffer = ByteArray(256)
+            var endedByEof = false
             try {
                 val input = s.inputStream
                 while (readerRunning.get()) {
                     val n = input.read(buffer)
-                    if (n < 0) break
+                    if (n < 0) {
+                        // #3183 — a clean remote EOF is a DROP (the adapter
+                        // closed the socket): signalled below so the Dart
+                        // onDone fires, instead of the thread dying silently.
+                        endedByEof = true
+                        break
+                    }
                     if (n == 0) continue
                     val slice = buffer.copyOfRange(0, n).toList()
-                    val sink = eventSink
-                    if (sink != null) {
-                        android.os.Handler(android.os.Looper.getMainLooper()).post {
-                            sink.success(slice)
-                        }
-                    }
+                    postToSink { sink -> sink.success(slice) }
                 }
             } catch (e: IOException) {
                 Log.w(TAG, "reader: $e")
+                // #3183 — the reader exiting on IOException was INVISIBLE to
+                // Dart (sink.success was the only sink call in this file), so
+                // ClassicElmChannel's onError never fired and a mid-session
+                // Classic drop was discovered only lazily on the next write.
+                // A DELIBERATE teardown (disconnect() flips readerRunning
+                // false, then closes the socket, which interrupts read() with
+                // an IOException) is NOT a drop — stay silent for it.
+                if (readerRunning.get()) {
+                    postToSink { sink ->
+                        sink.error("io", e.message ?: "read failed", null)
+                    }
+                }
+                return@thread
             }
+            if (endedByEof) {
+                postToSink { sink -> sink.endOfStream() }
+            }
+        }
+    }
+
+    /** #3183 — deliver one sink callback on the MAIN thread (EventChannel
+     *  sinks must only be touched from the platform thread). No-op when no
+     *  Dart listener is attached. */
+    private fun postToSink(block: (EventChannel.EventSink) -> Unit) {
+        val sink = eventSink ?: return
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            block(sink)
         }
     }
 
@@ -297,9 +330,18 @@ object Obd2ClassicPlugin {
 
     private fun disconnect() {
         readerRunning.set(false)
+        val hadConnection = socket != null
         try { socket?.close() } catch (_: IOException) {}
         socket = null
         readerThread = null
+        // #3183 — end the Dart-side byte stream on a deliberate teardown too,
+        // in case a listener is still attached (the normal Dart close()
+        // cancels its subscription first, making this a no-op). Guarded so
+        // the pre-connect "ensure any prior socket is closed" call never
+        // signals when there was nothing to tear down.
+        if (hadConnection) {
+            postToSink { sink -> sink.endOfStream() }
+        }
     }
 
     private fun adapterOrNull(context: Context): BluetoothAdapter? {

--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -413,12 +413,16 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
   ),
   // OBDLink CX — Scantool's newest STN-chip BLE adapter, CAN-FD
   // capable, popular with BMW owners (#1641).
+  // #3180 — the CX does NOT use the MX+/LX 18F0/2AF1/2AF0 layout it was
+  // originally pinned to: the vendor-documented CX GATT profile is service
+  // FFF0 with notify FFF1 / write FFF2 (the Nordic-UART-style family). The
+  // wrong hint made the exact-UUID first-priority match miss on every CX.
   Obd2AdapterProfile(
     id: 'obdlink-cx',
     displayName: 'OBDLink CX',
-    serviceUuid: '000018f0-0000-1000-8000-00805f9b34fb',
-    writeCharUuid: '00002af1-0000-1000-8000-00805f9b34fb',
-    notifyCharUuid: '00002af0-0000-1000-8000-00805f9b34fb',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
     nameMatchers: ['obdlink cx'],
   ),
   // Carista OBD2 — Nordic UART like vLinker but advertises as

--- a/lib/features/consumption/data/obd2/ble_adapter_state_gate.dart
+++ b/lib/features/consumption/data/obd2/ble_adapter_state_gate.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+/// #3182 — bounded wait for the Bluetooth adapter to report `poweredOn`
+/// before the FIRST scan / connect is dispatched.
+///
+/// FBP's darwin side creates the `CBCentralManager` LAZILY in the first
+/// method call and immediately rejects a scan/connect issued while the
+/// manager still reports state `unknown` ("bluetooth must be turned on.
+/// (unknown)") — i.e. the very first BLE action after a cold app launch
+/// failed spuriously even though the radio was on. Waiting (bounded) for
+/// `adapterState == on` lets CoreBluetooth finish powering the manager up.
+///
+/// Best-effort by contract:
+///   * a genuinely-off adapter never emits `on`, so the wait times out and
+///     the caller FALLS THROUGH to the existing dispatch — whose rejection
+///     still maps to the proper typed [Obd2BluetoothOff];
+///   * any probe failure (platform channel quirk) is logged and swallowed —
+///     the gate must never block or fail a scan/connect on its own.
+///
+/// [states] is injectable for tests (`FlutterBluePlus.adapterState` is a
+/// static and unfakeable otherwise).
+Future<void> waitForAdapterOn({
+  Stream<BluetoothAdapterState>? states,
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  try {
+    await (states ?? FlutterBluePlus.adapterState)
+        .where((s) => s == BluetoothAdapterState.on)
+        .first
+        .timeout(timeout);
+  } on TimeoutException {
+    // Adapter never reported `on` within the budget — either genuinely off
+    // (the caller's dispatch surfaces the typed Obd2BluetoothOff) or a slow
+    // platform; either way the caller proceeds.
+  } catch (_) {
+    // Best-effort gate: a failing adapterState probe — a platform-channel
+    // quirk, a missing plugin in a test harness, or the state stream ending
+    // without an `on` (StateError from `.first`) — must never block or fail
+    // the scan/connect that follows; the dispatch's own error mapping owns
+    // surfacing real conditions.
+  }
+}

--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'adapter_registry.dart';
+import 'ble_adapter_state_gate.dart';
 import 'elm_byte_channel.dart';
 import 'flutter_blue_plus_elm_channel.dart';
 import 'obd2_connection_errors.dart';
@@ -74,11 +75,19 @@ class PluginBluetoothFacade implements BluetoothFacade {
     // onError. Route the rejection back through the controller so
     // the picker / VIN reader sees a typed `Obd2BluetoothOff` (or
     // the original plugin exception for any unrelated failure).
+    // #3182 — wait (bounded) for `adapterState == on` BEFORE dispatching the
+    // scan. FBP's darwin side creates the CBCentralManager lazily in the
+    // first method call and instantly rejects a scan issued while it still
+    // reports `unknown` — the first post-launch scan failed spuriously on
+    // iOS. On timeout the scan is dispatched anyway, so a genuinely-off
+    // adapter still surfaces the typed Obd2BluetoothOff via the mapping below.
     unawaited(
-      FlutterBluePlus.startScan(
-        withServices: serviceUuids.map(Guid.new).toList(),
-        timeout: timeout,
-      ).catchError((Object e, StackTrace st) {
+      waitForAdapterOn()
+          .then((_) => FlutterBluePlus.startScan(
+                withServices: serviceUuids.map(Guid.new).toList(),
+                timeout: timeout,
+              ))
+          .catchError((Object e, StackTrace st) {
         if (controller.isClosed) return;
         final mapped = _mapBluetoothError(e);
         controller.addError(mapped, st);
@@ -274,6 +283,10 @@ class PluginBluetoothFacade implements BluetoothFacade {
     );
 
     try {
+      // #3182 — same lazy-CBCentralManager gate as [scan]: the seed scan is
+      // often the FIRST BLE call of the session (the direct-by-MAC reconnect
+      // path), so it must not be rejected with state `unknown` on iOS.
+      await waitForAdapterOn();
       // withRemoteIds filters the scan to just this MAC (Android: 48-bit MAC,
       // iOS: 128-bit GUID) so the OS surfaces a fresh handle quickly without
       // sweeping the whole BLE neighbourhood.

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -227,6 +227,12 @@ class ClassicElmChannel implements ElmByteChannel {
       await _plugin.write(bytes);
     } catch (e, st) {
       _open = false;
+      // #3183 — the LAZY drop-discovery path: a drop noticed on write (no
+      // reader error/done edge fired, or the native side never surfaced one)
+      // must ALSO emit the #3019 proactive link-drop signal, or the
+      // trip-independent reconnect controller stays asleep until the next
+      // write that never comes. The reader onError/onDone paths already do.
+      _signalDrop();
       debugPrint('ClassicElmChannel: write failed — reclassifying as a '
           'recoverable disconnect (#2671): $e\n$st');
       throw const Obd2DisconnectedException(

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -34,7 +34,14 @@ class ClassicElmChannel implements ElmByteChannel {
   final Obd2ClassicMethodChannel _plugin;
 
   StreamSubscription<List<int>>? _subscription;
-  final StreamController<List<int>> _incoming =
+
+  /// #3179 — NOT final: [close] closes the broadcast controller, and the
+  /// transport's open-retry loop (plus any reconnect) calls `close()` +
+  /// `open()` on the SAME channel instance, so [open] must be able to
+  /// recreate it. With a `final` controller the "recovered" link was a
+  /// zombie: every socket byte hit the #2953 `isClosed` guard and was
+  /// silently dropped, so every reply timed out.
+  StreamController<List<int>> _incoming =
       StreamController<List<int>>.broadcast();
   bool _open = false;
 
@@ -64,6 +71,18 @@ class ClassicElmChannel implements ElmByteChannel {
   @override
   Future<void> open() async {
     if (_open) return;
+    // #3179 — make the channel safely RE-openable. The transport's open-retry
+    // loop (#2906) and the reconnect path call close() + open() on the SAME
+    // instance; close() closed `_incoming` and latched `_closing`, and
+    // neither was ever undone — so the "recovered" link was a zombie (bytes
+    // silently dropped by the #2953 guard, the proactive drop signal
+    // suppressed forever). Reset both latches and, when a prior close()
+    // closed the controller, recreate it before connecting.
+    _closing = false;
+    _dropSignalled = false;
+    if (_incoming.isClosed) {
+      _incoming = StreamController<List<int>>.broadcast();
+    }
     // #2466 — gated comm-diagnostics connect-lifecycle tee. A no-op
     // unless Feature.debugMode armed the collector; each call
     // early-returns on `!enabled`, so production pays one cached-bool

--- a/lib/features/consumption/data/obd2/classic_method_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_method_channel.dart
@@ -79,6 +79,18 @@ class Obd2ClassicMethodChannel {
     await _methodChannel.invokeMethod<void>('disconnect');
   }
 
+  /// #3183 — the device's `Build.VERSION.SDK_INT` from the native side.
+  /// Throws ([MissingPluginException] / [PlatformException] / [StateError])
+  /// when the native plugin predates the method or the probe fails — the
+  /// caller ([PluginObd2Permissions]) owns the fallback.
+  Future<int> sdkInt() async {
+    final v = await _methodChannel.invokeMethod<int>('sdkInt');
+    if (v == null) {
+      throw StateError('sdkInt: native side returned null');
+    }
+    return v;
+  }
+
   /// Incoming bytes from the socket's input stream, pushed by the
   /// reader thread on the native side. Subscribing starts the
   /// EventChannel; cancelling stops listening but the socket stays

--- a/lib/features/consumption/data/obd2/elm_gatt_profiles.dart
+++ b/lib/features/consumption/data/obd2/elm_gatt_profiles.dart
@@ -94,7 +94,7 @@ class ResolvedElmGatt {
 ///     Veepeak, Carista, Vgate, BlueDriver, …).
 ///   * FFE0 — HM-10 / CC254x module family (SmartOBD + many cheap clones),
 ///     usually a single dual-mode FFE1 char.
-///   * 18F0 — Scantool STN (OBDLink MX+/LX/CX).
+///   * 18F0 — Scantool STN (OBDLink MX+/LX; the CX is FFF0-family, #3180).
 ///   * 6E40… — the canonical Nordic UART Service (some firmware exposes it).
 const List<String> kElmBleServiceFamilies = [
   '0000fff0-0000-1000-8000-00805f9b34fb',

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
+import 'ble_adapter_state_gate.dart';
 import 'ble_disconnect_classifier.dart';
 import 'ble_link_tuner.dart';
 import 'connection_drop_debouncer.dart';
@@ -66,10 +67,10 @@ class FlutterBluePlusElmChannel
   /// #3118 — iOS-aware. iOS CoreBluetooth's `discoverServices` is slower than
   /// Android's, so the OBDLink CX's GATT-table resolution can blow Android's
   /// tight 5 s on a cold iPhone connect. Android keeps 5 s (byte-identical).
-  static Duration get _discoverTimeout =>
-      defaultTargetPlatform == TargetPlatform.iOS
-          ? const Duration(seconds: 8)
-          : const Duration(seconds: 5);
+  /// #3182 — int SECONDS now, passed to FBP's own `timeout:` parameter (see
+  /// [discoverAndBind]) instead of an outer Dart `.timeout()`.
+  static int get _discoverTimeoutSecs =>
+      defaultTargetPlatform == TargetPlatform.iOS ? 8 : 5;
 
   /// #3014 — bound `setNotifyValue`, for the same reason: a clone that accepts
   /// the descriptor write but never ACKs would otherwise block 15 s.
@@ -80,16 +81,19 @@ class FlutterBluePlusElmChannel
   /// CoreBluetooth than Android's 4 s. #3113 only widened the `connect()` budget
   /// (iOS 7 s); this very next step still clipped at 4 s. iOS gets 7 s; Android
   /// keeps 4 s (byte-identical — the #2242/#3014 tight bound stays load-bearing).
-  static Duration get _setNotifyTimeout =>
-      defaultTargetPlatform == TargetPlatform.iOS
-          ? const Duration(seconds: 7)
-          : const Duration(seconds: 4);
+  /// #3182 — int SECONDS now, passed to FBP's own `timeout:` parameter.
+  static int get _setNotifyTimeoutSecs =>
+      defaultTargetPlatform == TargetPlatform.iOS ? 7 : 4;
 
-  /// #3118 — test seams to lock the iOS-aware post-connect budgets.
+  /// #3118 — test seams to lock the iOS-aware post-connect budgets. Kept as
+  /// [Duration]s (built from the int-seconds FBP budgets) so the existing
+  /// budget-pinning tests stay byte-identical.
   @visibleForTesting
-  static Duration get debugDiscoverTimeout => _discoverTimeout;
+  static Duration get debugDiscoverTimeout =>
+      Duration(seconds: _discoverTimeoutSecs);
   @visibleForTesting
-  static Duration get debugSetNotifyTimeout => _setNotifyTimeout;
+  static Duration get debugSetNotifyTimeout =>
+      Duration(seconds: _setNotifyTimeoutSecs);
 
   /// #3014 — best-effort MTU asked for during the bounded-connect path. Clones
   /// often reject it; the post-discovery `requestMtu` in [tuneForRecording]
@@ -310,6 +314,13 @@ class FlutterBluePlusElmChannel
   @protected
   @visibleForTesting
   Future<void> connectDevice() async {
+    // #3182 — wait (bounded, best-effort) for `adapterState == on` before ANY
+    // connect dispatch. FBP's darwin side creates the CBCentralManager lazily
+    // in the first method call and instantly rejects a connect issued while
+    // it still reports `unknown` — so a cold-launch direct connect failed
+    // spuriously on iOS. On timeout the connect proceeds, so a genuinely-off
+    // adapter still surfaces through the existing error classification.
+    await waitForAdapterOn();
     final timeout = _connectTimeout;
     if (_autoConnect) {
       // #2261 concern 2 — passive autoConnect GATT wait. No bounded timeout:
@@ -434,9 +445,16 @@ class FlutterBluePlusElmChannel
   Future<void> discoverAndBind() async {
     // #3014 — bound discoverServices on its own short budget (FBP default 15 s)
     // so a clone whose GATT table never resolves fails in ~5 s as `gattTimeout`,
-    // not a 15 s hang. The TimeoutException classifies to `gattTimeout`.
+    // not a 15 s hang.
+    // #3182 — the budget is now FBP's OWN `timeout:` parameter, not an outer
+    // Dart `.timeout()`: the outer form fired OUR TimeoutException at the
+    // budget but left FBP's GLOBAL per-device mutex held for the full 15 s
+    // default, serializing (deadlocking) every retry that followed. FBP's
+    // native timeout releases the mutex at our budget; its
+    // FlutterBluePlusException ("Timed out after Ns") still classifies as
+    // `gattTimeout` (see classifyBleOpenOutcome).
     final services =
-        await _device.discoverServices().timeout(_discoverTimeout);
+        await _device.discoverServices(timeout: _discoverTimeoutSecs);
     // #3014 — property-based discovery: adapt FBP services into the pure
     // descriptor shape, then resolve the write+notify pair by characteristic
     // PROPERTY across the known ELM families, with the registry UUIDs as a
@@ -485,7 +503,9 @@ class FlutterBluePlusElmChannel
       (c) => c.uuid.str.toLowerCase() == resolved.notifyCharUuid.toLowerCase(),
     );
     // #3014 — bound setNotifyValue on its own short budget too.
-    await _notifyChar!.setNotifyValue(true).timeout(_setNotifyTimeout);
+    // #3182 — via FBP's own `timeout:` (mutex released at our budget; the
+    // outer Dart `.timeout()` left it held up to 15 s — see above).
+    await _notifyChar!.setNotifyValue(true, timeout: _setNotifyTimeoutSecs);
     _subscription = _notifyChar!.lastValueStream.listen(
       handleNotifyBytes,
       onError: (e, st) {
@@ -680,11 +700,19 @@ class FlutterBluePlusElmChannel
   /// The raw characteristic write, behind a [protected] [visibleForTesting]
   /// seam so a fault-injection test can drive [write]'s #2900 reclassification
   /// without a real BLE stack (a real [BluetoothCharacteristic] is not
-  /// mockable). Production writes exactly as before.
+  /// mockable).
+  ///
+  /// #3182 — write mode follows the RESOLVED characteristic's properties
+  /// instead of a hardcoded `withoutResponse: true`: FBP fails loudly when
+  /// asked for a write mode the characteristic doesn't advertise, so a clone
+  /// whose write char only supports acknowledged writes could never receive a
+  /// single command. `writeWithoutResponse` is still preferred whenever the
+  /// adapter advertises it (fastest BLE write path).
   @protected
   @visibleForTesting
   Future<void> writeRaw(BluetoothCharacteristic char, List<int> bytes) =>
-      char.write(bytes, withoutResponse: true);
+      char.write(bytes,
+          withoutResponse: char.properties.writeWithoutResponse);
 
   /// #2900 test seam — prime an established session so a fault-injection test
   /// can drive [write] without the real connect path. #2907 — also wires

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -119,7 +119,14 @@ class FlutterBluePlusElmChannel
   BluetoothCharacteristic? _notifyChar;
   StreamSubscription<List<int>>? _subscription;
   StreamSubscription<BluetoothConnectionState>? _connStateSubscription;
-  final StreamController<List<int>> _incoming =
+
+  /// #3179 — NOT final: [close] closes the broadcast controller, and the
+  /// transport's open-retry loop (plus any reconnect) calls `close()` +
+  /// `open()` on the SAME channel instance, so [open] must be able to
+  /// recreate it. With a `final` controller the "recovered" link was a
+  /// zombie: every notify byte hit a closed controller and the reply timed
+  /// out forever.
+  StreamController<List<int>> _incoming =
       StreamController<List<int>>.broadcast();
   bool _open = false;
 
@@ -138,7 +145,13 @@ class FlutterBluePlusElmChannel
   /// disconnect still surfaces in ~1–2 s (not the ~15 s read timeout). On
   /// confirmation it pushes a typed [Obd2DisconnectedException] onto the byte
   /// stream, which the transport re-throws so [TripDropDetector] sees a drop.
-  late final ConnectionDropDebouncer _dropDebouncer;
+  /// #3179 — NOT `late final`: [close] disposes it, so a reopen rebuilds it
+  /// (same debounce, same callback) instead of reviving a disposed one.
+  late ConnectionDropDebouncer _dropDebouncer;
+
+  /// #3179 — the configured debounce, kept so [open] can rebuild
+  /// [_dropDebouncer] after a close() → open() cycle.
+  final Duration _dropDebounce;
 
   /// #3014 — scan-before-connect seed (THE highest-leverage SmartOBD fix).
   /// Runs a brief TARGETED scan for this device's MAC before the cold
@@ -170,7 +183,8 @@ class FlutterBluePlusElmChannel
   })  : _uuids = uuids ?? Elm327BleUuids.vgate,
         _connectTimeout = connectTimeout,
         _autoConnect = autoConnect,
-        _scanSeed = scanSeed {
+        _scanSeed = scanSeed,
+        _dropDebounce = dropDebounce {
     _dropDebouncer = ConnectionDropDebouncer(
       debounce: dropDebounce,
       onConfirmed: _onDropConfirmed,
@@ -210,6 +224,23 @@ class FlutterBluePlusElmChannel
   @override
   Future<void> open() async {
     if (_open) return;
+    // #3179 — make the channel safely RE-openable. The transport's open-retry
+    // loop (#2906/#3014) and the reconnect path call close() + open() on the
+    // SAME instance; close() closed `_incoming` and latched `_closing`, and
+    // neither was ever undone — so the "recovered" link was a zombie (notify
+    // bytes silently dropped, the drop debouncer + drop-signal permanently
+    // dead). Reset the deliberate-close + drop-signal latches and, when a
+    // prior close() closed the controller, recreate it and rebuild the
+    // disposed debouncer before the GATT dance runs.
+    _closing = false;
+    _dropSignalled = false;
+    if (_incoming.isClosed) {
+      _incoming = StreamController<List<int>>.broadcast();
+      _dropDebouncer = ConnectionDropDebouncer(
+        debounce: _dropDebounce,
+        onConfirmed: _onDropConfirmed,
+      );
+    }
     // #2466 — gated comm-diagnostics connect-lifecycle tee. A no-op unless
     // `Feature.debugMode` armed the collector; each call early-returns on
     // `!enabled`, so production pays one cached-bool read per event.
@@ -456,12 +487,7 @@ class FlutterBluePlusElmChannel
     // #3014 — bound setNotifyValue on its own short budget too.
     await _notifyChar!.setNotifyValue(true).timeout(_setNotifyTimeout);
     _subscription = _notifyChar!.lastValueStream.listen(
-      (bytes) {
-        // #2467 — tee the raw chunk into the gated comm-diagnostics
-        // wire-framing counters (double-gated, so production pays nothing).
-        noteObd2Framing(bytes);
-        _incoming.add(bytes);
-      },
+      handleNotifyBytes,
       onError: (e, st) {
         // #2900 — a mid-session disconnect can surface here too (the GATT/ATT
         // stack errors the notify stream when the adapter drops). Clear the
@@ -494,6 +520,28 @@ class FlutterBluePlusElmChannel
       },
     );
   }
+
+  /// #3179 — the notify-stream DATA handler, extracted so a reopen test can
+  /// drive the EXACT production byte path without a real BLE stack (FBP's
+  /// `lastValueStream` is unfakeable). Tees the chunk into the gated
+  /// comm-diagnostics framing counters (#2467) and feeds the live incoming
+  /// controller. The `isClosed` guard mirrors [ClassicElmChannel]'s #2953
+  /// late-byte guard: a chunk already queued on the event loop can land
+  /// AFTER close() closed `_incoming` — drop it silently, never throw.
+  @protected
+  @visibleForTesting
+  void handleNotifyBytes(List<int> bytes) {
+    noteObd2Framing(bytes);
+    if (!_incoming.isClosed) _incoming.add(bytes);
+  }
+
+  /// #3179 test seam — feed a raw connection-state edge into the drop
+  /// debouncer exactly as the FBP `connectionState` listener does, so a test
+  /// can prove drop detection still works after a close() → open() cycle
+  /// (the real stream is unfakeable).
+  @visibleForTesting
+  void debugNoteConnectionState({required bool disconnected}) =>
+      _dropDebouncer.noteConnectionState(disconnected: disconnected);
 
   /// #2261 concern 1 — subscribe to the connection-state stream so a real
   /// disconnect is noticed in ~1–2 s. The first emission is the current state

--- a/lib/features/consumption/data/obd2/obd2_permissions.dart
+++ b/lib/features/consumption/data/obd2/obd2_permissions.dart
@@ -3,8 +3,11 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'classic_method_channel.dart';
 
 part 'obd2_permissions.g.dart';
 
@@ -65,7 +68,14 @@ abstract class Obd2Permissions {
 /// re-prompt — the picker UI offers an "Open Settings" deep link in
 /// that branch.
 class PluginObd2Permissions implements Obd2Permissions {
-  const PluginObd2Permissions();
+  /// [sdkIntProvider] is the Android SDK-level probe (#3183) — injectable so
+  /// tests can drive the permission-set selection without a platform channel.
+  /// Defaults to the real native `Build.VERSION.SDK_INT` probe.
+  const PluginObd2Permissions({
+    Future<int> Function() sdkIntProvider = _probeAndroidSdkInt,
+  }) : _sdkIntProvider = sdkIntProvider;
+
+  final Future<int> Function() _sdkIntProvider;
 
   @override
   Future<Obd2PermissionState> request() async {
@@ -148,20 +158,36 @@ class PluginObd2Permissions implements Obd2Permissions {
     return Obd2PermissionState.denied;
   }
 
-  /// Read the device's SDK level via the `permission_handler` plugin's
-  /// DeviceInfo plugin would be cleaner, but that pulls another dep.
-  /// Instead we fall back to [Platform.version] parsing, which is
-  /// allowed by Flutter's Platform channel when missing, and default
-  /// to 33 (Android 13) when parsing fails — biasing toward the newer
-  /// permission model is safer than accidentally falling back to the
-  /// legacy location prompt.
-  static Future<int> _androidSdkInt() async {
-    // Platform.version looks like "3.5.0 (stable) ... (Android SDK 33)"
-    // in debug but not in release. Hard-code 33 as the default; callers
-    // that need a precise read can inject a fake `Obd2Permissions`.
-    return 33;
+  /// #3183 — the device's REAL SDK level via the injected probe. The old
+  /// implementation hard-coded 33, which made the `< 31` legacy
+  /// location-permission branch in [_permissionsFor] unreachable — on
+  /// Android ≤ 11 the BLE scan was "granted" without any location
+  /// permission and silently returned zero results. Falls back to 33
+  /// (the modern split-permission model) when the probe fails — e.g. an
+  /// old native side without the `sdkInt` method — because biasing newer
+  /// is safer than wrongly showing the legacy location prompt on a modern
+  /// device.
+  Future<int> _androidSdkInt() async {
+    try {
+      return await _sdkIntProvider();
+    } catch (_) {
+      // Best-effort probe with a documented bias: a missing/old native
+      // method must never break the permission flow.
+      return 33;
+    }
   }
+
+  /// #3183 test seam — the permission set [request]/[current] would ask for,
+  /// resolved through the (injectable) SDK probe + its 33 fallback.
+  @visibleForTesting
+  Future<List<Permission>> debugRequiredPermissions() async =>
+      _permissionsFor(await _androidSdkInt());
 }
+
+/// #3183 — default production probe: `Build.VERSION.SDK_INT` over the
+/// existing in-repo Classic plugin's MethodChannel (no extra dependency —
+/// the alternative, device_info_plus, is not in the dependency set).
+Future<int> _probeAndroidSdkInt() => const Obd2ClassicMethodChannel().sdkInt();
 
 @Riverpod(keepAlive: true)
 Obd2Permissions obd2Permissions(Ref ref) => const PluginObd2Permissions();

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -603,6 +603,23 @@ void main() {
           registry.resolve(_candidate(name: 'OBDLink MX+', services: []))?.id,
           'obdlink-mx');
     });
+
+    test(
+        '#3180 — the OBDLink CX profile pins the vendor-documented FFF0 '
+        'service / FFF2 write / FFF1 notify layout (NOT the MX+/LX 18F0)',
+        () {
+      final cx = registry.profiles.firstWhere((p) => p.id == 'obdlink-cx');
+      expect(cx.serviceUuid, '0000fff0-0000-1000-8000-00805f9b34fb',
+          reason: 'the real CX exposes service FFF0 — the previous 18F0 was '
+              'the MX+/LX layout and made the exact-UUID hint miss');
+      expect(cx.writeCharUuid, '0000fff2-0000-1000-8000-00805f9b34fb');
+      expect(cx.notifyCharUuid, '0000fff1-0000-1000-8000-00805f9b34fb');
+      // The MX+/LX siblings keep their custom 18F0 family untouched.
+      final mx = registry.profiles.firstWhere((p) => p.id == 'obdlink-mx');
+      final lx = registry.profiles.firstWhere((p) => p.id == 'obdlink-lx');
+      expect(mx.serviceUuid, '000018f0-0000-1000-8000-00805f9b34fb');
+      expect(lx.serviceUuid, '000018f0-0000-1000-8000-00805f9b34fb');
+    });
   });
 
   _transportForNameTests(registry);

--- a/test/features/consumption/data/obd2/ble_adapter_state_gate_test.dart
+++ b/test/features/consumption/data/obd2/ble_adapter_state_gate_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'ble_adapter_state_gate.dart';
+
+/// #3182 — the bounded poweredOn gate run before every BLE scan / connect
+/// dispatch. FBP's darwin side creates the CBCentralManager lazily and
+/// instantly rejects the first scan/connect with state `unknown`; the gate
+/// waits for `adapterState == on` but must FALL THROUGH (never throw, never
+/// hang) when the adapter is genuinely off or the probe fails, so the
+/// existing typed-error mapping (Obd2BluetoothOff) still owns those cases.
+void main() {
+  group('waitForAdapterOn (#3182)', () {
+    test('completes as soon as the adapter reports on', () async {
+      final states = StreamController<BluetoothAdapterState>();
+      final sw = Stopwatch()..start();
+      final wait = waitForAdapterOn(
+        states: states.stream,
+        timeout: const Duration(seconds: 3),
+      );
+      states.add(BluetoothAdapterState.unknown);
+      states.add(BluetoothAdapterState.on);
+
+      await wait;
+      sw.stop();
+      expect(sw.elapsed, lessThan(const Duration(seconds: 1)),
+          reason: 'the gate must resolve on the `on` edge, not the timeout');
+      await states.close();
+    });
+
+    test(
+        'falls through (returns normally) at the timeout when the adapter '
+        'never reports on — a genuinely-off radio keeps its existing '
+        'Obd2BluetoothOff surfacing', () async {
+      final states = StreamController<BluetoothAdapterState>();
+      final wait = waitForAdapterOn(
+        states: states.stream,
+        timeout: const Duration(milliseconds: 50),
+      );
+      states.add(BluetoothAdapterState.off);
+
+      await expectLater(wait, completes,
+          reason: 'the gate is best-effort: it must never throw the '
+              'TimeoutException at the caller');
+      await states.close();
+    });
+
+    test('falls through when the state stream ends without an on', () async {
+      final states = Stream<BluetoothAdapterState>.fromIterable(
+        const [BluetoothAdapterState.unknown],
+      );
+      await expectLater(
+        waitForAdapterOn(
+            states: states, timeout: const Duration(seconds: 3)),
+        completes,
+      );
+    });
+
+    test('falls through when the state probe errors', () async {
+      final states = Stream<BluetoothAdapterState>.error(
+        StateError('platform channel unavailable'),
+      );
+      await expectLater(
+        waitForAdapterOn(
+            states: states, timeout: const Duration(seconds: 3)),
+        completes,
+        reason: 'a failing probe must never block or fail the scan/connect '
+            'that follows',
+      );
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_gatt133_recovery_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_gatt133_recovery_test.dart
@@ -37,7 +37,9 @@ class _Gatt133Channel implements ElmByteChannel, Obd2GattRecoverable {
   /// (recoverable but non-133) timeout — so the no-refresh case is provable.
   final bool transientIsGatt133;
 
-  final _controller = StreamController<List<int>>.broadcast();
+  // #3179 — models the FIXED re-openable channel contract: close() closes the
+  // controller, open() recreates it (the production channels now do the same).
+  var _controller = StreamController<List<int>>.broadcast();
   int openAttempts = 0;
   int closeCalls = 0;
   int refreshCalls = 0;
@@ -46,6 +48,9 @@ class _Gatt133Channel implements ElmByteChannel, Obd2GattRecoverable {
   @override
   Future<void> open() async {
     openAttempts++;
+    if (_controller.isClosed) {
+      _controller = StreamController<List<int>>.broadcast();
+    }
     if (openAttempts <= failuresBefore133Success) {
       if (transientIsGatt133) {
         throw FlutterBluePlusException(
@@ -77,6 +82,10 @@ class _Gatt133Channel implements ElmByteChannel, Obd2GattRecoverable {
 
   @override
   Stream<List<int>> get incoming => _controller.stream;
+
+  /// #3179 — deliver notify bytes the way the real channel does: onto the
+  /// live incoming controller.
+  void deliver(List<int> bytes) => _controller.add(bytes);
 
   @override
   Future<void> write(List<int> bytes) async {}
@@ -120,6 +129,29 @@ void main() {
       expect(channel.openAttempts, 2);
       expect(channel.refreshCalls, 0,
           reason: 'a timeout is not a cache-poisoning 133 — no refresh');
+    });
+
+    test(
+        '#3179 — after the 133-retry succeeds, BYTES FLOW end-to-end: a '
+        'command is written, notify bytes complete the reply (the attempt '
+        'counts above were the documented false-green)', () async {
+      final channel = _Gatt133Channel(failuresBefore133Success: 1);
+      final transport = BluetoothObd2Transport(
+        channel,
+        readTimeout: const Duration(milliseconds: 400),
+      );
+      addTearDown(transport.disconnect);
+
+      await transport.connect();
+
+      final reply = transport.sendCommand('010D');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      channel.deliver('41 0D 00\r>'.codeUnits);
+
+      await expectLater(reply, completion(contains('41 0D 00')),
+          reason: 'the recovered channel must move bytes — a zombie channel '
+              'whose incoming controller stayed closed drops them and the '
+              'reply times out (#3179)');
     });
 
     test(

--- a/test/features/consumption/data/obd2/classic_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_elm_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_link_drop_signal.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 /// Captured call to [_FakeObd2ClassicMethodChannel.connect].
@@ -384,6 +385,37 @@ void main() {
         reason: 'the raw PlatformException must be reclassified as a '
             'recoverable typed disconnect (matching the #2524 precedent)',
       );
+
+      await channel.close();
+    });
+
+    test(
+        '#3183 — a write-time drop ALSO fires the proactive link-drop signal '
+        'so the trip-independent reconnect controller is kicked', () async {
+      // The lazy write-failure path was the ONLY drop discovery that never
+      // called _signalDrop(): a drop noticed on write (no reader error /
+      // done edge yet) left the reconnect controller asleep.
+      fake.writeError =
+          PlatformException(code: 'state', message: 'not connected');
+      final channel = ClassicElmChannel(address: 'AA:BB:CC:DD:EE:83',
+          plugin: fake);
+      await channel.open();
+
+      final drops = <Obd2LinkDropEvent>[];
+      final dropSub = Obd2LinkDropSignal.instance.drops.listen(drops.add);
+      addTearDown(dropSub.cancel);
+
+      await expectLater(
+        channel.write([0x41, 0x54]),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(drops, hasLength(1),
+          reason: 'the write-failure drop path must emit the #3019 proactive '
+              'signal exactly like the reader onError/onDone paths');
+      expect(drops.single.transportKind, 'classic');
+      expect(drops.single.mac, 'AA:BB:CC:DD:EE:83');
 
       await channel.close();
     });

--- a/test/features/consumption/data/obd2/classic_method_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_method_channel_test.dart
@@ -154,5 +154,34 @@ void main() {
 
       expect(called, isTrue);
     });
+
+    test('#3183 — sdkInt returns the native Build.VERSION.SDK_INT', () async {
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        expect(call.method, 'sdkInt');
+        return 30;
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      expect(await plugin.sdkInt(), 30);
+    });
+
+    test('#3183 — sdkInt throws on a null native reply (caller falls back)',
+        () async {
+      messenger.setMockMethodCallHandler(methodChannel, (_) async => null);
+      const plugin = Obd2ClassicMethodChannel();
+      await expectLater(plugin.sdkInt(), throwsStateError);
+    });
+
+    test(
+        '#3183 — sdkInt throws when the native side predates the method '
+        '(MissingPluginException — the permission flow falls back to 33)',
+        () async {
+      messenger.setMockMethodCallHandler(methodChannel, null);
+      const plugin = Obd2ClassicMethodChannel();
+      await expectLater(
+        plugin.sdkInt(),
+        throwsA(isA<MissingPluginException>()),
+      );
+    });
   });
 }

--- a/test/features/consumption/data/obd2/elm_channel_reopen_test.dart
+++ b/test/features/consumption/data/obd2/elm_channel_reopen_test.dart
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'classic_elm_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'classic_method_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'flutter_blue_plus_elm_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_link_drop_signal.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3179 — the zombie retry channel.
+///
+/// [BluetoothObd2Transport.connect] retries a recoverable `open()` failure by
+/// `close()` + `open()` on the SAME channel instance. But both production
+/// channels ([FlutterBluePlusElmChannel], [ClassicElmChannel]) used a `final`
+/// broadcast `_incoming` controller that `close()` closes and `open()` never
+/// recreated, and a `_closing` latch that was never reset — so the "recovered"
+/// link was a zombie: every later notify byte was silently dropped (the
+/// `isClosed` guard), every reply timed out, and drop detection / drop-error
+/// delivery were permanently dead.
+///
+/// These tests drive the REAL channels through close() → open() and assert
+/// bytes + drop signals flow on the reopened link. RED on master.
+class _ReopenFakePlugin extends Obd2ClassicMethodChannel {
+  _ReopenFakePlugin({this.failuresBeforeSuccess = 0});
+
+  /// How many connectDetailed calls fail (rfcomm-open false) before success.
+  final int failuresBeforeSuccess;
+  int connectCalls = 0;
+  final writes = <List<int>>[];
+  Object? writeError;
+
+  /// Re-openable native side: each EventChannel listen gets the live stream.
+  StreamController<List<int>> incomingController =
+      StreamController<List<int>>.broadcast();
+
+  @override
+  Future<ClassicConnectResult> connectDetailed({
+    required String address,
+    required String uuid,
+  }) async {
+    connectCalls++;
+    if (connectCalls <= failuresBeforeSuccess) {
+      return (ok: false, strategy: 'exhausted', error: 'rfcomm open failed');
+    }
+    return (ok: true, strategy: 'secure', error: null);
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    writes.add(List<int>.from(bytes));
+    final e = writeError;
+    if (e != null) throw e;
+  }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<List<int>> get incoming => incomingController.stream;
+
+  Future<void> dispose() async {
+    if (!incomingController.isClosed) await incomingController.close();
+  }
+}
+
+/// FBP channel with the unfakeable seams stubbed so open()/close()/open() runs
+/// without a BLE stack (the #3014 _TestChannel precedent).
+class _ReopenableFbpChannel extends FlutterBluePlusElmChannel {
+  _ReopenableFbpChannel(super.device, {super.dropDebounce});
+
+  @override
+  Future<void> connectDevice() async {}
+
+  @override
+  Future<void> discoverAndBind() async {}
+
+  @override
+  void bindConnectionState() {}
+
+  @override
+  Future<void> tuneForRecording() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  silenceErrorLoggerSpool();
+
+  group('#3179 — transport open-retry must yield a LIVE channel', () {
+    test(
+        'a recoverable first open() failure + a successful retry → bytes flow '
+        'end-to-end (write a command, deliver notify bytes, reply completes)',
+        () async {
+      final plugin = _ReopenFakePlugin(failuresBeforeSuccess: 1);
+      addTearDown(plugin.dispose);
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+      final transport = BluetoothObd2Transport(
+        channel,
+        readTimeout: const Duration(milliseconds: 400),
+      );
+      addTearDown(transport.disconnect);
+
+      // Attempt 1 fails recoverably (Obd2AdapterUnresponsive), the transport
+      // close()s + retries, attempt 2 succeeds.
+      await transport.connect();
+      expect(transport.isConnected, isTrue);
+      expect(plugin.connectCalls, 2);
+
+      // The recovered link must MOVE BYTES — the documented false-green was
+      // asserting only attempt counts while the reopened channel's incoming
+      // controller stayed closed and every reply timed out.
+      final reply = transport.sendCommand('010D');
+      // Let the queued write land before the adapter "answers".
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(plugin.writes, isNotEmpty,
+          reason: 'the command must reach the (re)opened link');
+      plugin.incomingController.add('41 0D 00\r>'.codeUnits);
+
+      await expectLater(reply, completion(contains('41 0D 00')),
+          reason: 'notify bytes on the reopened channel must complete the '
+              'pending reply — a zombie channel drops them silently');
+    });
+  });
+
+  group('#3179 — ClassicElmChannel is safely re-openable', () {
+    test('close() → open() → incoming bytes flow again', () async {
+      final plugin = _ReopenFakePlugin();
+      addTearDown(plugin.dispose);
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+
+      await channel.open();
+      await channel.close();
+      await channel.open();
+      expect(channel.isOpen, isTrue);
+
+      final received = <List<int>>[];
+      final sub = channel.incoming.listen(received.add);
+      addTearDown(sub.cancel);
+      plugin.incomingController.add([0x41, 0x54]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, [
+        [0x41, 0x54],
+      ]);
+      await channel.close();
+    });
+
+    test(
+        'drop detection still works after a reopen — a reader-stream error '
+        'fires the proactive link-drop signal AND surfaces on incoming',
+        () async {
+      final plugin = _ReopenFakePlugin();
+      addTearDown(plugin.dispose);
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+
+      await channel.open();
+      await channel.close(); // deliberate close latches `_closing` on master
+      await channel.open();
+
+      final drops = <Obd2LinkDropEvent>[];
+      final dropSub = Obd2LinkDropSignal.instance.drops.listen(drops.add);
+      addTearDown(dropSub.cancel);
+      final errors = <Object>[];
+      final sub = channel.incoming.listen((_) {}, onError: errors.add);
+      addTearDown(sub.cancel);
+
+      plugin.incomingController.addError(
+        PlatformException(code: 'state', message: 'not connected'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(channel.isOpen, isFalse);
+      expect(errors, isNotEmpty,
+          reason: 'the socket error must be forwarded on the reopened '
+              'incoming stream so a pending command fails fast');
+      expect(drops, hasLength(1),
+          reason: 'an unexpected drop AFTER a reopen must still fire the '
+              'proactive link-drop signal (the `_closing`/`_dropSignalled` '
+              'latches must reset on open)');
+      await channel.close();
+    });
+  });
+
+  group('#3179 — FlutterBluePlusElmChannel is safely re-openable', () {
+    test('close() → open() → the incoming stream is live (not done)',
+        () async {
+      final channel = _ReopenableFbpChannel(
+        BluetoothDevice.fromId('AA:BB:CC:DD:EE:79'),
+      );
+
+      await channel.open();
+      await channel.close();
+      await channel.open();
+      expect(channel.isOpen, isTrue);
+
+      var doneFired = false;
+      final sub = channel.incoming.listen((_) {}, onDone: () {
+        doneFired = true;
+      });
+      addTearDown(sub.cancel);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(doneFired, isFalse,
+          reason: 'after a reopen the incoming stream must be a LIVE '
+              'controller, not the closed one the previous close() left');
+      await channel.close();
+    });
+
+    test('close() → open() → notify bytes flow on the reopened stream',
+        () async {
+      final channel = _ReopenableFbpChannel(
+        BluetoothDevice.fromId('AA:BB:CC:DD:EE:80'),
+      );
+
+      await channel.open();
+      await channel.close();
+      await channel.open();
+
+      final received = <List<int>>[];
+      final sub = channel.incoming.listen(received.add);
+      addTearDown(sub.cancel);
+      // The exact production notify-stream data path (#3179 seam).
+      channel.handleNotifyBytes([0x41, 0x0D]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, [
+        [0x41, 0x0D],
+      ]);
+      await channel.close();
+    });
+
+    test(
+        'drop detection still works after a reopen — a debounce-confirmed '
+        'disconnect edge delivers the typed drop error AND fires the '
+        'proactive link-drop signal', () async {
+      final channel = _ReopenableFbpChannel(
+        BluetoothDevice.fromId('AA:BB:CC:DD:EE:81'),
+        dropDebounce: const Duration(milliseconds: 30),
+      );
+
+      await channel.open();
+      await channel.close(); // disposes the debouncer + latches `_closing`
+      await channel.open();
+
+      final drops = <Obd2LinkDropEvent>[];
+      final dropSub = Obd2LinkDropSignal.instance.drops.listen(drops.add);
+      addTearDown(dropSub.cancel);
+      final errors = <Object>[];
+      final sub = channel.incoming.listen((_) {}, onError: errors.add);
+      addTearDown(sub.cancel);
+
+      channel.debugNoteConnectionState(disconnected: true);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(errors, hasLength(1),
+          reason: 'the confirmed drop must push the typed disconnect onto '
+              'the reopened byte stream');
+      expect(errors.single, isA<Obd2DisconnectedException>());
+      expect(drops, hasLength(1),
+          reason: 'the proactive drop signal must fire after a reopen — the '
+              '`_closing`/`_dropSignalled` latches reset on open()');
+      await channel.close();
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_test.dart
@@ -1,12 +1,18 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
     'flutter_blue_plus_elm_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connect_classifier.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connect_trace.dart';
 
 /// #3014 (Epic #3013, Phase 2) — SCAN-BEFORE-CONNECT, the single
 /// highest-leverage SmartOBD fix.
@@ -181,6 +187,41 @@ void main() {
           const Duration(seconds: 4));
       expect(FlutterBluePlusElmChannel.debugDiscoverTimeout,
           const Duration(seconds: 5));
+    });
+  });
+
+  group('#3182 — FBP-native timeout errors still classify as gattTimeout', () {
+    // The discover/setNotify budgets now ride FBP's OWN `timeout:` parameter
+    // (releasing FBP's global mutex at our budget) instead of an outer Dart
+    // `.timeout()`. The error SHAPE therefore changed from Dart's
+    // TimeoutException to FBP's FlutterBluePlusException with a "Timed out
+    // after Ns" description — the open-outcome classifier must keep mapping
+    // it onto gattTimeout, or the connect trace would degrade to `unknown`.
+    test('the FBP fbpTimeout exception shape maps to gattTimeout', () {
+      final discoverTimeout = FlutterBluePlusException(
+        ErrorPlatform.fbp,
+        'discoverServices',
+        FbpErrorCode.timeout.index,
+        'Timed out after 8s',
+      );
+      final setNotifyTimeout = FlutterBluePlusException(
+        ErrorPlatform.fbp,
+        'setNotifyValue',
+        FbpErrorCode.timeout.index,
+        'Timed out after 7s',
+      );
+      expect(classifyBleOpenOutcome(discoverTimeout),
+          Obd2ConnectOutcome.gattTimeout);
+      expect(classifyBleOpenOutcome(setNotifyTimeout),
+          Obd2ConnectOutcome.gattTimeout);
+    });
+
+    test('the legacy Dart TimeoutException still maps to gattTimeout', () {
+      expect(
+        classifyBleOpenOutcome(
+            TimeoutException('discoverServices', const Duration(seconds: 5))),
+        Obd2ConnectOutcome.gattTimeout,
+      );
     });
   });
 }

--- a/test/features/consumption/data/obd2/obd2_permissions_test.dart
+++ b/test/features/consumption/data/obd2/obd2_permissions_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:permission_handler/permission_handler.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 
@@ -49,6 +50,38 @@ void main() {
       );
       expect(await fake.current(), Obd2PermissionState.denied);
       expect(await fake.request(), Obd2PermissionState.granted);
+    });
+  });
+
+  group('PluginObd2Permissions — SDK-aware permission set (#3183)', () {
+    // The probe was hard-coded to 33, making the <31 legacy
+    // location-permission branch UNREACHABLE — on Android ≤ 11 a BLE scan
+    // without location permission silently returns zero results.
+    test('Android ≤ 11 (SDK < 31) asks for the legacy location permission',
+        () async {
+      final perms = PluginObd2Permissions(sdkIntProvider: () async => 30);
+      expect(await perms.debugRequiredPermissions(),
+          [Permission.locationWhenInUse]);
+    });
+
+    test('Android 12+ (SDK ≥ 31) asks for the split BLE permissions',
+        () async {
+      final perms31 = PluginObd2Permissions(sdkIntProvider: () async => 31);
+      final perms34 = PluginObd2Permissions(sdkIntProvider: () async => 34);
+      expect(await perms31.debugRequiredPermissions(),
+          [Permission.bluetoothScan, Permission.bluetoothConnect]);
+      expect(await perms34.debugRequiredPermissions(),
+          [Permission.bluetoothScan, Permission.bluetoothConnect]);
+    });
+
+    test(
+        'a failing probe falls back to 33 (the modern model) — an old native '
+        'side without the sdkInt method must never break the flow', () async {
+      final perms = PluginObd2Permissions(
+        sdkIntProvider: () async => throw StateError('no native method'),
+      );
+      expect(await perms.debugRequiredPermissions(),
+          [Permission.bluetoothScan, Permission.bluetoothConnect]);
     });
   });
 

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -129,7 +129,10 @@ void main() {
     // `recognized` flag, and the two unrecognized placeholder profiles. Pure
     // data + lookup growth on the existing catalog class; decomposition still
     // tracked by #2190.
-    'lib/features/consumption/data/obd2/adapter_registry.dart': 693,
+    // #3180 — 693 → 697: comment-only growth documenting WHY the OBDLink CX
+    // profile is the FFF0/FFF2/FFF1 layout (not the MX+/LX 18F0 it was
+    // wrongly pinned to). Decomposition still tracked by #2190.
+    'lib/features/consumption/data/obd2/adapter_registry.dart': 697,
     // #2969 — grandfathered at 563 (was 389, under-cap before). The #2969
     // connect-trace instrumentation opens/finalises a trace at the FIVE public
     // connect entry points (the single virtual-dispatch chokepoint every live
@@ -204,7 +207,17 @@ void main() {
     // iOS-aware (const → platform-branching getters + dartdoc) so a slow iOS
     // CoreBluetooth CCCD write no longer clips the OBDLink CX at 4s, plus two
     // @visibleForTesting accessors to lock the budgets. Android byte-identical.
-    'lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart': 700,
+    // #3179/#3182 — 700 → 776: (1) the channel is now safely RE-openable
+    // (open() resets the `_closing`/`_dropSignalled` latches, recreates the
+    // closed `_incoming` controller + the disposed drop debouncer) so the
+    // transport's close()+open() retry no longer yields a zombie link, with
+    // the `handleNotifyBytes`/`debugNoteConnectionState` seams that make it
+    // testable; (2) the discover/setNotify budgets moved onto FBP's own
+    // `timeout:` parameters (mutex-releasing) and the #3182 poweredOn gate
+    // runs before connectDevice. Mostly dartdoc explaining the two field
+    // failure modes; the drop/reopen state cannot leave this cohesive channel
+    // body. Decomposition of the channel is tracked by #2190.
+    'lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart': 776,
     // #2953 — grandfathered at 405 (5 over): the _probeSafely / _connectSafely
     // catches were rerouted from a raw `errorLogger.log` ERROR spool to the
     // shared `recordObd2ConnectTransient` de-noiser (a parked-car engine-off


### PR DESCRIPTION
First implementation wave of epic #3178 (P0). All four defects were adversarially verified before implementation (see the verification summary on #3178); every fix shipped RED-on-master first.

- Closes #3179 — both ELM byte channels are now safely re-openable; the open-retry no longer yields a deaf zombie link (RED: byte-flow after reopen failed with `Bad state: Cannot add new events after calling close`)
- Closes #3182 — poweredOn gate before scan/connect (kills the false cold-start 'Bluetooth is off'), FBP-native discover/setNotify timeouts (releases FBP's global mutex at our budget instead of holding it up to 15s), property-aware write mode
- Closes #3180 — OBDLink CX registry profile corrected to its real FFF0/FFF1/FFF2 layout (hygiene; the family fallback rescued it at runtime)
- Closes #3183 — Android Classic socket death now reaches Dart (sink.error/endOfStream + proactive drop signal on write failure); real SDK probe replaces the hardcoded 33 that silently broke BLE scans on Android ≤11

Budgets are byte-identical to the #3113/#3118 values; Android behavior unchanged except where it was broken. Validation: analyze clean (pre-existing anonKey info only); 1665 + 373 tests green incl. new reopen/byte-flow, drop-signal, registry, and permission-matrix suites; gradle Kotlin compile clean; clean-codegen zero drift.

Remaining in the epic: #3181 pairing mode (needs ARB strings), #3184 persistent traces, #3185 supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)