### PR TITLE
fix(diag): release-visible failures, PII scrubbing, startup-brick forensics, trace hygiene (#3143 #3145 #3148 #3149 #3150)

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/constants/app_constants.dart';
 import '../core/country/country_switch_listener.dart';
+import '../core/logging/error_logger.dart';
 import '../core/language/language_provider.dart';
 import '../core/notifications/notification_launch_listener.dart';
 import '../core/theme/theme_mode_provider.dart';
@@ -73,8 +74,9 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
           .read(tripRecordingProvider.notifier)
           .onAppLifecycleStateChanged(state);
     } catch (e, st) {
-      debugPrint(
-          'TankstellenApp: onAppLifecycleStateChanged failed: $e\n$st');
+      // #3143 — release-visible: debugPrint is no-opped in release.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+          context: {'where': 'onAppLifecycleStateChanged'}));
     }
     if (state != AppLifecycleState.paused &&
         state != AppLifecycleState.inactive) {
@@ -89,7 +91,8 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
       final notifier = ref.read(tripRecordingProvider.notifier);
       unawaited(notifier.onAppBackgrounded());
     } catch (e, st) {
-      debugPrint('TankstellenApp: onAppBackgrounded failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+          context: {'where': 'onAppBackgrounded'}));
     }
   }
 

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -192,7 +192,8 @@ class AppInitializer {
           '${packageInfo.version}+${packageInfo.buildNumber}',
         );
       } catch (e, st) {
-        debugPrint('PackageInfo resolution failed (#570): $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'resolveRuntimeVersion (#570)'}));
       }
     });
 
@@ -214,7 +215,8 @@ class AppInitializer {
         debugPrint(
             'VehicleProfileCatalogMigrator: matched $matched profile(s)');
       } catch (e, st) {
-        debugPrint('VehicleProfileCatalogMigrator: deferred run failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'vehicleProfileCatalogMigrator'}));
       }
     });
 
@@ -236,8 +238,8 @@ class AppInitializer {
       try {
         unawaited(container.read(legacyToggleMigrationProvider.future));
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: legacyToggleMigration kick-off failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'legacyToggleMigration kick-off'}));
       }
     });
 
@@ -250,8 +252,8 @@ class AppInitializer {
       try {
         container.read(tripVeRecomputeListenerProvider);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: η_v recompute listener kick-off failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'tripVeRecomputeListener kick-off'}));
       }
     });
 
@@ -264,8 +266,8 @@ class AppInitializer {
       try {
         container.read(obd2DebugSessionLoggingProvider);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: OBD2 debug-logging kick-off failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'obd2DebugSessionLogging kick-off'}));
       }
     });
 
@@ -278,9 +280,8 @@ class AppInitializer {
       try {
         container.read(obd2CommDiagnosticsGateProvider);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: OBD2 comm-diagnostics gate kick-off failed: '
-            '$e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'obd2CommDiagnosticsGate kick-off'}));
       }
     });
 
@@ -453,7 +454,9 @@ class AppInitializer {
       try {
         await body();
       } catch (e, st) {
-        debugPrint('AppInitializer: deferred task failed: $e\n$st');
+        // #3143 — release-visible: debugPrint is no-opped in release.
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'deferPostFirstFrame'}));
       }
     }
 
@@ -498,7 +501,10 @@ class AppInitializer {
     try {
       await body();
     } catch (e, st) {
-      debugPrint('AppInitializer: $label init failed: $e\n$st');
+      // #3143 — pre-bind, so this spools via IsolateErrorSpool and is
+      // drained into the trace pipeline post-first-frame.
+      unawaited(errorLogger.log(ErrorLayer.background, e, st,
+          context: {'where': 'serviceInit', 'service': label}));
     }
   }
 
@@ -535,15 +541,20 @@ class AppInitializer {
               onConflict: 'id',
             );
           } catch (e, st) {
-            debugPrint('TankSync: users upsert failed: $e\n$st');
+            unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+                context: {'where': 'maybeInitTankSync users upsert'}));
           }
         }
         debugPrint('TankSync: ready');
       }).timeout(const Duration(seconds: 8));
-    } on TimeoutException {
-      debugPrint('TankSync: init timed out after 8s, proceeding without sync');
+    } on TimeoutException catch (e, st) {
+      // #3143 — proceeding without sync, but record it: a silent init
+      // timeout previously looked identical to "sync works" in the field.
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: {'where': 'maybeInitTankSync', 'timeoutSeconds': 8}));
     } catch (e, st) {
-      debugPrint('TankSync init failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: {'where': 'maybeInitTankSync'}));
     }
   }
 
@@ -593,7 +604,8 @@ class AppInitializer {
       // budget stays bounded.
       await TripsSync.pruneOldDetails();
     } catch (e, st) {
-      debugPrint('AppInitializer._runTripsSyncMerge failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: {'where': 'runTripsSyncMerge'}));
     }
   }
 
@@ -675,12 +687,13 @@ class AppInitializer {
       // discrimination was removed: every launch URI is a route to stash.
       container.read(pendingWidgetUriProvider.notifier).set(uri);
     } on TimeoutException {
-      debugPrint(
-        'AppInitializer: widget-launch probe timed out at 200 ms — '
-        'falling back to the warm-click stream',
-      );
+      // Expected benign race (stuck plugin / slow channel) — the warm-click
+      // stream still delivers the URI. Breadcrumb, not an ERROR trace.
+      BreadcrumbCollector.add('widget-launch-probe-timeout',
+          detail: '200ms — falling back to the warm-click stream');
     } catch (e, st) {
-      debugPrint('AppInitializer._stashWidgetLaunchUri failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: {'where': 'stashWidgetLaunchUri'}));
     }
   }
 
@@ -722,8 +735,8 @@ class AppInitializer {
               await container.read(autoRecordBadgeServiceProvider.future);
           await badge.increment();
         } catch (e, st) {
-          debugPrint(
-              'AppInitializer: activeTripRecovery badge bump failed: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.background, e, st,
+              context: {'where': 'activeTripRecovery badge bump'}));
         }
       },
     );
@@ -750,8 +763,9 @@ class AppInitializer {
                   .read(autoRecordBadgeServiceProvider.future);
               await badge.increment();
             } catch (e, st) {
-              debugPrint(
-                  'AppInitializer: activeTripRecovery recovered badge bump failed: $e\n$st');
+              unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
+                'where': 'activeTripRecovery recovered badge bump'
+              }));
             }
           }
           // Auto-navigate to /trip-recording on the next frame so
@@ -766,13 +780,15 @@ class AppInitializer {
               final goRouter = container.read(routerProvider);
               goRouter.go('/trip-recording');
             } catch (e, st) {
-              debugPrint(
-                  'AppInitializer: activeTripRecovery go(/trip-recording) failed: $e\n$st');
+              unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
+                'where': 'activeTripRecovery go(/trip-recording)'
+              }));
             }
           });
         } catch (e, st) {
-          debugPrint(
-              'AppInitializer: activeTripRecovery restoreFromSnapshot failed: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
+            'where': 'activeTripRecovery restoreFromSnapshot'
+          }));
         }
     }
   }
@@ -809,8 +825,8 @@ class AppInitializer {
               await container.read(autoRecordBadgeServiceProvider.future);
           await badge.increment();
         } catch (e, st) {
-          debugPrint(
-              'AppInitializer: pausedTripRecovery badge bump failed: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.background, e, st,
+              context: {'where': 'pausedTripRecovery badge bump'}));
         }
       },
     );
@@ -905,7 +921,8 @@ class AppInitializer {
     try {
       container.read(nearestWidgetRefreshProvider);
     } catch (e, st) {
-      debugPrint('AppInitializer: nearestWidgetRefresh start failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.background, e, st,
+          context: {'where': 'nearestWidgetRefresh start'}));
     }
 
     // #1004 phase 4-WAL — recover paused trips that were never
@@ -922,8 +939,8 @@ class AppInitializer {
       try {
         await _runPausedTripRecovery(container);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: pausedTripRecovery failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'pausedTripRecovery'}));
       }
     });
 
@@ -939,8 +956,8 @@ class AppInitializer {
       try {
         await _runActiveTripRecovery(container);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: activeTripRecovery failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'activeTripRecovery'}));
       }
     });
 
@@ -957,8 +974,8 @@ class AppInitializer {
       try {
         container.read(autoRecordOrchestratorProvider);
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: autoRecordOrchestrator init failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'autoRecordOrchestrator init'}));
       }
     });
 
@@ -983,8 +1000,8 @@ class AppInitializer {
               'trip-history box not open yet');
         }
       } catch (e, st) {
-        debugPrint(
-            'AppInitializer: vehicle aggregator wiring failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'vehicle aggregator wiring'}));
       }
     });
 
@@ -1005,7 +1022,8 @@ class AppInitializer {
               'AppInitializer: drained $replayed isolate error(s) into TraceRecorder');
         }
       } catch (e, st) {
-        debugPrint('AppInitializer: isolate spool drain failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'isolate spool drain'}));
       }
     });
 

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -21,6 +21,7 @@ import '../core/cache/cache_manager.dart';
 import '../core/feedback/auto_record_badge_provider.dart';
 import '../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../core/telemetry/storage/isolate_error_spool.dart';
+import '../core/telemetry/storage/startup_failure_store.dart';
 import '../core/telemetry/storage/trace_storage.dart';
 import '../core/telemetry/trace_recorder.dart';
 import '../core/logging/error_logger.dart';
@@ -122,7 +123,21 @@ class AppInitializer {
     try {
       await _initStorage();
     } on HiveCorruptionException catch (e, st) {
+      // #3149 — Hive is down, so errorLogger's spool can't write either;
+      // persist the cause to a plain file the NEXT launch replays.
+      await StartupFailureStore.persist(e, st);
       unawaited(errorLogger.log(ErrorLayer.storage, e, st));
+      runApp(const StorageRecoveryHost());
+      return;
+    } catch (e, st) {
+      // #3149 — any OTHER storage-phase failure (the secure-storage
+      // cipher StorageInitException, a TraceStorage/loadApiKey/
+      // ensureDefaultProfile fault) previously escaped uncaught: no Zone
+      // handler exists yet (handlers install in _launch), so the user
+      // froze on the splash with zero telemetry. Same recovery route.
+      await StartupFailureStore.persist(e, st);
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: {'where': 'initStorage'}));
       runApp(const StorageRecoveryHost());
       return;
     }
@@ -1025,6 +1040,22 @@ class AppInitializer {
         unawaited(errorLogger.log(ErrorLayer.background, e, st,
             context: {'where': 'isolate spool drain'}));
       }
+    });
+
+    // #3149 — replay the Hive-independent record of a previous BRICKED
+    // launch (storage phase failed before any telemetry channel was up;
+    // the cause was persisted to a plain file) into the trace pipeline,
+    // so the maintainer finally sees why the splash froze.
+    _deferPostFirstFrame(() async {
+      final failure = await StartupFailureStore.drain();
+      if (failure == null) return;
+      await errorLogger.log(
+        ErrorLayer.storage,
+        Exception('previous launch bricked during startup: '
+            '${failure['errorType']}: ${failure['error']}'),
+        StackTrace.fromString(failure['stack'] as String? ?? ''),
+        context: {'where': 'startupFailureReplay', 'at': failure['at']},
+      );
     });
 
     StartupTimer.instance.mark('first_frame');

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -123,18 +123,15 @@ class AppInitializer {
     try {
       await _initStorage();
     } on HiveCorruptionException catch (e, st) {
-      // #3149 — Hive is down, so errorLogger's spool can't write either;
-      // persist the cause to a plain file the NEXT launch replays.
+      // #3149 — Hive is down (spool can't write); plain-file the cause.
       await StartupFailureStore.persist(e, st);
       unawaited(errorLogger.log(ErrorLayer.storage, e, st));
       runApp(const StorageRecoveryHost());
       return;
     } catch (e, st) {
-      // #3149 — any OTHER storage-phase failure (the secure-storage
-      // cipher StorageInitException, a TraceStorage/loadApiKey/
-      // ensureDefaultProfile fault) previously escaped uncaught: no Zone
-      // handler exists yet (handlers install in _launch), so the user
-      // froze on the splash with zero telemetry. Same recovery route.
+      // #3149 — any OTHER storage-phase fault (secure-storage cipher,
+      // TraceStorage, loadApiKey…) previously escaped uncaught — no Zone
+      // handler exists yet — freezing the splash with zero telemetry.
       await StartupFailureStore.persist(e, st);
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
           context: {'where': 'initStorage'}));
@@ -878,6 +875,7 @@ class AppInitializer {
         details.exception,
         details.stack ?? StackTrace.current,
         context: <String, Object?>{
+          'where': 'FlutterError.onError', // #3150 — name the handler
           'library': details.library,
           'context': details.context?.toString(),
         },
@@ -886,7 +884,10 @@ class AppInitializer {
     // Capture async / platform errors that escape the framework.
     PlatformDispatcher.instance.onError = (error, stack) {
       if (_isTileFetchNoise(error) || isBenignStreamCancel(error)) return true;
-      errorLogger.log(ErrorLayer.other, error, stack);
+      // #3150 — context so a dispatcher-caught trace is distinguishable
+      // from a bare errorLogger call site.
+      errorLogger.log(ErrorLayer.other, error, stack,
+          context: const {'where': 'PlatformDispatcher.onError'});
       return true;
     };
   }
@@ -1042,10 +1043,8 @@ class AppInitializer {
       }
     });
 
-    // #3149 — replay the Hive-independent record of a previous BRICKED
-    // launch (storage phase failed before any telemetry channel was up;
-    // the cause was persisted to a plain file) into the trace pipeline,
-    // so the maintainer finally sees why the splash froze.
+    // #3149 — replay a previous bricked launch's plain-file cause record
+    // into the trace pipeline, so the frozen splash finally has a why.
     _deferPostFirstFrame(() async {
       final failure = await StartupFailureStore.drain();
       if (failure == null) return;

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -215,7 +215,9 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
         duration: const Duration(seconds: 5),
       );
     } catch (e, st) {
-      debugPrint('ShellScreen: swipe hint skipped: $e\n$st');
+      // #3143 — release-visible: debugPrint is no-opped in release.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+          context: {'where': 'ShellScreen swipe hint'}));
     }
   }
 

--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -9,7 +9,6 @@ import '../../features/alerts/data/repositories/alert_repository.dart';
 import '../../features/widget/data/home_widget_service.dart';
 import '../logging/error_logger.dart';
 import '../storage/hive_storage.dart';
-import '../telemetry/storage/isolate_error_spool.dart';
 import '../cache/cache_manager.dart';
 import 'background_price_history_writer.dart';
 import 'background_price_source.dart';
@@ -118,7 +117,8 @@ class BackgroundAlertScanCoordinator {
   /// Returns `true` when a scan actually ran, `false` when it was skipped
   /// (lock contention or cooldown).
   ///
-  /// Every failure is caught and spooled through [IsolateErrorSpool] for the
+  /// Every failure is caught and routed through `errorLogger` (which spools
+  /// via the isolate error spool when unbound, #3150) for the
   /// foreground TraceRecorder; the call returns `false` rather than
   /// propagating, so a flaky network or storage fault can't crash the OS-
   /// spawned background isolate. The whole body is wrapped in
@@ -163,14 +163,14 @@ class BackgroundAlertScanCoordinator {
       await _dedup.recordScan(now: at, trigger: trigger.tag);
       return true;
     } catch (e, st) {
+      // #3150 — single log call. `errorLogger.log` already routes to the
+      // IsolateErrorSpool when unbound (background isolate), so the former
+      // explicit `IsolateErrorSpool.enqueue` double-logged every scan
+      // failure; the bg_scan tag now travels in the context map instead.
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
-        'where': 'BackgroundAlertScanCoordinator: scan failed (${trigger.tag})'
+        'where': 'BackgroundAlertScanCoordinator: scan failed (${trigger.tag})',
+        'isolateTaskName': 'bg_scan_${trigger.tag}',
       }));
-      await IsolateErrorSpool.enqueue(
-        isolateTaskName: 'bg_scan_${trigger.tag}',
-        error: e,
-        stack: st,
-      );
       return false;
     } finally {
       try {

--- a/lib/core/background/background_scan_tracer.dart
+++ b/lib/core/background/background_scan_tracer.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart'
 import 'package:hive/hive.dart';
 
 import '../logging/error_logger.dart';
+import '../telemetry/collectors/breadcrumb_collector.dart';
 import '../services/diagnostics/data_access_recorder.dart';
 import '../services/diagnostics/data_access_trace_export.dart';
 
@@ -93,7 +94,10 @@ class BackgroundScanTracer {
       await DataAccessTraceExport.export(trace);
     } on MissingPluginException {
       // Defensive: the channel was unavailable despite the root-isolate probe
-      // (e.g. an isolate without a registrant). Degrade to a skip, not ERROR.
+      // (e.g. an isolate without a registrant). Degrade to a skip, not ERROR
+      // — but leave a release-visible breadcrumb (#3143).
+      BreadcrumbCollector.add('bg-trace-export-skipped',
+          detail: 'public_files channel unavailable');
       debugPrint('BackgroundScanTracer.exportIfEnabled: public_files channel '
           'unavailable — skipping Downloads export.');
     } catch (e, st) {

--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -223,7 +223,8 @@ class CacheManager implements CacheStrategy {
       await _storage.cacheData(key, {
         'payload': data,
         'storedAt': DateTime.now().millisecondsSinceEpoch,
-        'source': source.index,
+        // #3150 — the enum NAME, not the reorder-fragile index.
+        'source': source.name,
         'ttlMs': ttl.inMilliseconds,
       });
     } on FileSystemException catch (e, st) {
@@ -257,12 +258,21 @@ class CacheManager implements CacheStrategy {
       storedAt: DateTime.fromMillisecondsSinceEpoch(
         raw['storedAt'] as int? ?? 0,
       ),
-      originalSource: ServiceSource.values.elementAtOrNull(
-            raw['source'] as int? ?? 0,
-          ) ??
-          ServiceSource.cache,
+      originalSource: _sourceFrom(raw['source']),
       ttl: Duration(milliseconds: raw['ttlMs'] as int? ?? 300000),
     );
+  }
+
+  /// Resolves the persisted `source` — enum name (new) or index (legacy);
+  /// unknown values fall back to [ServiceSource.cache] (pre-#3150 behaviour).
+  static ServiceSource _sourceFrom(dynamic raw) {
+    if (raw is String) {
+      return ServiceSource.values.asNameMap()[raw] ?? ServiceSource.cache;
+    }
+    if (raw is int) {
+      return ServiceSource.values.elementAtOrNull(raw) ?? ServiceSource.cache;
+    }
+    return ServiceSource.cache;
   }
 
   /// Get data only if the cache entry is still valid (not expired).

--- a/lib/core/services/impl/native_geocoding_provider.dart
+++ b/lib/core/services/impl/native_geocoding_provider.dart
@@ -74,9 +74,11 @@ class NativeGeocodingProvider implements GeocodingProvider {
       // expected offline failure to a breadcrumb rather than an ERROR trace.
       // A genuine native-geocoder fault still ERROR-logs.
       if (isOfflineError(e)) {
+        // #3145 — coords bucketed to 1 decimal: triage never needs more.
         BreadcrumbCollector.add(
           'Native country detection skipped — offline',
-          detail: 'lat=$lat lng=$lng type=${e.runtimeType}',
+          detail: 'lat=${lat.toStringAsFixed(1)} '
+              'lng=${lng.toStringAsFixed(1)} type=${e.runtimeType}',
         );
         return null;
       }
@@ -102,9 +104,11 @@ class NativeGeocodingProvider implements GeocodingProvider {
       // failure is expected (falls back to "lat, lng"), so breadcrumb it
       // rather than ERROR-log. A genuine fault still persists.
       if (isOfflineError(e)) {
+        // #3145 — coords bucketed to 1 decimal: triage never needs more.
         BreadcrumbCollector.add(
           'Native reverse geocoding skipped — offline',
-          detail: 'lat=$lat lng=$lng type=${e.runtimeType}',
+          detail: 'lat=${lat.toStringAsFixed(1)} '
+              'lng=${lng.toStringAsFixed(1)} type=${e.runtimeType}',
         );
         return '$lat, $lng';
       }

--- a/lib/core/services/impl/nominatim_geocoding_provider.dart
+++ b/lib/core/services/impl/nominatim_geocoding_provider.dart
@@ -137,9 +137,11 @@ class NominatimGeocodingProvider implements GeocodingProvider {
       // to a breadcrumb rather than an ERROR trace (field traces #8/#9). A
       // genuine API error (4xx/5xx, parse) still ERROR-logs.
       if (isOfflineError(e)) {
+        // #3145 — coords bucketed to 1 decimal: triage never needs more.
         BreadcrumbCollector.add(
           'Nominatim reverse geocoding skipped — offline',
-          detail: 'lat=$lat lng=$lng type=${e.type}',
+          detail: 'lat=${lat.toStringAsFixed(1)} '
+              'lng=${lng.toStringAsFixed(1)} type=${e.type}',
         );
         return '$lat, $lng';
       }
@@ -172,9 +174,11 @@ class NominatimGeocodingProvider implements GeocodingProvider {
       // already falls back to the next provider / null), so breadcrumb it
       // rather than ERROR-log (field traces #8/#9). Genuine errors persist.
       if (isOfflineError(e)) {
+        // #3145 — coords bucketed to 1 decimal: triage never needs more.
         BreadcrumbCollector.add(
           'Nominatim country detection skipped — offline',
-          detail: 'lat=$lat lng=$lng type=${e.type}',
+          detail: 'lat=${lat.toStringAsFixed(1)} '
+              'lng=${lng.toStringAsFixed(1)} type=${e.type}',
         );
         return null;
       }

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -1,12 +1,10 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import 'hive_cipher_loader.dart';
 import 'hive_isolate_ownership.dart';
 import 'hive_legacy_migration.dart';
 import 'hive_schema_migration.dart';
@@ -127,7 +125,6 @@ class HiveBoxes {
     priceHistory,
     alerts,
   };
-  static const _hiveEncryptionKeyName = 'hive_encryption_key';
 
   /// Meta box recording the schema version of each persistent box
   /// (#1686). Unencrypted — it holds only small integers, no PII — and
@@ -147,20 +144,9 @@ class HiveBoxes {
   /// cached-`Station` key set here so a future change without a bump FAILS.
   static const int currentSchemaVersion = 2;
 
-  static Future<HiveAesCipher> _loadCipher() async {
-    const secureStorage = FlutterSecureStorage();
-    final existing = await secureStorage.read(key: _hiveEncryptionKeyName);
-    if (existing != null) {
-      final keyBytes = base64Url.decode(existing);
-      return HiveAesCipher(keyBytes);
-    }
-    final key = Hive.generateSecureKey();
-    await secureStorage.write(
-      key: _hiveEncryptionKeyName,
-      value: base64UrlEncode(key),
-    );
-    return HiveAesCipher(key);
-  }
+  // #3149 — the secure-storage cipher load (and its StorageInitException
+  // re-tag) lives in HiveCipherLoader so a keychain/keystore fault
+  // surfaces typed instead of bricking the splash untyped.
 
   /// Test hook for [HiveLegacyMigration.migrateToEncrypted] (#1686).
   @visibleForTesting
@@ -198,7 +184,7 @@ class HiveBoxes {
   /// `init()` opens is still open before it returns.
   static Future<void> init() async {
     await Hive.initFlutter();
-    final cipher = await _loadCipher();
+    final cipher = await HiveCipherLoader.loadGuarded();
 
     // Phase 1 — migrate any pre-encryption plaintext boxes. The probes
     // are independent, so they (and any migration) run in parallel.
@@ -285,7 +271,7 @@ class HiveBoxes {
   /// Initialize Hive in a background isolate with proper encryption.
   static Future<void> initInIsolate() async {
     await Hive.initFlutter();
-    final cipher = await _loadCipher();
+    final cipher = await HiveCipherLoader.loadGuarded();
     await Hive.openBox(settings, encryptionCipher: cipher);
     await Hive.openBox(favorites, encryptionCipher: cipher);
     await Hive.openBox(profiles, encryptionCipher: cipher); // #2205 BG widget

--- a/lib/core/storage/hive_cipher_loader.dart
+++ b/lib/core/storage/hive_cipher_loader.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Thrown when storage initialisation fails BEFORE the Hive boxes can
+/// even be opened — e.g. a `PlatformException` out of the
+/// FlutterSecureStorage encryption-key read (#3149). Sibling of
+/// `HiveCorruptionException`: both are routed by `AppInitializer.run` to
+/// the same `StorageRecoveryHost` instead of leaving the user frozen on
+/// the splash. Kept distinct because the recovery *advice* differs — the
+/// box files are fine; it is the keychain/keystore path that failed.
+class StorageInitException implements Exception {
+  /// Human-readable detail of what failed.
+  final String message;
+
+  /// The underlying fault (e.g. the secure-storage `PlatformException`).
+  final Object? cause;
+
+  const StorageInitException(this.message, [this.cause]);
+
+  @override
+  String toString() => 'StorageInitException: $message'
+      '${cause == null ? '' : ' (cause: $cause)'}';
+}
+
+/// Loads (or first-run generates) the AES cipher that encrypts the
+/// PII-bearing Hive boxes. Extracted from `HiveBoxes` (#3149) so the
+/// secure-storage round-trip has one owner and one guarded entry point.
+class HiveCipherLoader {
+  HiveCipherLoader._();
+
+  static const _hiveEncryptionKeyName = 'hive_encryption_key';
+
+  static Future<HiveAesCipher> _loadCipher() async {
+    const secureStorage = FlutterSecureStorage();
+    final existing = await secureStorage.read(key: _hiveEncryptionKeyName);
+    if (existing != null) {
+      final keyBytes = base64Url.decode(existing);
+      return HiveAesCipher(keyBytes);
+    }
+    final key = Hive.generateSecureKey();
+    await secureStorage.write(
+      key: _hiveEncryptionKeyName,
+      value: base64UrlEncode(key),
+    );
+    return HiveAesCipher(key);
+  }
+
+  /// Test seam (#3149): the raw cipher load, injectable so a secure-
+  /// storage fault (`PlatformException` from the keychain/keystore) can
+  /// be driven without a platform channel.
+  @visibleForTesting
+  static Future<HiveAesCipher> Function() cipherLoader = _loadCipher;
+
+  /// Reset the [cipherLoader] seam. Call from `tearDown`.
+  @visibleForTesting
+  static void resetCipherLoaderForTest() {
+    cipherLoader = _loadCipher;
+  }
+
+  /// #3149 — the FlutterSecureStorage read in [_loadCipher] used to sit
+  /// OUTSIDE the `on HiveError` re-tag in `HiveBoxes.init`, so a
+  /// keychain/keystore `PlatformException` escaped as an untyped error
+  /// the startup path had no catch for: the user froze on the splash
+  /// with no recovery screen and no telemetry. Re-tag it as a typed
+  /// [StorageInitException] (preserving the original stack) so
+  /// `AppInitializer.run` routes it to the same `StorageRecoveryHost`
+  /// as a corrupted box.
+  static Future<HiveAesCipher> loadGuarded() async {
+    try {
+      return await cipherLoader();
+    } catch (e, st) {
+      Error.throwWithStackTrace(
+        StorageInitException(
+            'the secure-storage encryption key could not be loaded', e),
+        st,
+      );
+    }
+  }
+}

--- a/lib/core/sync/schema_verifier.dart
+++ b/lib/core/sync/schema_verifier.dart
@@ -75,7 +75,12 @@ class SchemaVerifier {
             .count()
             .then((_) => MapEntry(table, true))
             .catchError((Object e, StackTrace st) {
-          unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'SchemaVerifier: table check failed'}));
+          // #3150 — name the table: "table check failed" without it left
+          // the self-hoster's missing table unidentifiable.
+          unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {
+            'where': 'SchemaVerifier: table check failed',
+            'table': table,
+          }));
           return MapEntry(table, false);
         }),
       ),

--- a/lib/core/telemetry/collectors/app_state_collector.dart
+++ b/lib/core/telemetry/collectors/app_state_collector.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../storage/storage_providers.dart';
+import '../../../features/feature_management/application/feature_flags_provider.dart';
 import '../models/error_trace.dart';
 
 class AppStateCollector {
@@ -25,6 +26,20 @@ class AppStateCollector {
       activeProfileName: profile?['name'] as String?,
       lastApiEndpoint: _lastApiEndpoint,
       lastSearchParams: _lastSearchParams,
+      enabledFeatures: _enabledFeatures(ref),
     );
+  }
+
+  /// #3150 — the enabled feature-flag names at error time (sorted for a
+  /// stable rendering). Defensive: the collector runs inside the error
+  /// path, so a provider-graph fault here must degrade to an empty list
+  /// rather than losing the whole trace.
+  static List<String> _enabledFeatures(Ref ref) {
+    try {
+      return ref.read(enabledFeaturesProvider).map((f) => f.name).toList()
+        ..sort();
+    } catch (_) {
+      return const [];
+    }
   }
 }

--- a/lib/core/telemetry/integrations/riverpod_trace_observer.dart
+++ b/lib/core/telemetry/integrations/riverpod_trace_observer.dart
@@ -23,6 +23,10 @@ final class RiverpodTraceObserver extends ProviderObserver {
   ) {
     // Fire-and-forget: the observer's contract is synchronous. Dropping
     // the future is fine because `errorLogger.log` never throws.
-    errorLogger.log(ErrorLayer.providers, error, stackTrace);
+    // #3150 — name the failing provider: a bare `[providers]` trace was
+    // un-triageable without it.
+    errorLogger.log(ErrorLayer.providers, error, stackTrace, context: {
+      'provider': context.provider.toString(),
+    });
   }
 }

--- a/lib/core/telemetry/models/error_trace.dart
+++ b/lib/core/telemetry/models/error_trace.dart
@@ -65,6 +65,12 @@ abstract class AppStateSnapshot with _$AppStateSnapshot {
     String? activeProfileName,
     String? lastApiEndpoint,
     String? lastSearchParams,
+
+    /// #3150 — the enabled feature-flag names at error time. Most field
+    /// reports hinge on which features were on (developer mode, OBD2,
+    /// EV search…); without this the trace can't answer it. Defaulted
+    /// so pre-#3150 persisted traces still parse.
+    @Default([]) List<String> enabledFeatures,
   }) = _AppStateSnapshot;
 
   factory AppStateSnapshot.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/telemetry/models/error_trace.freezed.dart
+++ b/lib/core/telemetry/models/error_trace.freezed.dart
@@ -676,7 +676,11 @@ as String,
 /// @nodoc
 mixin _$AppStateSnapshot {
 
- String? get activeRoute; String? get activeProfileId; String? get activeProfileName; String? get lastApiEndpoint; String? get lastSearchParams;
+ String? get activeRoute; String? get activeProfileId; String? get activeProfileName; String? get lastApiEndpoint; String? get lastSearchParams;/// #3150 — the enabled feature-flag names at error time. Most field
+/// reports hinge on which features were on (developer mode, OBD2,
+/// EV search…); without this the trace can't answer it. Defaulted
+/// so pre-#3150 persisted traces still parse.
+ List<String> get enabledFeatures;
 /// Create a copy of AppStateSnapshot
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -689,16 +693,16 @@ $AppStateSnapshotCopyWith<AppStateSnapshot> get copyWith => _$AppStateSnapshotCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppStateSnapshot&&(identical(other.activeRoute, activeRoute) || other.activeRoute == activeRoute)&&(identical(other.activeProfileId, activeProfileId) || other.activeProfileId == activeProfileId)&&(identical(other.activeProfileName, activeProfileName) || other.activeProfileName == activeProfileName)&&(identical(other.lastApiEndpoint, lastApiEndpoint) || other.lastApiEndpoint == lastApiEndpoint)&&(identical(other.lastSearchParams, lastSearchParams) || other.lastSearchParams == lastSearchParams));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppStateSnapshot&&(identical(other.activeRoute, activeRoute) || other.activeRoute == activeRoute)&&(identical(other.activeProfileId, activeProfileId) || other.activeProfileId == activeProfileId)&&(identical(other.activeProfileName, activeProfileName) || other.activeProfileName == activeProfileName)&&(identical(other.lastApiEndpoint, lastApiEndpoint) || other.lastApiEndpoint == lastApiEndpoint)&&(identical(other.lastSearchParams, lastSearchParams) || other.lastSearchParams == lastSearchParams)&&const DeepCollectionEquality().equals(other.enabledFeatures, enabledFeatures));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activeRoute,activeProfileId,activeProfileName,lastApiEndpoint,lastSearchParams);
+int get hashCode => Object.hash(runtimeType,activeRoute,activeProfileId,activeProfileName,lastApiEndpoint,lastSearchParams,const DeepCollectionEquality().hash(enabledFeatures));
 
 @override
 String toString() {
-  return 'AppStateSnapshot(activeRoute: $activeRoute, activeProfileId: $activeProfileId, activeProfileName: $activeProfileName, lastApiEndpoint: $lastApiEndpoint, lastSearchParams: $lastSearchParams)';
+  return 'AppStateSnapshot(activeRoute: $activeRoute, activeProfileId: $activeProfileId, activeProfileName: $activeProfileName, lastApiEndpoint: $lastApiEndpoint, lastSearchParams: $lastSearchParams, enabledFeatures: $enabledFeatures)';
 }
 
 
@@ -709,7 +713,7 @@ abstract mixin class $AppStateSnapshotCopyWith<$Res>  {
   factory $AppStateSnapshotCopyWith(AppStateSnapshot value, $Res Function(AppStateSnapshot) _then) = _$AppStateSnapshotCopyWithImpl;
 @useResult
 $Res call({
- String? activeRoute, String? activeProfileId, String? activeProfileName, String? lastApiEndpoint, String? lastSearchParams
+ String? activeRoute, String? activeProfileId, String? activeProfileName, String? lastApiEndpoint, String? lastSearchParams, List<String> enabledFeatures
 });
 
 
@@ -726,14 +730,15 @@ class _$AppStateSnapshotCopyWithImpl<$Res>
 
 /// Create a copy of AppStateSnapshot
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? activeRoute = freezed,Object? activeProfileId = freezed,Object? activeProfileName = freezed,Object? lastApiEndpoint = freezed,Object? lastSearchParams = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? activeRoute = freezed,Object? activeProfileId = freezed,Object? activeProfileName = freezed,Object? lastApiEndpoint = freezed,Object? lastSearchParams = freezed,Object? enabledFeatures = null,}) {
   return _then(_self.copyWith(
 activeRoute: freezed == activeRoute ? _self.activeRoute : activeRoute // ignore: cast_nullable_to_non_nullable
 as String?,activeProfileId: freezed == activeProfileId ? _self.activeProfileId : activeProfileId // ignore: cast_nullable_to_non_nullable
 as String?,activeProfileName: freezed == activeProfileName ? _self.activeProfileName : activeProfileName // ignore: cast_nullable_to_non_nullable
 as String?,lastApiEndpoint: freezed == lastApiEndpoint ? _self.lastApiEndpoint : lastApiEndpoint // ignore: cast_nullable_to_non_nullable
 as String?,lastSearchParams: freezed == lastSearchParams ? _self.lastSearchParams : lastSearchParams // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,enabledFeatures: null == enabledFeatures ? _self.enabledFeatures : enabledFeatures // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 
@@ -818,10 +823,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams,  List<String> enabledFeatures)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AppStateSnapshot() when $default != null:
-return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams);case _:
+return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams,_that.enabledFeatures);case _:
   return orElse();
 
 }
@@ -839,10 +844,10 @@ return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams,  List<String> enabledFeatures)  $default,) {final _that = this;
 switch (_that) {
 case _AppStateSnapshot():
-return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams);case _:
+return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams,_that.enabledFeatures);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -859,10 +864,10 @@ return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? activeRoute,  String? activeProfileId,  String? activeProfileName,  String? lastApiEndpoint,  String? lastSearchParams,  List<String> enabledFeatures)?  $default,) {final _that = this;
 switch (_that) {
 case _AppStateSnapshot() when $default != null:
-return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams);case _:
+return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,_that.lastApiEndpoint,_that.lastSearchParams,_that.enabledFeatures);case _:
   return null;
 
 }
@@ -874,7 +879,7 @@ return $default(_that.activeRoute,_that.activeProfileId,_that.activeProfileName,
 @JsonSerializable()
 
 class _AppStateSnapshot implements AppStateSnapshot {
-  const _AppStateSnapshot({this.activeRoute, this.activeProfileId, this.activeProfileName, this.lastApiEndpoint, this.lastSearchParams});
+  const _AppStateSnapshot({this.activeRoute, this.activeProfileId, this.activeProfileName, this.lastApiEndpoint, this.lastSearchParams, final  List<String> enabledFeatures = const []}): _enabledFeatures = enabledFeatures;
   factory _AppStateSnapshot.fromJson(Map<String, dynamic> json) => _$AppStateSnapshotFromJson(json);
 
 @override final  String? activeRoute;
@@ -882,6 +887,21 @@ class _AppStateSnapshot implements AppStateSnapshot {
 @override final  String? activeProfileName;
 @override final  String? lastApiEndpoint;
 @override final  String? lastSearchParams;
+/// #3150 — the enabled feature-flag names at error time. Most field
+/// reports hinge on which features were on (developer mode, OBD2,
+/// EV search…); without this the trace can't answer it. Defaulted
+/// so pre-#3150 persisted traces still parse.
+ final  List<String> _enabledFeatures;
+/// #3150 — the enabled feature-flag names at error time. Most field
+/// reports hinge on which features were on (developer mode, OBD2,
+/// EV search…); without this the trace can't answer it. Defaulted
+/// so pre-#3150 persisted traces still parse.
+@override@JsonKey() List<String> get enabledFeatures {
+  if (_enabledFeatures is EqualUnmodifiableListView) return _enabledFeatures;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_enabledFeatures);
+}
+
 
 /// Create a copy of AppStateSnapshot
 /// with the given fields replaced by the non-null parameter values.
@@ -896,16 +916,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppStateSnapshot&&(identical(other.activeRoute, activeRoute) || other.activeRoute == activeRoute)&&(identical(other.activeProfileId, activeProfileId) || other.activeProfileId == activeProfileId)&&(identical(other.activeProfileName, activeProfileName) || other.activeProfileName == activeProfileName)&&(identical(other.lastApiEndpoint, lastApiEndpoint) || other.lastApiEndpoint == lastApiEndpoint)&&(identical(other.lastSearchParams, lastSearchParams) || other.lastSearchParams == lastSearchParams));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppStateSnapshot&&(identical(other.activeRoute, activeRoute) || other.activeRoute == activeRoute)&&(identical(other.activeProfileId, activeProfileId) || other.activeProfileId == activeProfileId)&&(identical(other.activeProfileName, activeProfileName) || other.activeProfileName == activeProfileName)&&(identical(other.lastApiEndpoint, lastApiEndpoint) || other.lastApiEndpoint == lastApiEndpoint)&&(identical(other.lastSearchParams, lastSearchParams) || other.lastSearchParams == lastSearchParams)&&const DeepCollectionEquality().equals(other._enabledFeatures, _enabledFeatures));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activeRoute,activeProfileId,activeProfileName,lastApiEndpoint,lastSearchParams);
+int get hashCode => Object.hash(runtimeType,activeRoute,activeProfileId,activeProfileName,lastApiEndpoint,lastSearchParams,const DeepCollectionEquality().hash(_enabledFeatures));
 
 @override
 String toString() {
-  return 'AppStateSnapshot(activeRoute: $activeRoute, activeProfileId: $activeProfileId, activeProfileName: $activeProfileName, lastApiEndpoint: $lastApiEndpoint, lastSearchParams: $lastSearchParams)';
+  return 'AppStateSnapshot(activeRoute: $activeRoute, activeProfileId: $activeProfileId, activeProfileName: $activeProfileName, lastApiEndpoint: $lastApiEndpoint, lastSearchParams: $lastSearchParams, enabledFeatures: $enabledFeatures)';
 }
 
 
@@ -916,7 +936,7 @@ abstract mixin class _$AppStateSnapshotCopyWith<$Res> implements $AppStateSnapsh
   factory _$AppStateSnapshotCopyWith(_AppStateSnapshot value, $Res Function(_AppStateSnapshot) _then) = __$AppStateSnapshotCopyWithImpl;
 @override @useResult
 $Res call({
- String? activeRoute, String? activeProfileId, String? activeProfileName, String? lastApiEndpoint, String? lastSearchParams
+ String? activeRoute, String? activeProfileId, String? activeProfileName, String? lastApiEndpoint, String? lastSearchParams, List<String> enabledFeatures
 });
 
 
@@ -933,14 +953,15 @@ class __$AppStateSnapshotCopyWithImpl<$Res>
 
 /// Create a copy of AppStateSnapshot
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? activeRoute = freezed,Object? activeProfileId = freezed,Object? activeProfileName = freezed,Object? lastApiEndpoint = freezed,Object? lastSearchParams = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? activeRoute = freezed,Object? activeProfileId = freezed,Object? activeProfileName = freezed,Object? lastApiEndpoint = freezed,Object? lastSearchParams = freezed,Object? enabledFeatures = null,}) {
   return _then(_AppStateSnapshot(
 activeRoute: freezed == activeRoute ? _self.activeRoute : activeRoute // ignore: cast_nullable_to_non_nullable
 as String?,activeProfileId: freezed == activeProfileId ? _self.activeProfileId : activeProfileId // ignore: cast_nullable_to_non_nullable
 as String?,activeProfileName: freezed == activeProfileName ? _self.activeProfileName : activeProfileName // ignore: cast_nullable_to_non_nullable
 as String?,lastApiEndpoint: freezed == lastApiEndpoint ? _self.lastApiEndpoint : lastApiEndpoint // ignore: cast_nullable_to_non_nullable
 as String?,lastSearchParams: freezed == lastSearchParams ? _self.lastSearchParams : lastSearchParams // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,enabledFeatures: null == enabledFeatures ? _self._enabledFeatures : enabledFeatures // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 

--- a/lib/core/telemetry/models/error_trace.g.dart
+++ b/lib/core/telemetry/models/error_trace.g.dart
@@ -86,6 +86,11 @@ _AppStateSnapshot _$AppStateSnapshotFromJson(Map<String, dynamic> json) =>
       activeProfileName: json['activeProfileName'] as String?,
       lastApiEndpoint: json['lastApiEndpoint'] as String?,
       lastSearchParams: json['lastSearchParams'] as String?,
+      enabledFeatures:
+          (json['enabledFeatures'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
     );
 
 Map<String, dynamic> _$AppStateSnapshotToJson(_AppStateSnapshot instance) =>
@@ -95,6 +100,7 @@ Map<String, dynamic> _$AppStateSnapshotToJson(_AppStateSnapshot instance) =>
       'activeProfileName': instance.activeProfileName,
       'lastApiEndpoint': instance.lastApiEndpoint,
       'lastSearchParams': instance.lastSearchParams,
+      'enabledFeatures': instance.enabledFeatures,
     };
 
 _ServiceChainSnapshot _$ServiceChainSnapshotFromJson(

--- a/lib/core/telemetry/pii_scrubber.dart
+++ b/lib/core/telemetry/pii_scrubber.dart
@@ -60,6 +60,17 @@ class PiiScrubber {
     r'-?\d{1,3}\.\d{2,}\s*,\s*-?\d{1,3}\.\d{2,}',
   );
 
+  /// #3145 — key/value coordinate shapes the adjacency rule above misses:
+  /// the breadcrumb details (`lat=48.13 lng=11.57`) and map-rendered
+  /// context maps (`{lat: 48.13, lng: 11.57}`) that the geocoding /
+  /// search call sites emit. Matches a lat/lng/lon(gitude) KEY followed
+  /// by `=` or `:` and a signed decimal, redacting key+value together.
+  /// Keyed so a plain price (`diesel: 1.789`) is never touched.
+  static final RegExp _coordKeyValueRegex = RegExp(
+    r'\b(?:lat|latitude|lng|lon|longitude)\s*[=:]\s*-?\d{1,3}\.\d+',
+    caseSensitive: false,
+  );
+
   /// Token-like string: at least 20 alphanumeric characters in a row,
   /// no spaces. Catches API keys, JWT segments, anonymous Supabase
   /// session ids, and station-id+coord composites. Anchored on word
@@ -82,6 +93,7 @@ class PiiScrubber {
     if (text.isEmpty) return text;
     var out = text.replaceAll(_emailRegex, emailMarker);
     out = out.replaceAll(_coordRegex, coordMarker);
+    out = out.replaceAll(_coordKeyValueRegex, coordMarker);
     out = out.replaceAll(_tokenRegex, tokenMarker);
     return out;
   }

--- a/lib/core/telemetry/storage/startup_failure_store.dart
+++ b/lib/core/telemetry/storage/startup_failure_store.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Hive-INDEPENDENT persistence for a fatal startup failure (#3149).
+///
+/// When the storage phase bricks (corrupted box, secure-storage cipher
+/// failure, trace-box open fault), every normal observability channel is
+/// dead: Hive is down, so the trace store AND the isolate error spool
+/// can't write, and `debugPrint` is no-opped in release. The recovery
+/// screen tells the *user* something, but the *maintainer* learned
+/// nothing — the cause evaporated with the process.
+///
+/// This store writes a tiny `startup_failure.json` into the app
+/// documents directory with plain `dart:io` file I/O — no Hive, no
+/// Riverpod, no platform plugins beyond path_provider — so the NEXT
+/// successful launch can [drain] it into the trace pipeline.
+///
+/// Best-effort on both sides: a [persist] or [drain] fault is swallowed
+/// (with a `debugPrint` for dev runs) — observability must never make a
+/// bricked startup worse, and a corrupt record must never brick the
+/// healthy launch reading it.
+class StartupFailureStore {
+  StartupFailureStore._();
+
+  /// File name inside the app documents directory.
+  static const String fileName = 'startup_failure.json';
+
+  /// Test seam: where the record lives. Defaults to the app documents
+  /// directory; tests point it at a temp dir (and can throw to drive
+  /// the fault path).
+  @visibleForTesting
+  static Future<Directory> Function() directoryProvider =
+      getApplicationDocumentsDirectory;
+
+  /// Reset the test seam. Call from `tearDown`.
+  @visibleForTesting
+  static void resetForTest() {
+    directoryProvider = getApplicationDocumentsDirectory;
+  }
+
+  /// Persist the startup-bricking [error] + [stack]. Overwrites any
+  /// previous record — the most recent failed launch is the one worth
+  /// triaging. Swallows its own failures (see class doc).
+  static Future<void> persist(Object error, StackTrace stack) async {
+    try {
+      final dir = await directoryProvider();
+      final file = File('${dir.path}/$fileName');
+      await file.writeAsString(jsonEncode(<String, String>{
+        'at': DateTime.now().toIso8601String(),
+        'errorType': error.runtimeType.toString(),
+        'error': error.toString(),
+        'stack': stack.toString(),
+      }));
+    } catch (e, st) {
+      // Hive is already down when persist runs; there is no deeper
+      // fallback channel left. Dev-visible only, by construction.
+      debugPrint('StartupFailureStore: persist failed: $e\n$st');
+    }
+  }
+
+  /// Read-and-delete the pending record from a previous bricked launch,
+  /// or `null` when there is none (the overwhelmingly common case — one
+  /// `File.exists` stat). Deleting before returning guarantees a
+  /// poisoned record is reported at most once.
+  static Future<Map<String, dynamic>?> drain() async {
+    try {
+      final dir = await directoryProvider();
+      final file = File('${dir.path}/$fileName');
+      if (!file.existsSync()) return null;
+      final raw = await file.readAsString();
+      await file.delete();
+      return jsonDecode(raw) as Map<String, dynamic>;
+    } catch (e, st) {
+      debugPrint('StartupFailureStore: drain failed: $e\n$st');
+      return null;
+    }
+  }
+}

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../models/error_trace.dart';
+import '../pii_scrubber.dart';
 
 part 'trace_storage.g.dart';
 
@@ -156,6 +157,12 @@ class TraceStorage {
   /// stable; `parsedCount` and `unparsedCount` were added in #1301 to
   /// surface schema-drift to the user (and to keep the unreadable
   /// payload available under `unparsedRaw` for offline debugging).
+  ///
+  /// #3145 — every exported entry runs through [PiiScrubber]: this
+  /// document leaves the device (email attachments, GitHub issues), so
+  /// it must honour the same redaction policy as the Sentry uploader.
+  /// Parsed traces use [PiiScrubber.scrubErrorTrace]; the unparsed raw
+  /// maps get a deep string scrub via [_scrubRawDeep].
   String exportAsJson() {
     // #2310 — single deserialise pass: partition the box into parsed
     // traces + unparsed raw maps once, instead of the former
@@ -168,9 +175,28 @@ class TraceStorage {
       'traceCount': traces.length + unparsed.length,
       'parsedCount': traces.length,
       'unparsedCount': unparsed.length,
-      'traces': traces.map((t) => t.toJson()).toList(),
-      'unparsedRaw': unparsed,
+      'traces': traces
+          .map((t) => PiiScrubber.scrubErrorTrace(t).toJson())
+          .toList(),
+      'unparsedRaw': unparsed.map(_scrubRawDeep).toList(),
     });
+  }
+
+  /// Recursively applies [PiiScrubber.scrubText] to every string value
+  /// in a raw (schema-drifted) trace map so the #1301 `unparsedRaw`
+  /// escape hatch honours the same redaction policy as parsed traces
+  /// (#3145). Keys are left intact — they are schema, not user data.
+  Map<String, dynamic> _scrubRawDeep(Map<String, dynamic> raw) {
+    dynamic scrubValue(dynamic value) {
+      if (value is String) return PiiScrubber.scrubText(value);
+      if (value is Map<String, dynamic>) {
+        return value.map((k, v) => MapEntry(k, scrubValue(v)));
+      }
+      if (value is List) return value.map(scrubValue).toList();
+      return value;
+    }
+
+    return raw.map((k, v) => MapEntry(k, scrubValue(v)));
   }
 
   /// Single walk over `_box.values` that splits every entry into the

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -315,9 +315,11 @@ class RouteSearchState extends _$RouteSearchState {
         // #2146 — sample failures are tolerated (other points still
         // yield results), but route to the exportable log so
         // recurring blackouts of EV results are recoverable.
+        // #3145 — coords bucketed to 1 decimal: triage never needs more.
         unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
           'where': 'RouteSearch EV: sample point query',
-          'lat': point.latitude, 'lng': point.longitude,
+          'lat': point.latitude.toStringAsFixed(1),
+          'lng': point.longitude.toStringAsFixed(1),
         }));
       }
     }

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'0f71955333c1aceeec41a9f0b7e4da72a4dc407f';
+String _$routeSearchStateHash() => r'801f60c5d6c388d6f6c6286dbb2d01ce7b9ce442';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -87,10 +87,12 @@ Future<String?> tryReverseGeocode(
   } on Exception catch (e, st) {
     // #2146 — non-fatal, but route so silent failures surface in
     // the exportable log for bug-report triage.
+    // #3145 — coords are bucketed to 1 decimal (~11 km): enough for
+    // triage, no longer a precise user location in the exportable log.
     unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
       'where': 'search_provider: tryReverseGeocode',
-      'lat': lat,
-      'lng': lng,
+      'lat': lat.toStringAsFixed(1),
+      'lng': lng.toStringAsFixed(1),
     }));
     return null;
   }

--- a/lib/features/station_services/austria/austria_opening_hours_adapter.dart
+++ b/lib/features/station_services/austria/austria_opening_hours_adapter.dart
@@ -88,12 +88,9 @@ class AustriaOpeningHoursAdapter extends OpeningHoursAdapter {
         rawSource: rawProviderData is String ? rawProviderData : null,
       );
     } catch (e, st) {
-      // The adapter must never propagate a fault to the station-detail UI.
-      assert(() {
-        // ignore: avoid_print
-        print('AustriaOpeningHoursAdapter.parse failed: $e\n$st');
-        return true;
-      }());
+      // The adapter must never propagate a fault to the station-detail UI
+      // — degrade to no-data, release-visibly (#3148).
+      reportParseFailure('AT', e, st);
       return WeeklyOpeningHours.notAvailable;
     }
   }

--- a/lib/features/station_services/chile/chile_opening_hours_adapter.dart
+++ b/lib/features/station_services/chile/chile_opening_hours_adapter.dart
@@ -114,12 +114,9 @@ class ChileOpeningHoursAdapter extends OpeningHoursAdapter {
       return _parseSchedule(trimmed, folded);
     } catch (e, st) {
       // Contract: the adapter feeds user-facing UI and must never propagate a
-      // parse fault to the station-detail screen — degrade to no-data.
-      assert(() {
-        // ignore: avoid_print
-        print('ChileOpeningHoursAdapter.parse failed: $e\n$st');
-        return true;
-      }());
+      // parse fault to the station-detail screen — degrade to no-data,
+      // release-visibly (#3148).
+      reportParseFailure('CL', e, st);
       return WeeklyOpeningHours.notAvailable;
     }
   }

--- a/lib/features/station_services/germany/germany_opening_hours_adapter.dart
+++ b/lib/features/station_services/germany/germany_opening_hours_adapter.dart
@@ -147,12 +147,8 @@ class GermanyOpeningHoursAdapter extends OpeningHoursAdapter {
       );
     } catch (e, st) {
       // Contract: the adapter must never propagate a fault to the
-      // station-detail UI — degrade to no-data.
-      assert(() {
-        // ignore: avoid_print
-        print('GermanyOpeningHoursAdapter.parse failed: $e\n$st');
-        return true;
-      }());
+      // station-detail UI — degrade to no-data, release-visibly (#3148).
+      reportParseFailure('DE', e, st);
       return WeeklyOpeningHours.notAvailable;
     }
   }

--- a/lib/features/station_services/opening_hours/opening_hours_adapter.dart
+++ b/lib/features/station_services/opening_hours/opening_hours_adapter.dart
@@ -1,6 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../station_detail/domain/opening_hours.dart';
 
 /// Per-country adapter that normalises a provider's raw opening-hours payload
@@ -27,4 +33,37 @@ abstract class OpeningHoursAdapter {
   /// Normalises [rawProviderData] into a [WeeklyOpeningHours]. Pure, never
   /// throws, never returns `null` — see the class contract.
   WeeklyOpeningHours parse(dynamic rawProviderData);
+
+  /// Country codes that already reported a parse failure this session
+  /// (#3148). One static set shared by every adapter: each adapter passes
+  /// its own country code, so the throttle is per adapter, per session.
+  static final Set<String> _reportedCountries = <String>{};
+
+  /// Clears the per-session throttle. Call from test `setUp`/`tearDown`.
+  @visibleForTesting
+  static void resetParseFailureReportsForTest() => _reportedCountries.clear();
+
+  /// #3148 — release-visible parse-failure report for the catch block every
+  /// adapter's [parse] carries. The previous assert-wrapped `print` was
+  /// compiled out of release builds, so a provider changing its hours format
+  /// degraded EVERY station to "no data" with zero field signal.
+  ///
+  /// Throttled to the first occurrence per adapter per session: a format
+  /// change hits every station card in a result list, and one trace is
+  /// enough to triage. Adds an `oh-parse-failed` breadcrumb (drained into
+  /// every error trace) and routes one errorLogger ERROR with the country
+  /// + exception type. Swallows nothing new — callers still return
+  /// [WeeklyOpeningHours.notAvailable].
+  @protected
+  void reportParseFailure(String countryCode, Object e, StackTrace st) {
+    if (!_reportedCountries.add(countryCode)) return;
+    BreadcrumbCollector.add(
+      'oh-parse-failed',
+      detail: '$countryCode ${e.runtimeType}',
+    );
+    unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+      'where': 'OpeningHoursAdapter.parse',
+      'country': countryCode,
+    }));
+  }
 }

--- a/lib/features/station_services/portugal/portugal_opening_hours_adapter.dart
+++ b/lib/features/station_services/portugal/portugal_opening_hours_adapter.dart
@@ -98,12 +98,9 @@ class PortugalOpeningHoursAdapter extends OpeningHoursAdapter {
             : OpeningHoursAvailability.partial,
       );
     } catch (e, st) {
-      // The adapter must never propagate a fault to the station-detail UI.
-      assert(() {
-        // ignore: avoid_print
-        print('PortugalOpeningHoursAdapter.parse failed: $e\n$st');
-        return true;
-      }());
+      // The adapter must never propagate a fault to the station-detail UI
+      // — degrade to no-data, release-visibly (#3148).
+      reportParseFailure('PT', e, st);
       return WeeklyOpeningHours.notAvailable;
     }
   }

--- a/lib/features/station_services/spain/spain_opening_hours_adapter.dart
+++ b/lib/features/station_services/spain/spain_opening_hours_adapter.dart
@@ -121,12 +121,8 @@ class SpainOpeningHoursAdapter extends OpeningHoursAdapter {
       );
     } catch (e, st) {
       // Contract: the adapter must never propagate a fault to the
-      // station-detail UI — degrade to no-data.
-      assert(() {
-        // ignore: avoid_print
-        print('SpainOpeningHoursAdapter.parse failed: $e\n$st');
-        return true;
-      }());
+      // station-detail UI — degrade to no-data, release-visibly (#3148).
+      reportParseFailure('ES', e, st);
       return WeeklyOpeningHours.notAvailable;
     }
   }

--- a/test/app/app_initializer_release_visible_catch_test.dart
+++ b/test/app/app_initializer_release_visible_catch_test.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/app_initializer.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// #3143 — startup catch handlers must be release-visible. `_bootstrap()`
+/// no-ops `debugPrint` in release builds, so a catch whose only action was
+/// `debugPrint` swallowed the failure in production. This test pins the
+/// runtime behaviour for the shared deferral helper: a failing deferred
+/// body is routed through `errorLogger` (→ TraceRecorder / Sentry), not
+/// just printed. The static sweep over lib/app + lib/core/background is
+/// enforced by `test/lint/no_debugprint_only_catch_test.dart`.
+class _CapturingRecorder implements TraceRecorder {
+  final captured = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    captured.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'a failing deferred body records via errorLogger with the '
+      'deferPostFirstFrame context (#3143)', (tester) async {
+    final recorder = _CapturingRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    addTearDown(errorLogger.resetForTest);
+
+    final attempted = Completer<void>();
+    AppInitializer.deferPostFirstFrame(() async {
+      try {
+        throw StateError('simulated deferred-init failure');
+      } finally {
+        attempted.complete();
+      }
+    });
+
+    // A real frame fires the post-frame callback; runAsync drains the
+    // genuine microtask queue so the helper's catch (and its errorLogger
+    // call) settles before the assertion (same pattern as #2729).
+    await tester.pumpWidget(const SizedBox());
+    await tester.runAsync(() async {
+      await attempted.future.timeout(const Duration(seconds: 5));
+      // Let the helper's catch block + errorLogger.log continuation run.
+      await Future<void>.delayed(Duration.zero);
+    });
+    await tester.pump();
+    await tester.idle();
+
+    expect(recorder.captured, hasLength(1),
+        reason: 'the deferred failure must reach the TraceRecorder pipeline');
+    final logged = recorder.captured.single;
+    expect(logged, isA<ContextualError>());
+    final contextual = logged as ContextualError;
+    expect(contextual.layer, ErrorLayer.background);
+    expect(contextual.context?['where'], 'deferPostFirstFrame');
+    expect(contextual.inner, isA<StateError>());
+    expect(tester.takeException(), isNull,
+        reason: 'the failure must be logged, never rethrown');
+  });
+}

--- a/test/app/startup_brick_recovery_test.dart
+++ b/test/app/startup_brick_recovery_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/hive_cipher_loader.dart';
+
+/// #3149 — the startup-brick gap around #2294: `run()` caught ONLY
+/// HiveCorruptionException, while `_loadCipher()` (FlutterSecureStorage)
+/// sat outside the HiveError re-tag, and TraceStorage.init / loadApiKey /
+/// ensureDefaultProfile were unguarded — any of those faulting froze the
+/// user on the splash with zero telemetry (handlers install only in
+/// `_launch`). These tests pin:
+///
+///  1. a fake secure-storage throw surfaces as the typed
+///     StorageInitException (with the cause attached) that `run()` routes
+///     to the SAME StorageRecoveryHost as a corrupted box;
+///  2. structurally, `run()` carries a catch-all after the specific
+///     catch, both persist the cause Hive-independently
+///     (StartupFailureStore), and the next launch replays it.
+///
+/// The persistence + replay round-trip itself is unit-tested in
+/// test/core/telemetry/storage/startup_failure_store_test.dart; the
+/// structural source-scan mirrors the #2294 test
+/// (test/app/widgets/storage_recovery_screen_test.dart).
+void main() {
+  group('secure-storage fault → typed StorageInitException (#3149)', () {
+    tearDown(HiveCipherLoader.resetCipherLoaderForTest);
+
+    test('a PlatformException from the cipher load is re-tagged with the '
+        'cause + original stack preserved', () async {
+      final fault = PlatformException(
+          code: 'keystore_unavailable',
+          message: 'BAD_DECRYPT after OS credential reset');
+      HiveCipherLoader.cipherLoader = () async => throw fault;
+
+      try {
+        await HiveCipherLoader.loadGuarded();
+        fail('must throw');
+      } on StorageInitException catch (e, st) {
+        expect(e.cause, same(fault),
+            reason: 'the recovery path + persisted record need the root '
+                'cause, not just the re-tag');
+        expect(e.toString(), contains('secure-storage'));
+        expect(st.toString(), contains('startup_brick_recovery_test'),
+            reason: 'Error.throwWithStackTrace must preserve the original '
+                'throwing stack');
+      }
+    });
+
+    test('StorageInitException is a sibling of HiveCorruptionException, '
+        'not a subtype (run() catches it via the catch-all)', () {
+      const e = StorageInitException('msg');
+      expect(e, isNot(isA<HiveCorruptionException>()));
+      expect(e, isA<Exception>());
+    });
+  });
+
+  group('AppInitializer wires unknown storage failures to recovery (#3149)',
+      () {
+    late String initSource;
+    late String hiveBoxesSource;
+
+    setUpAll(() {
+      initSource = File('lib/app/app_initializer.dart').readAsStringSync();
+      hiveBoxesSource =
+          File('lib/core/storage/hive_boxes.dart').readAsStringSync();
+    });
+
+    test('HiveBoxes.init / initInIsolate load the cipher via the guarded '
+        'path', () {
+      expect(hiveBoxesSource, contains('await HiveCipherLoader.loadGuarded()'),
+          reason: 'the secure-storage read must be inside the typed '
+              're-tag so a PlatformException cannot escape untyped');
+      expect(
+          RegExp(r'await _loadCipher\(\)').hasMatch(hiveBoxesSource), isFalse,
+          reason: 'no init path may bypass the guard');
+    });
+
+    test('run() has a catch-all AFTER the specific HiveCorruptionException '
+        'catch, routing to the same StorageRecoveryHost', () {
+      final specific = initSource.indexOf('on HiveCorruptionException');
+      expect(specific, isNonNegative);
+      final rest = initSource.substring(specific);
+      final catchAll = rest.indexOf('} catch (e, st) {');
+      expect(catchAll, isNonNegative,
+          reason: 'unknown storage failures (cipher, trace box, profile '
+              'seed) must not escape uncaught — no Zone handler exists yet');
+      // The catch-all block must route to the recovery host too.
+      final afterCatchAll = rest.substring(catchAll);
+      final block = afterCatchAll.substring(
+          0, afterCatchAll.indexOf("StartupTimer.instance.mark('storage_ready')"));
+      expect(block, contains('runApp(const StorageRecoveryHost())'));
+      expect(block, contains('errorLogger.log(ErrorLayer.storage'));
+    });
+
+    test('both storage-brick catches persist the cause Hive-independently '
+        'and the next launch replays it', () {
+      final specific = initSource.indexOf('on HiveCorruptionException');
+      final upToStorageReady = initSource.substring(
+          specific, initSource.indexOf("mark('storage_ready')"));
+      expect(
+          RegExp(r'StartupFailureStore\.persist')
+              .allMatches(upToStorageReady)
+              .length,
+          2,
+          reason: 'Hive is down in both paths — the spool cannot record; '
+              'only the plain file survives for the next launch');
+      expect(initSource, contains('StartupFailureStore.drain()'),
+          reason: 'a persisted brick record must be replayed into the '
+              'trace pipeline on the next successful launch');
+      expect(initSource, contains("'where': 'startupFailureReplay'"));
+    });
+  });
+}

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -169,6 +169,54 @@ void main() {
     });
   });
 
+  group('CacheManager - source persisted by NAME (#3150)', () {
+    test('put writes source.name, not the reorder-fragile enum index',
+        () async {
+      await cache.put(
+        'named-source',
+        {'v': 1},
+        ttl: const Duration(minutes: 5),
+        source: ServiceSource.tankerkoenigApi,
+      );
+      final raw = fakeStorage.getCachedData('named-source');
+      expect(raw!['source'], ServiceSource.tankerkoenigApi.name,
+          reason: 'an enum reorder must not silently re-attribute every '
+              'cached entry\'s source');
+      expect(cache.get('named-source')!.originalSource,
+          ServiceSource.tankerkoenigApi);
+    });
+
+    test('legacy index-typed entry (pre-#3150) still resolves', () async {
+      await fakeStorage.cacheData('legacy-entry', {
+        'payload': {'v': 1},
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': ServiceSource.prixCarburantsApi.index,
+        'ttlMs': const Duration(minutes: 5).inMilliseconds,
+      });
+      expect(cache.get('legacy-entry')!.originalSource,
+          ServiceSource.prixCarburantsApi);
+    });
+
+    test('unknown source name / out-of-range index fall back to cache',
+        () async {
+      await fakeStorage.cacheData('unknown-name', {
+        'payload': {'v': 1},
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': 'someRetiredSource',
+        'ttlMs': const Duration(minutes: 5).inMilliseconds,
+      });
+      expect(cache.get('unknown-name')!.originalSource, ServiceSource.cache);
+
+      await fakeStorage.cacheData('bad-index', {
+        'payload': {'v': 1},
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': 9999,
+        'ttlMs': const Duration(minutes: 5).inMilliseconds,
+      });
+      expect(cache.get('bad-index')!.originalSource, ServiceSource.cache);
+    });
+  });
+
   group('CacheManager - getFresh', () {
     test('getFresh returns entry when not expired (fresh hit)', () async {
       await cache.put(

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -180,8 +180,14 @@ void main() {
       });
 
       test('_loadCipher uses FlutterSecureStorage', () {
+        // #3149 — the cipher load moved to HiveCipherLoader so a
+        // keychain/keystore fault surfaces as a typed StorageInitException
+        // (guarded path) instead of bricking the splash untyped. The
+        // contract — key in FlutterSecureStorage under the legacy name —
+        // is unchanged.
         final source =
-            File('lib/core/storage/hive_boxes.dart').readAsStringSync();
+            File('lib/core/storage/hive_cipher_loader.dart')
+                .readAsStringSync();
 
         expect(
           source.contains('FlutterSecureStorage'),

--- a/test/core/telemetry/error_trace_test.dart
+++ b/test/core/telemetry/error_trace_test.dart
@@ -59,4 +59,25 @@ void main() {
       expect(ErrorCategory.unknown.displayName, 'Unknown');
     });
   });
+
+  group('AppStateSnapshot.enabledFeatures (#3150)', () {
+    test('round-trips through JSON', () {
+      const snapshot = AppStateSnapshot(
+        activeRoute: '/search',
+        enabledFeatures: ['debugMode', 'obd2'],
+      );
+      final restored = AppStateSnapshot.fromJson(snapshot.toJson());
+      expect(restored.enabledFeatures, ['debugMode', 'obd2']);
+    });
+
+    test('pre-#3150 persisted JSON (no enabledFeatures key) still parses, '
+        'defaulting to empty', () {
+      final restored = AppStateSnapshot.fromJson(const {
+        'activeRoute': '/search',
+        'activeProfileId': 'p1',
+      });
+      expect(restored.enabledFeatures, isEmpty);
+      expect(restored.activeRoute, '/search');
+    });
+  });
 }

--- a/test/core/telemetry/integrations/riverpod_trace_observer_test.dart
+++ b/test/core/telemetry/integrations/riverpod_trace_observer_test.dart
@@ -74,6 +74,11 @@ void main() {
         expect(fakeRecorder.capturedError.toString(), contains('boom'));
         expect(fakeRecorder.capturedError.toString(), contains('providers'));
         expect(fakeRecorder.capturedStack, isNotNull);
+        // #3150 — the failing provider's name travels in the context map:
+        // a bare `[providers]` trace was un-triageable without it.
+        final contextual = fakeRecorder.capturedError as ContextualError;
+        expect(contextual.context?['provider'], isNotNull);
+        expect(contextual.context!['provider'].toString(), isNotEmpty);
       },
     );
 

--- a/test/core/telemetry/pii_scrubber_test.dart
+++ b/test/core/telemetry/pii_scrubber_test.dart
@@ -341,4 +341,25 @@ void main() {
       expect(out, contains('0.25'));
     });
   });
+
+  group('never-throws contract (#2349 fault injection)', () {
+    test('scrubText returns normally on adversarial inputs', () {
+      // Pathological strings that stress every regex branch at once:
+      // unbalanced braces, regex metacharacters, surrogate-heavy text,
+      // and a megastring of repeated near-matches.
+      final adversarial = <String?>[
+        null,
+        '',
+        r'lat=NaN lng={]\(*+?^$ 48. , .5',
+        'lat: ${'9' * 400}.${'9' * 400}',
+        '\u{1F600}' * 100,
+        'a@b lat=,, lng== 12.,34. ${'lat=1.1 ' * 5000}',
+      ];
+      for (final input in adversarial) {
+        expect(() => PiiScrubber.scrubText(input), returnsNormally);
+        expect(() => PiiScrubber.scrubBreadcrumbMessage(input),
+            returnsNormally);
+      }
+    });
+  });
 }

--- a/test/core/telemetry/pii_scrubber_test.dart
+++ b/test/core/telemetry/pii_scrubber_test.dart
@@ -286,4 +286,59 @@ void main() {
       expect(scrubbed.serviceChainState, isNull);
     });
   });
+
+  group('key/value coordinate shapes (#3145)', () {
+    // The adjacency regex (`<num>,<num>`) misses the key/value shapes the
+    // geocoding + search call sites actually emit. These are the EXACT
+    // strings produced at those call sites — each previously survived
+    // the scrubber unredacted.
+
+    test('redacts the native-geocoding breadcrumb detail (lat=… lng=…)', () {
+      // native_geocoding_provider.dart breadcrumb detail shape.
+      const msg = 'lat=48.137154 lng=11.576124 type=PlatformException';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('48.137154')));
+      expect(out, isNot(contains('11.576124')));
+      expect(out, contains(PiiScrubber.coordMarker));
+      expect(out, contains('type=PlatformException'),
+          reason: 'the non-PII triage hint must survive');
+    });
+
+    test('redacts the nominatim breadcrumb detail (lat=… lng=… type=…)', () {
+      // nominatim_geocoding_provider.dart breadcrumb detail shape.
+      const msg =
+          'lat=48.137154 lng=11.576124 type=DioExceptionType.connectionError';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('48.137154')));
+      expect(out, isNot(contains('11.576124')));
+    });
+
+    test('redacts a map-rendered context ({lat: …, lng: …})', () {
+      // The ContextualError.toString() rendering of the search /
+      // route-search errorLogger context maps.
+      const msg = '[services] DioException [connection error] '
+          '[context={where: search_provider: tryReverseGeocode, '
+          'lat: 48.137154, lng: 11.576124}]';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('48.137154')));
+      expect(out, isNot(contains('11.576124')));
+      expect(out, contains('tryReverseGeocode'),
+          reason: 'the where hint must survive for triage');
+    });
+
+    test('redacts lon-keyed and latitude/longitude-keyed values too', () {
+      const msg = 'request lon=2.3522 latitude: 48.8566 Longitude=151.2093';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('2.3522')));
+      expect(out, isNot(contains('48.8566')));
+      expect(out, isNot(contains('151.2093')));
+    });
+
+    test('does not redact non-coordinate decimals near other words', () {
+      const msg = 'price for diesel: 1.789 at relativeError: 0.25';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, contains('1.789'));
+      expect(out, contains('0.25'));
+    });
+  });
 }

--- a/test/core/telemetry/storage/startup_failure_store_test.dart
+++ b/test/core/telemetry/storage/startup_failure_store_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/telemetry/storage/startup_failure_store.dart';
+
+/// #3149 — when the storage phase bricks, Hive (and with it the trace
+/// store + isolate spool) is dead, so the cause must persist through a
+/// plain file the next successful launch can replay. These tests pin the
+/// round-trip, the read-once semantics, and the best-effort fault paths
+/// on both sides.
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('startup_failure_');
+    StartupFailureStore.directoryProvider = () async => tempDir;
+  });
+
+  tearDown(() {
+    StartupFailureStore.resetForTest();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('persist → drain round-trips error type, message and stack', () async {
+    final error = StateError('keychain unavailable');
+    final stack = StackTrace.current;
+    await StartupFailureStore.persist(error, stack);
+
+    final record = await StartupFailureStore.drain();
+    expect(record, isNotNull);
+    expect(record!['errorType'], 'StateError');
+    expect(record['error'], contains('keychain unavailable'));
+    expect(record['stack'], contains('startup_failure_store_test'));
+    expect(DateTime.tryParse(record['at'] as String), isNotNull);
+  });
+
+  test('drain deletes the record — a poisoned record reports at most once',
+      () async {
+    await StartupFailureStore.persist(Exception('boom'), StackTrace.current);
+    expect(await StartupFailureStore.drain(), isNotNull);
+    expect(await StartupFailureStore.drain(), isNull,
+        reason: 'second drain must find nothing');
+    expect(
+        File('${tempDir.path}/${StartupFailureStore.fileName}').existsSync(),
+        isFalse);
+  });
+
+  test('drain returns null when no failure was ever persisted', () async {
+    expect(await StartupFailureStore.drain(), isNull);
+  });
+
+  test('a later persist overwrites the earlier record', () async {
+    await StartupFailureStore.persist(Exception('first'), StackTrace.current);
+    await StartupFailureStore.persist(Exception('second'), StackTrace.current);
+    final record = await StartupFailureStore.drain();
+    expect(record!['error'], contains('second'));
+  });
+
+  test('persist swallows a directory-provider fault (fault injection)',
+      () async {
+    StartupFailureStore.directoryProvider =
+        () async => throw const FileSystemException('disk gone');
+    await expectLater(
+      StartupFailureStore.persist(Exception('boom'), StackTrace.current),
+      completes,
+      reason: 'observability must never make a bricked startup worse',
+    );
+  });
+
+  test('drain swallows a corrupt record and returns null (fault injection)',
+      () async {
+    final file = File('${tempDir.path}/${StartupFailureStore.fileName}');
+    file.writeAsStringSync('{not json');
+    expect(await StartupFailureStore.drain(), isNull,
+        reason: 'a corrupt record must never brick the healthy launch');
+  });
+
+  test('the record is plain JSON a maintainer can read off-device', () async {
+    await StartupFailureStore.persist(Exception('boom'), StackTrace.current);
+    final raw = File('${tempDir.path}/${StartupFailureStore.fileName}')
+        .readAsStringSync();
+    expect(() => jsonDecode(raw), returnsNormally);
+  });
+}

--- a/test/core/telemetry/storage/trace_storage_test.dart
+++ b/test/core/telemetry/storage/trace_storage_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/pii_scrubber.dart';
 import 'package:tankstellen/core/telemetry/storage/trace_storage.dart';
 
 /// Create a plain JSON map that Hive can serialize (no freezed objects).
@@ -508,6 +509,50 @@ void main() {
         // — i.e. it's already a plain Map<String, dynamic> tree, not a
         // Hive-shaped Map<dynamic, dynamic> that would blow up on encode.
         expect(() => jsonEncode(unparsed), returnsNormally);
+      });
+    });
+
+    group('exportAsJson PII scrub (#3145)', () {
+      test('a stored trace containing coordinates exports redacted', () async {
+        final json = _makePlainJson(id: 'coord-trace');
+        // Inject the coordinate shapes the geocoding / search call sites
+        // emit: a key/value breadcrumb detail, a map-rendered context in
+        // the error message, and an adjacency pair in the search params.
+        json['errorMessage'] =
+            '[services] DioException [context={where: tryReverseGeocode, '
+            'lat: 48.137154, lng: 11.576124}]';
+        json['appState'] = {
+          ...(json['appState'] as Map<String, dynamic>),
+          'lastSearchParams': 'around 48.137154, 11.576124 radius 5',
+        };
+        json['breadcrumbs'] = [
+          {
+            'timestamp': '2026-06-01T10:00:00.000',
+            'action': 'Native country detection skipped — offline',
+            'detail': 'lat=48.137154 lng=11.576124 type=PlatformException',
+          },
+        ];
+        await Hive.box('error_traces').put('coord-trace', json);
+
+        final raw = storage.exportAsJson();
+        expect(raw, isNot(contains('48.137154')),
+            reason: 'the local export leaves the device (email / GitHub '
+                'issue) and previously applied NO scrubbing');
+        expect(raw, isNot(contains('11.576124')));
+        expect(raw, contains(PiiScrubber.coordMarker));
+      });
+
+      test('unparsedRaw entries are deep-scrubbed too', () async {
+        // Schema-drifted entry (no id → fails fromJson) carrying coords.
+        final broken = _makePlainJson(id: 'drifted')..remove('id');
+        broken['errorMessage'] = 'failed at lat=48.137154 lng=11.576124';
+        await Hive.box('error_traces').put('drifted', broken);
+
+        final raw = storage.exportAsJson();
+        final decoded = jsonDecode(raw) as Map<String, dynamic>;
+        expect(decoded['unparsedCount'], 1);
+        expect(raw, isNot(contains('48.137154')));
+        expect(raw, isNot(contains('11.576124')));
       });
     });
   });

--- a/test/features/station_services/opening_hours/opening_hours_parse_failure_report_test.dart
+++ b/test/features/station_services/opening_hours/opening_hours_parse_failure_report_test.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:collection';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/austria/austria_opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/chile/chile_opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/germany/germany_opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/opening_hours/opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/portugal/portugal_opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/spain/spain_opening_hours_adapter.dart';
+
+/// #3148 — the five country opening-hours adapters used to swallow parse
+/// failures in an assert-wrapped `print`, which is compiled out of release
+/// builds: a provider format change degraded every station to "no data"
+/// with zero field signal. The catch now emits an `oh-parse-failed`
+/// breadcrumb + one errorLogger ERROR, throttled to the first occurrence
+/// per adapter per session, while still returning
+/// [WeeklyOpeningHours.notAvailable].
+class _CapturingRecorder implements TraceRecorder {
+  final captured = <ContextualError>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    captured.add(error as ContextualError);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Garbage that passes each adapter's `is Map` shape check and then throws
+/// on the first key access — a guaranteed in-`try` fault, exactly like a
+/// provider payload whose nested shape changed under the adapter.
+class _ThrowingMap extends MapBase<dynamic, dynamic> {
+  @override
+  dynamic operator [](Object? key) =>
+      throw StateError('simulated provider-shape fault');
+
+  @override
+  void operator []=(dynamic key, dynamic value) {}
+
+  @override
+  void clear() {}
+
+  @override
+  Iterable<dynamic> get keys =>
+      throw StateError('simulated provider-shape fault');
+
+  @override
+  dynamic remove(Object? key) => null;
+}
+
+void main() {
+  late _CapturingRecorder recorder;
+
+  setUp(() {
+    recorder = _CapturingRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    BreadcrumbCollector.clear();
+    OpeningHoursAdapter.resetParseFailureReportsForTest();
+  });
+
+  tearDown(() {
+    errorLogger.resetForTest();
+    BreadcrumbCollector.clear();
+    OpeningHoursAdapter.resetParseFailureReportsForTest();
+  });
+
+  /// Adapters whose parse path reads from a Map payload — feeding the
+  /// throwing map drives the real catch block.
+  final mapDrivenAdapters = <String, OpeningHoursAdapter>{
+    'DE': const GermanyOpeningHoursAdapter(),
+    'PT': const PortugalOpeningHoursAdapter(),
+    'AT': const AustriaOpeningHoursAdapter(),
+    'CL': const ChileOpeningHoursAdapter(),
+  };
+
+  for (final entry in mapDrivenAdapters.entries) {
+    group('${entry.value.runtimeType} (${entry.key})', () {
+      test('garbage input degrades to notAvailable AND fires breadcrumb + '
+          'errorLogger once across two calls', () {
+        final adapter = entry.value;
+        final garbage = _ThrowingMap();
+
+        expect(adapter.parse(garbage), WeeklyOpeningHours.notAvailable);
+        expect(adapter.parse(garbage), WeeklyOpeningHours.notAvailable,
+            reason: 'second call must also degrade gracefully');
+
+        final crumbs = BreadcrumbCollector.snapshot()
+            .where((b) => b.action == 'oh-parse-failed')
+            .toList();
+        expect(crumbs, hasLength(1),
+            reason: 'breadcrumb throttled to first occurrence per session');
+        expect(crumbs.single.detail, startsWith(entry.key));
+        expect(crumbs.single.detail, contains('StateError'));
+
+        expect(recorder.captured, hasLength(1),
+            reason: 'errorLogger throttled to first occurrence per session');
+        final logged = recorder.captured.single;
+        expect(logged.layer, ErrorLayer.services);
+        expect(logged.context?['country'], entry.key);
+        expect(logged.inner, isA<StateError>());
+      });
+    });
+  }
+
+  group('SpainOpeningHoursAdapter (ES)', () {
+    test('non-string garbage degrades to notAvailable without reporting '
+        '(shape-narrowed before the try body can fault)', () {
+      const adapter = SpainOpeningHoursAdapter();
+      expect(adapter.parse(_ThrowingMap()), WeeklyOpeningHours.notAvailable);
+      expect(
+          BreadcrumbCollector.snapshot()
+              .where((b) => b.action == 'oh-parse-failed'),
+          isEmpty);
+    });
+  });
+
+  group('shared reporter throttle', () {
+    test('reports once per country, independent across countries', () {
+      const de = GermanyOpeningHoursAdapter();
+      const pt = PortugalOpeningHoursAdapter();
+      final garbage = _ThrowingMap();
+
+      de.parse(garbage);
+      de.parse(garbage);
+      pt.parse(garbage);
+
+      final crumbs = BreadcrumbCollector.snapshot()
+          .where((b) => b.action == 'oh-parse-failed')
+          .map((b) => b.detail)
+          .toList();
+      expect(crumbs, hasLength(2),
+          reason: 'one report per adapter/country, not per call');
+      expect(recorder.captured.map((c) => c.context?['country']),
+          containsAll(<String>['DE', 'PT']));
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -64,7 +64,13 @@ void main() {
     // debugPrint-only catch handlers converted to `errorLogger.log(...)`
     // with a `where` context map (each conversion is +1 line); enforced
     // at 0 by test/lint/no_debugprint_only_catch_test.dart.
-    'lib/app/app_initializer.dart': 1046,
+    // #3149 — re-grandfathered 1046 → 1077: the startup-brick fix adds
+    // the catch-all after the HiveCorruptionException catch (route
+    // unknown storage failures to the same StorageRecoveryHost), the
+    // Hive-independent StartupFailureStore.persist in both brick paths,
+    // and the next-launch replay drain. The store itself is a new file;
+    // these lines are only the run()/_launch wiring.
+    'lib/app/app_initializer.dart': 1077,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -60,7 +60,11 @@ void main() {
     // adjacent trips merge. The unit-tested logic lives in the per-entity
     // provider seams; this is the (compacted) launch glue. Decomposition
     // of this god-file is tracked separately.
-    'lib/app/app_initializer.dart': 1028,
+    // #3143 — re-grandfathered 1028 → 1046: ~20 release-silent
+    // debugPrint-only catch handlers converted to `errorLogger.log(...)`
+    // with a `where` context map (each conversion is +1 line); enforced
+    // at 0 by test/lint/no_debugprint_only_catch_test.dart.
+    'lib/app/app_initializer.dart': 1046,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device

--- a/test/lint/never_throws_contract_test.dart
+++ b/test/lint/never_throws_contract_test.dart
@@ -51,7 +51,6 @@ void main() {
   const grandfathered = <String>{
     'lib/core/services/radar/corridor_location_cache.dart',
     'lib/core/sync/trip_shares_sync.dart',
-    'lib/core/telemetry/pii_scrubber.dart',
     'lib/features/consumption/data/obd2/adapter_capability.dart',
     'lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart',
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart',

--- a/test/lint/no_debugprint_only_catch_test.dart
+++ b/test/lint/no_debugprint_only_catch_test.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan regression test (#3143): no catch block in the startup /
+/// background layers may have `debugPrint` as its ONLY statement.
+///
+/// ## Why
+/// `AppInitializer._bootstrap()` no-ops `debugPrint` in release builds,
+/// so a catch handler whose only action is `debugPrint(...)` is a
+/// SILENT swallow in production — the failure never reaches the
+/// `errorLogger` / TraceRecorder / Sentry pipeline and is invisible to
+/// field triage. The startup phases (`lib/app/`) and the background
+/// scan machinery (`lib/core/background/`) are exactly the code that
+/// runs when nobody is watching, so they get a hard gate.
+///
+/// ## What is forbidden
+/// A `catch (...) { ... }` or `on Type { ... }` block (in the scanned
+/// directories) whose body contains nothing but `debugPrint(...)`
+/// statement(s) and comments.
+///
+/// ## What is allowed
+/// - A body that ALSO calls `errorLogger.log(...)` (or anything else) —
+///   keeping a `debugPrint` alongside the structured log is fine.
+/// - A breadcrumb-only body for expected, benign races (the breadcrumb
+///   ring is drained into every error trace, so it is release-visible).
+/// - Generated files (`.g.dart`, `.freezed.dart`).
+/// - The catch inside `AppInitializer._runEntitySyncMerge` — that
+///   method is owned by the in-flight #3077 follow-up branch
+///   (file-ownership boundary); it is allowlisted below until that
+///   branch lands and the entry can be removed. The allowlist may only
+///   ever SHRINK.
+void main() {
+  test(
+      'no debugPrint-only catch handlers in lib/app + lib/core/background '
+      '(#3143)', () {
+    // Allowlisted bodies, matched by substring of the debugPrint message.
+    // ⚠️ May only shrink — see the docstring.
+    const allowlistedBodyMarkers = <String>[
+      '_runEntitySyncMerge', // owned by the in-flight #3077 branch
+    ];
+
+    final offenders = <String>[];
+    // `catch (e, st) {` and bare `on TimeoutException {` openers.
+    final catchOpener = RegExp(
+      r'(?:\bon\s+[\w<>.]+\s*(?:catch\s*\([^)]*\))?|\bcatch\s*\([^)]*\))\s*\{',
+    );
+
+    for (final dir in ['lib/app', 'lib/core/background']) {
+      for (final entity in Directory(dir).listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final src = entity.readAsStringSync();
+        for (final m in catchOpener.allMatches(src)) {
+          final body = _blockBody(src, m.end - 1);
+          if (body == null) continue;
+          if (!_isDebugPrintOnly(body)) continue;
+          if (allowlistedBodyMarkers.any(body.contains)) continue;
+          final line = src.substring(0, m.start).split('\n').length;
+          final path = entity.path.replaceAll('\\', '/');
+          offenders.add('$path:$line');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'debugPrint-only catch handlers are invisible in release '
+          'builds (debugPrint is no-opped in _bootstrap). Route the '
+          'failure through `errorLogger.log(ErrorLayer.<layer>, e, st, '
+          'context: {...})` (a debugPrint alongside is fine), or — for an '
+          'expected benign race — a BreadcrumbCollector breadcrumb.\n'
+          'Offending sites:\n${offenders.join('\n')}',
+    );
+  });
+}
+
+/// Returns the text between the brace at [openBraceIdx] and its matching
+/// close brace, or null when unbalanced.
+String? _blockBody(String src, int openBraceIdx) {
+  var depth = 0;
+  for (var i = openBraceIdx; i < src.length; i++) {
+    final ch = src[i];
+    if (ch == '{') depth++;
+    if (ch == '}') {
+      depth--;
+      if (depth == 0) return src.substring(openBraceIdx + 1, i);
+    }
+  }
+  return null;
+}
+
+/// True when [body], stripped of comments and blank lines, consists of
+/// nothing but `debugPrint(...)` statement(s).
+bool _isDebugPrintOnly(String body) {
+  final withoutComments = body
+      .split('\n')
+      .where((l) {
+        final t = l.trim();
+        return t.isNotEmpty && !t.startsWith('//');
+      })
+      .join('\n')
+      .trim();
+  if (withoutComments.isEmpty) return false;
+  if (!withoutComments.contains('debugPrint')) return false;
+  final residue = withoutComments
+      .replaceAll(RegExp(r'debugPrint\s*\([^;]*\)\s*;', dotAll: true), '')
+      .trim();
+  return residue.isEmpty;
+}


### PR DESCRIPTION
## Diagnosability wave 1 — release-visible failures, PII scrubbing, startup-brick forensics, trace hygiene

Five issues from epic #3142 (diagnosability/traceability → A), one commit each:

- **#3143** — ~100 release-silent `debugPrint`-only catch handlers (including ALL launch sync failures) now reach `errorLogger`, so field failures produce traces instead of vanishing in release builds.
- **#3145** — coordinate PII leak plugged: the scrubber now catches lat/lon in messages and context, breadcrumbs are scrubbed, coordinates are bucketed (~1.1 km) and the local trace export passes through the same scrubbing.
- **#3148** — opening-hours parse failures are release-visible, throttled to once per source per session (was a debug-only assert+print).
- **#3149** — startup brick beyond HiveCorruption: any storage-phase fault (secure-storage cipher, TraceStorage…) routes to the recovery screen, and the cause is persisted to a Hive-independent plain file that the next launch replays into the trace pipeline.
- **#3150** — trace hygiene: provider/table/feature context on logs, `FlutterError`/`PlatformDispatcher` handler attribution, and the cache source persisted by enum **name** instead of reorder-fragile index (with legacy-index read fallback).

Closes #3143, closes #3145, closes #3148, closes #3149, closes #3150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
