### PR TITLE
perf(es): parsed-Station per-province cache on the shared keyed dataset mixin (#3156)

### DIFF
--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -202,3 +202,114 @@ mixin CachedDatasetMixin {
     }
   }
 }
+
+/// Keyed variant of [CachedDatasetMixin] (#3156).
+///
+/// Some bulk feeds are not ONE national dataset but a *family* of datasets
+/// keyed by a sub-national identifier (ES MITECO: one row set per province).
+/// [CachedDatasetMixin] is single-dataset — one freshness clock, one in-flight
+/// fetch slot — which forced MITECO to hand-roll the very same TTL /
+/// read-through / offline-fallback state machine, a fork where mixin fixes
+/// (the #2313 fetch dedupe, the #3154 off-isolate disk deserialize) never
+/// reached Spain. This mixin is that state machine with per-[key] clocks and
+/// in-flight slots.
+mixin KeyedCachedDatasetMixin {
+  final Map<String, DateTime> _keyedCachedAt = {};
+
+  /// Per-key in-flight fetch slots — same #2313 dedupe contract as
+  /// [CachedDatasetMixin]: concurrent callers for the SAME key share one
+  /// download (the first caller's closure, so a later caller's `CancelToken`
+  /// only awaits, never cancels); different keys fetch independently.
+  final Map<String, Future<dynamic>> _keyedPendingLoads = {};
+
+  /// Whether the in-memory dataset for [key] is still fresh.
+  bool isKeyedDatasetFresh(String key, Duration ttl) {
+    final cachedAt = _keyedCachedAt[key];
+    return cachedAt != null && DateTime.now().difference(cachedAt) < ttl;
+  }
+
+  /// Mark [key]'s in-memory dataset as just refreshed.
+  void markKeyedDatasetRefreshed(String key) =>
+      _keyedCachedAt[key] = DateTime.now();
+
+  /// Stamp [key]'s freshness clock to [age] ago — used when a dataset is
+  /// rehydrated from disk so its remaining freshness reflects the persisted
+  /// copy's age, not the moment of rehydration (#2264).
+  void markKeyedDatasetRefreshedAt(String key, Duration age) =>
+      _keyedCachedAt[key] = DateTime.now().subtract(age);
+
+  /// Per-key [CachedDatasetMixin.loadPersistentDataset] — identical
+  /// soft/hard-TTL, read-through, dedupe and offline-fallback semantics, with
+  /// two host-shaped differences:
+  ///
+  ///  - [persistent] is nullable, so hosts whose disk cache is optional (the
+  ///    pure in-memory parser tests pass no [CacheStrategy]) run the same code
+  ///    path minus the disk steps, and
+  ///  - when [fetch] fails and no disk copy exists, a stale in-memory [cached]
+  ///    copy is served as the last resort before rethrowing (the pre-#3156
+  ///    MITECO offline behaviour: hours-stale province rows beat failing the
+  ///    whole search).
+  Future<T> loadKeyedPersistentDataset<T>({
+    required String key,
+    required T? cached,
+    required Duration softTtl,
+    required Duration hardTtl,
+    required PersistentDataset<T>? persistent,
+    required Future<T> Function() fetch,
+    required void Function(T value) store,
+  }) async {
+    if (cached != null && isKeyedDatasetFresh(key, softTtl)) return cached;
+
+    // Disk read-through — survives cold start + offline; deserialize runs
+    // through compute() inside [PersistentDataset.readAsync] (#3154).
+    if (persistent != null &&
+        (cached == null || !isKeyedDatasetFresh(key, hardTtl))) {
+      final disk = await persistent.readAsync();
+      if (disk != null && disk.age <= hardTtl) {
+        store(disk.value);
+        markKeyedDatasetRefreshedAt(key, disk.age);
+        if (disk.age <= softTtl) return disk.value;
+        // Soft-stale: fall through to refresh, keeping the disk copy as the
+        // fallback if the network is unavailable.
+      }
+    }
+
+    try {
+      final value = await _dedupedKeyedFetch<T>(key, fetch);
+      store(value);
+      markKeyedDatasetRefreshed(key);
+      await persistent?.write(value, hardTtl: hardTtl);
+      return value;
+    } on Object {
+      // Network failed — serve any persisted copy rather than throw.
+      if (persistent != null) {
+        final disk = await persistent.readAsync(); // #3154 — off-isolate
+        if (disk != null) {
+          store(disk.value);
+          markKeyedDatasetRefreshedAt(key, disk.age);
+          return disk.value;
+        }
+      }
+      // Last resort: a stale in-memory copy beats failing the search.
+      if (cached != null) return cached;
+      rethrow;
+    }
+  }
+
+  /// Per-key twin of the unkeyed mixin's deduped fetch (#2313): collapses
+  /// concurrent calls for the same [key] onto a single in-flight future,
+  /// clearing the slot once it settles so a later call refetches.
+  Future<T> _dedupedKeyedFetch<T>(String key, Future<T> Function() fetch) {
+    final inFlight = _keyedPendingLoads[key];
+    if (inFlight != null) return inFlight.then((v) => v as T);
+    final started = fetch();
+    _keyedPendingLoads[key] = started;
+    return started.whenComplete(() {
+      // Only clear if it's still our future (a later refetch may have
+      // replaced it).
+      if (identical(_keyedPendingLoads[key], started)) {
+        _keyedPendingLoads.remove(key);
+      }
+    });
+  }
+}

--- a/lib/core/services/persistent_dataset.dart
+++ b/lib/core/services/persistent_dataset.dart
@@ -79,8 +79,9 @@ class PersistentDataset<T> {
   /// nothing is persisted / it fails to deserialize.
   ///
   /// Synchronous variant — deserializes **on the calling isolate**. Kept for
-  /// callers with small per-key payloads (the ES per-province rows); bulk
-  /// whole-country readers go through [readAsync] (#3154).
+  /// [readWithin] and small-payload test assertions; every production dataset
+  /// reader goes through [readAsync] (#3154; ES moved onto it via the keyed
+  /// mixin in #3156).
   ({T value, Duration age})? read() {
     final entry = _cache.get(_key);
     if (entry == null) return null;

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -9,6 +9,7 @@ import '../../search/domain/entities/station.dart';
 import '../../../core/cache/cache_manager.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/services/dio_factory.dart';
+import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
@@ -25,7 +26,9 @@ import 'spain_provinces.dart';
 /// The API has no coordinate/radius search — only by province/municipality.
 /// Strategy: fetch all stations, calculate distances locally, filter by radius.
 /// The full dataset (~12,000 stations) is cached aggressively.
-class MitecoStationService with StationServiceHelpers implements StationService {
+class MitecoStationService
+    with StationServiceHelpers, KeyedCachedDatasetMixin
+    implements StationService {
   static const String defaultBaseUrl =
       'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
       '/PreciosCarburantes';
@@ -34,6 +37,7 @@ class MitecoStationService with StationServiceHelpers implements StationService 
   final String _baseUrl;
   final CacheStrategy? _cache;
   final DateTime Function() _now;
+  final WeeklyOpeningHours Function(String horario) _parseOpeningHours;
 
   /// #2181 — Dio injectable for tests; defaults to the standard factory.
   /// #2193 — [baseUrl] injectable too, harmonising the override surface
@@ -42,11 +46,14 @@ class MitecoStationService with StationServiceHelpers implements StationService 
   /// omit it for the pure in-memory behaviour the parser tests rely on.
   /// #3189 — [now] is the clock seam for the schedule-derived `isOpen`;
   /// defaults to the wall clock.
+  /// #3156 — [parseOpeningHours] is the parse-count seam for the no-re-parse
+  /// regression test; defaults to the real [SpainOpeningHoursAdapter].
   MitecoStationService({
     Dio? dio,
     String? baseUrl,
     CacheStrategy? cache,
     DateTime Function()? now,
+    WeeklyOpeningHours Function(String horario)? parseOpeningHours,
   })  : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 20),
@@ -54,7 +61,9 @@ class MitecoStationService with StationServiceHelpers implements StationService 
             ),
         _baseUrl = baseUrl ?? defaultBaseUrl,
         _cache = cache,
-        _now = now ?? DateTime.now;
+        _now = now ?? DateTime.now,
+        _parseOpeningHours =
+            parseOpeningHours ?? const SpainOpeningHoursAdapter().parse;
 
   // #2264 — soft/hard dataset TTLs mirror the ES FuelServicePolicy (soft 6 h,
   // hard 24 h). The legacy single-list 10-minute cache is replaced by a
@@ -62,10 +71,19 @@ class MitecoStationService with StationServiceHelpers implements StationService 
   static const Duration _softTtl = Duration(hours: 6);
   static const Duration _hardTtl = Duration(hours: 24);
 
-  /// Per-province in-memory cache, keyed by `IDProvincia`. The previous single
-  /// unkeyed `_cachedStations` list meant the first province searched was
-  /// served for every later search regardless of location (#2264).
-  final Map<String, _ProvinceCache> _byProvince = {};
+  /// Per-province raw rows, keyed by `IDProvincia` (#2264 — province A's
+  /// stations are never served for B). Kept for [getStationDetail]'s id
+  /// lookup; they are also the persisted format, so the on-disk
+  /// `dataset:ES:province-<id>` entries of existing installs stay readable.
+  final Map<String, List<Map<String, dynamic>>> _rowsByProvince = {};
+
+  /// Per-province *parsed* [Station] templates (#3156). The expensive parse —
+  /// including the regex [SpainOpeningHoursAdapter] pass per row — runs ONCE
+  /// per dataset refresh (inside the keyed-mixin `store` callback), not on
+  /// every search; a dense province used to re-pay 800-2500 row parses per
+  /// repeat search. Templates carry placeholder `dist`/`isOpen`;
+  /// [_withSearchContext] stamps the real per-search values.
+  final Map<String, List<Station>> _stationsByProvince = {};
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -79,22 +97,38 @@ class MitecoStationService with StationServiceHelpers implements StationService 
       final provinceIds =
           spainProvincesNear(params.lat, params.lng, params.radiusKm);
 
-      final allStations = <Station>[];
+      // Dedupe across province borders by station id, pairing every cached
+      // template with its distance to the search centre. #3152
+      // filter-before-copyWith: only the in-result survivors below pay the
+      // `copyWith` + open-now computation.
+      final candidates = <(Station, double)>[];
       final seenIds = <String>{};
       for (final provinceId in provinceIds) {
-        final rawStations =
+        final templates =
             await _stationsForProvince(provinceId, cancelToken: cancelToken);
-        for (final r in rawStations) {
-          final station = _parseStation(r, params.lat, params.lng);
-          // Dedupe across province borders by station id.
-          if (station != null && seenIds.add(station.id)) {
-            allStations.add(station);
-          }
+        for (final t in templates) {
+          if (!seenIds.add(t.id)) continue;
+          candidates
+              .add((t, roundedDistance(params.lat, params.lng, t.lat, t.lng)));
         }
       }
 
-      // Filter by radius; if nothing found, return nearest 20
-      final stations = filterByRadius(allStations, params.radiusKm);
+      // Same semantics as [StationServiceHelpers.filterByRadius] (within
+      // radius; if nothing found, the nearest 20), applied on the (template,
+      // dist) pairs so out-of-radius templates are never materialised.
+      var survivors = [
+        for (final c in candidates)
+          if (c.$2 <= params.radiusKm) c,
+      ];
+      if (survivors.isEmpty && candidates.isNotEmpty) {
+        candidates.sort((a, b) => a.$2.compareTo(b.$2));
+        survivors = candidates.take(20).toList();
+      }
+
+      final stations = [
+        for (final (template, dist) in survivors)
+          _withSearchContext(template, dist),
+      ];
 
       // Sort
       sortStations(stations, params);
@@ -105,45 +139,36 @@ class MitecoStationService with StationServiceHelpers implements StationService 
     }
   }
 
-  /// Returns the raw station rows for one province, served from (in order):
-  /// the fresh in-memory copy, the persisted Hive copy (read-through, when a
-  /// cache is wired), then the network — and persisted on a fresh fetch.
-  Future<List<Map<String, dynamic>>> _stationsForProvince(
+  /// Returns the parsed [Station] templates for one province, served from (in
+  /// order): the fresh in-memory copy, the persisted Hive copy (read-through,
+  /// when a cache is wired), then the network — and persisted on a fresh
+  /// fetch. The TTL / read-through / dedupe / offline state machine lives in
+  /// the shared [KeyedCachedDatasetMixin] (#3156 — it used to be hand-rolled
+  /// here, a fork that mixin fixes never reached); this method only wires the
+  /// per-province seams and parses rows → templates once per refresh.
+  Future<List<Station>> _stationsForProvince(
     String provinceId, {
     CancelToken? cancelToken,
   }) async {
-    final mem = _byProvince[provinceId];
-    if (mem != null &&
-        DateTime.now().difference(mem.fetchedAt) < _softTtl) {
-      return mem.rows;
-    }
-
-    final persistent = _persistentFor(provinceId);
-    if (persistent != null) {
-      final disk = persistent.read();
-      if (disk != null && disk.age <= _hardTtl) {
-        _byProvince[provinceId] =
-            _ProvinceCache(disk.value, DateTime.now().subtract(disk.age));
-        if (disk.age <= _softTtl) return disk.value;
-      }
-    }
-
-    try {
-      final rows = await _fetchProvince(provinceId, cancelToken: cancelToken);
-      _byProvince[provinceId] = _ProvinceCache(rows, DateTime.now());
-      await persistent?.write(rows, hardTtl: _hardTtl);
-      return rows;
-    } on Object {
-      // Network failed — serve any persisted/in-memory copy rather than throw.
-      final disk = persistent?.read();
-      if (disk != null) {
-        _byProvince[provinceId] =
-            _ProvinceCache(disk.value, DateTime.now().subtract(disk.age));
-        return disk.value;
-      }
-      if (mem != null) return mem.rows;
-      rethrow;
-    }
+    await loadKeyedPersistentDataset<List<Map<String, dynamic>>>(
+      key: provinceId,
+      cached: _rowsByProvince[provinceId],
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: _persistentFor(provinceId),
+      fetch: () => _fetchProvince(provinceId, cancelToken: cancelToken),
+      store: (rows) {
+        _rowsByProvince[provinceId] = rows;
+        // #3156 — parse once per dataset refresh, NOT once per search. The
+        // two maps are only ever written together here, so a non-null
+        // `_rowsByProvince[id]` guarantees its parsed twin below.
+        _stationsByProvince[provinceId] =
+            rows.map(_parseStation).whereType<Station>().toList(
+                  growable: false,
+                );
+      },
+    );
+    return _stationsByProvince[provinceId] ?? const [];
   }
 
   PersistentDataset<List<Map<String, dynamic>>>? _persistentFor(
@@ -187,9 +212,13 @@ class MitecoStationService with StationServiceHelpers implements StationService 
     return list.cast<Map<String, dynamic>>();
   }
 
-  Station? _parseStation(
-    Map<String, dynamic> r, double searchLat, double searchLng,
-  ) {
+  /// Parse one raw MITECO row into a [Station] *template* (#3156): every
+  /// search-independent field is final, while `dist` (0 placeholder) and
+  /// `isOpen` (legacy heuristic placeholder) are stamped per search / detail
+  /// tap by [_withSearchContext]. Templates are cached per province in
+  /// [_stationsByProvince], so this — including the regex opening-hours
+  /// adapter — runs once per dataset refresh.
+  Station? _parseStation(Map<String, dynamic> r) {
     try {
       // Coordinates use comma as decimal separator
       final lat = _parseCommaDouble(r['Latitud']?.toString());
@@ -207,23 +236,7 @@ class MitecoStationService with StationServiceHelpers implements StationService 
       // [WeeklyOpeningHours]. The legacy `openingHoursText` / `isOpen` stay
       // for back-compat; the structured `weeklyHours` is the canonical
       // signal the #2706 detail-fallback threads into the detail screen.
-      final weeklyHours = const SpainOpeningHoursAdapter().parse(horario);
-
-      // #3189 — derive isOpen from the parsed schedule when available (the
-      // old heuristic returned true for ANY non-empty horario, so a
-      // "L-V: 06:00-23:00" station showed open at 3 AM). When the schedule is
-      // unusable, fall back to the legacy non-empty heuristic.
-      final fallbackOpen = horario.isNotEmpty && horario != 'Cerrado';
-      final bool isOpen;
-      if (weeklyHours.availability == OpeningHoursAvailability.notProvided) {
-        isOpen = fallbackOpen;
-      } else {
-        isOpen = switch (computeOpenNow(weeklyHours, _now()).status) {
-          OpenStatus.open => true,
-          OpenStatus.closed => false,
-          OpenStatus.unknown => fallbackOpen,
-        };
-      }
+      final weeklyHours = _parseOpeningHours(horario);
 
       // #753 — `es-` prefix so a MITECO `IDEESS` (bare numeric) cannot
       // collide with another country's numeric id space.
@@ -239,7 +252,9 @@ class MitecoStationService with StationServiceHelpers implements StationService 
         place: city,
         lat: lat,
         lng: lng,
-        dist: roundedDistance(searchLat, searchLng, lat, lng),
+        // Placeholder — [_withSearchContext] stamps the real per-search
+        // distance (templates are parsed before any search centre is known).
+        dist: 0,
         e5: _parseCommaDouble(r['Precio Gasolina 95 E5']?.toString()),
         e10: _parseCommaDouble(r['Precio Gasolina 95 E10']?.toString()),
         e98: _parseCommaDouble(r['Precio Gasolina 98 E5']?.toString()),
@@ -252,7 +267,9 @@ class MitecoStationService with StationServiceHelpers implements StationService 
             _parseCommaDouble(r['Precio Gasolina 95 E85']?.toString()),
         lpg: _parseCommaDouble(r['Precio Gases licuados del petróleo']?.toString()),
         cng: _parseCommaDouble(r['Precio Gas Natural Comprimido']?.toString()),
-        isOpen: isOpen,
+        // Placeholder (legacy non-empty heuristic) — [_withSearchContext]
+        // stamps the schedule-derived value at the moment of each search.
+        isOpen: horario.isNotEmpty && horario != 'Cerrado',
         openingHoursText: horario.isNotEmpty ? horario : null,
         openingHours: weeklyHours.availability ==
                 OpeningHoursAvailability.notProvided
@@ -268,6 +285,30 @@ class MitecoStationService with StationServiceHelpers implements StationService 
     }
   }
 
+  /// Stamp a cached [template] with the per-search values: the distance to
+  /// the search centre and the schedule-derived open state *at this moment*
+  /// (#3156 — `isOpen` is recomputed on every search precisely so the 6 h
+  /// province cache can never pin a stale open/closed flag; the pre-cache
+  /// code recomputed it implicitly by re-parsing every row).
+  Station _withSearchContext(Station template, double dist) =>
+      template.copyWith(dist: dist, isOpen: _isOpenNow(template));
+
+  /// #3189 open-now derivation, computed from the template's already-parsed
+  /// fields: the structured schedule when available (`openingHours` is null
+  /// exactly when the adapter returned `notProvided`), else the legacy
+  /// non-empty-horario heuristic.
+  bool _isOpenNow(Station template) {
+    final horario = template.openingHoursText ?? '';
+    final fallbackOpen = horario.isNotEmpty && horario != 'Cerrado';
+    final weeklyHours = template.openingHours;
+    if (weeklyHours == null) return fallbackOpen;
+    return switch (computeOpenNow(weeklyHours, _now()).status) {
+      OpenStatus.open => true,
+      OpenStatus.closed => false,
+      OpenStatus.unknown => fallbackOpen,
+    };
+  }
+
   /// Parse a number string that uses comma as decimal separator.
   /// "1,817" → 1.817, "" → null, null → null
   double? _parseCommaDouble(String? value) {
@@ -280,7 +321,7 @@ class MitecoStationService with StationServiceHelpers implements StationService 
     String stationId,
   ) async {
     // #2706 — MITECO is a BULK feed: there is no per-station detail endpoint.
-    // A search already cached every province's full rows in [_byProvince],
+    // A search already cached every province's full rows in [_rowsByProvince],
     // and each row carries name/brand/street/prices/coords. So a detail tap
     // that falls through the provider's in-search fast path (widget rows,
     // deep links, favorites) is resolved from that cache rather than throwing.
@@ -289,14 +330,12 @@ class MitecoStationService with StationServiceHelpers implements StationService 
         : stationId;
     final row = _findCachedRow(rawId);
     if (row != null) {
-      final lat = _parseCommaDouble(row['Latitud']?.toString()) ?? 0;
-      final lng = _parseCommaDouble(row['Longitud (WGS84)']?.toString()) ?? 0;
-      // Reuse the search parser; `dist` is irrelevant on the detail screen so
-      // the station's own coords double as the (no-op) search centre.
-      final station = _parseStation(row, lat, lng);
-      if (station != null) {
+      // Reuse the search parser; `dist` is irrelevant on the detail screen
+      // (stamped 0, as the pre-#3156 own-coords-as-centre parse yielded).
+      final template = _parseStation(row);
+      if (template != null) {
         return ServiceResult<StationDetail>(
-          data: StationDetail(station: station),
+          data: StationDetail(station: _withSearchContext(template, 0)),
           source: ServiceSource.cache,
           fetchedAt: DateTime.now(),
         );
@@ -310,10 +349,10 @@ class MitecoStationService with StationServiceHelpers implements StationService 
 
   /// Linear scan of every cached province for the raw `IDEESS` row matching
   /// [rawId] (#2706). A per-detail-tap scan is cheap and deliberately does NOT
-  /// restructure [_byProvince] (that would collide with the #2713 OH adapter).
+  /// restructure [_rowsByProvince].
   Map<String, dynamic>? _findCachedRow(String rawId) {
-    for (final province in _byProvince.values) {
-      for (final row in province.rows) {
+    for (final rows in _rowsByProvince.values) {
+      for (final row in rows) {
         if (row['IDEESS']?.toString() == rawId) return row;
       }
     }
@@ -326,13 +365,4 @@ class MitecoStationService with StationServiceHelpers implements StationService 
   ) async {
     return emptyPricesResult(ServiceSource.mitecoApi);
   }
-}
-
-/// One province's cached raw rows + when they were fetched (#2264). Keyed by
-/// `IDProvincia` in [MitecoStationService._byProvince] so province A's
-/// stations are never served for a search in province B.
-class _ProvinceCache {
-  final List<Map<String, dynamic>> rows;
-  final DateTime fetchedAt;
-  const _ProvinceCache(this.rows, this.fetchedAt);
 }

--- a/test/core/services/mixins/keyed_cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/keyed_cached_dataset_mixin_test.dart
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3156 — KeyedCachedDatasetMixin: the CachedDatasetMixin state machine with
+// per-key freshness clocks + in-flight fetch slots, for bulk feeds that are a
+// FAMILY of datasets (ES MITECO: one row set per province). Also covers the
+// two host-shaped deltas vs the unkeyed mixin: a nullable [persistent] (the
+// pure in-memory parser tests) and the stale-in-memory last-resort fallback
+// when a fetch fails with no disk copy.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/mixins/cached_dataset_mixin.dart';
+import 'package:tankstellen/core/services/persistent_dataset.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+
+class _TestKeyed with KeyedCachedDatasetMixin {}
+
+/// Tiny in-memory CacheStrategy for the persistence tests.
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+
+  @override
+  Future<void> put(String key, Map<String, dynamic> data,
+      {required Duration ttl, required ServiceSource source}) async {
+    _store[key] = CacheEntry(
+        payload: data,
+        storedAt: DateTime.now(),
+        originalSource: source,
+        ttl: ttl);
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final e = _store[key];
+    if (e == null || e.isExpired) return null;
+    return e;
+  }
+}
+
+PersistentDataset<List<int>> _intDataset(CacheStrategy cache, String name) =>
+    PersistentDataset<List<int>>(
+      cache: cache,
+      countryCode: 'XX',
+      datasetName: name,
+      source: ServiceSource.cache,
+      serialize: (v) => {'v': v},
+      deserialize: (j) => (j['v'] as List).cast<int>(),
+    );
+
+void main() {
+  late _TestKeyed keyed;
+
+  setUp(() => keyed = _TestKeyed());
+
+  group('per-key freshness clocks', () {
+    test('keys are independent: refreshing A leaves B stale', () {
+      keyed.markKeyedDatasetRefreshed('A');
+      expect(keyed.isKeyedDatasetFresh('A', const Duration(minutes: 5)), true);
+      expect(keyed.isKeyedDatasetFresh('B', const Duration(minutes: 5)), false);
+    });
+
+    test('markKeyedDatasetRefreshedAt pre-ages a single key', () {
+      keyed.markKeyedDatasetRefreshedAt('A', const Duration(hours: 2));
+      expect(keyed.isKeyedDatasetFresh('A', const Duration(hours: 1)), false);
+      expect(keyed.isKeyedDatasetFresh('A', const Duration(hours: 3)), true);
+    });
+  });
+
+  group('loadKeyedPersistentDataset', () {
+    test('returns the fresh in-memory copy without fetching', () async {
+      var fetchCalls = 0;
+      keyed.markKeyedDatasetRefreshed('28');
+
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '28',
+        cached: const [1, 2],
+        softTtl: const Duration(hours: 6),
+        hardTtl: const Duration(hours: 24),
+        persistent: null,
+        fetch: () async {
+          fetchCalls++;
+          return const [9];
+        },
+        store: (_) {},
+      );
+
+      expect(result, const [1, 2]);
+      expect(fetchCalls, 0);
+    });
+
+    test('a fresh key A does not satisfy a cold key B', () async {
+      var fetchCalls = 0;
+      keyed.markKeyedDatasetRefreshed('28');
+
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '08',
+        cached: null, // B has no in-memory copy
+        softTtl: const Duration(hours: 6),
+        hardTtl: const Duration(hours: 24),
+        persistent: null,
+        fetch: () async {
+          fetchCalls++;
+          return const [8];
+        },
+        store: (_) {},
+      );
+
+      expect(result, const [8]);
+      expect(fetchCalls, 1,
+          reason: "province A's freshness must never be served for B (#2264)");
+    });
+
+    test('fetches + persists + marks the key fresh when cold', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache, 'province-28');
+      List<int>? stored;
+
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '28',
+        cached: null,
+        softTtl: const Duration(hours: 6),
+        hardTtl: const Duration(hours: 24),
+        persistent: persistent,
+        fetch: () async => const [1, 2, 3],
+        store: (v) => stored = v,
+      );
+
+      expect(result, const [1, 2, 3]);
+      expect(stored, const [1, 2, 3]);
+      expect(persistent.read()?.value, const [1, 2, 3]);
+      expect(keyed.isKeyedDatasetFresh('28', const Duration(hours: 6)), true);
+    });
+
+    test('reads through from disk without fetching when persisted + fresh',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache, 'province-28');
+      await persistent.write(const [9, 9], hardTtl: const Duration(hours: 24));
+
+      var fetchCalls = 0;
+      List<int>? stored;
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '28',
+        cached: null,
+        softTtl: const Duration(hours: 6),
+        hardTtl: const Duration(hours: 24),
+        persistent: persistent,
+        fetch: () async {
+          fetchCalls++;
+          return const [0];
+        },
+        store: (v) => stored = v,
+      );
+
+      expect(result, const [9, 9]);
+      expect(fetchCalls, 0, reason: 'fresh disk copy must skip the network');
+      expect(stored, const [9, 9], reason: 'disk copy rehydrates into memory');
+    });
+
+    test('falls back to the persisted copy when fetch throws (offline)',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache, 'province-28');
+      await persistent.write(const [7], hardTtl: const Duration(hours: 24));
+
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '28',
+        cached: null,
+        softTtl: Duration.zero, // force a refresh attempt
+        hardTtl: const Duration(hours: 24),
+        persistent: persistent,
+        fetch: () async => throw Exception('offline'),
+        store: (_) {},
+      );
+
+      expect(result, const [7]);
+    });
+
+    test(
+        'falls back to the STALE in-memory copy when fetch fails with no '
+        'disk (pre-#3156 MITECO offline behaviour)', () async {
+      keyed.markKeyedDatasetRefreshedAt('28', const Duration(hours: 12));
+
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: '28',
+        cached: const [4, 4], // stale (12 h > 6 h soft TTL) but present
+        softTtl: const Duration(hours: 6),
+        hardTtl: const Duration(hours: 24),
+        persistent: null,
+        fetch: () async => throw Exception('offline'),
+        store: (_) {},
+      );
+
+      expect(result, const [4, 4],
+          reason: 'hours-stale rows beat failing the whole search');
+    });
+
+    test('rethrows when fetch fails and nothing at all is cached', () async {
+      expect(
+        () => keyed.loadKeyedPersistentDataset<List<int>>(
+          key: '28',
+          cached: null,
+          softTtl: const Duration(hours: 6),
+          hardTtl: const Duration(hours: 24),
+          persistent: _intDataset(_MemCache(), 'province-28'),
+          fetch: () async => throw Exception('boom'),
+          store: (_) {},
+        ),
+        throwsException,
+      );
+    });
+  });
+
+  group('per-key concurrent-fetch dedupe (#2313)', () {
+    test('two simultaneous cold calls for the SAME key issue ONE fetch',
+        () async {
+      var fetchCalls = 0;
+      final gate = Completer<void>();
+
+      Future<List<int>> slowFetch() async {
+        fetchCalls++;
+        await gate.future;
+        return const [5];
+      }
+
+      Future<List<int>> load() => keyed.loadKeyedPersistentDataset<List<int>>(
+            key: '28',
+            cached: null,
+            softTtl: const Duration(hours: 6),
+            hardTtl: const Duration(hours: 24),
+            persistent: null,
+            fetch: slowFetch,
+            store: (_) {},
+          );
+
+      final a = load();
+      final b = load();
+      gate.complete();
+      expect(await Future.wait([a, b]), [
+        const [5],
+        const [5],
+      ]);
+      expect(fetchCalls, 1);
+    });
+
+    test('simultaneous cold calls for DIFFERENT keys fetch independently',
+        () async {
+      final fetched = <String>[];
+      final gate = Completer<void>();
+
+      Future<List<int>> load(String key) =>
+          keyed.loadKeyedPersistentDataset<List<int>>(
+            key: key,
+            cached: null,
+            softTtl: const Duration(hours: 6),
+            hardTtl: const Duration(hours: 24),
+            persistent: null,
+            fetch: () async {
+              fetched.add(key);
+              await gate.future;
+              return const [1];
+            },
+            store: (_) {},
+          );
+
+      final a = load('28');
+      final b = load('08');
+      gate.complete();
+      await Future.wait([a, b]);
+      expect(fetched, unorderedEquals(['28', '08']),
+          reason: 'the in-flight slot is per key, not global');
+    });
+  });
+}

--- a/test/features/station_services/spain/miteco_parsed_cache_test.dart
+++ b/test/features/station_services/spain/miteco_parsed_cache_test.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3156 — Spain used to cache the RAW province rows and re-parse every one of
+// them on every search, including a regex opening-hours pass per row (a dense
+// province re-paid 800-2500 row parses per repeat search). The service now
+// caches the parsed Station templates per province via the shared
+// KeyedCachedDatasetMixin, so a repeat search re-parses NOTHING — while the
+// per-search values (dist, schedule-derived isOpen) are still stamped fresh.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
+import 'package:tankstellen/features/station_services/spain/spain_opening_hours_adapter.dart';
+
+import '../support/real_service_search.dart';
+
+/// One realistic MITECO row near the Madrid search centre, with a schedule
+/// (`L-D: 06:00-22:00`) so both the opening-hours parse and the per-search
+/// open-now stamping are exercised.
+Map<String, dynamic> _repsolMadrid() => {
+      'IDEESS': '1234',
+      'Rótulo': 'REPSOL',
+      'Dirección': 'CALLE MAYOR 1',
+      'Localidad': 'MADRID',
+      'C.P.': '28001',
+      'Latitud': '40,416775',
+      'Longitud (WGS84)': '-3,703790',
+      'Precio Gasolina 95 E5': '1,649',
+      'Precio Gasoleo A': '1,459',
+      'Horario': 'L-D: 06:00-22:00',
+    };
+
+Map<String, dynamic> _cepsaMadrid() => {
+      'IDEESS': '5678',
+      'Rótulo': 'CEPSA',
+      'Dirección': 'GRAN VIA 2',
+      'Localidad': 'MADRID',
+      'C.P.': '28013',
+      'Latitud': '40,420000',
+      'Longitud (WGS84)': '-3,705000',
+      'Precio Gasoleo A': '1,479',
+      'Horario': 'L-D: 24H',
+    };
+
+const _madrid = SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5);
+
+void main() {
+  group('ES parsed-Station per-province cache (#3156)', () {
+    test('a repeat search does NOT re-run the opening-hours parse', () async {
+      var parses = 0;
+      final dio = Dio()
+        ..httpClientAdapter =
+            FixedJsonAdapter(mitecoEnvelope([_repsolMadrid(), _cepsaMadrid()]));
+      final service = MitecoStationService(
+        dio: dio,
+        now: () => DateTime(2026, 6, 10, 12, 0),
+        // The #3156 parse-count seam: same real adapter, counted.
+        parseOpeningHours: (horario) {
+          parses++;
+          return const SpainOpeningHoursAdapter().parse(horario);
+        },
+      );
+
+      final first = await service.searchStations(_madrid);
+      expect(first.data.map((s) => s.id), contains('es-1234'),
+          reason: 'precondition: the first search parses + returns the row');
+      final parsesAfterFirst = parses;
+      expect(parsesAfterFirst, greaterThan(0),
+          reason: 'precondition: the first (cold) search runs the parser');
+
+      final second = await service.searchStations(_madrid);
+      expect(second.data.map((s) => s.id), contains('es-1234'),
+          reason: 'the cached templates must serve the same stations');
+      expect(parses, parsesAfterFirst,
+          reason: 'the second search must be served from the parsed '
+              'per-province Station cache — zero re-parses (#3156)');
+    });
+
+    test('isOpen is still recomputed per search from the cached schedule',
+        () async {
+      // Same service, same cached province — only the clock moves. Caching
+      // the parsed stations must NOT pin the open flag for the 6 h TTL.
+      var now = DateTime(2026, 6, 10, 12, 0); // Wed noon — inside 06:00-22:00
+      final dio = Dio()
+        ..httpClientAdapter =
+            FixedJsonAdapter(mitecoEnvelope([_repsolMadrid()]));
+      final service = MitecoStationService(dio: dio, now: () => now);
+
+      final atNoon = await service.searchStations(_madrid);
+      expect(atNoon.data.singleWhere((s) => s.id == 'es-1234').isOpen, isTrue);
+
+      now = DateTime(2026, 6, 10, 3, 0); // Wed 03:00 — outside the schedule
+      final atNight = await service.searchStations(_madrid);
+      expect(atNight.data.singleWhere((s) => s.id == 'es-1234').isOpen, isFalse,
+          reason: 'the cached parsed station must not pin a stale isOpen — '
+              'the open state is stamped per search (#3189 semantics kept)');
+    });
+
+    test('dist is stamped per search centre, not frozen into the cache',
+        () async {
+      final dio = Dio()
+        ..httpClientAdapter =
+            FixedJsonAdapter(mitecoEnvelope([_repsolMadrid()]));
+      final service =
+          MitecoStationService(dio: dio, now: () => DateTime(2026, 6, 10, 12));
+
+      final atStation = await service.searchStations(
+        const SearchParams(lat: 40.416775, lng: -3.703790, radiusKm: 5),
+      );
+      expect(atStation.data.single.dist, 0.0);
+
+      // ~5.5 km north of the station — the SAME cached template must carry a
+      // recomputed distance for the new centre.
+      final north = await service.searchStations(
+        const SearchParams(lat: 40.466775, lng: -3.703790, radiusKm: 10),
+      );
+      expect(north.data.single.dist, greaterThan(4.0));
+    });
+  });
+}


### PR DESCRIPTION
## Spain: parsed-Station per-province cache on the shared keyed dataset mixin

Final child of epic #3151 (hot-path efficiency):

- New `KeyedCachedDatasetMixin` — the existing `loadPersistentDataset` state machine (soft/hard TTL, disk read-through, concurrent-fetch dedupe, offline fallback) generalised with per-key freshness clocks and in-flight slots, reading through the #3154 `compute()`-backed `PersistentDataset.readAsync()`.
- MITECO's hand-rolled `_ProvinceCache` is deleted; parsed `Station` templates are cached per province and built once per dataset refresh, so a repeat search re-parses **zero** rows (proven by an invocation-count test through a parser seam). Per-search values (`dist`, clock-dependent `isOpen`) are stamped via `copyWith` onto in-radius survivors only; companion tests prove `isOpen` still flips when only the clock moves and `dist` recomputes for a new centre.
- The persisted `dataset:ES:province-<id>` format is byte-identical — existing installs' disk entries stay readable. All 5 pre-existing Spain test files (incl. the recorded MITECO fixtures) pass unmodified.

Closes #3156. With it, epic #3151 is fully implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
