### PR TITLE
build(ios): wire the TankstellenWidget extension into Runner.xcodeproj — blocked on portal/match setup (#3166)

### DIFF
--- a/docs/guides/ios-widget-extension.md
+++ b/docs/guides/ios-widget-extension.md
@@ -64,12 +64,23 @@ Dart side:
      `match appstore --force` and copy the new profile UUIDs into
      Xcode's "Signing & Capabilities" pane.
 
-## Required Xcode work
+## Required Xcode work — DONE (#3166)
 
-These steps cannot be scripted reliably from outside Xcode — the
-`project.pbxproj` schema for embedded extensions includes target
-dependencies, copy-files build phases, and code-sign settings that
-break the project file when hand-edited.
+> **Status:** the target wiring below shipped with #3166 —
+> `scripts/add_ios_widget_target.rb` (xcodeproj gem, idempotent)
+> performs Steps 1–4 reproducibly and has been applied to
+> `ios/Runner.xcodeproj`. The TankstellenWidget extension target now
+> builds and embeds in every `flutter build ios`. The steps are kept
+> below for reference / re-creation from scratch. What remains manual
+> is ONLY the Apple Developer Portal work above (App Group + widget
+> App ID + `match --force` re-provisioning) — until that is done, the
+> nightly TestFlight archive will fail signing, because both targets
+> now reference App Group entitlements and the widget's Release config
+> expects a `match AppStore de.tankstellen.tankstellen.TankstellenWidget`
+> profile. Add the widget bundle ID to `ios/fastlane/Matchfile`'s
+> `app_identifier` list and to `build_appstore`'s
+> `provisioningProfiles` map in `ios/fastlane/Fastfile` at the same
+> time (Step 5).
 
 ### Step 1 — Add the Widget Extension target
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - app_badge_plus (1.2.10):
+  - app_badge_plus (1.3.0):
     - Flutter
   - app_links (7.0.0):
     - Flutter
@@ -58,6 +58,8 @@ PODS:
   - home_widget (0.0.1):
     - Flutter
   - image_picker_ios (0.0.1):
+    - Flutter
+  - in_app_review (2.0.0):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
@@ -158,6 +160,7 @@ DEPENDENCIES:
   - google_mlkit_text_recognition (from `.symlinks/plugins/google_mlkit_text_recognition/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -224,6 +227,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/home_widget/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  in_app_review:
+    :path: ".symlinks/plugins/in_app_review/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   mobile_scanner:
@@ -254,7 +259,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/workmanager_apple/ios"
 
 SPEC CHECKSUMS:
-  app_badge_plus: 09939f19a075cc742cc155d8ed85e6d8601f0104
+  app_badge_plus: 21153eba871df802355eda3a9c316a228014c38c
   app_links: a754cbec3c255bd4bbb4d236ecc06f28cd9a7ce8
   camera_avfoundation: 968a9a5323c79a99c166ad9d7866bfd2047b5a9b
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
@@ -275,6 +280,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   home_widget: 54b4f6b36ed8d64cfee594a476225c35c3e45091
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   MLImage: 0de5c6c2bf9e93b80ef752e2797f0836f03b58c0
   MLKitCommon: 47d47b50a031d00db62f1b0efe5a1d8b09a3b2e6
@@ -300,6 +306,6 @@ SPEC CHECKSUMS:
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: 09c30bf7958e7da254512f11ad5352db42437d08
+PODFILE CHECKSUM: 1f10bc785de88a9ba6993b790b26e2ab35a7ddcb
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,16 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		147DDAF0846E20662D77E04B /* TankstellenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2E07975AC9E60A1BEB9B103C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C4E7855C3D7D6AF8148EDF /* Pods_Runner.framework */; };
+		314AA9FE74D319B7145C3199 /* NearestStationsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C8A9CAC0B84B64CE59171 /* NearestStationsWidgetView.swift */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+		35A2294918D818734C462990 /* StationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56BA2B737BFEAFAF64046B1 /* StationRow.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		A1A2A3A41E000001A0000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A2A3A41E000002A0000002 /* PrivacyInfo.xcprivacy */; };
+		595226A68EC384B12AF0A93F /* TankstellenWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		5E24927367580828DD745BD3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 53F08202EBE1619234A8ED70 /* Assets.xcassets */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A1A2A3A41E000001A0000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A2A3A41E000002A0000002 /* PrivacyInfo.xcprivacy */; };
+		C1D3C7BC3EE97D07059B912D /* NearestStationsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */; };
+		E05A76E23ACD50B61271D84D /* NearestStationsEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB9171C55A8C662C3106F67 /* NearestStationsEntry.swift */; };
 		E128B0129985B6FE9E2D5787 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE182BA7429614C5B4D896D8 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -28,9 +35,27 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
+		9EE0D6A3CA0DDF817BC0E263 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 93721746CA3E1F2E3FDD41E7;
+			remoteInfo = TankstellenWidget;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		45329B3DFE28CB2FC1D262E3 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				595226A68EC384B12AF0A93F /* TankstellenWidget.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -44,6 +69,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		021C8A9CAC0B84B64CE59171 /* NearestStationsWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearestStationsWidgetView.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		2815EFFDECEACD9EAFE42DF1 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -51,12 +77,17 @@
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		48958D39212C2CFDBF19D6DB /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TankstellenWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		53F08202EBE1619234A8ED70 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5B40EDA15C62D6CFC7C19599 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6AB9171C55A8C662C3106F67 /* NearestStationsEntry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearestStationsEntry.swift; sourceTree = "<group>"; };
 		71ACA3F4B705566570168EA7 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		74ED0D0DF9B4CEABF67FA791 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearestStationsProvider.swift; sourceTree = "<group>"; };
 		8B50DFEEBB486D1837152140 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -66,8 +97,12 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A1A2A3A41E000002A0000002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		AA0B2B41CF68C8C0A67F6D1B /* Runner.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		AE182BA7429614C5B4D896D8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C56BA2B737BFEAFAF64046B1 /* StationRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationRow.swift; sourceTree = "<group>"; };
+		D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TankstellenWidget.swift; sourceTree = "<group>"; };
 		E1C4E7855C3D7D6AF8148EDF /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6531D801740AA014ACC14D5 /* TankstellenWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = TankstellenWidget.entitlements; sourceTree = "<group>"; };
 		FCDDFC2EC66983E39B25D3E3 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -85,6 +120,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E128B0129985B6FE9E2D5787 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EB1A513B4189C76F812BC56 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +183,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				48223D43EF95E78CB3116309 /* Pods */,
 				94FD599D3EDAEA94F4AA4DC8 /* Frameworks */,
+				BB807E639934B03C01FF6EA6 /* TankstellenWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -149,6 +192,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -166,8 +210,25 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				AA0B2B41CF68C8C0A67F6D1B /* Runner.entitlements */,
 			);
 			path = Runner;
+			sourceTree = "<group>";
+		};
+		BB807E639934B03C01FF6EA6 /* TankstellenWidget */ = {
+			isa = PBXGroup;
+			children = (
+				D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */,
+				844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */,
+				6AB9171C55A8C662C3106F67 /* NearestStationsEntry.swift */,
+				021C8A9CAC0B84B64CE59171 /* NearestStationsWidgetView.swift */,
+				C56BA2B737BFEAFAF64046B1 /* StationRow.swift */,
+				53F08202EBE1619234A8ED70 /* Assets.xcassets */,
+				5B40EDA15C62D6CFC7C19599 /* Info.plist */,
+				E6531D801740AA014ACC14D5 /* TankstellenWidget.entitlements */,
+			);
+			name = TankstellenWidget;
+			path = TankstellenWidget;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -192,6 +253,23 @@
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		93721746CA3E1F2E3FDD41E7 /* TankstellenWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECC313F578CA4907DC3BC3F8 /* Build configuration list for PBXNativeTarget "TankstellenWidget" */;
+			buildPhases = (
+				9BAFB66FF1794AC92703AD8F /* Sources */,
+				9EB1A513B4189C76F812BC56 /* Frameworks */,
+				59A59997DFA370B8B6B6A173 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TankstellenWidget;
+			productName = TankstellenWidget;
+			productReference = 4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -202,6 +280,7 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				45329B3DFE28CB2FC1D262E3 /* Embed Foundation Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CAE2517D1F9C279634E0A884 /* [CP] Embed Pods Frameworks */,
 				974CFC8E83812C33DAFE05D8 /* [CP] Copy Pods Resources */,
@@ -209,6 +288,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				13B275AD898B08629DDCF912 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
@@ -250,6 +330,7 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				93721746CA3E1F2E3FDD41E7 /* TankstellenWidget */,
 			);
 		};
 /* End PBXProject section */
@@ -259,6 +340,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		59A59997DFA370B8B6B6A173 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E24927367580828DD745BD3 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -407,9 +496,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9BAFB66FF1794AC92703AD8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				147DDAF0846E20662D77E04B /* TankstellenWidget.swift in Sources */,
+				C1D3C7BC3EE97D07059B912D /* NearestStationsProvider.swift in Sources */,
+				E05A76E23ACD50B61271D84D /* NearestStationsEntry.swift in Sources */,
+				314AA9FE74D319B7145C3199 /* NearestStationsWidgetView.swift in Sources */,
+				35A2294918D818734C462990 /* StationRow.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		13B275AD898B08629DDCF912 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TankstellenWidget;
+			target = 93721746CA3E1F2E3FDD41E7 /* TankstellenWidget */;
+			targetProxy = 9EE0D6A3CA0DDF817BC0E263 /* PBXContainerItemProxy */;
+		};
 		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
@@ -484,7 +591,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -495,6 +602,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -517,10 +625,46 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
+		};
+		2CAC6D94A6BE367A38F663DB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = TankstellenWidget/TankstellenWidget.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = C4Y5RDF8P9;
+				INFOPLIST_FILE = TankstellenWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Sparkilo;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.TankstellenWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore de.tankstellen.tankstellen.TankstellenWidget";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -569,6 +713,42 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+			};
+			name = Profile;
+		};
+		7CC3A0BC7A7CFBBE6393CE42 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = TankstellenWidget/TankstellenWidget.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = C4Y5RDF8P9;
+				INFOPLIST_FILE = TankstellenWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Sparkilo;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.TankstellenWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
 		};
@@ -625,7 +805,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -678,7 +858,7 @@
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -689,6 +869,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -712,7 +893,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -723,6 +904,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -745,10 +927,46 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		FA573155DB42610EE48B0F3F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9740EEB31CF90195004384FC /* Generated.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = TankstellenWidget/TankstellenWidget.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = C4Y5RDF8P9;
+				INFOPLIST_FILE = TankstellenWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Sparkilo;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.TankstellenWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
@@ -779,6 +997,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECC313F578CA4907DC3BC3F8 /* Build configuration list for PBXNativeTarget "TankstellenWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2CAC6D94A6BE367A38F663DB /* Release */,
+				FA573155DB42610EE48B0F3F /* Debug */,
+				7CC3A0BC7A7CFBBE6393CE42 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/TankstellenWidget.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/TankstellenWidget.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93721746CA3E1F2E3FDD41E7"
+               BuildableName = "TankstellenWidget.appex"
+               BlueprintName = "TankstellenWidget"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/TankstellenWidget/NearestStationsWidgetView.swift
+++ b/ios/TankstellenWidget/NearestStationsWidgetView.swift
@@ -56,6 +56,7 @@ struct NearestStationsWidgetView: View {
             // landing without trying to open a station detail.
             URL(string: "tankstellenwidget://station?id=__widget_root__")
         )
+        .widgetBackgroundCompat()
     }
 
     private var header: some View {
@@ -119,6 +120,24 @@ private struct StationRowView: View {
                         .monospacedDigit()
                 }
             }
+        }
+    }
+}
+
+private extension View {
+    /// iOS 17 requires widgets to adopt `containerBackground(for: .widget)`
+    /// — without it WidgetKit renders a "Please adopt containerBackground
+    /// API" placeholder instead of the widget content. On iOS 16 (our
+    /// deployment target is 16.6) the in-view ZStack background above is
+    /// still the rendering path, so the shim is a no-op there.
+    @ViewBuilder
+    func widgetBackgroundCompat() -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            containerBackground(for: .widget) {
+                Color(.systemBackground)
+            }
+        } else {
+            self
         }
     }
 }

--- a/scripts/add_ios_widget_target.rb
+++ b/scripts/add_ios_widget_target.rb
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# Wires the TankstellenWidget WidgetKit extension target into
+# ios/Runner.xcodeproj (#3166).
+#
+# The ~405 LOC of SwiftUI widget code under ios/TankstellenWidget/ shipped
+# source-tracked but was never part of any Xcode build target — this script
+# performs the "Required Xcode work" of docs/guides/ios-widget-extension.md
+# reproducibly from the command line via the xcodeproj gem (bundled with the
+# fastlane stack):
+#
+#   1. adds an app-extension PBXNativeTarget "TankstellenWidget"
+#      (com.apple.product-type.app-extension, bundle id
+#      de.tankstellen.tankstellen.TankstellenWidget),
+#   2. compiles the five tracked Swift sources + Assets.xcassets, with the
+#      tracked Info.plist / TankstellenWidget.entitlements,
+#   3. bases every widget configuration on Flutter/Generated.xcconfig so
+#      CFBundleVersion ($(FLUTTER_BUILD_NUMBER)) tracks the host app,
+#   4. embeds the .appex in Runner via an "Embed Foundation Extensions"
+#      copy-files phase + target dependency,
+#   5. points Runner at ios/Runner/Runner.entitlements (the App Group
+#      entitlement file existed but was never referenced by
+#      CODE_SIGN_ENTITLEMENTS — without it the host app is signed WITHOUT
+#      the group and UserDefaults(suiteName:) sharing silently fails),
+#   6. mirrors Runner's signing per configuration: Automatic (team
+#      C4Y5RDF8P9) for Debug/Profile, Manual + match AppStore profile for
+#      Release,
+#   7. saves a shared build scheme for the new target.
+#
+# Idempotent: re-running on a project that already has the target is a no-op.
+#
+# Usage (from the repo root):
+#   ruby scripts/add_ios_widget_target.rb
+
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../ios/Runner.xcodeproj', __dir__)
+WIDGET_NAME = 'TankstellenWidget'.freeze
+WIDGET_BUNDLE_ID = 'de.tankstellen.tankstellen.TankstellenWidget'.freeze
+TEAM_ID = 'C4Y5RDF8P9'.freeze
+DEPLOYMENT_TARGET = '16.6'.freeze # matches the Runner target's setting
+SWIFT_SOURCES = %w[
+  TankstellenWidget.swift
+  NearestStationsProvider.swift
+  NearestStationsEntry.swift
+  NearestStationsWidgetView.swift
+  StationRow.swift
+].freeze
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+runner = project.targets.find { |t| t.name == 'Runner' }
+abort 'Runner target not found' unless runner
+
+if project.targets.any? { |t| t.name == WIDGET_NAME }
+  puts "#{WIDGET_NAME} target already present — nothing to do."
+  exit 0
+end
+
+generated_xcconfig = project.files.find { |f| f.path == 'Flutter/Generated.xcconfig' }
+abort 'Flutter/Generated.xcconfig reference not found' unless generated_xcconfig
+
+# --- 1. The extension target (also creates the .appex product reference and
+# one build configuration per project configuration: Debug/Release/Profile).
+widget = project.new_target(:app_extension, WIDGET_NAME, :ios, DEPLOYMENT_TARGET)
+
+# --- 2. Group + tracked files.
+group = project.main_group.new_group(WIDGET_NAME, WIDGET_NAME)
+swift_refs = SWIFT_SOURCES.map { |f| group.new_file(f) }
+assets_ref = group.new_file('Assets.xcassets')
+group.new_file('Info.plist')
+group.new_file("#{WIDGET_NAME}.entitlements")
+
+widget.add_file_references(swift_refs)
+widget.resources_build_phase.add_file_reference(assets_ref)
+
+# new_target links Foundation.framework via a file reference pinned to a
+# hard-coded SDK directory name that drifts with every Xcode release (and
+# does not exist on this machine's SDK). Swift auto-links Foundation /
+# SwiftUI / WidgetKit from the imports, so drop the explicit link.
+widget.frameworks_build_phase.files.dup.each do |bf|
+  ref = bf.file_ref
+  widget.frameworks_build_phase.remove_build_file(bf)
+  ref.remove_from_project if ref && ref.build_files.empty?
+end
+# ...and the now-empty "iOS" SDK-frameworks group it created.
+frameworks_group = project.main_group['Frameworks']
+if frameworks_group
+  ios_group = frameworks_group.children.find do |c|
+    c.is_a?(Xcodeproj::Project::Object::PBXGroup) &&
+      c.display_name == 'iOS' && c.empty?
+  end
+  ios_group&.remove_from_project
+end
+
+# --- 3. Build settings. Replace the xcodeproj template defaults wholesale so
+# the result matches what Xcode's own widget-extension template would write,
+# adapted to this project's conventions (versions pinned to the host via
+# Generated.xcconfig's FLUTTER_BUILD_NUMBER, signing mirroring Runner).
+widget.build_configurations.each do |config|
+  # Generated.xcconfig provides FLUTTER_BUILD_NUMBER / FLUTTER_ROOT. Do NOT
+  # use Flutter/Debug|Release.xcconfig here — those #include the Pods-Runner
+  # xcconfigs, which would inject the host app's pod link flags into the
+  # extension.
+  config.base_configuration_reference = generated_xcconfig
+
+  bs = config.build_settings
+  bs.clear
+  bs['ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME'] = 'AccentColor'
+  bs['ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME'] = 'WidgetBackground'
+  bs['CLANG_ENABLE_MODULES'] = 'YES'
+  bs['CODE_SIGN_ENTITLEMENTS'] = "#{WIDGET_NAME}/#{WIDGET_NAME}.entitlements"
+  bs['CURRENT_PROJECT_VERSION'] = '$(FLUTTER_BUILD_NUMBER)'
+  bs['DEVELOPMENT_TEAM'] = TEAM_ID
+  bs['INFOPLIST_FILE'] = "#{WIDGET_NAME}/Info.plist"
+  bs['INFOPLIST_KEY_CFBundleDisplayName'] = 'Sparkilo'
+  bs['IPHONEOS_DEPLOYMENT_TARGET'] = DEPLOYMENT_TARGET
+  bs['LD_RUNPATH_SEARCH_PATHS'] = [
+    '$(inherited)',
+    '@executable_path/Frameworks',
+    '@executable_path/../../Frameworks',
+  ]
+  # Track the host app exactly: Runner/Info.plist uses $(FLUTTER_BUILD_NAME)
+  # / $(FLUTTER_BUILD_NUMBER) and App Store validation requires the
+  # extension's CFBundleShortVersionString to match the containing app's.
+  bs['MARKETING_VERSION'] = '$(FLUTTER_BUILD_NAME)'
+  bs['PRODUCT_BUNDLE_IDENTIFIER'] = WIDGET_BUNDLE_ID
+  bs['PRODUCT_NAME'] = '$(TARGET_NAME)'
+  bs['SKIP_INSTALL'] = 'YES'
+  bs['SUPPORTED_PLATFORMS'] = 'iphoneos iphonesimulator'
+  bs['SUPPORTS_MACCATALYST'] = 'NO'
+  bs['SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD'] = 'NO'
+  bs['SWIFT_VERSION'] = '5.0'
+  bs['TARGETED_DEVICE_FAMILY'] = '1'
+  bs['VERSIONING_SYSTEM'] = 'apple-generic'
+
+  case config.name
+  when 'Debug'
+    bs['CODE_SIGN_IDENTITY'] = 'Apple Development'
+    bs['CODE_SIGN_STYLE'] = 'Automatic'
+    bs['PROVISIONING_PROFILE_SPECIFIER'] = ''
+    bs['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = 'DEBUG'
+    bs['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
+  when 'Release'
+    # Mirrors Runner's Release config: manual signing against the fastlane
+    # match distribution profile. The profile does not exist until the
+    # widget App ID + App Group are registered in the Apple Developer
+    # Portal and `match appstore --force` is re-run (see
+    # docs/guides/ios-widget-extension.md, "Required Apple Developer
+    # Portal work").
+    bs['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = 'Apple Distribution'
+    bs['CODE_SIGN_STYLE'] = 'Manual'
+    bs['PROVISIONING_PROFILE_SPECIFIER'] = "match AppStore #{WIDGET_BUNDLE_ID}"
+    bs['SWIFT_COMPILATION_MODE'] = 'wholemodule'
+    bs['SWIFT_OPTIMIZATION_LEVEL'] = '-O'
+  when 'Profile'
+    bs['CODE_SIGN_IDENTITY'] = 'Apple Development'
+    bs['CODE_SIGN_STYLE'] = 'Automatic'
+    bs['PROVISIONING_PROFILE_SPECIFIER'] = ''
+    bs['SWIFT_COMPILATION_MODE'] = 'wholemodule'
+    bs['SWIFT_OPTIMIZATION_LEVEL'] = '-O'
+  end
+end
+
+# --- 4. Embed the .appex in Runner + build-order dependency.
+#
+# The phase MUST come before Flutter's "Thin Binary" script phase (per the
+# Flutter app-extension docs): Thin Binary rewrites the whole .app bundle,
+# so an appex copy scheduled after it forms a dependency cycle that Xcode's
+# build system rejects ("Cycle inside Runner").
+embed = runner.copy_files_build_phases.find { |p| p.name == 'Embed Foundation Extensions' }
+unless embed
+  embed = project.new(Xcodeproj::Project::Object::PBXCopyFilesBuildPhase)
+  embed.name = 'Embed Foundation Extensions'
+  embed.symbol_dst_subfolder_spec = :plug_ins
+  embed.dst_path = ''
+  thin_binary = runner.build_phases.find { |p| p.display_name == 'Thin Binary' }
+  insert_at = thin_binary ? runner.build_phases.index(thin_binary) : runner.build_phases.length
+  runner.build_phases.insert(insert_at, embed)
+end
+build_file = embed.add_file_reference(widget.product_reference)
+build_file.settings = { 'ATTRIBUTES' => ['RemoveHeadersOnCopy'] }
+runner.add_dependency(widget)
+
+# --- 5. Wire the (pre-existing but never referenced) Runner entitlements so
+# the host app is actually signed with the App Group.
+runner_group = project.main_group['Runner']
+unless runner_group.files.any? { |f| f.path == 'Runner.entitlements' }
+  runner_group.new_file('Runner.entitlements')
+end
+runner.build_configurations.each do |config|
+  config.build_settings['CODE_SIGN_ENTITLEMENTS'] ||= 'Runner/Runner.entitlements'
+end
+
+project.save
+
+# --- 6. Shared scheme so `xcodebuild -list` / CI can address the target.
+scheme = Xcodeproj::XCScheme.new
+scheme.add_build_target(widget)
+scheme.save_as(PROJECT_PATH, WIDGET_NAME, true)
+
+puts "Added #{WIDGET_NAME} target (#{WIDGET_BUNDLE_ID}) to #{PROJECT_PATH}"


### PR DESCRIPTION
## Wire the TankstellenWidget extension into Runner.xcodeproj

> ⚠️ **DO NOT MERGE until the two manual steps below are done** — both Runner and the widget now carry App Group entitlements, so the nightly `ios-testflight.yml` will fail at signing until the portal + match steps exist. No auto-merge armed.

From epic #3165: the ~405 LOC SwiftUI home widget existed in the repo but in no build target. This PR:

- Adds the `TankstellenWidget` WidgetKit extension target (`de.tankstellen.tankstellen.TankstellenWidget`, iOS 16.6, versions tracking `Generated.xcconfig` so CFBundleVersion/MARKETING_VERSION always match the host), embedded before Flutter's Thin-Binary phase (after it, Xcode 26 reports a build cycle). Reproducible via `scripts/add_ios_widget_target.rb` (xcodeproj gem, idempotent).
- **Fixes a latent signing bug**: Runner never referenced `Runner.entitlements` via `CODE_SIGN_ENTITLEMENTS` — the host app was signed *without* the App Group, so widget↔app `UserDefaults` sharing could never have worked. App-group ID verified consistent across Swift, Dart and both entitlements files.
- One Swift fix in the unshipped code: availability-gated `containerBackground(for: .widget)` (iOS 17 renders a placeholder without it).
- Validated: full `flutter build ios --no-codesign` exit 0 with the `.appex` correctly in `Runner.app/PlugIns/` (arm64, right bundle id and extension point). The simulator-SDK `xcodebuild` failure is pre-existing ML Kit arm64-sim rot, unrelated.

### Manual steps before merge (maintainer)
1. **Apple Developer portal** (account fdittgen@gmx.de): create App Group `group.de.tankstellen.tankstellen`; enable App Groups on `de.tankstellen.tankstellen`; create the `…TankstellenWidget` App ID with the same group.
2. **fastlane match**: add the widget bundle id to `ios/fastlane/Matchfile` and to `build_appstore`'s `provisioningProfiles` in `ios/fastlane/Fastfile`, then run `match appstore` (+ development) to mint profiles with the App Group capability.

Then arm auto-merge. Closes #3166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
