### PR TITLE
refactor(sync): generic EntitySync<T> engine over the SyncTransport seam (#3127)

### DIFF
--- a/lib/core/sync/alerts_sync.dart
+++ b/lib/core/sync/alerts_sync.dart
@@ -1,20 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
-
 import '../../features/alerts/data/models/price_alert.dart';
 import '../utils/json_extensions.dart';
-import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import 'sync_helper.dart';
-import 'sync_run_trace.dart';
+import 'entity_sync.dart';
 import 'sync_transport.dart';
-import '../../core/logging/error_logger.dart';
 
 /// Price-alert sync with Supabase, pulled out of [SyncService] (#727).
+/// Since #3127 a thin codec config over the shared [EntitySync] engine.
 ///
 /// Bidirectional merge:
 ///   - local-only alerts upload to the `alerts` table (`id`-conflict
@@ -30,121 +23,63 @@ import '../../core/logging/error_logger.dart';
 /// so there is no server-side stamp to compare a local edit against —
 /// adding one is a new explicit column, i.e. a self-host schema change
 /// (HARD RULE 5: wizard SQL + verifier + `kSupabaseSchemaVersion` bump).
-/// Per that rule this stays a pure id-union merge for now; edit
-/// propagation for alerts is deferred to the sync epic alongside the
-/// schema-version bump.
+/// Per that rule this stays a pure id-union merge for now (no
+/// `localStamp` in the config below); edit propagation for alerts is
+/// deferred to the sync epic alongside the schema-version bump.
 class AlertsSync {
   AlertsSync._();
 
+  static final _sync = EntitySync<PriceAlert>(
+    table: 'alerts',
+    logName: 'AlertsSync',
+    idColumn: 'id',
+    selectColumns: '*',
+    onConflict: 'id',
+    idOf: (a) => a.id,
+    encode: (a, userId) => {
+      'id': a.id,
+      'user_id': userId,
+      'station_id': a.stationId,
+      'station_name': a.stationName,
+      'fuel_type': a.fuelType.name,
+      'target_price': a.targetPrice,
+      'is_active': a.isActive,
+      'created_at': a.createdAt.toUtc().toIso8601String(),
+    },
+    decode: (r) => PriceAlert.fromJson({
+      'id': r.getString('id') ?? '',
+      'stationId': r.getString('station_id') ?? '',
+      'stationName': r.getString('station_name') ?? '',
+      'fuelType': r.getString('fuel_type') ?? '',
+      'targetPrice': r.getDouble('target_price') ?? 0.0,
+      'isActive': r.getBool('is_active') ?? true,
+      'createdAt': r.getString('created_at') ?? '',
+    }),
+    // #3121 — alerts tombstone AFTER the row-delete attempt (and
+    // regardless of its outcome); see [EntitySync.tombstoneFirstDelete].
+    tombstoneFirstDelete: false,
+  );
+
   /// Merge [localAlerts] with the user's `alerts` rows on Supabase.
-  /// Returns the superset ([local] + server-only downloaded).
+  /// Returns the superset ([local] + server-only downloaded). The
+  /// engine drops tombstoned ids from BOTH sides before the union so a
+  /// deleted alert can't resurrect through the launch pull or another
+  /// device's still-local copy (#3121, same seam as favorites #3078).
   /// [transport] is injectable for tests.
   static Future<List<PriceAlert>> merge(
     List<PriceAlert> localAlerts, {
     SyncTransport? transport,
-  }) async {
-    final t = transport ?? SupabaseSyncTransport.currentOrNull();
-    if (t == null) {
-      debugPrint('AlertsSync.merge: not authenticated');
-      return localAlerts;
-    }
-
-    try {
-      final serverRows = await t.select('alerts', '*');
-      // #3121 — drop tombstoned ids from BOTH sides before the union so a
-      // deleted alert can't resurrect through the launch pull or another
-      // device's still-local copy (same seam as favorites/ignored, #3078).
-      final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('alerts', transport: t);
-      final liveServerRows = SyncHelper.removeTombstoned(
-        serverRows,
-        tombstoned,
-        key: (r) => r.getString('id'),
-      ).toList();
-      final liveLocalAlerts =
-          localAlerts.where((a) => !tombstoned.contains(a.id)).toList();
-      final serverAlertIds = liveServerRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localAlertIds = liveLocalAlerts.map((a) => a.id).toSet();
-
-      debugPrint('AlertsSync.merge: local=${localAlertIds.length}, '
-          'server=${serverAlertIds.length}');
-
-      // Upload local-only alerts.
-      final localOnly =
-          liveLocalAlerts.where((a) => !serverAlertIds.contains(a.id)).toList();
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((a) => {
-                  'id': a.id,
-                  'user_id': t.userId,
-                  'station_id': a.stationId,
-                  'station_name': a.stationName,
-                  'fuel_type': a.fuelType.name,
-                  'target_price': a.targetPrice,
-                  'is_active': a.isActive,
-                  'created_at': a.createdAt.toUtc().toIso8601String(),
-                })
-            .toList();
-        await t.upsert('alerts', rows, onConflict: 'id');
-        debugPrint('AlertsSync.merge: uploaded ${localOnly.length} alerts');
-      }
-
-      // Download server-only alerts.
-      final serverOnly = liveServerRows
-          .where((r) => !localAlertIds.contains(r.getString('id')));
-      final downloaded = serverOnly.map((r) {
-        return PriceAlert.fromJson({
-          'id': r.getString('id') ?? '',
-          'stationId': r.getString('station_id') ?? '',
-          'stationName': r.getString('station_name') ?? '',
-          'fuelType': r.getString('fuel_type') ?? '',
-          'targetPrice': r.getDouble('target_price') ?? 0.0,
-          'isActive': r.getBool('is_active') ?? true,
-          'createdAt': r.getString('created_at') ?? '',
-        });
-      }).toList();
-
-      // #3126 — per-table counts into the exportable trace.
-      SyncRunTrace.table(
-        'alerts',
-        uploaded: localOnly.length,
-        downloaded: downloaded.length,
-        tombstoned: tombstoned.length,
-      );
-
-      return [...liveLocalAlerts, ...downloaded];
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'AlertsSync.merge FAILED'}));
-      return localAlerts;
-    }
-  }
+  }) =>
+      _sync.merge(localAlerts, transport: transport);
 
   /// Delete a single alert row from the server and tombstone the id
   /// (#3121). Called only when the user explicitly removes an alert on
-  /// this device — the merge path doesn't delete. Mirrors the
-  /// `FavoritesSync.delete` pattern.
+  /// this device — the merge path doesn't delete.
   ///
   /// Local-first: the caller's local delete has already happened, so a
   /// server failure is logged, not rethrown — and the `deletions`
   /// tombstone is recorded regardless, so every later [merge] filters the
   /// id out even when the row delete failed transiently.
-  static Future<void> delete(String id) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-
-    try {
-      await client.from('alerts').delete().eq('user_id', userId).eq('id', id);
-      debugPrint('AlertsSync.delete: $id removed from server');
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
-          context: const {'where': 'AlertsSync.delete FAILED'}));
-    }
-    // #3121 — tombstone regardless of the row-delete outcome (record has
-    // its own internal guard), so the next merge filters the id either way.
-    await DeletionsSync.record('alerts', id);
-  }
+  static Future<void> delete(String id, {SyncTransport? transport}) =>
+      _sync.delete(id, transport: transport);
 }

--- a/lib/core/sync/baselines_sync.dart
+++ b/lib/core/sync/baselines_sync.dart
@@ -7,24 +7,26 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
+import '../../core/logging/error_logger.dart';
 import '../../features/consumption/data/baseline_sync.dart';
 import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import '../../core/logging/error_logger.dart';
+import 'entity_sync.dart';
+import 'sync_transport.dart';
 
 /// Per-vehicle OBD2 baseline sync with Supabase (#780), pulled out of
 /// [SyncService] (#727).
 ///
-/// Baselines are heavier than the other sync concerns: the payload
-/// is a JSON blob keyed by driving situation (per-situation
-/// accumulators the trip recorder builds), and the merge rule is
-/// "for every situation, the accumulator with the higher sample
-/// count wins". That merge logic lives in
-/// `features/consumption/data/baseline_sync.dart`
-/// (`mergeBaselineJson`, `totalSampleCount`) — we just wire it up to
-/// the Supabase `obd2_baselines` table here.
+/// Baselines keep a bespoke merge (NOT the #3127 [EntitySync] union:
+/// the payload is a JSON blob keyed by driving situation, and the merge
+/// rule is "for every situation, the accumulator with the higher sample
+/// count wins" — that logic lives in
+/// `features/consumption/data/baseline_sync.dart` (`mergeBaselineJson`,
+/// `totalSampleCount`)). Since #3127 the I/O rides the injectable
+/// [SyncTransport] seam and the delete shares [EntitySync.deleteRow].
 class BaselinesSync {
   BaselinesSync._();
+
+  static const _table = 'obd2_baselines';
 
   /// Two-way merge of one vehicle's baseline. Returns the merged JSON
   /// payload that callers should persist locally; returns the
@@ -34,14 +36,15 @@ class BaselinesSync {
   /// [totalSampleCountOverride] lets the caller supply a pre-computed
   /// total — the Dart layer already counts samples for the status UI,
   /// so we avoid decoding the JSON twice when it's already available.
+  /// [transport] is injectable for tests.
   static Future<String?> merge({
     required String vehicleId,
     required String? localJson,
     int? totalSampleCountOverride,
+    SyncTransport? transport,
   }) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) {
       debugPrint('BaselinesSync.merge: not authenticated');
       return localJson;
     }
@@ -51,22 +54,20 @@ class BaselinesSync {
       // re-uploaded here. If this vehicle's baseline is tombstoned, leave the
       // local copy untouched and don't push it back to the server.
       final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('obd2_baselines');
+          await DeletionsSync.fetchTombstonedIds(_table, transport: t);
       if (tombstoned.contains(vehicleId)) {
         debugPrint('BaselinesSync.merge: $vehicleId tombstoned — skipping');
         return localJson;
       }
 
-      final serverRow = await client
-          .from('obd2_baselines')
-          .select('data')
-          .eq('user_id', userId)
-          .eq('vehicle_id', vehicleId)
-          .maybeSingle();
-
-      final serverData = serverRow == null
+      final serverRows = await t.select(
+        _table,
+        'data',
+        filters: {'vehicle_id': vehicleId},
+      );
+      final serverData = serverRows.isEmpty
           ? null
-          : (serverRow['data'] as Map?)?.cast<String, dynamic>();
+          : (serverRows.first['data'] as Map?)?.cast<String, dynamic>();
 
       final merged = mergeBaselineJson(
         localJson,
@@ -79,42 +80,39 @@ class BaselinesSync {
       final total =
           totalSampleCountOverride ?? totalSampleCount(mergedDecoded);
 
-      await client.from('obd2_baselines').upsert(
-        {
-          'user_id': userId,
-          'vehicle_id': vehicleId,
-          'total_samples': total,
-          'data': mergedDecoded,
-          'updated_at': DateTime.now().toUtc().toIso8601String(),
-        },
+      await t.upsert(
+        _table,
+        [
+          {
+            'user_id': t.userId,
+            'vehicle_id': vehicleId,
+            'total_samples': total,
+            'data': mergedDecoded,
+            'updated_at': DateTime.now().toUtc().toIso8601String(),
+          },
+        ],
         onConflict: 'user_id,vehicle_id',
       );
       return merged;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'BaselinesSync.merge FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'BaselinesSync.merge FAILED'}));
       return localJson;
     }
   }
 
   /// Remove a single vehicle's baseline from the server. Called on
-  /// explicit "Forget baseline" from the vehicle edit UI. Silent on
-  /// failure — there's nothing the caller can do about a network
-  /// blip, and the local copy is already gone by the time this runs.
-  static Future<void> delete(String vehicleId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-    try {
-      // #3078/#3123 — tombstone-first (journal-backed): the tombstone must
-      // not depend on the row delete succeeding.
-      await DeletionsSync.record('obd2_baselines', vehicleId);
-      await client
-          .from('obd2_baselines')
-          .delete()
-          .eq('user_id', userId)
-          .eq('vehicle_id', vehicleId);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'BaselinesSync.delete FAILED'}));
-    }
-  }
+  /// explicit "Forget baseline" from the vehicle edit UI. Tombstone-
+  /// first (journal-backed, #3078/#3123) via the shared
+  /// [EntitySync.deleteRow]. Silent on failure — there's nothing the
+  /// caller can do about a network blip, and the local copy is already
+  /// gone by the time this runs.
+  static Future<void> delete(String vehicleId, {SyncTransport? transport}) =>
+      EntitySync.deleteRow(
+        table: _table,
+        idColumn: 'vehicle_id',
+        recordId: vehicleId,
+        logContext: 'BaselinesSync.delete',
+        transport: transport,
+      );
 }

--- a/lib/core/sync/entity_sync.dart
+++ b/lib/core/sync/entity_sync.dart
@@ -1,0 +1,302 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../core/logging/error_logger.dart';
+import '../utils/json_extensions.dart';
+import 'deletions_sync.dart';
+import 'sync_device_identity.dart';
+import 'sync_helper.dart';
+import 'sync_run_trace.dart';
+import 'sync_transport.dart';
+
+/// The generic per-entity sync engine (#3127, Epic #3120).
+///
+/// Before this existed, ~12 `*_sync.dart` files were structural clones of
+/// the same bidirectional merge (favorites vs ignored stations differed
+/// essentially by table name), so every fix to the merge algorithm —
+/// tombstone filtering (#3078/#3121), last-write-wins (#3122), the durable
+/// deletion journal (#3123), forensic stamps (#3125), run-trace counts
+/// (#3126) — had to be hand-copied N times. [EntitySync] is that algorithm
+/// written ONCE; each entity file shrinks to a declarative config (table
+/// name, codec, conflict key) plus thin static forwarders that preserve
+/// its long-standing public API.
+///
+/// The canonical [merge] pass, in order:
+///
+///  1. unauthenticated → return the local input unchanged (the feature
+///     keeps working on pure-local state);
+///  2. fetch the user's server rows + the entity's deletion tombstones
+///     (which drains the #3123 pending-deletions journal first);
+///  3. drop tombstoned ids from BOTH sides so a delete on another device
+///     never resurrects through the union (#3078);
+///  4. when the entity carries a [localStamp], split both-sides ids via
+///     [SyncHelper.lwwSplit] — local-newer re-uploads, server-newer
+///     overwrites the local copy (#3122);
+///  5. upload local-only (+ local-newer) records through [encode];
+///  6. decode server-only (+ server-newer) rows through [decode];
+///  7. report per-table up/down/tombstone counts to [SyncRunTrace] (#3126);
+///  8. return the merged union; any failure logs to [ErrorLayer.sync] and
+///     returns the local input unchanged — sync is fire-and-forget and
+///     must not derail the caller.
+///
+/// All I/O goes through the injectable [SyncTransport] seam (#3122):
+/// production resolves [SupabaseSyncTransport.currentOrNull], tests inject
+/// a fake — the per-entity authenticated paths are unit-testable without a
+/// live Supabase session, retiring the static-global-client problem the
+/// audit flagged.
+class EntitySync<T> {
+  /// The Supabase table this entity persists to. HARD RULE #5: a NEW
+  /// table requires schema_verifier + wizard SQL + a schema-version bump —
+  /// this class only reorganises existing tables.
+  final String table;
+
+  /// Prefix for debug prints and error-log contexts (e.g. `FavoritesSync`),
+  /// kept per-entity so existing log forensics stay greppable.
+  final String logName;
+
+  /// The server column carrying the record id (`id`, or `station_id` for
+  /// the id-set tables).
+  final String idColumn;
+
+  /// Column list for the merge's server fetch.
+  final String selectColumns;
+
+  /// Upsert conflict target making re-uploads idempotent.
+  final String onConflict;
+
+  /// The local record's id.
+  final String Function(T record) idOf;
+
+  /// Build the upload row for [record], owned by [userId].
+  final Map<String, dynamic> Function(T record, String userId) encode;
+
+  /// Decode a server row back into the domain record, or `null` to skip
+  /// it. A decoder that THROWS aborts the whole merge (input returned
+  /// unchanged) — wrap with [jsonbDataDecoder] for per-row resilience.
+  final T? Function(JsonRow row) decode;
+
+  /// The record's local edit stamp — non-null enables the #3122 LWW path
+  /// for ids present on both sides. `null` keeps the pure id-union merge
+  /// (e.g. `alerts`, whose table has no `updated_at` column to compare —
+  /// see the HARD RULE #5 deferral note in `alerts_sync.dart`).
+  final DateTime? Function(T record)? localStamp;
+
+  /// Whether [delete] writes the durable tombstone BEFORE the row delete
+  /// (the #3123 default) or after it (the `alerts` ordering, #3121). Both
+  /// always record the tombstone — only the network call order differs.
+  final bool tombstoneFirstDelete;
+
+  const EntitySync({
+    required this.table,
+    required this.logName,
+    required this.idColumn,
+    required this.selectColumns,
+    required this.onConflict,
+    required this.idOf,
+    required this.encode,
+    required this.decode,
+    this.localStamp,
+    this.tombstoneFirstDelete = true,
+  });
+
+  /// The id-set flavour shared by `favorites` / `ignored_stations` — the
+  /// two tables the audit called out as "differ essentially by table
+  /// name". One `(user_id, station_id)` row per id; the merged result is
+  /// the local ∪ server superset.
+  static EntitySync<String> idSet({
+    required String table,
+    required String logName,
+  }) =>
+      EntitySync<String>(
+        table: table,
+        logName: logName,
+        idColumn: 'station_id',
+        selectColumns: 'station_id',
+        onConflict: 'user_id,station_id',
+        idOf: (id) => id,
+        encode: (id, userId) => {'user_id': userId, 'station_id': id},
+        decode: (row) => row.getString('station_id'),
+      );
+
+  /// Merge [local] with the user's rows on the server. Returns the union,
+  /// with the fresher side winning for both-sides ids when [localStamp]
+  /// is configured (#3122 — see [SyncHelper.lwwSplit] for the
+  /// tie/missing-stamp policy). Unauthenticated and failure paths return
+  /// the input unchanged. [transport] is injectable for tests.
+  Future<List<T>> merge(List<T> local, {SyncTransport? transport}) async {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) {
+      debugPrint('$logName.merge: not authenticated');
+      return local;
+    }
+
+    try {
+      final serverRowsRaw = await t.select(table, selectColumns);
+
+      // #3078 — drop tombstoned ids from BOTH sides so a delete on another
+      // device can't resurrect through the union/re-upload below.
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds(table, transport: t);
+      final serverRows = SyncHelper.removeTombstoned(
+        serverRowsRaw,
+        tombstoned,
+        key: (r) => r.getString(idColumn),
+      ).toList();
+      final liveLocal =
+          local.where((r) => !tombstoned.contains(idOf(r))).toList();
+
+      final serverIds = serverRows
+          .map((r) => r.getString(idColumn))
+          .whereType<String>()
+          .toSet();
+      final localIds = liveLocal.map(idOf).toSet();
+
+      debugPrint('$logName.merge: local=${localIds.length}, '
+          'server=${serverIds.length}');
+
+      // #3122 — last-write-wins for ids present on both sides: a local
+      // edit re-uploads, a fresher server row overwrites the local copy.
+      final stamp = localStamp;
+      final lww = stamp == null
+          ? LwwSplit<T>(localNewer: const [], serverNewer: const [])
+          : SyncHelper.lwwSplit(
+              local: liveLocal,
+              serverRows: serverRows,
+              id: idOf,
+              localStamp: stamp,
+              tombstoned: tombstoned,
+            );
+
+      // Upload local-only + local-newer records.
+      final localOnly =
+          liveLocal.where((r) => !serverIds.contains(idOf(r))).toList();
+      final toUpload = [...localOnly, ...lww.localNewer];
+      if (toUpload.isNotEmpty) {
+        final rows = toUpload.map((r) => encode(r, t.userId)).toList();
+        await t.upsert(table, rows, onConflict: onConflict);
+        debugPrint('$logName.merge: uploaded ${toUpload.length} '
+            '(${lww.localNewer.length} local-newer edits)');
+      }
+
+      // Download server-only records…
+      final downloaded = serverRows
+          .where((r) => !localIds.contains(r.getString(idColumn)))
+          .map(decode)
+          .whereType<T>()
+          .toList();
+      // …and overwrite local copies the server has a fresher edit of.
+      final serverNewerById = <String, T>{
+        for (final r in lww.serverNewer.map(decode).whereType<T>()) idOf(r): r,
+      };
+
+      // #3126 — per-table counts into the exportable trace.
+      SyncRunTrace.table(
+        table,
+        uploaded: toUpload.length,
+        downloaded: downloaded.length + serverNewerById.length,
+        tombstoned: tombstoned.length,
+      );
+
+      return [
+        for (final r in liveLocal) serverNewerById[idOf(r)] ?? r,
+        ...downloaded,
+      ];
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: {'where': '$logName.merge FAILED'}));
+      return local;
+    }
+  }
+
+  /// Delete one record from the server and record its durable tombstone
+  /// (#3078/#3121/#3123) so no later [merge] resurrects it. Silent on
+  /// failure — the caller's local delete already happened. See
+  /// [tombstoneFirstDelete] for the call ordering.
+  Future<bool> delete(String recordId, {SyncTransport? transport}) =>
+      deleteRow(
+        table: table,
+        idColumn: idColumn,
+        recordId: recordId,
+        logContext: '$logName.delete',
+        tombstoneFirst: tombstoneFirstDelete,
+        transport: transport,
+      );
+
+  /// The shared tombstone-and-delete used by [delete] AND by the entities
+  /// that have a bespoke read path but the same clone-pattern delete
+  /// (ratings, baselines, itineraries). Returns `true` when the server row
+  /// delete succeeded, `false` when unauthenticated or on a transient
+  /// failure (the tombstone intent stays journaled either way, #3123).
+  static Future<bool> deleteRow({
+    required String table,
+    required String idColumn,
+    required String recordId,
+    required String logContext,
+    bool tombstoneFirst = true,
+    SyncTransport? transport,
+  }) async {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return false;
+
+    // #3078/#3123 — tombstone-first (journal-backed) by default: the
+    // durable "this id is dead" record must not depend on the row delete
+    // succeeding. `recordAll` has its own internal guard and does not
+    // throw back into this flow.
+    if (tombstoneFirst) {
+      await DeletionsSync.recordAll(table, [recordId], transport: t);
+    }
+    var deleted = false;
+    try {
+      await t.deleteWhere(table, {idColumn: recordId});
+      debugPrint('$logContext: $recordId removed from server');
+      deleted = true;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: {'where': '$logContext FAILED'}));
+    }
+    // #3121 — the alerts ordering: tombstone regardless of the row-delete
+    // outcome, after the delete attempt.
+    if (!tombstoneFirst) {
+      await DeletionsSync.recordAll(table, [recordId], transport: t);
+    }
+    return deleted;
+  }
+
+  /// The #3125 forensic origin stamps every uploaded JSONB `data` blob
+  /// carries (sync-transparent: decode ignores unknown keys, every
+  /// re-upload re-stamps with the writing device).
+  static Map<String, dynamic> forensicStamps() => {
+        'device_id': SyncDeviceIdentity.deviceId,
+        'app_version': SyncDeviceIdentity.appVersion,
+      };
+
+  /// The `updated_at` column value for an upload: carry the local edit
+  /// stamp so the next LWW compare sees equal stamps (skip) instead of a
+  /// phantom-newer server row; legacy unstamped records fall back to
+  /// upload time. Always UTC (#3124).
+  static String lwwStamp(DateTime? updatedAt) =>
+      (updatedAt ?? DateTime.now()).toUtc().toIso8601String();
+
+  /// A per-row resilient decoder for the JSONB-`data`-blob tables
+  /// (`fill_ups` / `vehicles`): a corrupt row logs under [where] and is
+  /// skipped instead of aborting the whole merge.
+  static T? Function(JsonRow) jsonbDataDecoder<T>(
+    T Function(Map<String, dynamic> json) fromJson, {
+    required String where,
+  }) =>
+      (row) {
+        final data = row['data'];
+        if (data is! Map<String, dynamic>) return null;
+        try {
+          return fromJson(data);
+        } catch (e, st) {
+          unawaited(
+              errorLogger.log(ErrorLayer.sync, e, st, context: {'where': where}));
+          return null;
+        }
+      };
+}

--- a/lib/core/sync/favorites_sync.dart
+++ b/lib/core/sync/favorites_sync.dart
@@ -1,108 +1,38 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
-
-import '../utils/json_extensions.dart';
-import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import 'sync_helper.dart';
-import 'sync_run_trace.dart';
-import '../../core/logging/error_logger.dart';
+import 'entity_sync.dart';
+import 'sync_transport.dart';
 
 /// Favorites sync with Supabase, pulled out of [SyncService] (#727).
 ///
 /// Bidirectional merge over the `favorites` table — local-only ids
 /// upload (idempotent via `(user_id, station_id)` upsert conflict),
-/// and the returned list is the union of local + server. Unlike the
-/// other id-based syncs, favorites additionally expose an explicit
-/// [delete] for "user unfavorited a station" — the other direction
-/// (server unfavorited) isn't a user-visible flow.
+/// and the returned list is the union of local + server. Since #3127
+/// this is a thin config over the shared [EntitySync.idSet] engine,
+/// which carries the tombstone filter (#3078), the durable deletion
+/// journal (#3123) and the per-table run-trace counts (#3126).
 class FavoritesSync {
   FavoritesSync._();
 
+  static final _sync =
+      EntitySync.idSet(table: 'favorites', logName: 'FavoritesSync');
+
   /// Merge [localFavoriteIds] with the user's `favorites` rows on
-  /// Supabase. Returns the superset (local ∪ server).
-  static Future<List<String>> merge(List<String> localFavoriteIds) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) {
-      debugPrint('FavoritesSync.merge: not authenticated '
-          '(client=${client != null}, userId=$userId)');
-      return localFavoriteIds;
-    }
-
-    try {
-      final serverRows = await client
-          .from('favorites')
-          .select('station_id')
-          .eq('user_id', userId);
-      // #3078 — drop tombstoned ids from the server set so a delete on
-      // another device can't resurrect through the union below.
-      final tombstoned = await DeletionsSync.fetchTombstonedIds('favorites');
-      final serverIds = SyncHelper.removeTombstoned(
-        serverRows.map((r) => r.getString('station_id')),
-        tombstoned,
-        key: (id) => id,
-      ).whereType<String>().toSet();
-      final localIds =
-          localFavoriteIds.where((id) => !tombstoned.contains(id)).toSet();
-
-      debugPrint('FavoritesSync.merge: local=${localIds.length}, '
-          'server=${serverIds.length}, userId=$userId');
-
-      // Upload local-only favorites.
-      final localOnly = localIds.difference(serverIds);
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((id) => {'user_id': userId, 'station_id': id})
-            .toList();
-        await client
-            .from('favorites')
-            .upsert(rows, onConflict: 'user_id,station_id');
-        debugPrint('FavoritesSync.merge: uploaded '
-            '${localOnly.length} new favorites');
-      }
-
-      // #3126 — per-table counts into the exportable trace.
-      SyncRunTrace.table(
-        'favorites',
-        uploaded: localOnly.length,
-        downloaded: serverIds.difference(localIds).length,
-        tombstoned: tombstoned.length,
-      );
-
-      return localIds.union(serverIds).toList();
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FavoritesSync.merge FAILED'}));
-      return localFavoriteIds;
-    }
-  }
+  /// Supabase. Returns the superset (local ∪ server). Unauthenticated
+  /// path returns the input unchanged. [transport] is injectable for
+  /// tests.
+  static Future<List<String>> merge(
+    List<String> localFavoriteIds, {
+    SyncTransport? transport,
+  }) =>
+      _sync.merge(localFavoriteIds, transport: transport);
 
   /// Delete a single favorite from the server. Called only when the
   /// user explicitly removes a favorite on this device — the union
-  /// merge path never deletes.
-  static Future<void> delete(String stationId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-
-    try {
-      // #3078/#3123 — tombstone-first: the tombstone is the durable "this
-      // id is dead" record (journal-backed), so it must not depend on the
-      // row delete succeeding — a network blip used to skip it entirely
-      // and the next union merge resurrected the favorite.
-      await DeletionsSync.record('favorites', stationId);
-      await client
-          .from('favorites')
-          .delete()
-          .eq('user_id', userId)
-          .eq('station_id', stationId);
-      debugPrint('FavoritesSync.delete: $stationId removed from server');
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FavoritesSync.delete FAILED'}));
-    }
-  }
+  /// merge path never deletes. Tombstone-first (#3078/#3123): the
+  /// durable "this id is dead" record must not depend on the row
+  /// delete succeeding.
+  static Future<void> delete(String stationId, {SyncTransport? transport}) =>
+      _sync.delete(stationId, transport: transport);
 }

--- a/lib/core/sync/fill_ups_sync.dart
+++ b/lib/core/sync/fill_ups_sync.dart
@@ -1,22 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
-
 import '../../features/consumption/domain/entities/fill_up.dart';
-import '../utils/json_extensions.dart';
-import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import 'sync_device_identity.dart';
-import 'sync_helper.dart';
-import 'sync_run_trace.dart';
+import 'entity_sync.dart';
 import 'sync_transport.dart';
-import '../../core/logging/error_logger.dart';
 
 /// Per-fill-up consumption-log sync with Supabase (#713), pulled out
-/// of [SyncService] (#727).
+/// of [SyncService] (#727). Since #3127 a thin codec config over the
+/// shared [EntitySync] engine.
 ///
 /// Same shape as [VehiclesSync]: the server row carries a full
 /// [FillUp] JSON blob and the download branch decodes each row back
@@ -28,6 +19,35 @@ import '../../core/logging/error_logger.dart';
 class FillUpsSync {
   FillUpsSync._();
 
+  static final _sync = EntitySync<FillUp>(
+    table: 'fill_ups',
+    logName: 'FillUpsSync',
+    idColumn: 'id',
+    selectColumns: 'id, data, updated_at',
+    onConflict: 'user_id,id',
+    idOf: (f) => f.id,
+    // #3122 — enables the LWW path for ids present on both sides.
+    localStamp: (f) => f.updatedAt,
+    encode: (f, userId) => {
+      'id': f.id,
+      'user_id': userId,
+      'vehicle_id': f.vehicleId,
+      'recorded_at': f.date.toIso8601String(),
+      // #3125 — forensic origin stamps ride INSIDE the JSONB blob
+      // (sync-transparent: decode ignores unknown keys, every re-upload
+      // re-stamps with the writing device).
+      'data': {...f.toJson(), ...EntitySync.forensicStamps()},
+      // Carry the local edit stamp so the next LWW compare sees equal
+      // stamps (skip) instead of a phantom-newer server row. Legacy
+      // unstamped records fall back to upload time.
+      'updated_at': EntitySync.lwwStamp(f.updatedAt),
+    },
+    decode: EntitySync.jsonbDataDecoder(
+      FillUp.fromJson,
+      where: 'FillUpsSync.merge decode failed',
+    ),
+  );
+
   /// Merge [localFillUps] with the user's `fill_ups` rows on
   /// Supabase. Returns the union, with the fresher side winning for ids
   /// present on both (#3122 LWW — see [SyncHelper.lwwSplit] for the
@@ -36,143 +56,12 @@ class FillUpsSync {
   static Future<List<FillUp>> merge(
     List<FillUp> localFillUps, {
     SyncTransport? transport,
-  }) async {
-    final t = transport ?? SupabaseSyncTransport.currentOrNull();
-    if (t == null) {
-      debugPrint('FillUpsSync.merge: not authenticated');
-      return localFillUps;
-    }
-
-    try {
-      final serverRowsRaw =
-          await t.select('fill_ups', 'id, data, updated_at');
-
-      // #3078 — drop tombstoned rows from BOTH sides so a delete on another
-      // device can't resurrect through the union/re-upload below.
-      final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('fill_ups', transport: t);
-      final serverRows = SyncHelper.removeTombstoned(
-        serverRowsRaw,
-        tombstoned,
-        key: (r) => r.getString('id'),
-      ).toList();
-      final liveLocal =
-          localFillUps.where((f) => !tombstoned.contains(f.id)).toList();
-
-      final serverIds = serverRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = liveLocal.map((f) => f.id).toSet();
-
-      debugPrint('FillUpsSync.merge: local=${localIds.length}, '
-          'server=${serverIds.length}');
-
-      // #3122 — last-write-wins for ids present on both sides: a local
-      // edit re-uploads, a fresher server row overwrites the local copy.
-      final lww = SyncHelper.lwwSplit(
-        local: liveLocal,
-        serverRows: serverRows,
-        id: (f) => f.id,
-        localStamp: (f) => f.updatedAt,
-        tombstoned: tombstoned,
-      );
-
-      // Upload local-only + local-newer fill-ups.
-      final localOnly =
-          liveLocal.where((f) => !serverIds.contains(f.id)).toList();
-      final toUpload = [...localOnly, ...lww.localNewer];
-      if (toUpload.isNotEmpty) {
-        final rows = toUpload
-            .map((f) => {
-                  'id': f.id,
-                  'user_id': t.userId,
-                  'vehicle_id': f.vehicleId,
-                  'recorded_at': f.date.toIso8601String(),
-                  // #3125 — forensic origin stamps ride INSIDE the JSONB
-                  // blob (sync-transparent: decode ignores unknown keys,
-                  // every re-upload re-stamps with the writing device).
-                  'data': {
-                    ...f.toJson(),
-                    'device_id': SyncDeviceIdentity.deviceId,
-                    'app_version': SyncDeviceIdentity.appVersion,
-                  },
-                  // Carry the local edit stamp so the next LWW compare
-                  // sees equal stamps (skip) instead of a phantom-newer
-                  // server row. Legacy unstamped records fall back to
-                  // upload time.
-                  'updated_at': (f.updatedAt ?? DateTime.now())
-                      .toUtc()
-                      .toIso8601String(),
-                })
-            .toList();
-        await t.upsert('fill_ups', rows, onConflict: 'user_id,id');
-        debugPrint('FillUpsSync.merge: uploaded ${toUpload.length} '
-            'fill-ups (${lww.localNewer.length} local-newer edits)');
-      }
-
-      FillUp? decode(Map<String, dynamic> r) {
-        final data = r['data'];
-        if (data is Map<String, dynamic>) {
-          try {
-            return FillUp.fromJson(data);
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.sync, e, st,
-                context: const {'where': 'FillUpsSync.merge decode failed'}));
-            return null;
-          }
-        }
-        return null;
-      }
-
-      // Download server-only fill-ups…
-      final downloaded = serverRows
-          .where((r) => !localIds.contains(r.getString('id')))
-          .map(decode)
-          .whereType<FillUp>()
-          .toList();
-      // …and overwrite local copies the server has a fresher edit of.
-      final serverNewerById = <String, FillUp>{
-        for (final f
-            in lww.serverNewer.map(decode).whereType<FillUp>())
-          f.id: f,
-      };
-
-      // #3126 — per-table counts into the exportable trace.
-      SyncRunTrace.table(
-        'fill_ups',
-        uploaded: toUpload.length,
-        downloaded: downloaded.length + serverNewerById.length,
-        tombstoned: tombstoned.length,
-      );
-
-      return [
-        for (final f in liveLocal) serverNewerById[f.id] ?? f,
-        ...downloaded,
-      ];
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FillUpsSync.merge FAILED'}));
-      return localFillUps;
-    }
-  }
+  }) =>
+      _sync.merge(localFillUps, transport: transport);
 
   /// Remove a single fill-up from the server (called on explicit
-  /// delete from the consumption log). Silent on failure.
-  static Future<void> delete(String fillUpId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-    try {
-      // #3078/#3123 — tombstone-first (journal-backed): the tombstone must
-      // not depend on the row delete succeeding.
-      await DeletionsSync.record('fill_ups', fillUpId);
-      await client
-          .from('fill_ups')
-          .delete()
-          .eq('user_id', userId)
-          .eq('id', fillUpId);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'FillUpsSync.delete FAILED'}));
-    }
-  }
+  /// delete from the consumption log). Tombstone-first (journal-backed,
+  /// #3078/#3123). Silent on failure.
+  static Future<void> delete(String fillUpId, {SyncTransport? transport}) =>
+      _sync.delete(fillUpId, transport: transport);
 }

--- a/lib/core/sync/ignored_stations_sync.dart
+++ b/lib/core/sync/ignored_stations_sync.dart
@@ -1,105 +1,38 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
-
-import '../utils/json_extensions.dart';
-import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import 'sync_helper.dart';
-import 'sync_run_trace.dart';
-import '../../core/logging/error_logger.dart';
+import 'entity_sync.dart';
+import 'sync_transport.dart';
 
 /// Ignored-stations sync with Supabase, pulled out of [SyncService] (#727).
 ///
-/// Same bidirectional-merge pattern as favorites: upload local-only
-/// ids (idempotent via `(user_id, station_id)` upsert conflict), then
-/// return the union of local + server sets. Unauthenticated path
-/// returns the input unchanged — the feature keeps working on pure
-/// local state when the user isn't signed in.
+/// Same bidirectional-merge pattern as favorites — which is exactly why
+/// both are now a one-line config over the shared [EntitySync.idSet]
+/// engine (#3127): upload local-only ids (idempotent via
+/// `(user_id, station_id)` upsert conflict), then return the union of
+/// local + server sets. Unauthenticated path returns the input
+/// unchanged — the feature keeps working on pure local state when the
+/// user isn't signed in.
 class IgnoredStationsSync {
   IgnoredStationsSync._();
 
+  static final _sync = EntitySync.idSet(
+      table: 'ignored_stations', logName: 'IgnoredStationsSync');
+
   /// Merge [localIgnoredIds] with the user's `ignored_stations` rows
-  /// on Supabase. Returns the superset (local ∪ server).
-  static Future<List<String>> merge(List<String> localIgnoredIds) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) {
-      debugPrint('IgnoredStationsSync.merge: not authenticated');
-      return localIgnoredIds;
-    }
-
-    try {
-      final serverRows = await client
-          .from('ignored_stations')
-          .select('station_id')
-          .eq('user_id', userId);
-      // #3078 — drop tombstoned ids so an un-ignore on another device
-      // doesn't resurrect through the union below.
-      final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('ignored_stations');
-      final serverIds = SyncHelper.removeTombstoned(
-        serverRows.map((r) => r.getString('station_id')),
-        tombstoned,
-        key: (id) => id,
-      ).whereType<String>().toSet();
-      final localIds =
-          localIgnoredIds.where((id) => !tombstoned.contains(id)).toSet();
-
-      debugPrint('IgnoredStationsSync.merge: local=${localIds.length}, '
-          'server=${serverIds.length}');
-
-      // Upload local-only ids.
-      final localOnly = localIds.difference(serverIds);
-      if (localOnly.isNotEmpty) {
-        final rows = localOnly
-            .map((id) => {'user_id': userId, 'station_id': id})
-            .toList();
-        await client
-            .from('ignored_stations')
-            .upsert(rows, onConflict: 'user_id,station_id');
-        debugPrint(
-            'IgnoredStationsSync.merge: uploaded ${localOnly.length}');
-      }
-
-      // #3126 — per-table counts into the exportable trace.
-      SyncRunTrace.table(
-        'ignored_stations',
-        uploaded: localOnly.length,
-        downloaded: serverIds.difference(localIds).length,
-        tombstoned: tombstoned.length,
-      );
-
-      return localIds.union(serverIds).toList();
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'IgnoredStationsSync.merge FAILED'}));
-      return localIgnoredIds;
-    }
-  }
+  /// on Supabase. Returns the superset (local ∪ server). [transport]
+  /// is injectable for tests.
+  static Future<List<String>> merge(
+    List<String> localIgnoredIds, {
+    SyncTransport? transport,
+  }) =>
+      _sync.merge(localIgnoredIds, transport: transport);
 
   /// Un-ignore a single station on the server (#3078). Before this existed
   /// the un-ignore path only re-ran [merge], whose union re-added the still-
   /// server row, so the station never actually un-hid. Now the server row is
-  /// deleted AND tombstoned, so neither side resurrects it. Silent on failure.
-  static Future<void> delete(String stationId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-    try {
-      // #3123 — tombstone-first (journal-backed): a failed row delete must
-      // not also skip the tombstone, or the un-ignore resurrects.
-      await DeletionsSync.record('ignored_stations', stationId);
-      await client
-          .from('ignored_stations')
-          .delete()
-          .eq('user_id', userId)
-          .eq('station_id', stationId);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
-          context: const {'where': 'IgnoredStationsSync.delete FAILED'}));
-    }
-  }
+  /// deleted AND tombstoned (tombstone-first, journal-backed — #3123), so
+  /// neither side resurrects it. Silent on failure.
+  static Future<void> delete(String stationId, {SyncTransport? transport}) =>
+      _sync.delete(stationId, transport: transport);
 }

--- a/lib/core/sync/itineraries_sync.dart
+++ b/lib/core/sync/itineraries_sync.dart
@@ -5,73 +5,86 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../core/logging/error_logger.dart';
 import '../../features/itinerary/domain/entities/saved_itinerary.dart';
 import '../utils/json_extensions.dart';
 import 'deletions_sync.dart';
-import 'supabase_client.dart';
+import 'entity_sync.dart';
 import 'sync_helper.dart';
-import '../../core/logging/error_logger.dart';
+import 'sync_transport.dart';
 
 /// Saved-itinerary sync with Supabase, pulled out of [SyncService]
 /// (#727).
 ///
-/// Unlike the other merge-style sync classes, itineraries are
-/// one-way from the server's perspective: local provider holds the
-/// source of truth and push explicitly via [save] / [delete] on
-/// every user action, then reconciles with [fetchAll] on login.
-/// Deduplication happens at the caller (the itinerary provider
-/// unions the local list with `fetchAll`'s return before rendering).
+/// Unlike the [EntitySync]-merged entities, itineraries are one-way
+/// from the server's perspective: the local provider holds the source
+/// of truth and pushes explicitly via [save] / [delete] on every user
+/// action, then reconciles with [fetchAll] on login. Deduplication
+/// happens at the caller (the itinerary provider unions the local list
+/// with `fetchAll`'s return before rendering). Since #3127 the I/O
+/// rides the injectable [SyncTransport] seam and the delete shares
+/// [EntitySync.deleteRow].
 class ItinerariesSync {
   ItinerariesSync._();
+
+  static const _table = 'itineraries';
 
   /// Save or update an itinerary on the server. Returns `true` on
   /// success, `false` when unauthenticated or the upsert fails —
   /// mirrors the original contract so the itinerary provider's
   /// "synced?" badge keeps working.
-  static Future<bool> save(SavedItinerary itinerary) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return false;
+  static Future<bool> save(
+    SavedItinerary itinerary, {
+    SyncTransport? transport,
+  }) async {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return false;
 
     try {
-      await client.from('itineraries').upsert({
-        'id': itinerary.id,
-        'user_id': userId,
-        'name': itinerary.name,
-        'waypoints': itinerary.waypoints,
-        'distance_km': itinerary.distanceKm,
-        'duration_minutes': itinerary.durationMinutes,
-        'avoid_highways': itinerary.avoidHighways,
-        'fuel_type': itinerary.fuelType,
-        'selected_station_ids': itinerary.selectedStationIds,
-        'updated_at': DateTime.now().toUtc().toIso8601String(),
-      }, onConflict: 'id');
+      await t.upsert(
+        _table,
+        [
+          {
+            'id': itinerary.id,
+            'user_id': t.userId,
+            'name': itinerary.name,
+            'waypoints': itinerary.waypoints,
+            'distance_km': itinerary.distanceKm,
+            'duration_minutes': itinerary.durationMinutes,
+            'avoid_highways': itinerary.avoidHighways,
+            'fuel_type': itinerary.fuelType,
+            'selected_station_ids': itinerary.selectedStationIds,
+            'updated_at': DateTime.now().toUtc().toIso8601String(),
+          },
+        ],
+        onConflict: 'id',
+      );
       debugPrint('ItinerariesSync.save: saved "${itinerary.name}"');
       return true;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.save FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'ItinerariesSync.save FAILED'}));
       return false;
     }
   }
 
-  /// Fetch every itinerary owned by the authenticated user. Returns
-  /// an empty list when unauthenticated or the query fails — the
-  /// provider keeps showing whatever was in local cache.
-  static Future<List<SavedItinerary>> fetchAll() async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return [];
+  /// Fetch every itinerary owned by the authenticated user, newest
+  /// edit first. Returns an empty list when unauthenticated or the
+  /// query fails — the provider keeps showing whatever was in local
+  /// cache.
+  static Future<List<SavedItinerary>> fetchAll({
+    SyncTransport? transport,
+  }) async {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return [];
 
     try {
-      final rows = await client
-          .from('itineraries')
-          .select()
-          .eq('user_id', userId)
-          .order('updated_at', ascending: false);
+      final rows = await t.select(_table, '*');
 
       // #3078 — never re-hydrate an itinerary deleted on another device.
-      final tombstoned = await DeletionsSync.fetchTombstonedIds('itineraries');
-      return SyncHelper.removeTombstoned(
+      final tombstoned =
+          await DeletionsSync.fetchTombstonedIds(_table, transport: t);
+      final result = SyncHelper.removeTombstoned(
         rows,
         tombstoned,
         key: (r) => r.getString('id'),
@@ -94,33 +107,30 @@ class ItinerariesSync {
               ? DateTime.tryParse(updatedAtStr) ?? DateTime.now()
               : DateTime.now(),
         );
-      }).toList();
+      }).toList()
+        // The pre-#3127 query ordered server-side
+        // (`order('updated_at', ascending: false)`); the transport seam
+        // is filter-only, so the same newest-first contract is applied
+        // here instead.
+        ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      return result;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.fetchAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'ItinerariesSync.fetchAll FAILED'}));
       return [];
     }
   }
 
   /// Delete a single itinerary from the server. Returns `true` on
   /// success, `false` when unauthenticated or the delete fails.
-  static Future<bool> delete(String itineraryId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return false;
-
-    try {
-      // #3078/#3123 — tombstone-first (journal-backed): the tombstone must
-      // not depend on the row delete succeeding.
-      await DeletionsSync.record('itineraries', itineraryId);
-      await client
-          .from('itineraries')
-          .delete()
-          .eq('id', itineraryId)
-          .eq('user_id', userId);
-      return true;
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItinerariesSync.delete FAILED'}));
-      return false;
-    }
-  }
+  /// Tombstone-first (journal-backed, #3078/#3123) via the shared
+  /// [EntitySync.deleteRow].
+  static Future<bool> delete(String itineraryId, {SyncTransport? transport}) =>
+      EntitySync.deleteRow(
+        table: _table,
+        idColumn: 'id',
+        recordId: itineraryId,
+        logContext: 'ItinerariesSync.delete',
+        transport: transport,
+      );
 }

--- a/lib/core/sync/ratings_sync.dart
+++ b/lib/core/sync/ratings_sync.dart
@@ -5,14 +5,17 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../core/logging/error_logger.dart';
 import '../utils/json_extensions.dart';
 import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import '../../core/logging/error_logger.dart';
+import 'entity_sync.dart';
+import 'sync_transport.dart';
 
 /// Station-rating sync with Supabase, pulled out of [SyncService] (#727).
 ///
-/// Three read/write paths on the `station_ratings` table:
+/// Ratings keep a bespoke read/write surface (an explicit-column table
+/// with no union merge), but since #3127 all I/O rides the injectable
+/// [SyncTransport] seam and the delete shares [EntitySync.deleteRow]:
 ///
 /// - [upsert] — add or update a rating (owner-private by default,
 ///   shareable when [shared] is true).
@@ -29,29 +32,38 @@ import '../../core/logging/error_logger.dart';
 class RatingsSync {
   RatingsSync._();
 
+  static const _table = 'station_ratings';
+
   /// Upsert a single station rating. Safe to call for both new and
   /// existing ratings — `onConflict` resolves by `(user_id, station_id)`.
   static Future<void> upsert(
     String stationId,
     int rating, {
     bool shared = false,
+    SyncTransport? transport,
   }) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return;
 
     try {
-      await client.from('station_ratings').upsert({
-        'user_id': userId,
-        'station_id': stationId,
-        'rating': rating,
-        'is_shared': shared,
-        'updated_at': DateTime.now().toUtc().toIso8601String(),
-      }, onConflict: 'user_id,station_id');
+      await t.upsert(
+        _table,
+        [
+          {
+            'user_id': t.userId,
+            'station_id': stationId,
+            'rating': rating,
+            'is_shared': shared,
+            'updated_at': DateTime.now().toUtc().toIso8601String(),
+          },
+        ],
+        onConflict: 'user_id,station_id',
+      );
       debugPrint(
           'RatingsSync.upsert: $stationId = $rating stars (shared=$shared)');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.upsert FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'RatingsSync.upsert FAILED'}));
     }
   }
 
@@ -64,16 +76,18 @@ class RatingsSync {
   /// authenticated. All ratings default to owner-private
   /// (`is_shared = false`) — the per-rating share toggle still goes
   /// through [upsert].
-  static Future<void> upsertAll(Map<String, int> ratings) async {
+  static Future<void> upsertAll(
+    Map<String, int> ratings, {
+    SyncTransport? transport,
+  }) async {
     if (ratings.isEmpty) return;
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return;
 
     final now = DateTime.now().toUtc().toIso8601String();
     final rows = ratings.entries
         .map((e) => {
-              'user_id': userId,
+              'user_id': t.userId,
               'station_id': e.key,
               'rating': e.value,
               'is_shared': false,
@@ -82,54 +96,41 @@ class RatingsSync {
         .toList();
 
     try {
-      await client
-          .from('station_ratings')
-          .upsert(rows, onConflict: 'user_id,station_id');
+      await t.upsert(_table, rows, onConflict: 'user_id,station_id');
       debugPrint('RatingsSync.upsertAll: ${rows.length} ratings in 1 round-trip');
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.upsertAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'RatingsSync.upsertAll FAILED'}));
     }
   }
 
   /// Delete a rating from the server. Typically called when the
   /// station is unfavorited (ratings live alongside favorites).
-  static Future<void> delete(String stationId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-
-    try {
-      // #3078/#3123 — tombstone-first (journal-backed) so another device's
-      // re-upload / fetch can't resurrect the deleted rating even when the
-      // row delete below fails transiently.
-      await DeletionsSync.record('station_ratings', stationId);
-      await client
-          .from('station_ratings')
-          .delete()
-          .eq('user_id', userId)
-          .eq('station_id', stationId);
-      debugPrint('RatingsSync.delete: $stationId removed');
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.delete FAILED'}));
-    }
-  }
+  /// Tombstone-first (journal-backed, #3078/#3123) via the shared
+  /// [EntitySync.deleteRow], so another device's re-upload / fetch
+  /// can't resurrect the deleted rating even when the row delete
+  /// fails transiently.
+  static Future<void> delete(String stationId, {SyncTransport? transport}) =>
+      EntitySync.deleteRow(
+        table: _table,
+        idColumn: 'station_id',
+        recordId: stationId,
+        logContext: 'RatingsSync.delete',
+        transport: transport,
+      );
 
   /// Fetch every rating owned by the authenticated user. Returns a
   /// `stationId → rating` map. Empty map when the session isn't
   /// authenticated or the query fails.
-  static Future<Map<String, int>> fetchAll() async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return {};
+  static Future<Map<String, int>> fetchAll({SyncTransport? transport}) async {
+    final t = transport ?? SupabaseSyncTransport.currentOrNull();
+    if (t == null) return {};
 
     try {
-      final rows = await client
-          .from('station_ratings')
-          .select('station_id, rating')
-          .eq('user_id', userId);
+      final rows = await t.select(_table, 'station_id, rating');
       // #3078 — never re-hydrate a rating the user deleted on another device.
       final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('station_ratings');
+          await DeletionsSync.fetchTombstonedIds(_table, transport: t);
       final result = <String, int>{};
       for (final r in rows) {
         final stationId = r.getString('station_id');
@@ -142,7 +143,8 @@ class RatingsSync {
       }
       return result;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'RatingsSync.fetchAll FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st,
+          context: const {'where': 'RatingsSync.fetchAll FAILED'}));
       return {};
     }
   }

--- a/lib/core/sync/vehicles_sync.dart
+++ b/lib/core/sync/vehicles_sync.dart
@@ -1,34 +1,50 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
-
 import '../../features/vehicle/domain/entities/vehicle_profile.dart';
-import '../utils/json_extensions.dart';
-import 'deletions_sync.dart';
-import 'supabase_client.dart';
-import 'sync_device_identity.dart';
-import 'sync_helper.dart';
-import 'sync_run_trace.dart';
+import 'entity_sync.dart';
 import 'sync_transport.dart';
-import '../../core/logging/error_logger.dart';
 
 /// Per-vehicle profile sync with Supabase (#713), pulled out of
-/// [SyncService] (#727).
+/// [SyncService] (#727). Since #3127 a thin codec config over the
+/// shared [EntitySync] engine.
 ///
-/// Vehicles are the one sync concern where the server row carries a
-/// full domain JSON blob (engine fuel type, display name, flex-fuel
-/// config, per-vehicle defaults) rather than a bare id — the
-/// download branch decodes each row back into a [VehicleProfile]
-/// and appends it to the local list.
+/// The server row carries a full domain JSON blob (engine fuel type,
+/// display name, flex-fuel config, per-vehicle defaults) rather than
+/// a bare id — the download branch decodes each row back into a
+/// [VehicleProfile] and appends it to the local list.
 ///
 /// Per-device `UserProfile`s are NOT synced (each device keeps its
 /// own defaulting), only the `VehicleProfile`s. That invariant is
 /// what the merge rule here preserves.
 class VehiclesSync {
   VehiclesSync._();
+
+  static final _sync = EntitySync<VehicleProfile>(
+    table: 'vehicles',
+    logName: 'VehiclesSync',
+    idColumn: 'id',
+    selectColumns: 'id, data, updated_at',
+    onConflict: 'user_id,id',
+    idOf: (v) => v.id,
+    // #3122 — enables the LWW path for ids present on both sides.
+    localStamp: (v) => v.updatedAt,
+    encode: (v, userId) => {
+      'id': v.id,
+      'user_id': userId,
+      // #3125 — forensic origin stamps ride INSIDE the JSONB blob
+      // (sync-transparent: decode ignores unknown keys, every re-upload
+      // re-stamps with the writing device).
+      'data': {...v.toJson(), ...EntitySync.forensicStamps()},
+      // Carry the local edit stamp so the next LWW compare sees equal
+      // stamps (skip). Legacy unstamped profiles fall back to upload time.
+      'updated_at': EntitySync.lwwStamp(v.updatedAt),
+    },
+    decode: EntitySync.jsonbDataDecoder(
+      VehicleProfile.fromJson,
+      where: 'VehiclesSync.merge decode failed',
+    ),
+  );
 
   /// Merge [localVehicles] with the user's `vehicles` rows on
   /// Supabase. Returns the union, with the fresher side winning for ids
@@ -38,142 +54,14 @@ class VehiclesSync {
   static Future<List<VehicleProfile>> merge(
     List<VehicleProfile> localVehicles, {
     SyncTransport? transport,
-  }) async {
-    final t = transport ?? SupabaseSyncTransport.currentOrNull();
-    if (t == null) {
-      debugPrint('VehiclesSync.merge: not authenticated');
-      return localVehicles;
-    }
-
-    try {
-      final serverRowsRaw =
-          await t.select('vehicles', 'id, data, updated_at');
-
-      // #3078 — drop tombstoned rows from BOTH sides so a delete on another
-      // device can't resurrect through the union/re-upload below.
-      final tombstoned =
-          await DeletionsSync.fetchTombstonedIds('vehicles', transport: t);
-      final serverRows = SyncHelper.removeTombstoned(
-        serverRowsRaw,
-        tombstoned,
-        key: (r) => r.getString('id'),
-      ).toList();
-      final liveLocal =
-          localVehicles.where((v) => !tombstoned.contains(v.id)).toList();
-
-      final serverIds = serverRows
-          .map((r) => r.getString('id'))
-          .whereType<String>()
-          .toSet();
-      final localIds = liveLocal.map((v) => v.id).toSet();
-
-      debugPrint('VehiclesSync.merge: local=${localIds.length}, '
-          'server=${serverIds.length}');
-
-      // #3122 — last-write-wins for ids present on both sides: a local
-      // edit re-uploads, a fresher server row overwrites the local copy.
-      final lww = SyncHelper.lwwSplit(
-        local: liveLocal,
-        serverRows: serverRows,
-        id: (v) => v.id,
-        localStamp: (v) => v.updatedAt,
-        tombstoned: tombstoned,
-      );
-
-      // Upload local-only + local-newer vehicles.
-      final localOnly =
-          liveLocal.where((v) => !serverIds.contains(v.id)).toList();
-      final toUpload = [...localOnly, ...lww.localNewer];
-      if (toUpload.isNotEmpty) {
-        final rows = toUpload
-            .map((v) => {
-                  'id': v.id,
-                  'user_id': t.userId,
-                  // #3125 — forensic origin stamps ride INSIDE the JSONB
-                  // blob (sync-transparent: decode ignores unknown keys,
-                  // every re-upload re-stamps with the writing device).
-                  'data': {
-                    ...v.toJson(),
-                    'device_id': SyncDeviceIdentity.deviceId,
-                    'app_version': SyncDeviceIdentity.appVersion,
-                  },
-                  // Carry the local edit stamp so the next LWW compare
-                  // sees equal stamps (skip). Legacy unstamped profiles
-                  // fall back to upload time.
-                  'updated_at': (v.updatedAt ?? DateTime.now())
-                      .toUtc()
-                      .toIso8601String(),
-                })
-            .toList();
-        await t.upsert('vehicles', rows, onConflict: 'user_id,id');
-        debugPrint('VehiclesSync.merge: uploaded ${toUpload.length} '
-            'vehicles (${lww.localNewer.length} local-newer edits)');
-      }
-
-      VehicleProfile? decode(Map<String, dynamic> r) {
-        final data = r['data'];
-        if (data is Map<String, dynamic>) {
-          try {
-            return VehicleProfile.fromJson(data);
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.sync, e, st,
-                context: const {'where': 'VehiclesSync.merge decode failed'}));
-            return null;
-          }
-        }
-        return null;
-      }
-
-      // Download server-only vehicles…
-      final downloaded = serverRows
-          .where((r) => !localIds.contains(r.getString('id')))
-          .map(decode)
-          .whereType<VehicleProfile>()
-          .toList();
-      // …and overwrite local copies the server has a fresher edit of.
-      final serverNewerById = <String, VehicleProfile>{
-        for (final v
-            in lww.serverNewer.map(decode).whereType<VehicleProfile>())
-          v.id: v,
-      };
-
-      // #3126 — per-table counts into the exportable trace.
-      SyncRunTrace.table(
-        'vehicles',
-        uploaded: toUpload.length,
-        downloaded: downloaded.length + serverNewerById.length,
-        tombstoned: tombstoned.length,
-      );
-
-      return [
-        for (final v in liveLocal) serverNewerById[v.id] ?? v,
-        ...downloaded,
-      ];
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'VehiclesSync.merge FAILED'}));
-      return localVehicles;
-    }
-  }
+  }) =>
+      _sync.merge(localVehicles, transport: transport);
 
   /// Remove a single vehicle from the server (called on explicit
-  /// delete from the vehicle list screen). Silent on failure — the
-  /// local delete already happened and there's nothing the caller
-  /// can do about a transient network blip.
-  static Future<void> delete(String vehicleId) async {
-    final client = TankSyncClient.client;
-    final userId = client?.auth.currentUser?.id;
-    if (client == null || userId == null) return;
-    try {
-      // #3078/#3123 — tombstone-first (journal-backed): the tombstone must
-      // not depend on the row delete succeeding.
-      await DeletionsSync.record('vehicles', vehicleId);
-      await client
-          .from('vehicles')
-          .delete()
-          .eq('user_id', userId)
-          .eq('id', vehicleId);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'VehiclesSync.delete FAILED'}));
-    }
-  }
+  /// delete from the vehicle list screen). Tombstone-first
+  /// (journal-backed, #3078/#3123). Silent on failure — the local
+  /// delete already happened and there's nothing the caller can do
+  /// about a transient network blip.
+  static Future<void> delete(String vehicleId, {SyncTransport? transport}) =>
+      _sync.delete(vehicleId, transport: transport);
 }

--- a/test/core/sync/entity_sync_test.dart
+++ b/test/core/sync/entity_sync_test.dart
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/entity_sync.dart';
+import 'package:tankstellen/core/sync/pending_deletions_journal.dart';
+import 'package:tankstellen/core/sync/sync_device_identity.dart';
+
+import '../../helpers/silence_error_logger.dart';
+import 'fake_sync_transport.dart';
+
+/// #3127 — the generic [EntitySync] engine the per-entity sync configs
+/// delegate to. The entity-level contracts (LWW, tombstones, stamps, run
+/// traces) stay pinned by their existing tests
+/// (`lww_merge_test.dart`, `sync_forensic_stamps_test.dart`, …); these
+/// tests pin the ENGINE-level invariants shared by every config,
+/// including the fault paths (offline select/upsert/delete).
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(() {
+    SyncDeviceIdentity.resetForTest('device-under-test');
+    PendingDeletionsJournal.load = () => null;
+    PendingDeletionsJournal.persist = (_) async {};
+  });
+
+  tearDown(() {
+    SyncDeviceIdentity.resetForTest();
+    PendingDeletionsJournal.resetForTest();
+  });
+
+  EntitySync<String> idSet() =>
+      EntitySync.idSet(table: 'favorites', logName: 'FavoritesSync');
+
+  group('EntitySync.merge — id-set flavour', () {
+    test('uploads local-only ids and downloads server-only ids', () async {
+      final fake = FakeSyncTransport(tables: {
+        'favorites': [
+          {'user_id': 'user-1', 'station_id': 'st-server'},
+          {'user_id': 'user-1', 'station_id': 'st-both'},
+        ],
+      });
+
+      final result =
+          await idSet().merge(['st-local', 'st-both'], transport: fake);
+
+      expect(fake.upsertedRows('favorites'), [
+        {'user_id': 'user-1', 'station_id': 'st-local'},
+      ]);
+      expect(fake.upsertCalls.single.onConflict, 'user_id,station_id');
+      expect(result, containsAll(['st-local', 'st-both', 'st-server']));
+      expect(result, hasLength(3));
+    });
+
+    test('a tombstoned id is dropped from BOTH sides of the union (#3078)',
+        () async {
+      final fake = FakeSyncTransport(tables: {
+        'favorites': [
+          {'user_id': 'user-1', 'station_id': 'st-dead'},
+        ],
+        'deletions': [
+          {'record_id': 'st-dead', 'table_name': 'favorites'},
+        ],
+      });
+
+      final result = await idSet().merge(['st-dead'], transport: fake);
+
+      expect(result, isEmpty);
+      expect(fake.upsertCalls, isEmpty,
+          reason: 'a tombstoned local id must not re-upload');
+    });
+
+    test('unauthenticated path returns the input unchanged', () async {
+      // No transport injected and no live Supabase session in unit tests.
+      final local = ['st-1', 'st-2'];
+      expect(await idSet().merge(local), equals(local));
+    });
+
+    test('an offline select returns the input unchanged (fault path)',
+        () async {
+      final fake = FakeSyncTransport()..failSelects = true;
+      final local = ['st-1'];
+      await expectLater(
+          idSet().merge(local, transport: fake), completion(equals(local)));
+    });
+
+    test('an offline upsert returns the input unchanged (fault path)',
+        () async {
+      final fake = FakeSyncTransport()..failUpserts = true;
+      await expectLater(idSet().merge(['st-1'], transport: fake),
+          completion(equals(['st-1'])));
+    });
+  });
+
+  group('EntitySync.deleteRow', () {
+    test('tombstone-first: tombstone lands even when the row delete fails',
+        () async {
+      final fake = FakeSyncTransport(tables: {
+        'favorites': [
+          {'user_id': 'user-1', 'station_id': 'st-1'},
+        ],
+      })
+        ..failDeletes = true;
+
+      final ok = await EntitySync.deleteRow(
+        table: 'favorites',
+        idColumn: 'station_id',
+        recordId: 'st-1',
+        logContext: 'FavoritesSync.delete',
+        transport: fake,
+      );
+
+      expect(ok, isFalse);
+      expect(
+          fake.upsertedRows('deletions').single['record_id'], 'st-1',
+          reason: 'the durable tombstone must not depend on the row delete');
+    });
+
+    test('deletes the row, scoped to the id column', () async {
+      final fake = FakeSyncTransport(tables: {
+        'favorites': [
+          {'user_id': 'user-1', 'station_id': 'st-1'},
+          {'user_id': 'user-1', 'station_id': 'st-2'},
+        ],
+      });
+
+      final ok = await EntitySync.deleteRow(
+        table: 'favorites',
+        idColumn: 'station_id',
+        recordId: 'st-1',
+        logContext: 'FavoritesSync.delete',
+        transport: fake,
+      );
+
+      expect(ok, isTrue);
+      expect(fake.deleteCalls.single.filters, {'station_id': 'st-1'});
+      expect(fake.tables['favorites']!.single['station_id'], 'st-2');
+    });
+
+    test('tombstone-AFTER ordering (the alerts flavour, #3121) still '
+        'records the tombstone on a failed delete', () async {
+      final fake = FakeSyncTransport()..failDeletes = true;
+
+      final ok = await EntitySync.deleteRow(
+        table: 'alerts',
+        idColumn: 'id',
+        recordId: 'a-1',
+        logContext: 'AlertsSync.delete',
+        tombstoneFirst: false,
+        transport: fake,
+      );
+
+      expect(ok, isFalse);
+      expect(fake.upsertedRows('deletions').single['record_id'], 'a-1');
+    });
+
+    test('unauthenticated path is a no-op returning false', () async {
+      await expectLater(
+        EntitySync.deleteRow(
+          table: 'favorites',
+          idColumn: 'station_id',
+          recordId: 'st-1',
+          logContext: 'FavoritesSync.delete',
+        ),
+        completion(isFalse),
+      );
+    });
+  });
+
+  group('EntitySync shared codec helpers', () {
+    test('forensicStamps carries the #3125 device identity', () {
+      expect(EntitySync.forensicStamps(), {
+        'device_id': 'device-under-test',
+        'app_version': SyncDeviceIdentity.appVersion,
+      });
+    });
+
+    test('lwwStamp carries the local edit stamp in UTC (#3124)', () {
+      final edited = DateTime.utc(2026, 6, 1, 12);
+      expect(EntitySync.lwwStamp(edited), edited.toIso8601String());
+      // Legacy unstamped record → upload-time fallback, still UTC.
+      expect(EntitySync.lwwStamp(null), endsWith('Z'));
+    });
+
+    test('jsonbDataDecoder skips a corrupt row instead of throwing', () {
+      final decode = EntitySync.jsonbDataDecoder<String>(
+        (json) => json['name'] as String,
+        where: 'EntitySyncTest decode failed',
+      );
+      expect(decode({'data': {'name': 'ok'}}), 'ok');
+      expect(decode({'data': {'name': 42}}), isNull,
+          reason: 'a throwing fromJson must degrade to a skipped row');
+      expect(decode({'data': 'not-a-map'}), isNull);
+      expect(decode(const {}), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Generic EntitySync<T> — one engine behind the 12 hand-copied entity sync classes

Final child of epic #3120 (sync integrity). Pure refactor, zero behavior change, zero schema change:

- **`EntitySync<T>`** (`lib/core/sync/entity_sync.dart`, 302 lines): one declarative config per synced entity (table, codec, id, optional LWW stamp, tombstone ordering). Its `merge` pass absorbs every seam the epic added — `SyncTransport` (#3122), pending-deletions journal drain (#3123), dual-side tombstone filtering (#3121), `lwwSplit` (#3122), forensic stamps (#3125), `SyncRunTrace` per-table counts (#3126), `ErrorLayer.sync` failure handling (#3128) — so the next synced entity is a config, not a 150-line copy.
- **Migrated**: favorites + ignored stations (id-set flavour, 108/105 → 38 lines each), alerts (LWW deferral and #3121 delete ordering preserved), fill-ups and vehicles (178/179 → 67 each, LWW + stamps). Ratings/baselines/itineraries keep their bespoke read shapes but now route all I/O through the injectable transport and the shared journal-backed delete.
- **Deliberately not migrated** (documented inline): trips (two-table batch + retention), trip shares (RPC), GDPR user-data aggregate, anon price history.
- All existing sync regression tests (`lww_merge`, `alerts_delete_resurrection`, `pending_deletions_journal`, `schema_verifier_completeness`, forensic stamps, run traces) pass **unmodified**; 12 new engine tests including offline fault paths. 5,710 tests green.

Closes #3127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
