### PR TITLE
feat(diag): leveled log facade, production health counters, alert scan journal (#3144 #3146 #3147)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -24,6 +24,7 @@ import '../core/telemetry/storage/isolate_error_spool.dart';
 import '../core/telemetry/storage/startup_failure_store.dart';
 import '../core/telemetry/storage/trace_storage.dart';
 import '../core/telemetry/trace_recorder.dart';
+import '../core/logging/app_log.dart';
 import '../core/logging/error_logger.dart';
 import '../core/notifications/local_notification_service.dart';
 import '../core/data/storage_repository.dart';
@@ -228,8 +229,7 @@ class AppInitializer {
         final catalog =
             await container.read(referenceVehicleCatalogProvider.future);
         final matched = await migrator.run(catalog: catalog);
-        debugPrint(
-            'VehicleProfileCatalogMigrator: matched $matched profile(s)');
+        log.info('VehicleProfileCatalogMigrator: matched $matched profile(s)');
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.background, e, st,
             context: {'where': 'vehicleProfileCatalogMigrator'}));
@@ -344,7 +344,12 @@ class AppInitializer {
             try {
               return PiiScrubber.scrubSentryEvent(event);
             } catch (e, st) {
-              debugPrint('Sentry beforeSend scrub failed: $e\n$st');
+              // #3144 — breadcrumb-level (NOT errorLogger): a warn-level
+              // trace from inside beforeSend could recurse through the
+              // Sentry upload path. The breadcrumb still rides inside the
+              // next persisted trace, so the scrub fault is field-visible.
+              log.info('Sentry beforeSend scrub failed: $e\n$st',
+                  tag: 'sentry');
               return event;
             }
           };
@@ -545,13 +550,13 @@ class AppInitializer {
       await Future(() async {
         await TankSyncClient.init(url: url, anonKey: key);
         if (TankSyncClient.client?.auth.currentUser == null) {
-          debugPrint('TankSync: session expired, re-authenticating...');
+          log.info('TankSync: session expired, re-authenticating...');
           await TankSyncClient.signInAnonymously();
         }
         final sessionId = TankSyncClient.client?.auth.currentUser?.id;
         final storedId = storage.getSetting('sync_user_id') as String?;
         if (sessionId != null && sessionId != storedId) {
-          debugPrint('TankSync: userId changed');
+          log.info('TankSync: userId changed');
           await storage.putSetting('sync_user_id', sessionId);
         }
         if (sessionId != null) {
@@ -565,7 +570,7 @@ class AppInitializer {
                 context: {'where': 'maybeInitTankSync users upsert'}));
           }
         }
-        debugPrint('TankSync: ready');
+        log.info('TankSync: ready');
       }).timeout(const Duration(seconds: 8));
     } on TimeoutException catch (e, st) {
       // #3143 — proceeding without sync, but record it: a silent init
@@ -852,7 +857,7 @@ class AppInitializer {
     );
     final recovered = await service.recoverStale();
     if (recovered > 0) {
-      debugPrint(
+      log.info(
           'AppInitializer: recovered $recovered paused trip(s) into history');
     }
   }
@@ -1019,8 +1024,7 @@ class AppInitializer {
         await HiveBoxes.initDeferred();
         final wired = wireAggregatorIntoTripHistory(container);
         if (!wired) {
-          debugPrint(
-              'AppInitializer: vehicle aggregator hook deferred — '
+          log.info('AppInitializer: vehicle aggregator hook deferred — '
               'trip-history box not open yet');
         }
       } catch (e, st) {
@@ -1042,7 +1046,7 @@ class AppInitializer {
         final recorder = container.read(traceRecorderProvider);
         final replayed = await IsolateErrorSpool.drain(recorder);
         if (replayed > 0) {
-          debugPrint(
+          log.info(
               'AppInitializer: drained $replayed isolate error(s) into TraceRecorder');
         }
       } catch (e, st) {

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -20,6 +20,7 @@ import '../core/constants/app_constants.dart';
 import '../core/cache/cache_manager.dart';
 import '../core/feedback/auto_record_badge_provider.dart';
 import '../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../core/telemetry/health_counters.dart';
 import '../core/telemetry/storage/isolate_error_spool.dart';
 import '../core/telemetry/storage/startup_failure_store.dart';
 import '../core/telemetry/storage/trace_storage.dart';
@@ -428,6 +429,7 @@ class AppInitializer {
       // ring, registers the persist hook + the `obd2ConnectTraces` export
       // section. Independent of the other two (own box); best-effort.
       Obd2ConnectTracePersistence.init(),
+      HealthCounters.init(), // #3146 — always-on production counters
     ]);
 
     // Verify all countries have registered service implementations.

--- a/lib/core/background/alert_scan_journal.dart
+++ b/lib/core/background/alert_scan_journal.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../logging/error_logger.dart';
+import '../storage/hive_boxes.dart';
+
+/// Rolling journal of background alert-scan runs (#3147).
+///
+/// Alert delivery previously had no persisted audit trail: scans
+/// ran/skipped (lock contention, cooldown), stations fetched and
+/// "N alerts triggered" were all debugPrint-only, so a field report of
+/// "my alerts never fire" yielded an export showing only *errors* — not
+/// whether scans ran at all, were skipped, or fired. This journal makes
+/// the standing alert SLA (1-3x/day, ≤3-4h) field-verifiable: every
+/// trigger appends one compact row, the last [maxEntries] rows are kept,
+/// and the rows ride inside the existing `TraceStorage.exportAsJson()`
+/// payload under `diagnostics.alertScanJournal`.
+///
+/// Rows are PII-free by construction: timestamps, trigger tags,
+/// skip reasons, counts and error *types* — never station ids, prices,
+/// or coordinates.
+///
+/// Persists under the already-encrypted [HiveBoxes.alerts] box (open in
+/// both the main and background isolates), alongside the
+/// `BackgroundScanDedupStore` rows — no extra box in the WorkManager
+/// isolate, and the export read happens in the foreground where the box
+/// is open anyway. Like the dedup store, every method degrades to a
+/// no-op when the box is unavailable — journalling must never break a
+/// scan. Local-only: deliberately NOT a synced TankSync table.
+class AlertScanJournal {
+  /// Hive key holding the rolling `List` of journal rows.
+  static const String journalKey = 'bg_scan_journal';
+
+  /// Rows kept, newest last. ~20 rows ≈ 1-2 weeks of twice-daily scans
+  /// plus their skipped siblings — enough to answer "did scans run this
+  /// week?" while staying tiny in the alerts box and the export.
+  static const int maxEntries = 20;
+
+  Box? _boxOrNull() {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
+      return Hive.box(HiveBoxes.alerts);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'AlertScanJournal: alerts box unavailable',
+      }));
+      return null;
+    }
+  }
+
+  /// Append one scan-run row, rotating out the oldest beyond
+  /// [maxEntries]. Exactly one of the optional groups is expected:
+  /// [skippedReason] for a skipped trigger, [error] for a failed scan,
+  /// or the [stationsScanned]/[alertsFired] counts for a completed one.
+  /// Never throws — a journalling fault must never fail the scan.
+  Future<void> append({
+    required DateTime at,
+    required String trigger,
+    String? skippedReason,
+    int? stationsScanned,
+    int? alertsFired,
+    String? error,
+  }) async {
+    try {
+      final box = _boxOrNull();
+      if (box == null) {
+        debugPrint('AlertScanJournal.append: alerts box closed, '
+            'dropping ($trigger)');
+        return;
+      }
+      final rows = entries()
+        ..add(<String, Object?>{
+          'at': at.toUtc().toIso8601String(),
+          'trigger': trigger,
+          'skipped': ?skippedReason,
+          'stations': ?stationsScanned,
+          'alertsFired': ?alertsFired,
+          'error': ?error,
+        });
+      final start = rows.length > maxEntries ? rows.length - maxEntries : 0;
+      await box.put(journalKey, rows.sublist(start));
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'AlertScanJournal.append failed',
+      }));
+    }
+  }
+
+  /// The persisted rows, oldest first. Empty when the box is closed or
+  /// the key is missing/malformed. Never throws.
+  List<Map<String, Object?>> entries() {
+    try {
+      final raw = _boxOrNull()?.get(journalKey);
+      if (raw is! List) return <Map<String, Object?>>[];
+      return raw
+          .whereType<Map>()
+          .map((row) => row.map((k, v) => MapEntry('$k', v as Object?)))
+          .toList();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'AlertScanJournal.entries failed',
+      }));
+      return <Map<String, Object?>>[];
+    }
+  }
+
+  /// Export-ready section for `TraceStorage.exportAsJson()` —
+  /// newest-first so the most recent scans lead the payload.
+  static List<Map<String, Object?>> exportSection() =>
+      AlertScanJournal().entries().reversed.toList();
+
+  /// Clear the journal. Test-only / "clear all data" troubleshoot path.
+  @visibleForTesting
+  Future<void> clear() async {
+    await _boxOrNull()?.delete(journalKey);
+  }
+}

--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -10,6 +10,7 @@ import '../../features/widget/data/home_widget_service.dart';
 import '../logging/error_logger.dart';
 import '../storage/hive_storage.dart';
 import '../cache/cache_manager.dart';
+import 'alert_scan_journal.dart';
 import 'background_price_history_writer.dart';
 import 'background_price_source.dart';
 import 'background_scan_dedup_store.dart';
@@ -104,11 +105,15 @@ class BackgroundAlertScanCoordinator {
   static const retryBaseDelay = Duration(seconds: 2);
 
   final BackgroundScanDedupStore _dedup;
+  final AlertScanJournal _journal;
 
-  /// Creates a coordinator. [dedup] is injectable so unit tests can drive
-  /// the cooldown gate with a fake/seeded store.
-  BackgroundAlertScanCoordinator({BackgroundScanDedupStore? dedup})
-      : _dedup = dedup ?? BackgroundScanDedupStore();
+  /// Creates a coordinator. [dedup] and [journal] are injectable so unit
+  /// tests can drive the cooldown gate / journal with fakes.
+  BackgroundAlertScanCoordinator({
+    BackgroundScanDedupStore? dedup,
+    AlertScanJournal? journal,
+  })  : _dedup = dedup ?? BackgroundScanDedupStore(),
+        _journal = journal ?? AlertScanJournal();
 
   /// Run one background scan on behalf of [trigger].
   ///
@@ -140,6 +145,11 @@ class BackgroundAlertScanCoordinator {
         debugPrint(
             'BackgroundAlertScanCoordinator: could not acquire Hive lock '
             '(${trigger.tag}), skipping');
+        // #3147 — best-effort: the alerts box is usually NOT open on this
+        // path (the lock holder owns it), so the append may no-op; the
+        // concurrent holder journals its own completed row.
+        await _journal.append(
+            at: at, trigger: trigger.tag, skippedReason: 'hive_lock');
         return false;
       }
 
@@ -153,14 +163,25 @@ class BackgroundAlertScanCoordinator {
         debugPrint(
             'BackgroundAlertScanCoordinator: scan skipped (${trigger.tag}) '
             '— last scan $last is within ${cooldown.inMinutes}m cooldown');
+        await _journal.append(
+            at: at, trigger: trigger.tag, skippedReason: 'cooldown');
         return false;
       }
 
-      await _runScanBody(HiveStorage());
+      final summary = await _runScanBody(HiveStorage());
 
       // Stamp completion only after the body finishes so a crash mid-scan
       // leaves the door open for the next trigger to retry.
       await _dedup.recordScan(now: at, trigger: trigger.tag);
+      // #3147 — persisted audit row: when, what trigger, how many stations
+      // were fetched, how many notifications fired. Rides in the export so
+      // "why didn't I get an alert?" is answerable in the field.
+      await _journal.append(
+        at: at,
+        trigger: trigger.tag,
+        stationsScanned: summary.stationsScanned,
+        alertsFired: summary.alertsFired,
+      );
       return true;
     } catch (e, st) {
       // #3150 — single log call. `errorLogger.log` already routes to the
@@ -171,6 +192,10 @@ class BackgroundAlertScanCoordinator {
         'where': 'BackgroundAlertScanCoordinator: scan failed (${trigger.tag})',
         'isolateTaskName': 'bg_scan_${trigger.tag}',
       }));
+      // #3147 — the error TYPE only (PII-safe), so the journal shows a
+      // failed run distinctly from "no scan ran at all".
+      await _journal.append(
+          at: at, trigger: trigger.tag, error: e.runtimeType.toString());
       return false;
     } finally {
       try {
@@ -188,7 +213,10 @@ class BackgroundAlertScanCoordinator {
   /// once-a-day viewed stations, #2212), record history, evaluate per-
   /// station / velocity / radius alerts, refresh the home widgets. Assumes
   /// Hive is already initialised in this isolate and the lock is held.
-  Future<void> _runScanBody(HiveStorage storage) async {
+  /// Returns the journal counts (#3147): stations with fetched prices +
+  /// total notifications fired across the three runners.
+  Future<({int stationsScanned, int alertsFired})> _runScanBody(
+      HiveStorage storage) async {
     await HiveStorage.loadApiKey();
     final apiKey = storage.getApiKey();
 
@@ -234,7 +262,7 @@ class BackgroundAlertScanCoordinator {
     if (allStationIds.isEmpty) {
       // #609 — users without favorites still need a populated nearest widget.
       await _refreshNearestWidgetFromSearch(storage);
-      return;
+      return (stationsScanned: 0, alertsFired: 0);
     }
 
     // 2. Fetch prices via the registry-driven per-country source (#2862): the
@@ -291,7 +319,7 @@ class BackgroundAlertScanCoordinator {
       await BackgroundPriceHistoryWriter.updateCachedStations(storage, prices);
     }
 
-    await BackgroundScanRunners.runPerStationAlerts(
+    var alertsFired = await BackgroundScanRunners.runPerStationAlerts(
       repo: repo,
       alerts: alerts,
       prices: prices,
@@ -301,7 +329,7 @@ class BackgroundAlertScanCoordinator {
     );
 
     if (prices.isNotEmpty) {
-      await BackgroundScanRunners.runVelocity(
+      alertsFired += await BackgroundScanRunners.runVelocity(
         storage: storage,
         prices: prices,
         now: now,
@@ -310,7 +338,7 @@ class BackgroundAlertScanCoordinator {
       );
     }
 
-    await BackgroundScanRunners.runRadiusAlerts(
+    alertsFired += await BackgroundScanRunners.runRadiusAlerts(
       now: now,
       resolver: resolver,
       templates: templates,
@@ -326,6 +354,8 @@ class BackgroundAlertScanCoordinator {
     // #2866 — dev-gated: snapshot + export this scan's data-access trace so the
     // maintainer reads `aggregates().compliant` per provider (no-op otherwise).
     await tracer.exportIfEnabled();
+
+    return (stationsScanned: prices.length, alertsFired: alertsFired);
   }
 
   /// #609 — nearest-widget refresh from a real search (or legacy fallback).

--- a/lib/core/background/background_scan_runners.dart
+++ b/lib/core/background/background_scan_runners.dart
@@ -23,7 +23,6 @@ import '../notifications/notification_service.dart';
 import '../services/country_service_registry.dart';
 import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
-import '../telemetry/storage/isolate_error_spool.dart';
 import '../utils/json_extensions.dart';
 import 'country_alert_strategy_resolver.dart';
 import 'fuel_price_fields.dart';
@@ -53,7 +52,9 @@ class BackgroundScanRunners {
   /// LPG / CNG / E98 alert in a country whose provider exposes that fuel fires,
   /// and the notification renders in that country's currency. DE e5/e10/diesel
   /// resolution + the euro are unchanged.
-  static Future<void> runPerStationAlerts({
+  /// Returns the number of notifications fired (#3147 — the count feeds
+  /// the coordinator's persisted scan journal).
+  static Future<int> runPerStationAlerts({
     required AlertRepository repo,
     required List<PriceAlert> alerts,
     required Map<String, Map<String, dynamic>> prices,
@@ -70,7 +71,7 @@ class BackgroundScanRunners {
               : 'no active alerts')
           : 'no prices fetched (refresh failed?)';
       debugPrint('BackgroundScanRunners: alert loop skipped — $reason');
-      return;
+      return 0;
     }
 
     final notify = notifier ?? LocalNotificationService();
@@ -119,6 +120,7 @@ class BackgroundScanRunners {
       await repo.saveAlert(alert.copyWith(lastTriggeredAt: now));
     }
     debugPrint('BackgroundScanRunners: $notificationCount alerts triggered');
+    return notificationCount;
   }
 
   /// #579 — velocity detector across nearby stations.
@@ -127,7 +129,8 @@ class BackgroundScanRunners {
   /// the active country ([fallbackCountryCode]), so the detector runs on the
   /// fuel the user's country actually exposes (e.g. an LPG velocity alert in FR)
   /// rather than the DE-only e5/e10/diesel switch.
-  static Future<void> runVelocity({
+  /// Returns 1 when a velocity notification fired, else 0 (#3147).
+  static Future<int> runVelocity({
     required HiveStorage storage,
     required Map<String, Map<String, dynamic>> prices,
     required DateTime now,
@@ -150,7 +153,7 @@ class BackgroundScanRunners {
       if (fuelKey == null) {
         debugPrint('BackgroundScanRunners: velocity skipped — '
             '${config.fuelType.apiValue} not in the active country feed');
-        return;
+        return 0;
       }
       final observations = <VelocityStationObservation>[];
       for (final entry in prices.entries) {
@@ -176,7 +179,7 @@ class BackgroundScanRunners {
       if (observations.isEmpty) {
         debugPrint('BackgroundScanRunners: velocity has no usable '
             'observations');
-        return;
+        return 0;
       }
       final userLat = storage.getSetting(StorageKeys.userPositionLat) as num?;
       final userLng = storage.getSetting(StorageKeys.userPositionLng) as num?;
@@ -189,17 +192,20 @@ class BackgroundScanRunners {
       if (event != null) {
         debugPrint('BackgroundScanRunners: velocity alert '
             '${event.fuelType.apiValue}, count=${event.stationCount}');
+        return 1;
       }
+      return 0;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'BackgroundScanRunners: velocity detector failed'
+      // #3147 bonus — single log call: `errorLogger.log` already routes
+      // to the IsolateErrorSpool when unbound, so the former explicit
+      // `IsolateErrorSpool.enqueue` double-logged every failure (halving
+      // the effective spool depth); context travels in the map instead.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'BackgroundScanRunners: velocity detector failed',
+        'isolateTaskName': 'velocity_detector',
+        'priceCount': prices.length,
       }));
-      await IsolateErrorSpool.enqueue(
-        isolateTaskName: 'velocity_detector',
-        error: e,
-        stack: st,
-        contextMap: <String, dynamic>{'priceCount': prices.length},
-      );
+      return 0;
     }
   }
 
@@ -219,7 +225,8 @@ class BackgroundScanRunners {
   /// country reuse one strategy (and, for bulk, one in-memory dataset). A
   /// centre whose country has no buildable strategy (e.g. the AU stub) yields
   /// no samples this scan.
-  static Future<void> runRadiusAlerts({
+  /// Returns the number of radius alerts fired (#3147).
+  static Future<int> runRadiusAlerts({
     required DateTime now,
     required CountryAlertStrategyResolver resolver,
     required BackgroundNotificationTemplates templates,
@@ -229,7 +236,7 @@ class BackgroundScanRunners {
       final radiusAlerts = await store.list();
       if (radiusAlerts.where((a) => a.enabled).isEmpty) {
         debugPrint('BackgroundScanRunners: no active radius alerts');
-        return;
+        return 0;
       }
       final notifier = LocalNotificationService();
       await notifier.initialize();
@@ -268,15 +275,14 @@ class BackgroundScanRunners {
         },
       );
       debugPrint('BackgroundScanRunners: ${fired.length} radius alerts fired');
+      return fired.length;
     } catch (e, st) {
+      // #3147 bonus — single log call (see [runVelocity]'s catch).
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'BackgroundScanRunners: radius alert runner failed'
+        'where': 'BackgroundScanRunners: radius alert runner failed',
+        'isolateTaskName': 'radius_alerts',
       }));
-      await IsolateErrorSpool.enqueue(
-        isolateTaskName: 'radius_alerts',
-        error: e,
-        stack: st,
-      );
+      return 0;
     }
   }
 }

--- a/lib/core/logging/app_log.dart
+++ b/lib/core/logging/app_log.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../telemetry/collectors/breadcrumb_collector.dart';
+import 'error_logger.dart';
+
+/// Severity levels of the [AppLog] facade (#3144).
+enum LogLevel {
+  /// Developer chatter: visible on the debug console only, fully
+  /// invisible in release builds (no logcat / os_log emission).
+  debug,
+
+  /// User-flow milestones ("sync ready", "migrated N profiles"): debug
+  /// console + a [BreadcrumbCollector] breadcrumb, so the last
+  /// [BreadcrumbCollector.maxBreadcrumbs] of them ride along inside
+  /// every persisted error trace — release-visible without consuming a
+  /// slot in the bounded trace ring.
+  info,
+
+  /// Unexpected-but-survivable conditions: full [errorLogger] pipeline
+  /// (persisted trace, export, opt-in Sentry) tagged `level: warn` so
+  /// triage can separate warnings from hard errors.
+  warn,
+
+  /// Hard failures: delegates to [errorLogger] unchanged.
+  error,
+}
+
+/// Leveled logging facade over the existing `errorLogger` / `debugPrint`
+/// split (#3144).
+///
+/// Before this facade a call site had exactly two choices: `debugPrint`
+/// (release-invisible — `_bootstrap()` no-ops it in release builds, and
+/// even when emitted it never reaches the trace export) or a full
+/// `errorLogger.log(...)` ERROR trace (which consumes one of the 50
+/// ring slots). The four levels above fill the gap; see [LogLevel] for
+/// the routing of each.
+///
+/// ## Contract
+/// Every method never throws — logging must never derail the caller.
+/// The error/warn path inherits [ErrorLogger.log]'s own never-throws
+/// contract; the debug/info path catches locally and falls back to a
+/// bare [debugPrint].
+///
+/// ## Why a singleton, not a Riverpod provider
+/// Same rationale as [ErrorLogger]: the facade must be callable from
+/// background isolates and pre-container startup phases, so it cannot
+/// depend on a provider scope. `errorLogger` already routes to the
+/// isolate spool when unbound, and the facade simply delegates.
+class AppLog {
+  AppLog._();
+
+  /// Test seam: force the console gate on/off regardless of
+  /// [kDebugMode] (which is always `true` under `flutter test`).
+  @visibleForTesting
+  bool? debugConsoleOverride;
+
+  /// Test seam: capture console lines instead of [debugPrint].
+  @visibleForTesting
+  void Function(String line)? consoleSinkOverride;
+
+  /// Reset all test seams.
+  @visibleForTesting
+  void resetForTest() {
+    debugConsoleOverride = null;
+    consoleSinkOverride = null;
+  }
+
+  bool get _consoleEnabled => debugConsoleOverride ?? kDebugMode;
+
+  /// Developer-only chatter. Console in debug builds, a no-op in
+  /// release. Never throws.
+  void debug(String message, {String? tag}) {
+    try {
+      _console(tag, message);
+    } catch (e, st) {
+      debugPrint('AppLog.debug failed: $e\n$st');
+    }
+  }
+
+  /// User-flow milestone. Console in debug builds + a breadcrumb that
+  /// rides inside every subsequently persisted error trace, so the
+  /// statement is release-visible in the field export without spending
+  /// a trace-ring slot. Never throws.
+  void info(String message, {String? tag}) {
+    try {
+      BreadcrumbCollector.add(tag ?? 'log', detail: message);
+      _console(tag, message);
+    } catch (e, st) {
+      debugPrint('AppLog.info failed: $e\n$st');
+    }
+  }
+
+  /// Unexpected-but-survivable condition. Routes through the full
+  /// [errorLogger] pipeline (persisted + exportable + opt-in Sentry)
+  /// tagged `level: warn`, so it is release-visible as a trace but
+  /// distinguishable from a hard error during triage. Never throws.
+  void warn(
+    String message, {
+    String? tag,
+    Object? error,
+    StackTrace? stack,
+    ErrorLayer layer = ErrorLayer.other,
+    Map<String, Object?>? context,
+  }) {
+    try {
+      _console(tag, message);
+      unawaited(errorLogger.log(layer, error ?? message, stack, context: {
+        'level': 'warn',
+        'tag': ?tag,
+        if (error != null) 'message': message,
+        ...?context,
+      }));
+    } catch (e, st) {
+      debugPrint('AppLog.warn failed: $e\n$st');
+    }
+  }
+
+  /// Hard failure. Delegates to [errorLogger.log] unchanged — same
+  /// pipeline, same routing (TraceRecorder when foreground-bound,
+  /// isolate spool otherwise). Never throws.
+  void error(
+    Object error,
+    StackTrace? stack, {
+    ErrorLayer layer = ErrorLayer.other,
+    Map<String, Object?>? context,
+  }) {
+    unawaited(errorLogger.log(layer, error, stack, context: context));
+  }
+
+  void _console(String? tag, String message) {
+    if (!_consoleEnabled) return;
+    final line = tag == null ? message : '[$tag] $message';
+    final sink = consoleSinkOverride;
+    if (sink != null) {
+      sink(line);
+    } else {
+      debugPrint(line);
+    }
+  }
+}
+
+/// Process-wide singleton, mirroring [errorLogger]. Safe to call from
+/// any isolate.
+final AppLog log = AppLog._();

--- a/lib/core/services/diagnostics/data_access_recorder.dart
+++ b/lib/core/services/diagnostics/data_access_recorder.dart
@@ -3,6 +3,7 @@
 
 import 'dart:collection';
 
+import '../../telemetry/health_counters.dart';
 import '../service_result.dart';
 import 'data_access_event.dart';
 import 'data_access_trace.dart';
@@ -91,6 +92,22 @@ void recordDataAccess(
   int? latencyMicros,
   bool isStale = false,
 }) {
+  // #3146 — always-on production tally (runs BEFORE the dev-recorder
+  // null-guard): every chain outcome bumps a persisted per-day counter
+  // so a silently degrading provider (stale fallbacks creeping up, fresh
+  // hits collapsing) is visible in the error-log export. Names are
+  // low-cardinality + PII-free; the bump is an in-memory map merge.
+  switch (hit) {
+    case DataAccessHit.networkApi:
+      healthCounters.increment('api.${healthCountryTag(country)}.ok');
+    case DataAccessHit.hiveFresh:
+      healthCounters.increment('cache.${healthCountryTag(country)}.freshHits');
+    case DataAccessHit.hiveStale:
+      healthCounters
+          .increment('api.${healthCountryTag(country)}.staleFallbacks');
+    case DataAccessHit.coalesced:
+      break; // a shared in-flight future, not a data-source outcome
+  }
   if (recorder == null) return;
   recorder.add(DataAccessEvent(
     at: DateTime.now(),
@@ -109,3 +126,14 @@ void recordDataAccess(
 /// otherwise null. A free function so chain call sites read
 /// `count: dataAccessResultCount(data)` without a local cast.
 int? dataAccessResultCount(Object? data) => data is List ? data.length : null;
+
+/// #3146 — counter tap for the chain's API-failure path (the catch that
+/// precedes the stale-cache fallback). Lives here, not inline in the
+/// chain, for the same file-length reason as [recordDataAccess].
+void recordDataAccessFailure(String country) =>
+    healthCounters.increment('api.${healthCountryTag(country)}.failures');
+
+/// Normalised low-cardinality country tag for counter names. Legacy
+/// call sites construct the chain with an empty `countryCode`.
+String healthCountryTag(String country) =>
+    country.isEmpty ? 'unknown' : country.toLowerCase();

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -206,6 +206,7 @@ class StationServiceChain implements StationService {
       _budget?.recordRequest(countryCode);
       return result;
     } on Exception catch (e, st) {
+      recordDataAccessFailure(countryCode); // #3146 — always-on tally
       // #2296 — log the API-failure path (stack was previously discarded)
       // so a sustained upstream outage leaves a breadcrumb. Non-fatal.
       unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {

--- a/lib/core/sync/sync_helper.dart
+++ b/lib/core/sync/sync_helper.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'sync_provider.dart';
 import '../../core/logging/error_logger.dart';
+import '../telemetry/health_counters.dart';
 import '../utils/json_extensions.dart';
 
 /// Shared helper to execute sync operations only when TankSync is connected.
@@ -50,9 +51,14 @@ class SyncHelper {
     try {
       final syncState = ref.read(syncStateProvider);
       if (syncState.enabled) {
+        // #3146 — always-on per-entity run/failure tallies, so a
+        // 1-in-10-failing sync table is visible in the error-log export
+        // (the catch below already traces each individual failure).
+        healthCounters.increment('sync.${context.toLowerCase()}.runs');
         await syncFn();
       }
     } catch (e, st) {
+      healthCounters.increment('sync.${context.toLowerCase()}.failures');
       unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: {'where': 'SyncHelper[$context]: sync failed'}));
     }
   }

--- a/lib/core/telemetry/health_counters.dart
+++ b/lib/core/telemetry/health_counters.dart
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Always-on, persisted, named health counters (#3146).
+///
+/// The app previously had ZERO production metrics: the only counting
+/// infrastructure (DataAccessRecorder, Obd2CommDiagnostics) is debug-
+/// gated, so a country API that silently degrades (empty lists, stale
+/// fallbacks, soft-429s), a 1-in-10-failing sync table, or a slowly
+/// dying BLE adapter produced no field signal at all — the chain falls
+/// back to stale cache and the maintainer finds out from app reviews.
+///
+/// This is a deliberately tiny counter box:
+///   - [increment] is an in-memory map bump (hot-path safe, never
+///     throws) that debounce-schedules a flush;
+///   - [flush] merges the pending deltas into a per-day Hive row
+///     (`yyyy-MM-dd` → `{name: count}`) and prunes rows older than
+///     [retainDays];
+///   - the rows ride inside the existing `TraceStorage.exportAsJson()`
+///     payload under `diagnostics.healthCounters`, so the existing
+///     error-log export action is the only consent/export surface (no
+///     new SaaS, the no-paid-services constraint is untouched).
+///
+/// Counter names are dot-namespaced, low-cardinality and PII-free by
+/// construction (country codes, sync-table names, `ble.connect.*`) —
+/// never station ids, coordinates or user data.
+///
+/// ## Isolate model
+/// Only the foreground isolate calls [init] (AppInitializer's storage
+/// phase), so only the foreground ever opens the box — a background
+/// isolate's increments stay in memory and die with the isolate. That
+/// is intentional: lazily opening the box from the WorkManager isolate
+/// would bypass the HiveIsolateLock that serialises cross-isolate box
+/// access.
+class HealthCounters {
+  /// [clock] is a test seam for the day-bucket key and prune cutoff.
+  HealthCounters({DateTime Function()? clock}) : _clock = clock ?? DateTime.now;
+
+  static const String boxName = 'health_counters';
+
+  /// Days of per-day rows kept on flush. Two weeks covers the "user
+  /// reports an issue a few days later" window while keeping the box
+  /// (and the export payload) tiny.
+  static const int retainDays = 14;
+
+  /// Debounce window between the first pending increment and the
+  /// automatic flush, so a burst of increments costs one Hive write.
+  static const Duration flushDebounce = Duration(seconds: 30);
+
+  final DateTime Function() _clock;
+  final Map<String, int> _pending = <String, int>{};
+  Timer? _flushTimer;
+
+  /// Open the counter box. Foreground-only, called once from
+  /// AppInitializer's storage phase alongside `TraceStorage.init()`.
+  static Future<void> init() async {
+    await Hive.openBox(boxName);
+  }
+
+  /// Whether a debounced flush is currently scheduled (test hook).
+  @visibleForTesting
+  bool get hasScheduledFlush => _flushTimer?.isActive ?? false;
+
+  /// Drop pending deltas + cancel the scheduled flush (test hook).
+  @visibleForTesting
+  void resetForTest() {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    _pending.clear();
+  }
+
+  /// Bump counter [name] by [by]. Hot-path safe: an in-memory map merge
+  /// plus (at most) one Timer arm. Never throws — a metrics fault must
+  /// not derail the instrumented caller.
+  void increment(String name, {int by = 1}) {
+    try {
+      _pending[name] = (_pending[name] ?? 0) + by;
+      // Arm the debounce only once the box is actually open: a closed
+      // box can't be flushed anyway (background isolate / pre-init
+      // startup / widget tests, where a stray pending Timer would trip
+      // the pending-timer assertion). Pre-init increments stay pending
+      // and ride along with the first post-init flush.
+      if (Hive.isBoxOpen(boxName)) {
+        _flushTimer ??= Timer(flushDebounce, () {
+          _flushTimer = null;
+          unawaited(flush());
+        });
+      }
+    } catch (e, st) {
+      debugPrint('HealthCounters.increment failed: $e\n$st');
+    }
+  }
+
+  /// Merge the pending deltas into today's persisted row and prune
+  /// rows older than [retainDays]. A closed box (background isolate,
+  /// or pre-[init] startup) keeps the deltas pending for a later
+  /// flush. Never throws.
+  Future<void> flush() async {
+    try {
+      _flushTimer?.cancel();
+      _flushTimer = null;
+      if (_pending.isEmpty) return;
+      if (!Hive.isBoxOpen(boxName)) return; // keep pending — see docstring
+      final box = Hive.box(boxName);
+      final today = _dayKey(_clock());
+      final row = _rowFrom(box.get(today));
+      for (final entry in _pending.entries) {
+        row[entry.key] = (row[entry.key] ?? 0) + entry.value;
+      }
+      _pending.clear();
+      await box.put(today, row);
+      await _prune(box, today);
+    } catch (e, st) {
+      debugPrint('HealthCounters.flush failed: $e\n$st');
+    }
+  }
+
+  /// Serialise-ready snapshot for the error-log export: every persisted
+  /// per-day row, with today's row merged with the still-pending
+  /// in-memory deltas so an export taken right after an increment is
+  /// complete. Never throws — returns whatever is readable.
+  Map<String, Object?> exportSnapshot() {
+    try {
+      final days = <String, Map<String, int>>{};
+      if (Hive.isBoxOpen(boxName)) {
+        final box = Hive.box(boxName);
+        for (final key in box.keys) {
+          days['$key'] = _rowFrom(box.get(key));
+        }
+      }
+      if (_pending.isNotEmpty) {
+        final today = days.putIfAbsent(_dayKey(_clock()), () => {});
+        for (final entry in _pending.entries) {
+          today[entry.key] = (today[entry.key] ?? 0) + entry.value;
+        }
+      }
+      return <String, Object?>{'days': days};
+    } catch (e, st) {
+      debugPrint('HealthCounters.exportSnapshot failed: $e\n$st');
+      return const <String, Object?>{};
+    }
+  }
+
+  /// Delete rows older than [retainDays] before [today]'s date. Day
+  /// keys sort lexicographically, so a plain string compare suffices.
+  Future<void> _prune(Box box, String today) async {
+    final cutoff = _dayKey(_clock().subtract(const Duration(days: retainDays)));
+    final stale =
+        box.keys.where((k) => '$k'.compareTo(cutoff) < 0).toList(growable: false);
+    for (final key in stale) {
+      await box.delete(key);
+    }
+  }
+
+  static String _dayKey(DateTime at) {
+    final d = at.toUtc();
+    final mm = d.month.toString().padLeft(2, '0');
+    final dd = d.day.toString().padLeft(2, '0');
+    return '${d.year}-$mm-$dd';
+  }
+
+  /// Coerce a Hive-returned value (untyped `Map<dynamic, dynamic>`)
+  /// into a fresh `{name: count}` row, dropping anything malformed.
+  static Map<String, int> _rowFrom(Object? raw) {
+    final row = <String, int>{};
+    if (raw is Map) {
+      raw.forEach((key, value) {
+        if (value is int) row['$key'] = value;
+      });
+    }
+    return row;
+  }
+}
+
+/// Process-wide singleton, mirroring `errorLogger` / `log`: callable
+/// from any isolate and from pre-container startup phases.
+final HealthCounters healthCounters = HealthCounters();

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../background/alert_scan_journal.dart';
 import '../health_counters.dart';
 import '../models/error_trace.dart';
 import '../pii_scrubber.dart';
@@ -196,6 +197,9 @@ class TraceStorage {
       // country codes / sync-table names / ble.*, never user data).
       'diagnostics': <String, Object?>{
         'healthCounters': healthCounters.exportSnapshot(),
+        // #3147 — the rolling alert-scan journal (ran / skipped+why /
+        // failed, stations fetched, alerts fired), newest first.
+        'alertScanJournal': AlertScanJournal.exportSection(),
       },
     };
     // #3184 — feature-registered sections (e.g. obd2ConnectTraces). A

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../health_counters.dart';
 import '../models/error_trace.dart';
 import '../pii_scrubber.dart';
 
@@ -189,6 +190,13 @@ class TraceStorage {
           .map((t) => PiiScrubber.scrubErrorTrace(t).toJson())
           .toList(),
       'unparsedRaw': unparsed.map(_scrubRawDeep).toList(),
+      // #3146 — always-on production health signals ride in the SAME
+      // export the user already mails/attaches; every builder is
+      // never-throws + PII-free by construction (counter names are
+      // country codes / sync-table names / ble.*, never user data).
+      'diagnostics': <String, Object?>{
+        'healthCounters': healthCounters.exportSnapshot(),
+      },
     };
     // #3184 — feature-registered sections (e.g. obd2ConnectTraces). A
     // throwing supplier must never kill the export the user is mid-way

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -19,6 +19,7 @@ import '../../providers/alert_provider.dart';
 import '../../providers/radius_alerts_provider.dart';
 import '../widgets/alert_station_picker_sheet.dart';
 import '../widgets/alert_statistics_card.dart';
+import '../widgets/alerts_last_checked_footer.dart';
 import '../widgets/radius_alert_create_sheet.dart';
 
 class AlertsScreen extends ConsumerWidget {
@@ -138,6 +139,10 @@ class _AlertsBody extends ConsumerWidget {
             onRetry: () => ref.invalidate(radiusAlertsProvider),
           ),
         ),
+        // #3147 — "last checked" footer: surfaces the dedup store's
+        // last-completed-scan stamp so a user can verify the background
+        // scan actually runs (the alert-SLA field check).
+        const AlertsLastCheckedFooter(),
       ],
     );
   }

--- a/lib/features/alerts/presentation/widgets/alerts_last_checked_footer.dart
+++ b/lib/features/alerts/presentation/widgets/alerts_last_checked_footer.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/background/background_scan_dedup_store.dart';
+import '../../../../l10n/app_localizations.dart';
+
+/// Footer line showing when the last background alert scan completed
+/// (#3147). Reads the [BackgroundScanDedupStore] stamp the coordinator
+/// writes after every completed scan; shows a "never ran yet" hint until
+/// the first one lands — so the standing alert SLA (1-3x/day) is
+/// user-verifiable instead of debugPrint-only. A one-shot read per build
+/// is enough: the screen rebuilds on every visit and the stamp changes
+/// at most a few times a day.
+class AlertsLastCheckedFooter extends StatelessWidget {
+  const AlertsLastCheckedFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return FutureBuilder<DateTime?>(
+      future: BackgroundScanDedupStore().lastScanAt(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final at = snapshot.data;
+        final String label;
+        if (at == null) {
+          label = l10n?.alertsLastCheckedNever ??
+              "Prices haven't been checked in the background yet";
+        } else {
+          final locale = Localizations.localeOf(context).toString();
+          final when = DateFormat.yMd(locale).add_Hm().format(at.toLocal());
+          label = l10n?.alertsLastChecked(when) ?? 'Last checked: $when';
+        }
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: Text(
+            label,
+            key: const ValueKey('alerts-last-checked'),
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -28,6 +28,7 @@ import 'supported_pids_cache.dart';
 import 'supported_pids_probe.dart' show kObd2ProtocolSearchTimeout;
 import 'supported_pids_resolver.dart';
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/telemetry/health_counters.dart';
 
 // #3035 — re-export the tri-state `0100` probe outcome so the connection
 // layer (which imports this service) gates `ignitionOff` on [busProbe]
@@ -533,6 +534,10 @@ class Obd2Service implements Obd2RawCommandPort {
       AutoRecordEventKind.connectStarted,
       mac: adapterMac,
     );
+    // #3146 — always-on connect-rate tally (attempts vs successes), so a
+    // slowly-failing adapter is visible in the error-log export even when
+    // the debug-gated comm-diagnostics collector is off.
+    healthCounters.increment('ble.connect.attempts');
     try {
       _adapter = adapter;
       // #2268 concern 2 — a fresh connect resets the wake observation;
@@ -710,6 +715,7 @@ class Obd2Service implements Obd2RawCommandPort {
         mac: adapterMac,
         detail: adapterFirmware,
       );
+      healthCounters.increment('ble.connect.successes'); // #3146
       return true;
     } catch (e, st) {
       // #3181 — a TYPED pairing failure from the channel's setNotify stage
@@ -739,6 +745,7 @@ class Obd2Service implements Obd2RawCommandPort {
         mac: adapterMac,
         detail: e.toString(),
       );
+      healthCounters.increment('ble.connect.failures'); // #3146
       return false;
     }
   }

--- a/lib/l10n/_fragments/alert_scan_status_de.arb
+++ b/lib/l10n/_fragments/alert_scan_status_de.arb
@@ -1,0 +1,13 @@
+{
+  "alertsLastChecked": "Zuletzt geprüft: {when}",
+  "@alertsLastChecked": {
+    "description": "Footer line on the alerts screen showing when the background alert scan last completed (#3147), so the alert SLA is field-verifiable. {when} is a locale-formatted date + time.",
+    "placeholders": {
+      "when": { "type": "String" }
+    }
+  },
+  "alertsLastCheckedNever": "Preise wurden im Hintergrund noch nicht geprüft",
+  "@alertsLastCheckedNever": {
+    "description": "Footer line on the alerts screen when no background alert scan has ever completed (#3147)."
+  }
+}

--- a/lib/l10n/_fragments/alert_scan_status_en.arb
+++ b/lib/l10n/_fragments/alert_scan_status_en.arb
@@ -1,0 +1,13 @@
+{
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "description": "Footer line on the alerts screen showing when the background alert scan last completed (#3147), so the alert SLA is field-verifiable. {when} is a locale-formatted date + time.",
+    "placeholders": {
+      "when": { "type": "String" }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "description": "Footer line on the alerts screen when no background alert scan has ever completed (#3147)."
+  }
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1539,6 +1539,19 @@
   "velocityAlertNotificationBody": "{count} Tankstellen um bis zu {cents}¢ in der letzten Stunde gefallen",
   "radiusAlertGroupedTitle": "{label}: {count} Tankstellen ≤ {threshold} {currency}",
   "radiusAlertGroupedMore": "+ {count} weitere",
+  "alertsLastChecked": "Zuletzt geprüft: {when}",
+  "@alertsLastChecked": {
+    "description": "Footer line on the alerts screen showing when the background alert scan last completed (#3147), so the alert SLA is field-verifiable. {when} is a locale-formatted date + time.",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Preise wurden im Hintergrund noch nicht geprüft",
+  "@alertsLastCheckedNever": {
+    "description": "Footer line on the alerts screen when no background alert scan has ever completed (#3147)."
+  },
   "alertTargetPriceWithCurrency": "Zielpreis ({currency})",
   "@alertTargetPriceWithCurrency": {
     "description": "Label of the target-price field in the create-alert dialog, parameterised with the station country's currency symbol now that background alerts fire for every country (#2865).",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2016,6 +2016,19 @@
       }
     }
   },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "description": "Footer line on the alerts screen showing when the background alert scan last completed (#3147), so the alert SLA is field-verifiable. {when} is a locale-formatted date + time.",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "description": "Footer line on the alerts screen when no background alert scan has ever completed (#3147)."
+  },
   "alertTargetPriceWithCurrency": "Target price ({currency})",
   "@alertTargetPriceWithCurrency": {
     "description": "Label of the target-price field in the create-alert dialog, parameterised with the station country's currency symbol now that background alerts fire for every country (#2865).",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1091,6 +1091,8 @@
   "velocityAlertNotificationBody": "⟦{count} šŧáŧîóñš đřóƥƥéđ ƀý úƥ ŧó {cents}¢ îñ ŧĥé łášŧ ĥóúř ···············⟧",
   "radiusAlertGroupedTitle": "⟦{label}: {count} šŧáŧîóñš ≤ {threshold} {currency} ····⟧",
   "radiusAlertGroupedMore": "⟦+ {count} ɱóřé ··⟧",
+  "alertsLastChecked": "⟦Łášŧ çĥéçķéđ: {when} ·····⟧",
+  "alertsLastCheckedNever": "⟦Ƥřîçéš ĥáṽéñ'ŧ ƀééñ çĥéçķéđ îñ ŧĥé ƀáçķǧřóúñđ ýéŧ ··················⟧",
   "alertTargetPriceWithCurrency": "⟦Ŧářǧéŧ ƥřîçé ({currency}) ·····⟧",
   "alertThresholdWithCurrency": "⟦Ŧĥřéšĥółđ ({currency}/Ł) ·····⟧",
   "approachOverlaySection": "⟦Ƒúéł Šŧáŧîóñ Řáđář ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4839,5 +4839,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6708,6 +6708,18 @@ abstract class AppLocalizations {
   /// **'+ {count} more'**
   String radiusAlertGroupedMore(String count);
 
+  /// Footer line on the alerts screen showing when the background alert scan last completed (#3147), so the alert SLA is field-verifiable. {when} is a locale-formatted date + time.
+  ///
+  /// In en, this message translates to:
+  /// **'Last checked: {when}'**
+  String alertsLastChecked(String when);
+
+  /// Footer line on the alerts screen when no background alert scan has ever completed (#3147).
+  ///
+  /// In en, this message translates to:
+  /// **'Prices haven\'t been checked in the background yet'**
+  String get alertsLastCheckedNever;
+
   /// Label of the target-price field in the create-alert dialog, parameterised with the station country's currency symbol now that background alerts fire for every country (#2865).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3687,6 +3687,15 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Целева цена ($currency)';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3670,6 +3670,15 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Cílová cena ($currency)';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3657,6 +3657,15 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Målpris ($currency)';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3680,6 +3680,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Zuletzt geprüft: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Preise wurden im Hintergrund noch nicht geprüft';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Zielpreis ($currency)';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3684,6 +3684,15 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Τιμή-στόχος ($currency)';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3642,6 +3642,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Target price ($currency)';
   }
@@ -11489,6 +11498,15 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   String radiusAlertGroupedMore(String count) {
     return '⟦+ $count ɱóřé ··⟧';
   }
+
+  @override
+  String alertsLastChecked(String when) {
+    return '⟦Łášŧ çĥéçķéđ: $when ·····⟧';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      '⟦Ƥřîçéš ĥáṽéñ\'ŧ ƀééñ çĥéçķéđ îñ ŧĥé ƀáçķǧřóúñđ ýéŧ ··················⟧';
 
   @override
   String alertTargetPriceWithCurrency(String currency) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3679,6 +3679,15 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Precio objetivo ($currency)';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3657,6 +3657,15 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Sihthind ($currency)';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3660,6 +3660,15 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Tavoitehinta ($currency)';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3689,6 +3689,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Prix cible ($currency)';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3664,6 +3664,15 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Ciljna cijena ($currency)';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3682,6 +3682,15 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Célár ($currency)';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3674,6 +3674,15 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Prezzo obiettivo ($currency)';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3681,6 +3681,15 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Tikslinė kaina ($currency)';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3680,6 +3680,15 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Mērķa cena ($currency)';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3656,6 +3656,15 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Målpris ($currency)';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3673,6 +3673,15 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Streefprijs ($currency)';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3668,6 +3668,15 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Cena docelowa ($currency)';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3681,6 +3681,15 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Preço-alvo ($currency)';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3682,6 +3682,15 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Preț țintă ($currency)';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3674,6 +3674,15 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Cieľová cena ($currency)';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3659,6 +3659,15 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Ciljna cena ($currency)';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3658,6 +3658,15 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String alertsLastChecked(String when) {
+    return 'Last checked: $when';
+  }
+
+  @override
+  String get alertsLastCheckedNever =>
+      'Prices haven\'t been checked in the background yet';
+
+  @override
   String alertTargetPriceWithCurrency(String currency) {
     return 'Målpris ($currency)';
   }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4736,5 +4736,20 @@
   "@obd2PairingConfirmHint": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "alertsLastChecked": "Last checked: {when}",
+  "@alertsLastChecked": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "alertsLastCheckedNever": "Prices haven't been checked in the background yet",
+  "@alertsLastCheckedNever": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/background/alert_scan_journal_test.dart
+++ b/test/core/background/alert_scan_journal_test.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/background/alert_scan_journal.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+
+/// #3147 — rolling journal of background alert-scan runs, persisted in
+/// the alerts box alongside the dedup rows so "why didn't I get an
+/// alert?" is answerable from the error-log export.
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_scan_journal_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    if (!Hive.isBoxOpen(HiveBoxes.alerts)) {
+      await Hive.openBox(HiveBoxes.alerts);
+    }
+    await Hive.box(HiveBoxes.alerts).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  final t0 = DateTime.utc(2026, 6, 10, 8);
+
+  group('append + entries', () {
+    test('a completed scan row round-trips with its counts', () async {
+      final journal = AlertScanJournal();
+      await journal.append(
+        at: t0,
+        trigger: 'workmanager_periodic',
+        stationsScanned: 12,
+        alertsFired: 2,
+      );
+
+      final rows = journal.entries();
+      expect(rows, hasLength(1));
+      expect(rows.single['at'], t0.toIso8601String());
+      expect(rows.single['trigger'], 'workmanager_periodic');
+      expect(rows.single['stations'], 12);
+      expect(rows.single['alertsFired'], 2);
+      expect(rows.single.containsKey('skipped'), isFalse);
+      expect(rows.single.containsKey('error'), isFalse);
+    });
+
+    test('skipped and failed rows record why a scan did not complete',
+        () async {
+      final journal = AlertScanJournal();
+      await journal.append(
+          at: t0, trigger: 'android_widget', skippedReason: 'cooldown');
+      await journal.append(
+          at: t0.add(const Duration(hours: 1)),
+          trigger: 'ios_bg_refresh',
+          error: 'TimeoutException');
+
+      final rows = journal.entries();
+      expect(rows[0]['skipped'], 'cooldown');
+      expect(rows[1]['error'], 'TimeoutException');
+    });
+
+    test('rotation keeps only the newest maxEntries rows', () async {
+      final journal = AlertScanJournal();
+      for (var i = 0; i < AlertScanJournal.maxEntries + 5; i++) {
+        await journal.append(
+          at: t0.add(Duration(minutes: i)),
+          trigger: 'workmanager_periodic',
+          stationsScanned: i,
+          alertsFired: 0,
+        );
+      }
+
+      final rows = journal.entries();
+      expect(rows, hasLength(AlertScanJournal.maxEntries));
+      expect(rows.first['stations'], 5,
+          reason: 'the 5 oldest rows must have been rotated out');
+      expect(rows.last['stations'], AlertScanJournal.maxEntries + 4);
+    });
+
+    test('exportSection returns the rows newest-first', () async {
+      final journal = AlertScanJournal();
+      await journal.append(
+          at: t0, trigger: 'workmanager_periodic', stationsScanned: 1);
+      await journal.append(
+          at: t0.add(const Duration(hours: 6)),
+          trigger: 'android_widget',
+          skippedReason: 'cooldown');
+
+      final section = AlertScanJournal.exportSection();
+      expect(section, hasLength(2));
+      expect(section.first['trigger'], 'android_widget',
+          reason: 'the most recent scan must lead the export payload');
+    });
+  });
+
+  group('never-throws contract (fault injection)', () {
+    test('append/entries degrade to a no-op when the alerts box is closed',
+        () async {
+      await Hive.box(HiveBoxes.alerts).close();
+      final journal = AlertScanJournal();
+
+      await expectLater(
+        journal.append(at: t0, trigger: 'workmanager_periodic'),
+        completes,
+      );
+      expect(journal.entries, returnsNormally);
+      expect(journal.entries(), isEmpty);
+      expect(AlertScanJournal.exportSection, returnsNormally);
+
+      await Hive.openBox(HiveBoxes.alerts); // restore for the next test
+    });
+
+    test('a malformed persisted value is ignored, then overwritten',
+        () async {
+      final box = Hive.box(HiveBoxes.alerts);
+      await box.put(AlertScanJournal.journalKey, 'not-a-list');
+      final journal = AlertScanJournal();
+
+      expect(journal.entries(), isEmpty);
+      await expectLater(
+        journal.append(at: t0, trigger: 'workmanager_periodic'),
+        completes,
+      );
+      expect(journal.entries(), hasLength(1));
+    });
+  });
+}

--- a/test/core/logging/app_log_test.dart
+++ b/test/core/logging/app_log_test.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/app_log.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// Captures every `record` call without standing up a real
+/// TraceStorage / TraceUploader / Riverpod stack. Mirrors the fake in
+/// `test/core/logging/error_logger_test.dart`.
+class _FakeTraceRecorder implements TraceRecorder {
+  final calls = <(Object, StackTrace)>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add((error, stackTrace));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _FakeTraceRecorder recorder;
+  late List<String> console;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _FakeTraceRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    BreadcrumbCollector.clear();
+    console = <String>[];
+    log.resetForTest();
+    log.debugConsoleOverride = true;
+    log.consoleSinkOverride = console.add;
+  });
+
+  tearDown(() {
+    errorLogger.resetForTest();
+    log.resetForTest();
+    BreadcrumbCollector.clear();
+  });
+
+  group('level routing (#3144)', () {
+    test('debug: console only — no breadcrumb, no trace', () async {
+      log.debug('chatter', tag: 'unit');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(console, ['[unit] chatter']);
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
+      expect(recorder.calls, isEmpty);
+    });
+
+    test('debug: fully silent when the console gate is off (release)', () {
+      log.debugConsoleOverride = false;
+      log.debug('chatter');
+
+      expect(console, isEmpty);
+    });
+
+    test('info: console + breadcrumb, but never a trace-ring slot',
+        () async {
+      log.info('sync ready', tag: 'TankSync');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(console, ['[TankSync] sync ready']);
+      final crumbs = BreadcrumbCollector.snapshot();
+      expect(crumbs, hasLength(1));
+      expect(crumbs.single.action, 'TankSync');
+      expect(crumbs.single.detail, 'sync ready');
+      expect(recorder.calls, isEmpty,
+          reason: 'info must not consume a slot in the bounded trace ring');
+    });
+
+    test('info: breadcrumb survives with the console gate off (release '
+        'visibility)', () {
+      log.debugConsoleOverride = false;
+      log.info('migrated 3 profiles');
+
+      expect(console, isEmpty);
+      expect(BreadcrumbCollector.snapshot(), hasLength(1));
+    });
+
+    test('warn: routes to the errorLogger pipeline tagged level=warn',
+        () async {
+      log.warn('soft 429 from provider',
+          tag: 'api', layer: ErrorLayer.services, context: {'country': 'es'});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(recorder.calls, hasLength(1));
+      final rendered = recorder.calls.single.$1.toString();
+      expect(rendered, contains('[services]'));
+      expect(rendered, contains('soft 429 from provider'));
+      expect(rendered, contains('level: warn'));
+      expect(rendered, contains('country: es'));
+    });
+
+    test('warn: forwards a caught error object + keeps the message',
+        () async {
+      final boom = StateError('boom');
+      log.warn('scrub failed', error: boom, stack: StackTrace.current);
+      await Future<void>.delayed(Duration.zero);
+
+      final rendered = recorder.calls.single.$1.toString();
+      expect(rendered, contains('boom'));
+      expect(rendered, contains('scrub failed'));
+    });
+
+    test('error: delegates to errorLogger unchanged', () async {
+      final stack = StackTrace.fromString('#0 unit (file.dart:1)');
+      log.error(Exception('hard fail'), stack,
+          layer: ErrorLayer.sync, context: {'where': 'unit'});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(recorder.calls, hasLength(1));
+      expect(recorder.calls.single.$2, same(stack));
+      final rendered = recorder.calls.single.$1.toString();
+      expect(rendered, contains('[sync]'));
+      expect(rendered, contains('hard fail'));
+    });
+  });
+
+  group('never-throws contract (fault injection)', () {
+    test('debug/info return normally when the console sink throws', () {
+      log.consoleSinkOverride = (_) => throw StateError('sink fault');
+
+      expect(() => log.debug('x'), returnsNormally);
+      expect(() => log.info('x'), returnsNormally);
+    });
+
+    test('warn returns normally when the console sink throws', () {
+      log.consoleSinkOverride = (_) => throw StateError('sink fault');
+
+      expect(() => log.warn('x'), returnsNormally);
+    });
+
+    test('warn/error return normally when the recorder throws', () async {
+      // ErrorLogger.log's own never-throws contract absorbs a throwing
+      // recorder; the facade must not re-surface it either.
+      errorLogger.testRecorderOverride = _ThrowingRecorder();
+
+      expect(() => log.warn('x'), returnsNormally);
+      expect(() => log.error(Exception('x'), null), returnsNormally);
+      await Future<void>.delayed(Duration.zero);
+    });
+  });
+}
+
+class _ThrowingRecorder implements TraceRecorder {
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    throw StateError('recorder fault');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/core/telemetry/health_counters_test.dart
+++ b/test/core/telemetry/health_counters_test.dart
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/telemetry/health_counters.dart';
+import 'package:tankstellen/core/telemetry/storage/trace_storage.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('health_counters_test_');
+    Hive.init(tempDir.path);
+    await HealthCounters.init();
+  });
+
+  tearDown(() async {
+    healthCounters.resetForTest();
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  HealthCounters counters({DateTime? at}) =>
+      HealthCounters(clock: () => at ?? DateTime.utc(2026, 6, 10, 12));
+
+  group('increment + flush (#3146)', () {
+    test('flush persists the pending deltas under the day key', () async {
+      final c = counters();
+      c.increment('api.de.ok');
+      c.increment('api.de.ok');
+      c.increment('sync.favorites.failures', by: 3);
+
+      await c.flush();
+
+      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      expect(row['api.de.ok'], 2);
+      expect(row['sync.favorites.failures'], 3);
+    });
+
+    test('flush merges into an existing day row instead of replacing it',
+        () async {
+      final c = counters();
+      c.increment('ble.connect.attempts');
+      await c.flush();
+      c.increment('ble.connect.attempts');
+      c.increment('ble.connect.successes');
+      await c.flush();
+
+      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      expect(row['ble.connect.attempts'], 2);
+      expect(row['ble.connect.successes'], 1);
+    });
+
+    test('increment arms the debounced auto-flush once', () {
+      final c = counters();
+      expect(c.hasScheduledFlush, isFalse);
+      c.increment('api.de.ok');
+      expect(c.hasScheduledFlush, isTrue);
+      c.increment('api.de.ok');
+      expect(c.hasScheduledFlush, isTrue);
+      c.resetForTest();
+    });
+
+    test('flush prunes day rows older than the retention window', () async {
+      final box = Hive.box(HealthCounters.boxName);
+      await box.put('2026-01-01', {'api.de.ok': 9});
+      await box.put('2026-06-09', {'api.de.ok': 1});
+
+      final c = counters(); // clock = 2026-06-10
+      c.increment('api.de.ok');
+      await c.flush();
+
+      expect(box.get('2026-01-01'), isNull,
+          reason: 'rows older than retainDays must be pruned on flush');
+      expect(box.get('2026-06-09'), isNotNull,
+          reason: 'rows inside the window must be kept');
+    });
+  });
+
+  group('exportSnapshot', () {
+    test('merges persisted rows with the still-pending deltas', () async {
+      final c = counters();
+      c.increment('api.es.staleFallbacks');
+      await c.flush();
+      c.increment('api.es.staleFallbacks'); // pending, not yet flushed
+
+      final snapshot = c.exportSnapshot();
+      final days = snapshot['days'] as Map;
+      final today = days['2026-06-10'] as Map;
+      expect(today['api.es.staleFallbacks'], 2);
+      c.resetForTest();
+    });
+
+    test('rides inside TraceStorage.exportAsJson under diagnostics',
+        () async {
+      await TraceStorage.init();
+      healthCounters.increment('api.de.failures');
+
+      final raw = TraceStorage().exportAsJson();
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      final diagnostics = decoded['diagnostics'] as Map<String, dynamic>;
+      final counters = diagnostics['healthCounters'] as Map<String, dynamic>;
+      final days = counters['days'] as Map<String, dynamic>;
+      expect(
+        days.values.any((row) => (row as Map)['api.de.failures'] == 1),
+        isTrue,
+        reason: 'a pending increment must be visible in the export',
+      );
+    });
+  });
+
+  group('never-throws contract (fault injection)', () {
+    test('increment/flush/exportSnapshot return normally on a clock fault',
+        () async {
+      final c = HealthCounters(clock: () => throw StateError('clock fault'));
+      expect(() => c.increment('api.de.ok'), returnsNormally);
+      await expectLater(c.flush(), completes);
+      expect(c.exportSnapshot, returnsNormally);
+      c.resetForTest();
+    });
+
+    test('flush with the box closed keeps the deltas pending and completes',
+        () async {
+      final c = counters();
+      c.increment('api.de.ok');
+      await Hive.box(HealthCounters.boxName).close();
+
+      await expectLater(c.flush(), completes);
+
+      // Re-open: the pending delta survives to the next flush.
+      await HealthCounters.init();
+      await c.flush();
+      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      expect(row['api.de.ok'], 1);
+    });
+
+    test('increment with Hive entirely closed returns normally', () async {
+      await Hive.close();
+      final c = counters();
+      expect(() => c.increment('api.de.ok'), returnsNormally);
+      expect(c.exportSnapshot, returnsNormally);
+    });
+
+    test('flush skips malformed persisted rows without throwing', () async {
+      final box = Hive.box(HealthCounters.boxName);
+      await box.put('2026-06-10', 'not-a-map');
+
+      final c = counters();
+      c.increment('api.de.ok');
+      await expectLater(c.flush(), completes);
+
+      final row = box.get('2026-06-10') as Map;
+      expect(row['api.de.ok'], 1,
+          reason: 'a malformed row is replaced by a fresh counted row');
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -83,7 +83,10 @@ void main() {
     // plus the loop-avoidance rationale comment on the Sentry beforeSend
     // scrub fallback (the 8 remaining info-level debugPrints became
     // `log.info(...)` roughly line-for-line).
-    'lib/app/app_initializer.dart': 1087,
+    // #3146 — re-grandfathered 1087 → 1089: `HealthCounters.init()` joins
+    // the storage-phase `Future.wait` (+ its import) so the always-on
+    // counter box opens in the foreground isolate only.
+    'lib/app/app_initializer.dart': 1089,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device
@@ -362,11 +365,18 @@ void main() {
     // resolver's `searchSend:` wiring + the probe-constant import. The probe
     // logic itself stays in the under-cap supported_pids_probe.dart;
     // decomposition of this god-class still tracked by #2187/#2188.
+<<<<<<< HEAD
     // #3181 — 1673 → 1688: the connect-catch now stamps a TYPED
     // Obd2PairingRequired onto the active connect trace (first-wins) before
     // the never-throws `false` return flattens it, so `_openAndInit` can
     // rethrow the typed pairing error (+ the trace-log imports + rationale).
     'lib/features/consumption/data/obd2/obd2_service.dart': 1688,
+=======
+    // #3146 — 1673 → 1680: the three always-on `healthCounters` connect-rate
+    // taps (attempts / successes / failures) + import + rationale comment, so
+    // a slowly-failing BLE adapter is visible in the error-log export.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1680,
+>>>>>>> 91a938b5 (feat(telemetry): always-on persisted health counters in the error-log export (#3146))
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -83,10 +83,10 @@ void main() {
     // plus the loop-avoidance rationale comment on the Sentry beforeSend
     // scrub fallback (the 8 remaining info-level debugPrints became
     // `log.info(...)` roughly line-for-line).
-    // #3146 — re-grandfathered 1087 → 1089: `HealthCounters.init()` joins
+    // #3146 — re-grandfathered 1087 → 1090: `HealthCounters.init()` joins
     // the storage-phase `Future.wait` (+ its import) so the always-on
     // counter box opens in the foreground isolate only.
-    'lib/app/app_initializer.dart': 1089,
+    'lib/app/app_initializer.dart': 1090,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device
@@ -365,18 +365,15 @@ void main() {
     // resolver's `searchSend:` wiring + the probe-constant import. The probe
     // logic itself stays in the under-cap supported_pids_probe.dart;
     // decomposition of this god-class still tracked by #2187/#2188.
-<<<<<<< HEAD
     // #3181 — 1673 → 1688: the connect-catch now stamps a TYPED
     // Obd2PairingRequired onto the active connect trace (first-wins) before
     // the never-throws `false` return flattens it, so `_openAndInit` can
     // rethrow the typed pairing error (+ the trace-log imports + rationale).
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1688,
-=======
-    // #3146 — 1673 → 1680: the three always-on `healthCounters` connect-rate
-    // taps (attempts / successes / failures) + import + rationale comment, so
-    // a slowly-failing BLE adapter is visible in the error-log export.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1680,
->>>>>>> 91a938b5 (feat(telemetry): always-on persisted health counters in the error-log export (#3146))
+    // #3146 — re-grandfathered 1688 → 1689: the three always-on
+    // `healthCounters` connect-rate taps (attempts / successes / failures)
+    // + import + rationale comment, so a slowly-failing BLE adapter is
+    // visible in the error-log export.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1689,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -79,7 +79,11 @@ void main() {
     // #3126 — re-grandfathered 1081 → 1084: the sync-run-id mint
     // (`SyncRunTrace.begin('launch')` + import) before the launch merges,
     // so the per-table sync counts thread under one run id in the trace.
-    'lib/app/app_initializer.dart': 1084,
+    // #3144 — re-grandfathered 1084 → 1087: the leveled-log-facade import
+    // plus the loop-avoidance rationale comment on the Sentry beforeSend
+    // scrub fallback (the 8 remaining info-level debugPrints became
+    // `log.info(...)` roughly line-for-line).
+    'lib/app/app_initializer.dart': 1087,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device


### PR DESCRIPTION
## Diagnosability wave 2 — log facade, production health counters, alert scan journal

The remaining three children of epic #3142:

- **#3144 — leveled log facade**: `log.debug/info/warn/error` over the errorLogger/debugPrint split. `info` lands as a breadcrumb (release-visible inside every persisted trace without consuming a trace-ring slot), `warn` is a persisted trace tagged `level: warn`, `error` delegates to errorLogger. The 8 remaining info-level debugPrints in `app_initializer.dart` migrated; the big dangerous-handler sweep already shipped in #3206.
- **#3146 — production health counters**: in-memory named counters with a debounced per-day Hive flush (14-day prune) tapped at the chokepoints — per-country API ok/failures/stale-fallbacks + cache fresh-hits via `recordDataAccess`, per-entity sync runs/failures in `SyncHelper`, BLE connect attempts/successes/failures in `Obd2Service`. Exported under `diagnostics.healthCounters` in the error-log export; local-only, no synced table (HARD RULE #5 not triggered).
- **#3147 — alert scan journal**: a rolling 20-row journal of every scan outcome (trigger, skip reason, stations fetched, alerts fired, error type only — PII-safe) in the encrypted alerts box, exported newest-first under `diagnostics.alertScanJournal` — "why didn't I get an alert?" is now answerable from one export. Plus a "last checked" footer on the alerts screen (2 new ARB keys, fanned to all 23 locales + pseudo-locale) and removal of the runners' double-log into the isolate spool.

Closes #3144, closes #3146, closes #3147. With these, epic #3142 is fully implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
