### PR TITLE
fix(sync): integrity wave 1 — alert-delete tombstones, UTC timestamps, per-entity launch timeouts + ErrorLayer.sync

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -598,14 +598,12 @@ class AppInitializer {
   }
 
   /// #3077 — on app launch, pull the remaining server→local entities into
-  /// local storage so cross-device rows land without a manual sync gesture,
-  /// mirroring [_runTripsSyncMerge]. TankSync was upload-only for these:
-  /// the download branch existed in each `*_sync.dart` but had no
-  /// connect/launch caller (fill-ups + vehicles), or its return was
-  /// discarded (ratings), or it only fired on a local edit (alerts). The
-  /// per-entity pull-persist seams (`*.pullFromServer` /
-  /// `syncAndPersistRatings`) are the unit-tested units; this method is
-  /// the launch-time glue, mirroring the untested `_runTripsSyncMerge`.
+  /// local storage so cross-device rows land without a manual sync
+  /// gesture. TankSync was upload-only for these: the download branch
+  /// existed in each `*_sync.dart` but had no connect/launch caller
+  /// (fill-ups + vehicles), its return was discarded (ratings), or it only
+  /// fired on a local edit (alerts). The per-entity pull-persist seams are
+  /// the unit-tested units; this method is the launch-time glue.
   ///
   /// Consent gates (conservative — never pull data the user hasn't
   /// consented to):
@@ -618,9 +616,8 @@ class AppInitializer {
   ///   gate (`tripsSyncEnabledProvider` = email ∧ cloudSync ∧ syncTrips).
   ///
   /// No-ops cleanly when TankSync isn't initialised or the user is signed
-  /// out (each `*Sync` method short-circuits on a null user id, returning
-  /// the input unchanged). Each entity is independently error-protected so
-  /// one failing pull never blocks the others.
+  /// out. Each entity is independently error-protected AND time-budgeted
+  /// (#3128) so one failing or hung pull never blocks the others.
   static Future<void> _runEntitySyncMerge(
     ProviderContainer container,
     StorageRepository storage,
@@ -643,10 +640,13 @@ class AppInitializer {
     };
     for (final entry in pulls.entries) {
       try {
-        await entry.value();
+        await entry.value().timeout(const Duration(seconds: 15));
+      } on TimeoutException catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+            context: {'where': 'entity pull timed out', 'entity': entry.key}));
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer._runEntitySyncMerge ${entry.key} failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+            context: {'where': 'entity pull FAILED', 'entity': entry.key}));
       }
     }
   }

--- a/lib/core/sync/alerts_sync.dart
+++ b/lib/core/sync/alerts_sync.dart
@@ -71,7 +71,7 @@ class AlertsSync {
                   'fuel_type': a.fuelType.name,
                   'target_price': a.targetPrice,
                   'is_active': a.isActive,
-                  'created_at': a.createdAt.toIso8601String(),
+                  'created_at': a.createdAt.toUtc().toIso8601String(),
                 })
             .toList();
         await client.from('alerts').upsert(rows, onConflict: 'id');

--- a/lib/core/sync/alerts_sync.dart
+++ b/lib/core/sync/alerts_sync.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 
 import '../../features/alerts/data/models/price_alert.dart';
 import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
 import 'supabase_client.dart';
+import 'sync_helper.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Price-alert sync with Supabase, pulled out of [SyncService] (#727).
@@ -36,18 +38,29 @@ class AlertsSync {
     try {
       final serverRows =
           await client.from('alerts').select().eq('user_id', userId);
-      final serverAlertIds = serverRows
+      // #3121 — drop tombstoned ids from BOTH sides before the union so a
+      // deleted alert can't resurrect through the launch pull or another
+      // device's still-local copy (same seam as favorites/ignored, #3078).
+      final tombstoned = await DeletionsSync.fetchTombstonedIds('alerts');
+      final liveServerRows = SyncHelper.removeTombstoned(
+        serverRows,
+        tombstoned,
+        key: (r) => r.getString('id'),
+      ).toList();
+      final liveLocalAlerts =
+          localAlerts.where((a) => !tombstoned.contains(a.id)).toList();
+      final serverAlertIds = liveServerRows
           .map((r) => r.getString('id'))
           .whereType<String>()
           .toSet();
-      final localAlertIds = localAlerts.map((a) => a.id).toSet();
+      final localAlertIds = liveLocalAlerts.map((a) => a.id).toSet();
 
       debugPrint('AlertsSync.merge: local=${localAlertIds.length}, '
           'server=${serverAlertIds.length}');
 
       // Upload local-only alerts.
       final localOnly =
-          localAlerts.where((a) => !serverAlertIds.contains(a.id)).toList();
+          liveLocalAlerts.where((a) => !serverAlertIds.contains(a.id)).toList();
       if (localOnly.isNotEmpty) {
         final rows = localOnly
             .map((a) => {
@@ -66,7 +79,7 @@ class AlertsSync {
       }
 
       // Download server-only alerts.
-      final serverOnly = serverRows
+      final serverOnly = liveServerRows
           .where((r) => !localAlertIds.contains(r.getString('id')));
       final downloaded = serverOnly.map((r) {
         return PriceAlert.fromJson({
@@ -80,10 +93,36 @@ class AlertsSync {
         });
       }).toList();
 
-      return [...localAlerts, ...downloaded];
+      return [...liveLocalAlerts, ...downloaded];
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'AlertsSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'AlertsSync.merge FAILED'}));
       return localAlerts;
     }
+  }
+
+  /// Delete a single alert row from the server and tombstone the id
+  /// (#3121). Called only when the user explicitly removes an alert on
+  /// this device — the merge path doesn't delete. Mirrors the
+  /// `FavoritesSync.delete` pattern.
+  ///
+  /// Local-first: the caller's local delete has already happened, so a
+  /// server failure is logged, not rethrown — and the `deletions`
+  /// tombstone is recorded regardless, so every later [merge] filters the
+  /// id out even when the row delete failed transiently.
+  static Future<void> delete(String id) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+
+    try {
+      await client.from('alerts').delete().eq('user_id', userId).eq('id', id);
+      debugPrint('AlertsSync.delete: $id removed from server');
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'AlertsSync.delete FAILED'}));
+    }
+    // #3121 — tombstone regardless of the row-delete outcome (record has
+    // its own internal guard), so the next merge filters the id either way.
+    await DeletionsSync.record('alerts', id);
   }
 }

--- a/lib/core/sync/baselines_sync.dart
+++ b/lib/core/sync/baselines_sync.dart
@@ -91,7 +91,7 @@ class BaselinesSync {
       );
       return merged;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'BaselinesSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'BaselinesSync.merge FAILED'}));
       return localJson;
     }
   }
@@ -112,7 +112,7 @@ class BaselinesSync {
           .eq('vehicle_id', vehicleId);
       await DeletionsSync.record('obd2_baselines', vehicleId); // #3078
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'BaselinesSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'BaselinesSync.delete FAILED'}));
     }
   }
 }

--- a/lib/core/sync/baselines_sync.dart
+++ b/lib/core/sync/baselines_sync.dart
@@ -85,7 +85,7 @@ class BaselinesSync {
           'vehicle_id': vehicleId,
           'total_samples': total,
           'data': mergedDecoded,
-          'updated_at': DateTime.now().toIso8601String(),
+          'updated_at': DateTime.now().toUtc().toIso8601String(),
         },
         onConflict: 'user_id,vehicle_id',
       );

--- a/lib/core/sync/community_config.dart
+++ b/lib/core/sync/community_config.dart
@@ -47,7 +47,7 @@ class CommunityConfig {
       _cachedUrl = config['supabase_url'] as String?;
       _cachedKey = config['supabase_anon_key'] as String?;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'CommunityConfig: failed to load asset'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'CommunityConfig: failed to load asset'}));
     }
   }
 

--- a/lib/core/sync/deletions_sync.dart
+++ b/lib/core/sync/deletions_sync.dart
@@ -47,7 +47,7 @@ class DeletionsSync {
     final userId = client?.auth.currentUser?.id;
     if (client == null || userId == null) return;
 
-    final now = DateTime.now().toIso8601String();
+    final now = DateTime.now().toUtc().toIso8601String();
     final rows = ids
         .map((id) => {
               'user_id': userId,

--- a/lib/core/sync/deletions_sync.dart
+++ b/lib/core/sync/deletions_sync.dart
@@ -64,7 +64,7 @@ class DeletionsSync {
       debugPrint('DeletionsSync.record: ${ids.length} tombstone(s) '
           'for "$tableName"');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'DeletionsSync.record FAILED'}));
     }
   }
@@ -88,7 +88,7 @@ class DeletionsSync {
           .whereType<String>()
           .toSet();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'DeletionsSync.fetchTombstonedIds FAILED'}));
       return {};
     }

--- a/lib/core/sync/favorites_sync.dart
+++ b/lib/core/sync/favorites_sync.dart
@@ -67,7 +67,7 @@ class FavoritesSync {
 
       return localIds.union(serverIds).toList();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FavoritesSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FavoritesSync.merge FAILED'}));
       return localFavoriteIds;
     }
   }
@@ -90,7 +90,7 @@ class FavoritesSync {
       await DeletionsSync.record('favorites', stationId);
       debugPrint('FavoritesSync.delete: $stationId removed from server');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FavoritesSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FavoritesSync.delete FAILED'}));
     }
   }
 }

--- a/lib/core/sync/fill_ups_sync.dart
+++ b/lib/core/sync/fill_ups_sync.dart
@@ -91,7 +91,7 @@ class FillUpsSync {
           try {
             return FillUp.fromJson(data);
           } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FillUpsSync.merge decode failed'}));
+            unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FillUpsSync.merge decode failed'}));
             return null;
           }
         }
@@ -100,7 +100,7 @@ class FillUpsSync {
 
       return [...liveLocal, ...downloaded];
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FillUpsSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FillUpsSync.merge FAILED'}));
       return localFillUps;
     }
   }
@@ -119,7 +119,7 @@ class FillUpsSync {
           .eq('id', fillUpId);
       await DeletionsSync.record('fill_ups', fillUpId); // #3078
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FillUpsSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FillUpsSync.delete FAILED'}));
     }
   }
 }

--- a/lib/core/sync/fill_ups_sync.dart
+++ b/lib/core/sync/fill_ups_sync.dart
@@ -72,7 +72,7 @@ class FillUpsSync {
                   'vehicle_id': f.vehicleId,
                   'recorded_at': f.date.toIso8601String(),
                   'data': f.toJson(),
-                  'updated_at': DateTime.now().toIso8601String(),
+                  'updated_at': DateTime.now().toUtc().toIso8601String(),
                 })
             .toList();
         await client

--- a/lib/core/sync/ignored_stations_sync.dart
+++ b/lib/core/sync/ignored_stations_sync.dart
@@ -66,7 +66,7 @@ class IgnoredStationsSync {
 
       return localIds.union(serverIds).toList();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'IgnoredStationsSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'IgnoredStationsSync.merge FAILED'}));
       return localIgnoredIds;
     }
   }
@@ -87,7 +87,7 @@ class IgnoredStationsSync {
           .eq('station_id', stationId);
       await DeletionsSync.record('ignored_stations', stationId);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'IgnoredStationsSync.delete FAILED'}));
     }
   }

--- a/lib/core/sync/itineraries_sync.dart
+++ b/lib/core/sync/itineraries_sync.dart
@@ -44,7 +44,7 @@ class ItinerariesSync {
         'avoid_highways': itinerary.avoidHighways,
         'fuel_type': itinerary.fuelType,
         'selected_station_ids': itinerary.selectedStationIds,
-        'updated_at': DateTime.now().toIso8601String(),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
       }, onConflict: 'id');
       debugPrint('ItinerariesSync.save: saved "${itinerary.name}"');
       return true;

--- a/lib/core/sync/itineraries_sync.dart
+++ b/lib/core/sync/itineraries_sync.dart
@@ -49,7 +49,7 @@ class ItinerariesSync {
       debugPrint('ItinerariesSync.save: saved "${itinerary.name}"');
       return true;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ItinerariesSync.save FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.save FAILED'}));
       return false;
     }
   }
@@ -96,7 +96,7 @@ class ItinerariesSync {
         );
       }).toList();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ItinerariesSync.fetchAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.fetchAll FAILED'}));
       return [];
     }
   }
@@ -117,7 +117,7 @@ class ItinerariesSync {
       await DeletionsSync.record('itineraries', itineraryId); // #3078
       return true;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ItinerariesSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.delete FAILED'}));
       return false;
     }
   }

--- a/lib/core/sync/price_history_sync.dart
+++ b/lib/core/sync/price_history_sync.dart
@@ -66,7 +66,7 @@ class PriceHistorySync {
 
     try {
       final cutoff =
-          DateTime.now().subtract(Duration(days: days)).toIso8601String();
+          DateTime.now().toUtc().subtract(Duration(days: days)).toIso8601String();
       final rows = await client
           .from('price_snapshots')
           .select()

--- a/lib/core/sync/price_history_sync.dart
+++ b/lib/core/sync/price_history_sync.dart
@@ -75,7 +75,7 @@ class PriceHistorySync {
           .order('recorded_at', ascending: true);
       return List<Map<String, dynamic>>.from(rows);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'PriceHistorySync.fetch FAILED'}));
       return [];
     }

--- a/lib/core/sync/ratings_sync.dart
+++ b/lib/core/sync/ratings_sync.dart
@@ -51,7 +51,7 @@ class RatingsSync {
       debugPrint(
           'RatingsSync.upsert: $stationId = $rating stars (shared=$shared)');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.upsert FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.upsert FAILED'}));
     }
   }
 
@@ -87,7 +87,7 @@ class RatingsSync {
           .upsert(rows, onConflict: 'user_id,station_id');
       debugPrint('RatingsSync.upsertAll: ${rows.length} ratings in 1 round-trip');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.upsertAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.upsertAll FAILED'}));
     }
   }
 
@@ -109,7 +109,7 @@ class RatingsSync {
       await DeletionsSync.record('station_ratings', stationId);
       debugPrint('RatingsSync.delete: $stationId removed');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.delete FAILED'}));
     }
   }
 
@@ -141,7 +141,7 @@ class RatingsSync {
       }
       return result;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.fetchAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.fetchAll FAILED'}));
       return {};
     }
   }

--- a/lib/core/sync/ratings_sync.dart
+++ b/lib/core/sync/ratings_sync.dart
@@ -46,7 +46,7 @@ class RatingsSync {
         'station_id': stationId,
         'rating': rating,
         'is_shared': shared,
-        'updated_at': DateTime.now().toIso8601String(),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
       }, onConflict: 'user_id,station_id');
       debugPrint(
           'RatingsSync.upsert: $stationId = $rating stars (shared=$shared)');
@@ -70,7 +70,7 @@ class RatingsSync {
     final userId = client?.auth.currentUser?.id;
     if (client == null || userId == null) return;
 
-    final now = DateTime.now().toIso8601String();
+    final now = DateTime.now().toUtc().toIso8601String();
     final rows = ratings.entries
         .map((e) => {
               'user_id': userId,

--- a/lib/core/sync/schema_verifier.dart
+++ b/lib/core/sync/schema_verifier.dart
@@ -75,7 +75,7 @@ class SchemaVerifier {
             .count()
             .then((_) => MapEntry(table, true))
             .catchError((Object e, StackTrace st) {
-          unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'SchemaVerifier: table check failed'}));
+          unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'SchemaVerifier: table check failed'}));
           return MapEntry(table, false);
         }),
       ),
@@ -114,7 +114,7 @@ class SchemaVerifier {
       final value = row?['value'];
       return value == null ? 0 : (int.tryParse('$value') ?? 0);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'SchemaVerifier: schema-version probe failed'}));
       return 0;
     }

--- a/lib/core/sync/supabase_client.dart
+++ b/lib/core/sync/supabase_client.dart
@@ -171,7 +171,7 @@ class TankSyncClient {
     try {
       await c.auth.signOut();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TankSync: sign-out after upsert failure also failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TankSync: sign-out after upsert failure also failed'}));
     }
     _initialized = false;
     throw StateError(

--- a/lib/core/sync/sync_helper.dart
+++ b/lib/core/sync/sync_helper.dart
@@ -52,7 +52,7 @@ class SyncHelper {
         await syncFn();
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'SyncHelper[$context]: sync failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'SyncHelper[$context]: sync failed'}));
     }
   }
 

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -126,7 +126,7 @@ class SyncState extends _$SyncState {
       // Initial sync: upload local data to server (non-blocking)
       _performInitialSync(storage);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TankSync connect failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TankSync connect failed'}));
       rethrow;
     }
   }
@@ -254,7 +254,7 @@ class SyncState extends _$SyncState {
       // Sync local data to the new anonymous account
       _performInitialSync(storage);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'switchToAnonymous failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'switchToAnonymous failed'}));
       rethrow;
     }
   }
@@ -272,7 +272,7 @@ class SyncState extends _$SyncState {
       await UserDataSync.deleteAll();
       await TankSyncClient.signOut();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Delete account failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'Delete account failed'}));
     }
     await disconnect();
   }
@@ -283,7 +283,7 @@ class SyncState extends _$SyncState {
     try {
       await TankSyncClient.signOut();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TankSync signOut failed'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TankSync signOut failed'}));
     }
 
     await storage.putSetting('sync_enabled', false);
@@ -308,7 +308,7 @@ class SyncState extends _$SyncState {
         await syncAndPersistRatings(storage);
         debugPrint('InitialSync: complete');
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));
       }
     });
   }

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'a16a129ea3aeedbb1a32e98f1d07228a57f4c55d';
+String _$syncStateHash() => r'c082f3edd9335009c6c54aec743f272d65888695';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/core/sync/trip_shares_sync.dart
+++ b/lib/core/sync/trip_shares_sync.dart
@@ -131,7 +131,7 @@ class TripSharesSync {
       debugPrint('TripSharesSync.shareWithEmail: shared $tripId');
       return TripShareResult.shared;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: {'where': 'TripSharesSync.shareWithEmail FAILED for $tripId'}));
       return TripShareResult.failed;
     }
@@ -160,7 +160,7 @@ class TripSharesSync {
       debugPrint('TripSharesSync.createShareLink: minted token for $tripId');
       return token;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: {'where': 'TripSharesSync.createShareLink FAILED for $tripId'}));
       return null;
     }
@@ -184,7 +184,7 @@ class TripSharesSync {
       );
       return claimed is String && claimed.isNotEmpty;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'TripSharesSync.claimShareLink FAILED'}));
       return false;
     }
@@ -205,7 +205,7 @@ class TripSharesSync {
           .eq('trip_id', tripId);
       return parseShareRows(rows);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: {'where': 'TripSharesSync.listSharesForTrip FAILED for $tripId'}));
       return const [];
     }
@@ -226,7 +226,7 @@ class TripSharesSync {
           .eq('owner_id', userId);
       debugPrint('TripSharesSync.revoke: revoked $shareId');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: {'where': 'TripSharesSync.revoke FAILED for $shareId'}));
     }
   }
@@ -266,7 +266,7 @@ class TripSharesSync {
           .inFilter('id', tripIds.toList());
       return parseSharedSummaries(summaryRows);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'TripSharesSync.fetchSharedWithMe FAILED'}));
       return const [];
     }
@@ -301,7 +301,7 @@ class TripSharesSync {
       try {
         out.add(TripHistoryEntry.fromJson(data.cast<String, dynamic>()));
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st,
             context: {'where': 'TripSharesSync.parseSharedSummaries decode failed for ${r['id']}'}));
       }
     }

--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -68,7 +68,7 @@ class TripsSync {
           .upsert(buildSummaryRow(entry, userId), onConflict: 'user_id,id');
       debugPrint('TripsSync.uploadSummary: uploaded ${entry.id}');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.uploadSummary FAILED for ${entry.id}'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync.uploadSummary FAILED for ${entry.id}'}));
     }
     // Phase 4 (#1541) — fan out the heavy blob to `trip_details`.
     // [uploadDetails] no-ops when the entry has no samples /
@@ -111,7 +111,7 @@ class TripsSync {
       }, onConflict: 'user_id,id');
       debugPrint('TripsSync.uploadDetails: uploaded ${entry.id}');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.uploadDetails FAILED for ${entry.id}'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync.uploadDetails FAILED for ${entry.id}'}));
     }
   }
 
@@ -140,7 +140,7 @@ class TripsSync {
       if (data is! Map) return null;
       return data.cast<String, dynamic>();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.fetchDetails FAILED for $tripId'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync.fetchDetails FAILED for $tripId'}));
       return null;
     }
   }
@@ -161,7 +161,7 @@ class TripsSync {
           .eq('id', tripId);
       await DeletionsSync.record('trip_summaries', tripId); // #3078
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.deleteSummary FAILED for $tripId'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync.deleteSummary FAILED for $tripId'}));
     }
   }
 
@@ -222,7 +222,7 @@ class TripsSync {
           'downloaded=${merged.length - liveLocal.length}');
       return merged;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TripsSync.merge FAILED'}));
       return localEntries;
     }
   }
@@ -251,7 +251,7 @@ class TripsSync {
     try {
       await client.from(table).upsert(rows, onConflict: 'user_id,id');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync._batchUpsert $table FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync._batchUpsert $table FAILED'}));
     }
   }
 
@@ -320,7 +320,7 @@ class TripsSync {
       await client.from('trip_details').delete().eq('user_id', userId);
       debugPrint('TripsSync.forgetAllForUser: wiped server-side rows');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.forgetAllForUser FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TripsSync.forgetAllForUser FAILED'}));
     }
   }
 
@@ -345,7 +345,7 @@ class TripsSync {
           .eq('user_id', userId)
           .lt('updated_at', cutoff.toIso8601String());
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.pruneOldDetails FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'TripsSync.pruneOldDetails FAILED'}));
     }
   }
 
@@ -409,7 +409,7 @@ class TripsSync {
           TripHistoryEntry.fromJson(data.cast<String, dynamic>()),
         );
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.mergeRows decode failed for $id'}));
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'TripsSync.mergeRows decode failed for $id'}));
       }
     }
     return [...localEntries, ...downloaded];

--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -107,7 +107,7 @@ class TripsSync {
         'id': entry.id,
         'user_id': userId,
         'data': tripDetailsJson(entry),
-        'updated_at': DateTime.now().toIso8601String(),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
       }, onConflict: 'user_id,id');
       debugPrint('TripsSync.uploadDetails: uploaded ${entry.id}');
     } catch (e, st) {
@@ -284,7 +284,7 @@ class TripsSync {
     String userId, {
     DateTime? now,
   }) {
-    final stamp = (now ?? DateTime.now()).toIso8601String();
+    final stamp = (now ?? DateTime.now()).toUtc().toIso8601String();
     final rows = <Map<String, dynamic>>[];
     for (final entry in entries) {
       if (entry.samples.isEmpty && entry.gpsSampleDiagnostics.isEmpty) {
@@ -372,7 +372,7 @@ class TripsSync {
       // (samples + gpsd) goes to `public.trip_details` in
       // [uploadDetails] right after.
       'data': compactSummaryJson(entry),
-      'updated_at': (now ?? DateTime.now()).toIso8601String(),
+      'updated_at': (now ?? DateTime.now()).toUtc().toIso8601String(),
     };
   }
 

--- a/lib/core/sync/user_data_sync.dart
+++ b/lib/core/sync/user_data_sync.dart
@@ -75,7 +75,7 @@ class UserDataSync {
         'trip_details': tripDetails,
       };
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'UserDataSync.fetchAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'UserDataSync.fetchAll FAILED'}));
       return {'error': e.toString()};
     }
   }
@@ -121,7 +121,7 @@ class UserDataSync {
       try {
         await client.from(entry.key).delete().eq(entry.value, userId);
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st,
             context: {'where': 'UserDataSync.deleteAll FAILED for ${entry.key}'}));
       }
     }

--- a/lib/core/sync/vehicles_sync.dart
+++ b/lib/core/sync/vehicles_sync.dart
@@ -94,7 +94,7 @@ class VehiclesSync {
           try {
             return VehicleProfile.fromJson(data);
           } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'VehiclesSync.merge decode failed'}));
+            unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'VehiclesSync.merge decode failed'}));
             return null;
           }
         }
@@ -103,7 +103,7 @@ class VehiclesSync {
 
       return [...liveLocal, ...downloaded];
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'VehiclesSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'VehiclesSync.merge FAILED'}));
       return localVehicles;
     }
   }
@@ -124,7 +124,7 @@ class VehiclesSync {
           .eq('id', vehicleId);
       await DeletionsSync.record('vehicles', vehicleId); // #3078
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'VehiclesSync.delete FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'VehiclesSync.delete FAILED'}));
     }
   }
 }

--- a/lib/core/sync/vehicles_sync.dart
+++ b/lib/core/sync/vehicles_sync.dart
@@ -75,7 +75,7 @@ class VehiclesSync {
                   'id': v.id,
                   'user_id': userId,
                   'data': v.toJson(),
-                  'updated_at': DateTime.now().toIso8601String(),
+                  'updated_at': DateTime.now().toUtc().toIso8601String(),
                 })
             .toList();
         await client

--- a/lib/features/alerts/providers/alert_provider.dart
+++ b/lib/features/alerts/providers/alert_provider.dart
@@ -9,6 +9,7 @@ import '../../../core/notifications/notification_providers.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/sync_provider.dart';
 import '../../../core/sync/alerts_sync.dart';
+import '../../../core/sync/sync_helper.dart';
 import '../data/models/price_alert.dart';
 import '../data/repositories/alert_repository.dart';
 import '../../../core/logging/error_logger.dart';
@@ -32,6 +33,16 @@ typedef AlertsMergeFn = Future<List<PriceAlert>> Function(
 /// [AlertsSync.merge]; tests override this provider with a fake.
 @Riverpod(keepAlive: true)
 AlertsMergeFn alertsMergeFn(Ref ref) => AlertsSync.merge;
+
+/// Signature of the alert delete propagation (#3121). Defaults to
+/// [AlertsSync.delete]; overridable in tests so the delete-resurrection
+/// regression test can model the server without standing up Supabase.
+typedef AlertsDeleteFn = Future<void> Function(String id);
+
+/// Injectable delete-propagation function. Production code uses the real
+/// [AlertsSync.delete]; tests override this provider with a fake.
+@Riverpod(keepAlive: true)
+AlertsDeleteFn alertsDeleteFn(Ref ref) => AlertsSync.delete;
 
 @Riverpod(keepAlive: true)
 class AlertNotifier extends _$AlertNotifier {
@@ -60,10 +71,21 @@ class AlertNotifier extends _$AlertNotifier {
     final repo = ref.read(alertRepositoryProvider);
     await repo.deleteAlert(id);
     state = repo.getAlerts();
-    // #2246 — do NOT apply downloads after a delete: the server still
-    // holds the just-deleted row (AlertsSync has no delete propagation
-    // yet), so re-downloading it would resurrect the alert the user just
-    // removed. Upload-only keeps the local delete sticky on this device.
+    // #3121 — propagate the delete: remove the server row and record a
+    // `deletions` tombstone so the launch pull (#3077) or another
+    // device's union merge can't resurrect the alert. Local-first: the
+    // local delete above already happened, and fireAndForget swallows a
+    // server failure (the tombstone still filters the id from every
+    // later merge).
+    await SyncHelper.fireAndForget(
+      ref,
+      'Alerts.remove',
+      () => ref.read(alertsDeleteFnProvider)(id),
+    );
+    // #2246 — keep downloads suppressed on the remove path: the server
+    // delete above may not have landed on a flaky link, and the
+    // tombstone filter inside AlertsSync.merge already guards the next
+    // pull. Upload-only keeps the local delete sticky on this device.
     await _syncAlertsIfConnected(applyDownloads: false);
     await BackgroundService.reconcile();
   }

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -100,6 +100,55 @@ final class AlertsMergeFnProvider
 
 String _$alertsMergeFnHash() => r'6ec72990e3b88e6041de3ae2ae7711c643aaf6ec';
 
+/// Injectable delete-propagation function. Production code uses the real
+/// [AlertsSync.delete]; tests override this provider with a fake.
+
+@ProviderFor(alertsDeleteFn)
+final alertsDeleteFnProvider = AlertsDeleteFnProvider._();
+
+/// Injectable delete-propagation function. Production code uses the real
+/// [AlertsSync.delete]; tests override this provider with a fake.
+
+final class AlertsDeleteFnProvider
+    extends $FunctionalProvider<AlertsDeleteFn, AlertsDeleteFn, AlertsDeleteFn>
+    with $Provider<AlertsDeleteFn> {
+  /// Injectable delete-propagation function. Production code uses the real
+  /// [AlertsSync.delete]; tests override this provider with a fake.
+  AlertsDeleteFnProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'alertsDeleteFnProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$alertsDeleteFnHash();
+
+  @$internal
+  @override
+  $ProviderElement<AlertsDeleteFn> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AlertsDeleteFn create(Ref ref) {
+    return alertsDeleteFn(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AlertsDeleteFn value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AlertsDeleteFn>(value),
+    );
+  }
+}
+
+String _$alertsDeleteFnHash() => r'ce5095f5a836ad87c3a46924b647902e6c998bcd';
+
 @ProviderFor(AlertNotifier)
 final alertProvider = AlertNotifierProvider._();
 
@@ -132,7 +181,7 @@ final class AlertNotifierProvider
   }
 }
 
-String _$alertNotifierHash() => r'0f5704e93402174bd6244293687986dc85d1f8b8';
+String _$alertNotifierHash() => r'ffc95de425cd0dd670590cf1ebe85d4e55aa7763';
 
 abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
   List<PriceAlert> build();

--- a/test/core/sync/alerts_delete_resurrection_test.dart
+++ b/test/core/sync/alerts_delete_resurrection_test.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/notifications/notification_providers.dart';
+import 'package:tankstellen/core/notifications/notification_service.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/sync/alerts_sync.dart';
+import 'package:tankstellen/core/sync/sync_helper.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+import '../../helpers/silence_error_logger.dart';
+
+/// #3121 — deleted price alerts resurrect at the next launch.
+///
+/// `removeAlert` deleted only locally; alerts was the ONLY synced entity
+/// with neither server-delete propagation nor deletion tombstones. The
+/// #3077 launch pull (`pullFromServer` → `_applyMergedAlerts`) then
+/// re-persisted the surviving server row, resurrecting the alert the user
+/// just removed.
+///
+/// The fix mirrors FavoritesSync (#3078): `removeAlert` now propagates the
+/// delete (server row delete + `deletions` tombstone via
+/// [AlertsSync.delete]) and [AlertsSync.merge] filters tombstoned ids
+/// through the shared [SyncHelper.removeTombstoned] seam.
+///
+/// These tests drive the provider flow with a fake server store mutated by
+/// the injectable delete fn. They FAIL on the pre-fix code (no delete
+/// propagation exists, so the fake server keeps the row and the pull
+/// resurrects it) and PASS after.
+class _NoopNotificationService implements NotificationService {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<bool> requestPermission() async => true;
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+  @override
+  Future<void> showPriceAlert(
+      {required int id,
+      required String title,
+      required String body,
+      String? payload}) async {}
+  @override
+  Future<void> showServiceReminder(
+      {required int id, required String title, required String body}) async {}
+  @override
+  Future<void> cancelNotification(int id) async {}
+  @override
+  Future<void> cancelAll() async {}
+}
+
+PriceAlert _makeAlert({required String id, String stationId = 'station-1'}) {
+  return PriceAlert(
+    id: id,
+    stationId: stationId,
+    stationName: 'Test Station',
+    fuelType: FuelType.e10,
+    targetPrice: 1.50,
+    isActive: true,
+    createdAt: DateTime(2026, 1, 1),
+  );
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+  late FakeHiveStorage fakeStorage;
+
+  /// The fake server: rows surviving on Supabase. The fake merge fn
+  /// models the real [AlertsSync.merge] contract (returns
+  /// `[local, ...server-only]`); the fake delete fn models the real
+  /// [AlertsSync.delete] contract (removes the server row).
+  late List<PriceAlert> serverStore;
+  late List<String> propagatedDeletes;
+
+  setUp(() {
+    fakeStorage = FakeHiveStorage();
+    serverStore = [];
+    propagatedDeletes = [];
+  });
+
+  ProviderContainer createContainer({
+    Future<void> Function(String id)? deleteFn,
+  }) {
+    final container = ProviderContainer(
+      overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        notificationServiceProvider
+            .overrideWithValue(_NoopNotificationService()),
+        alertsMergeFnProvider.overrideWithValue((local) async {
+          final localIds = local.map((a) => a.id).toSet();
+          return [
+            ...local,
+            ...serverStore.where((s) => !localIds.contains(s.id)),
+          ];
+        }),
+        alertsDeleteFnProvider.overrideWithValue(deleteFn ??
+            (id) async {
+              propagatedDeletes.add(id);
+              serverStore.removeWhere((a) => a.id == id);
+            }),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('alert delete propagation + resurrection (#3121)', () {
+    test('removeAlert propagates the delete to the server', () async {
+      await fakeStorage.putSetting('sync_enabled', true);
+      final keep = _makeAlert(id: 'keep');
+      final gone = _makeAlert(id: 'gone', stationId: 'station-2');
+      await fakeStorage.saveAlerts([keep.toJson(), gone.toJson()]);
+      serverStore = [keep, gone];
+
+      final container = createContainer();
+      container.read(alertProvider);
+
+      await container.read(alertProvider.notifier).removeAlert('gone');
+
+      expect(propagatedDeletes, equals(['gone']),
+          reason: 'removeAlert must propagate the delete to the server — '
+              'pre-#3121 it deleted only locally');
+    });
+
+    test('deleted alert stays dead through the #3077 launch pull', () async {
+      await fakeStorage.putSetting('sync_enabled', true);
+      final keep = _makeAlert(id: 'keep');
+      final gone = _makeAlert(id: 'gone', stationId: 'station-2');
+      await fakeStorage.saveAlerts([keep.toJson(), gone.toJson()]);
+      serverStore = [keep, gone];
+
+      final container = createContainer();
+      container.read(alertProvider);
+
+      await container.read(alertProvider.notifier).removeAlert('gone');
+      // The next launch runs the explicit pull (#3077) — without delete
+      // propagation the surviving server row resurrects here.
+      await container.read(alertProvider.notifier).pullFromServer();
+
+      final stored = fakeStorage.getAlerts().map((a) => a['id']).toSet();
+      expect(stored, equals({'keep'}),
+          reason: 'the launch pull resurrected the deleted alert');
+      expect(container.read(alertProvider).map((a) => a.id).toSet(),
+          equals({'keep'}));
+    });
+
+    test('local delete succeeds even when the server delete throws',
+        () async {
+      await fakeStorage.putSetting('sync_enabled', true);
+      final gone = _makeAlert(id: 'gone');
+      await fakeStorage.saveAlerts([gone.toJson()]);
+      serverStore = [gone];
+
+      final container = createContainer(
+        deleteFn: (id) async => throw Exception('server unreachable'),
+      );
+      container.read(alertProvider);
+
+      // Local-first: the server failure must not throw back into the UI
+      // flow, and the local delete must stick.
+      await expectLater(
+          container.read(alertProvider.notifier).removeAlert('gone'),
+          completes);
+      expect(fakeStorage.getAlerts(), isEmpty);
+      expect(container.read(alertProvider), isEmpty);
+    });
+
+    test('delete propagation is not invoked when TankSync is disabled',
+        () async {
+      // sync_enabled not set → SyncHelper gate keeps the server untouched.
+      final gone = _makeAlert(id: 'gone');
+      await fakeStorage.saveAlerts([gone.toJson()]);
+
+      final container = createContainer();
+      container.read(alertProvider);
+
+      await container.read(alertProvider.notifier).removeAlert('gone');
+
+      expect(propagatedDeletes, isEmpty);
+      expect(fakeStorage.getAlerts(), isEmpty);
+    });
+  });
+
+  group('AlertsSync auth guards (#3121)', () {
+    test('delete is a no-op when unauthenticated', () async {
+      // Mirrors the FavoritesSync.delete guard test — returns normally
+      // without a Supabase client.
+      await expectLater(AlertsSync.delete('alert-1'), completes);
+    });
+  });
+
+  group('AlertsSync.merge tombstone seam (#3121)', () {
+    test('a tombstoned server alert row is dropped before the union', () {
+      // The same shared seam favorites/ignored use (#3078), keyed on the
+      // alert row's `id` column — pins the filter shape merge() wires up.
+      final serverRows = [
+        {'id': 'keep', 'station_id': 's-1'},
+        {'id': 'gone', 'station_id': 's-2'},
+      ];
+      final live = SyncHelper.removeTombstoned(
+        serverRows,
+        {'gone'},
+        key: (r) => r['id'],
+      ).toList();
+      expect(live, hasLength(1));
+      expect(live.single['id'], 'keep');
+    });
+  });
+}

--- a/test/lint/sync_error_layer_test.dart
+++ b/test/lint/sync_error_layer_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#3128): sync code must log to
+/// [ErrorLayer.sync], not the catch-all [ErrorLayer.other].
+///
+/// The `ErrorLayer` enum has a dedicated `sync` layer ("TankSync /
+/// Supabase / cloud sync flows"), but every catch block under
+/// `lib/core/sync/` shipped with `ErrorLayer.other` — burying sync
+/// failures in the unclassified bucket where the error-log triage view
+/// and per-layer sample rates can't see them.
+///
+/// What is forbidden (in `lib/core/sync/`):
+///   ErrorLayer.other
+///
+/// What is allowed:
+///   - `ErrorLayer.sync` (and any other specific layer where genuinely
+///     appropriate — only the catch-all is banned here).
+///   - generated files (`.g.dart`, `.freezed.dart`).
+///
+/// Baseline is **0** — never add an offender.
+void main() {
+  test('no ErrorLayer.other in lib/core/sync (#3128)', () {
+    final offenders = <String>[];
+    final banned = RegExp(r'ErrorLayer\.other\b');
+
+    final dir = Directory('lib/core/sync');
+    expect(dir.existsSync(), isTrue,
+        reason: 'run from the repo root (lib/core/sync not found)');
+
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) {
+        continue;
+      }
+
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        if (banned.hasMatch(lines[i])) {
+          offenders.add('${entity.path}:${i + 1}  ${lines[i].trim()}');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Sync code must log to ErrorLayer.sync, not the catch-all '
+          'ErrorLayer.other (#3128):\n${offenders.join('\n')}',
+    );
+  });
+}

--- a/test/lint/sync_utc_timestamps_test.dart
+++ b/test/lint/sync_utc_timestamps_test.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#3124): every sync timestamp serialized
+/// for Supabase must be UTC.
+///
+/// `DateTime.now().toIso8601String()` produces an **offset-less LOCAL**
+/// time string (`2026-06-10T14:30:00.000` — no `Z`, no `+02:00`).
+/// Postgres interprets an offset-less literal in a TIMESTAMPTZ column as
+/// UTC, so every `updated_at` / `deleted_at` uploaded this way is skewed
+/// by the device's UTC offset — corrupting cross-device ordering,
+/// tombstone freshness and retention cutoffs. The fix is
+/// `DateTime.now().toUtc().toIso8601String()` (the `Z`-suffixed form).
+///
+/// What is forbidden (in `lib/core/sync/`):
+///   DateTime.now().toIso8601String()
+///   (now ?? DateTime.now()).toIso8601String()
+///   DateTime.now().subtract(...).toIso8601String()
+///   …any `DateTime.now()`-rooted chain reaching `.toIso8601String()`
+///   without a `.toUtc()` in between.
+///
+/// What is allowed:
+///   - the same chain with `.toUtc()` anywhere before
+///     `.toIso8601String()`.
+///   - generated files (`.g.dart`, `.freezed.dart`).
+///
+/// Baseline is **0** — never add an offender.
+void main() {
+  test(
+      'no offset-less local DateTime.now() timestamps in lib/core/sync '
+      '(#3124)', () {
+    final offenders = <String>[];
+
+    // A `DateTime.now()`-rooted expression chain that reaches
+    // `.toIso8601String` within the same statement. `[^;]*?` tolerates
+    // intervening calls (`.subtract(...)`, a `(now ?? …)` null-fallback
+    // closing paren) and line breaks.
+    final chain = RegExp(r'DateTime\.now\(\)[^;]*?\.toIso8601String');
+
+    final dir = Directory('lib/core/sync');
+    expect(dir.existsSync(), isTrue,
+        reason: 'run from the repo root (lib/core/sync not found)');
+
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) {
+        continue;
+      }
+
+      final content = entity.readAsStringSync();
+      for (final match in chain.allMatches(content)) {
+        final snippet = match.group(0)!;
+        if (snippet.contains('.toUtc()')) continue;
+        final line = '\n'.allMatches(content.substring(0, match.start)).length + 1;
+        offenders.add(
+            '${entity.path}:$line  ${snippet.replaceAll(RegExp(r'\s+'), ' ')}');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Local-time timestamps uploaded to TIMESTAMPTZ columns '
+          '(#3124). Insert .toUtc() before .toIso8601String():\n'
+          '${offenders.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
Wave 3 of epic #3120. All RED-on-master first.

- Closes #3121 — deleted price alerts stay dead: server delete + 'alerts' tombstone via DeletionsSync, tombstone-filtered merge (RED: the launch pull resurrected the deleted alert). No Supabase schema change — alerts rows live in the existing `alerts` table, tombstones in the existing `deletions` table (schema v3 untouched, verifier test green).
- Closes #3124 — every sync upload timestamp is now UTC (11 sites; offset-less local time was skewing cross-device ordering by hours in TIMESTAMPTZ columns); zero-baseline lint test pins it. Two sites found beyond the audit list (price-history retention cutoff, trips injectable-now seam) fixed under the same defect class.
- Closes #3128 — each launch entity pull gets a 15s timeout (one hung postgrest call no longer stalls the rest), failures log via errorLogger; the 50-site ErrorLayer.other→sync sweep lands with a pin test, so sync errors finally bucket as sync in the trace pipeline.

Validation: analyze clean; 529 + 1709 tests green incl. new resurrection-regression, UTC-lint and ErrorLayer-pin suites; clean codegen.

Next in the epic: #3122 LWW edit propagation (deliberately AFTER UTC lands — it depends on comparable timestamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)