### PR TITLE
fix(country): tri-state isOpen honesty, country wall-clock hours, catalog-driven fuels, FR brand unification (#3198)

### DIFF
--- a/lib/core/background/background_price_shape.dart
+++ b/lib/core/background/background_price_shape.dart
@@ -37,8 +37,13 @@ Map<String, dynamic> stationPricesToTankerkoenigShape(StationPrices prices) => {
 /// `getPrices` returns empty by design (prices live on the dataset rows the
 /// search emits, not behind a per-station endpoint).
 Map<String, dynamic> stationToTankerkoenigShape(Station station) => {
-      TankerkoenigFields.status:
-          station.isOpen ? TankerkoenigFields.statusOpen : 'closed',
+      // #3198 — tri-state `Station.isOpen`: only a KNOWN-closed station
+      // reports 'closed'; an unknown state stays 'open' so price alerts
+      // keep evaluating for the many countries whose feed publishes no
+      // open/closed signal (the pre-#3198 behaviour for those countries).
+      TankerkoenigFields.status: station.isOpen == false
+          ? 'closed'
+          : TankerkoenigFields.statusOpen,
       TankerkoenigFields.e5: station.e5,
       TankerkoenigFields.e10: station.e10,
       TankerkoenigFields.diesel: station.diesel,

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -48,6 +48,12 @@ class CountryConfig {
   /// Defaults to '€/L' for the EUR-zone metric countries.
   final String pricePerUnitSuffix;
 
+  /// Per-fuel overrides of [pricePerUnitSuffix] (#3198). Most fuels share
+  /// the country-wide suffix; a fuel sold by a different physical unit
+  /// overrides here — Argentina's GNC is priced per cubic metre
+  /// (dollars per m³), not per litre. Read via [pricePerUnitSuffixFor].
+  final Map<FuelType, String> pricePerUnitSuffixByFuel;
+
   /// Whether this country's station service runs against a verified
   /// price feed (#1828).
   ///
@@ -85,8 +91,17 @@ class CountryConfig {
     this.distanceUnit = 'km',
     this.volumeUnit = 'L',
     this.pricePerUnitSuffix = '\u20ac/L',
+    this.pricePerUnitSuffixByFuel = const {},
     this.verified = true,
   });
+
+  /// The price-per-unit suffix for [fuelType]: the per-fuel override when
+  /// one exists, else the country-wide [pricePerUnitSuffix]. A null
+  /// [fuelType] (fuel not known at the call site) gets the country-wide
+  /// suffix.
+  String pricePerUnitSuffixFor(FuelType? fuelType) =>
+      (fuelType == null ? null : pricePerUnitSuffixByFuel[fuelType]) ??
+      pricePerUnitSuffix;
 }
 
 class Countries {
@@ -145,7 +160,15 @@ class Countries {
     requiresApiKey: false,
     apiProvider: 'E-Control Spritpreisrechner',
     attribution: 'Daten von E-Control (spritpreisrechner.at)',
-    fuelTypes: ['Super 95', 'Super 95 E10', 'Diesel'],
+    fuelTypes: ['Super 95', 'Diesel'],
+    // #3198 — E-Control publishes exactly one petrol grade (SUP); the old
+    // default set advertised an E10 the feed never carries (the service
+    // mirrored e5 into e10 to fill it). Catalog now matches the source.
+    supportedFuelTypes: {
+      FuelType.e5,
+      FuelType.diesel,
+      FuelType.electric,
+    },
     examplePostalCode: '1010',
     exampleCity: 'Wien',
   );
@@ -211,14 +234,16 @@ class Countries {
     requiresApiKey: false,
     apiProvider: 'OK / Shell / Q8',
     attribution: 'Data: ok.dk, shell.dk, q8.dk',
-    fuelTypes: ['Blyfri 95', 'Diesel'],
-    // #2180 — DenmarkStationService surfaces the single 95-octane grade
-    // ("Blyfri 95") as both e5 and e10, plus diesel. Add e10 so the
-    // profile picker matches what the search selector already shows.
+    fuelTypes: ['Blyfri 95', 'Oktan 100', 'Diesel', 'V-Power Diesel'],
+    // #3198 — the single Danish 95-octane grade is e5 only (the #2180
+    // e5→e10 mirror asserted an E10 price no DK feed publishes); the
+    // #3187 exact-grade mapping added the real premium grades instead:
+    // Oktan 100 / V-Power → e98, V-Power Diesel → dieselPremium.
     supportedFuelTypes: {
       FuelType.e5,
-      FuelType.e10,
+      FuelType.e98,
       FuelType.diesel,
+      FuelType.dieselPremium,
       FuelType.electric,
     },
     examplePostalCode: '1000',
@@ -240,13 +265,13 @@ class Countries {
     apiProvider: 'Secretaría de Energía',
     attribution: 'Datos: datos.energia.gob.ar',
     fuelTypes: ['Nafta', 'Gas Oil', 'GNC'],
-    // #2180 — aligned to what ArgentinaStationService actually emits:
-    // Nafta súper → e5/e10, Nafta premium → e98, Gas oil → diesel, Gas
-    // oil premium → dieselPremium, GNC → cng (see classifyArgentinaProduct
-    // and argentina_station_service.dart's Station mapping).
+    // #2180/#3198 — aligned to what ArgentinaStationService actually
+    // emits: Nafta súper → e5 (no e10 — the old mirror asserted an E10
+    // price the feed never publishes), Nafta premium → e98, Gas oil →
+    // diesel, Gas oil premium → dieselPremium, GNC → cng (see
+    // classifyArgentinaProduct and the service's Station mapping).
     supportedFuelTypes: {
       FuelType.e5,
-      FuelType.e10,
       FuelType.e98,
       FuelType.diesel,
       FuelType.dieselPremium,
@@ -256,6 +281,9 @@ class Countries {
     examplePostalCode: '1000',
     exampleCity: 'Buenos Aires',
     pricePerUnitSuffix: '\$/L',
+    // #3198 — GNC (CNG) is priced per cubic metre upstream, not per
+    // litre; the per-fuel override keeps every other fuel on \$/L.
+    pricePerUnitSuffixByFuel: {FuelType.cng: '\$/m\u00b3'},
   );
 
   // ── New countries (v4.1.0) ──
@@ -361,9 +389,10 @@ class Countries {
     apiProvider: 'goriva.si (gov.si)',
     attribution: 'Podatki: goriva.si / Ministrstvo za gospodarstvo',
     fuelTypes: ['NMB-95', 'NMB-100', 'Dizel', 'Dizel Premium', 'LPG'],
+    // #3198 — the single NMB-95 grade is e5 only (the old e5→e10 mirror
+    // asserted an E10 price goriva.si never publishes).
     supportedFuelTypes: {
       FuelType.e5,
-      FuelType.e10,
       FuelType.e98,
       FuelType.diesel,
       FuelType.dieselPremium,

--- a/lib/core/country/country_time.dart
+++ b/lib/core/country/country_time.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Country-anchored wall clock for opening-hours evaluation (#3198).
+///
+/// Weekly schedules (`WeeklyOpeningHours`) are *local* to the station:
+/// `Mon 07:00-19:00` means 07:00 at the pump, not on the user's phone.
+/// Evaluating them against the device-local `DateTime.now()` is correct
+/// in-country but wrong when browsing a foreign country from home (a
+/// Berlin user checking Seoul stations is 7-8 h off — every open/closed
+/// badge flips). [nowInCountry] returns a [DateTime] whose *components*
+/// (weekday / hour / minute) read as the target country's current wall
+/// time, which is exactly what `computeOpenNow` consumes.
+///
+/// Implementation: a small static UTC-offset table with the three DST
+/// rules that cover the supported countries — deliberately NOT a full
+/// IANA database (no paid/heavyweight dependency; the rules below are
+/// stable EU/UK law and the fixed-offset countries don't observe DST).
+/// Multi-zone countries (MX, CL) use their main population zone; the
+/// error for the remote zones is bounded and strictly smaller than the
+/// device-clock error this replaces.
+library;
+
+/// Minutes east of UTC for [countryCode] at the UTC instant [utcNow].
+///
+/// Unknown / null country codes return `null` — the caller falls back
+/// to the device-local clock (the pre-#3198 behaviour).
+int? utcOffsetMinutesFor(String? countryCode, DateTime utcNow) {
+  switch (countryCode) {
+    // Central European Time: CET (+60) / CEST (+120).
+    case 'DE':
+    case 'FR':
+    case 'AT':
+    case 'IT':
+    case 'ES': // mainland; Canaries are WET (-60 from this) — main zone.
+    case 'DK':
+    case 'LU':
+    case 'SI':
+      return _euDstActive(utcNow) ? 120 : 60;
+    // Western European Time: WET (0) / WEST (+60) — same EU change dates.
+    case 'PT': // mainland; Azores are -60 from this — main zone.
+    case 'GB': // UK GMT/BST follows the same last-Sunday rule.
+      return _euDstActive(utcNow) ? 60 : 0;
+    // Eastern European Time: EET (+120) / EEST (+180).
+    case 'GR':
+    case 'RO':
+      return _euDstActive(utcNow) ? 180 : 120;
+    // Fixed offsets — no DST observed.
+    case 'KR':
+      return 9 * 60; // KST
+    case 'AR':
+      return -3 * 60; // ART
+    case 'MX':
+      return -6 * 60; // central zone; MX abolished DST in 2022.
+    // Southern-hemisphere DST.
+    case 'CL':
+      // Continental Chile: -4 standard, -3 in (southern) summer —
+      // DST runs from the first Sunday of September to the first
+      // Sunday of April.
+      return _southernDstActive(utcNow) ? -3 * 60 : -4 * 60;
+    case 'AU':
+      // NSW (the FuelCheck coverage area): +10 standard, +11 from the
+      // first Sunday of October to the first Sunday of April.
+      return _auDstActive(utcNow) ? 11 * 60 : 10 * 60;
+    default:
+      return null;
+  }
+}
+
+/// The current wall-clock time in [countryCode], as a [DateTime] whose
+/// weekday/hour/minute components read in that country's local time.
+///
+/// Falls back to the device-local clock when the country is unknown.
+/// [utcNow] is the injectable clock seam for tests; it defaults to
+/// `DateTime.now().toUtc()`.
+DateTime nowInCountry(String? countryCode, {DateTime? utcNow}) {
+  final utc = (utcNow ?? DateTime.now()).toUtc();
+  final offsetMinutes = utcOffsetMinutesFor(countryCode, utc);
+  if (offsetMinutes == null) {
+    // Unknown country — device-local time (pre-#3198 behaviour).
+    return utcNow?.toLocal() ?? DateTime.now();
+  }
+  return utc.add(Duration(minutes: offsetMinutes));
+}
+
+/// EU/UK DST rule: active from 01:00 UTC on the last Sunday of March
+/// until 01:00 UTC on the last Sunday of October.
+bool _euDstActive(DateTime utc) {
+  final start = _lastSundayUtc(utc.year, DateTime.march, hourUtc: 1);
+  final end = _lastSundayUtc(utc.year, DateTime.october, hourUtc: 1);
+  return !utc.isBefore(start) && utc.isBefore(end);
+}
+
+/// Chilean DST rule (continental): active from the first Sunday of
+/// September until the first Sunday of April. Evaluated on the UTC
+/// calendar — the few-hour boundary fuzz is irrelevant at the
+/// open/closed-badge granularity this feeds.
+bool _southernDstActive(DateTime utc) {
+  final aprilEnd = _firstSundayUtc(utc.year, DateTime.april);
+  final septemberStart = _firstSundayUtc(utc.year, DateTime.september);
+  return utc.isBefore(aprilEnd) || !utc.isBefore(septemberStart);
+}
+
+/// NSW DST rule: active from the first Sunday of October until the
+/// first Sunday of April.
+bool _auDstActive(DateTime utc) {
+  final aprilEnd = _firstSundayUtc(utc.year, DateTime.april);
+  final octoberStart = _firstSundayUtc(utc.year, DateTime.october);
+  return utc.isBefore(aprilEnd) || !utc.isBefore(octoberStart);
+}
+
+/// 00:00/[hourUtc] UTC on the last Sunday of [month] in [year].
+DateTime _lastSundayUtc(int year, int month, {int hourUtc = 0}) {
+  // Last day of the month, then walk back to Sunday.
+  var d = DateTime.utc(year, month + 1, 0);
+  while (d.weekday != DateTime.sunday) {
+    d = d.subtract(const Duration(days: 1));
+  }
+  return DateTime.utc(year, month, d.day, hourUtc);
+}
+
+/// 00:00 UTC on the first Sunday of [month] in [year].
+DateTime _firstSundayUtc(int year, int month) {
+  var d = DateTime.utc(year, month, 1);
+  while (d.weekday != DateTime.sunday) {
+    d = d.add(const Duration(days: 1));
+  }
+  return DateTime.utc(year, month, d.day);
+}

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -447,7 +447,13 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 54.0, maxLat: 58.0, minLng: 7.5, maxLng: 15.5,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // DK (#3198): the single 95-octane grade is e5 only (no published
+      // E10); the #3187 exact-grade mapping emits Oktan 100 / V-Power →
+      // e98 and V-Power Diesel → dieselPremium.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.electric, FuelType.all,
+      ],
       policy: _dkPolicy,
     ),
     CountryServiceEntry(
@@ -474,13 +480,12 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 45.3, maxLat: 47.0, minLng: 13.3, maxLng: 16.7,
       ),
-      // Slovenia (#575): NMB-95 → e5 (also surfaced as e10 — single
-      // 95-octane grade), NMB-100/98 → e98, Dizel → diesel, Dizel
-      // Premium → dieselPremium, avtoplin-lpg → lpg, cng → cng. #2180:
-      // e10 + cng were missing here though SloveniaStationService emits
-      // both; added to match the service and the picker's supported set.
+      // Slovenia (#575/#3198): NMB-95 → e5 (single 95-octane grade — the
+      // old e5→e10 mirror is gone, goriva.si publishes no E10),
+      // NMB-100/98 → e98, Dizel → diesel, Dizel Premium → dieselPremium,
+      // avtoplin-lpg → lpg, cng → cng.
       availableFuelTypes: [
-        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.dieselPremium, FuelType.lpg, FuelType.cng,
         FuelType.electric, FuelType.all,
       ],
@@ -493,7 +498,11 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 46.0, maxLat: 49.5, minLng: 9.0, maxLng: 17.5,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // AT (#3198): E-Control publishes exactly one petrol grade (SUP);
+      // the default set advertised an E10 the feed never carries.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.diesel, FuelType.electric, FuelType.all,
+      ],
       policy: _atPolicy,
     ),
     CountryServiceEntry(
@@ -589,13 +598,11 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: -56.0, maxLat: -21.0, minLng: -74.0, maxLng: -53.0,
       ),
-      // AR (#2180): ArgentinaStationService emits Nafta súper → e5/e10,
-      // Nafta premium → e98, Gas oil → diesel, Gas oil premium →
-      // dieselPremium, GNC → cng. Promoted off _defaultFuelTypes (which
-      // dropped cng/e98/dieselPremium) so the selector surfaces every
-      // fuel the CSV actually publishes — GNC stations were unsearchable.
+      // AR (#2180/#3198): ArgentinaStationService emits Nafta súper → e5
+      // (no e10 — the feed publishes no E10 grade), Nafta premium → e98,
+      // Gas oil → diesel, Gas oil premium → dieselPremium, GNC → cng.
       availableFuelTypes: [
-        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.dieselPremium, FuelType.cng, FuelType.electric,
         FuelType.all,
       ],

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -4,6 +4,7 @@
 import 'package:intl/intl.dart';
 
 import '../country/country_config.dart';
+import '../../features/search/domain/entities/fuel_type.dart';
 import 'price_formatter.dart';
 
 /// Formats per-country unit strings: distance (km/mi), volume (L/gal),
@@ -83,10 +84,18 @@ class UnitFormatter {
   /// The caller always passes the value in the country's **primary**
   /// currency unit (EUR/GBP/AUD, not cents). The formatter scales
   /// into pence/cents when the country's suffix requires it.
-  static String formatPricePerUnit(double? price, {String? countryCode}) {
+  ///
+  /// [fuelType] selects a per-fuel suffix override when the country
+  /// defines one (#3198 — AR GNC is priced per m³, not per litre); when
+  /// omitted the country-wide suffix applies.
+  static String formatPricePerUnit(
+    double? price, {
+    String? countryCode,
+    FuelType? fuelType,
+  }) {
     if (price == null || price <= 0) return '--';
     final cfg = _resolve(countryCode);
-    final suffix = cfg.pricePerUnitSuffix;
+    final suffix = cfg.pricePerUnitSuffixFor(fuelType);
     // Sub-unit suffixes (pence, cents) render the price * 100 with
     // a single decimal — matches the UK forecourt "155.9 p/L" and
     // the AU "185.9 c/L" conventions.
@@ -100,8 +109,9 @@ class UnitFormatter {
 
   /// Short-form price-per-unit without value — returns just the
   /// suffix for UI that labels a column or axis ("€/L", "p/L", …).
-  static String pricePerUnitSuffix({String? countryCode}) =>
-      _resolve(countryCode).pricePerUnitSuffix;
+  /// [fuelType] selects a per-fuel override when one exists (#3198).
+  static String pricePerUnitSuffix({String? countryCode, FuelType? fuelType}) =>
+      _resolve(countryCode).pricePerUnitSuffixFor(fuelType);
 
   /// Format an average / instantaneous consumption value with its
   /// unit mask — `L/100 km` for combustion, `kWh/100 km` for EV.

--- a/lib/core/widgets/fuel_type_dropdown.dart
+++ b/lib/core/widgets/fuel_type_dropdown.dart
@@ -39,8 +39,14 @@ class FuelTypeDropdown extends ConsumerWidget {
     // switching country re-filters every picker without each call
     // site having to wire the provider itself. Explicit `options`
     // still wins.
-    final List<FuelType> items =
-        options ?? ref.watch(fuelTypePickerProvider);
+    final List<FuelType> items = [
+      ...options ?? ref.watch(fuelTypePickerProvider),
+    ];
+    // #3198 — a stored selection that the country catalog no longer
+    // offers (e.g. an e10 preference saved before the phantom-E10 cleanup)
+    // must stay renderable: DropdownButtonFormField asserts when the value
+    // is missing from items. Surface it so the user can pick a real grade.
+    if (!items.contains(value)) items.insert(0, value);
     return DropdownButtonFormField<FuelType>(
       initialValue: value,
       decoration: InputDecoration(
@@ -88,8 +94,12 @@ class NullableFuelTypeDropdown extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final List<FuelType> items =
-        options ?? ref.watch(fuelTypePickerProvider);
+    final List<FuelType> items = [
+      ...options ?? ref.watch(fuelTypePickerProvider),
+    ];
+    // #3198 — same legacy-selection guard as [FuelTypeDropdown] above.
+    final v = value;
+    if (v != null && !items.contains(v)) items.insert(0, v);
     return DropdownButtonFormField<FuelType?>(
       initialValue: value,
       decoration: InputDecoration(

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -72,7 +72,10 @@ class FillUpCard extends StatelessWidget {
     // (locale-aware 2 dp + currency symbol) instead of a hand-rolled
     // toStringAsFixed(2) that hardcodes the dot separator.
     final costStr = PriceFormatter.formatTotal(fillUp.totalCost);
-    final ppl = UnitFormatter.formatPricePerUnit(fillUp.pricePerLiter);
+    // #3198 — thread the fill-up's fuel so a per-fuel suffix override
+    // applies (AR GNC is priced per m³, not per litre).
+    final ppl = UnitFormatter.formatPricePerUnit(fillUp.pricePerLiter,
+        fuelType: fillUp.fuelType);
     // #1401 phase 7b — only render the verified-by-adapter chip when
     // both fuel-level captures are present. Either missing → no chip.
     final isVerifiedByAdapter = FillUpVariance.hasAdapterCapture(fillUp);

--- a/lib/features/search/domain/entities/station.dart
+++ b/lib/features/search/domain/entities/station.dart
@@ -30,7 +30,16 @@ abstract class Station with _$Station {
     @JsonKey(fromJson: _priceFromJson) double? e85,
     @JsonKey(fromJson: _priceFromJson) double? lpg,
     @JsonKey(fromJson: _priceFromJson) double? cng,
-    required bool isOpen,
+    // #3198 — tri-state open flag. `true` / `false` are *known* states (a
+    // provider flag, or schedule-derived at fetch time); `null` means the
+    // source gave no usable open/closed signal. Six countries used to
+    // hard-code `true` because the field was non-nullable, silently
+    // presenting possibly-closed stations as open to radar/alerts/cards.
+    // The UI renders `null` as "unknown" — never as open or closed.
+    // ADDITIVE for every codec (#2777 lesson): older cache/favorites/
+    // widget JSON carries an explicit bool (still read as-is); a missing
+    // or null key reads as null.
+    bool? isOpen,
     String? updatedAt,
     String? openingHoursText,  // "Lun 07:00-18:30, Mar 07:00-18:30..."
     // Epic C4 — structured weekly hours from a per-country

--- a/lib/features/search/domain/entities/station.freezed.dart
+++ b/lib/features/search/domain/entities/station.freezed.dart
@@ -15,7 +15,16 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Station {
 
- String get id; String get name; String get brand; String get street; String? get houseNumber;@JsonKey(fromJson: _postCodeToString) String get postCode; String get place; double get lat; double get lng; double get dist;@JsonKey(fromJson: _priceFromJson) double? get e5;@JsonKey(fromJson: _priceFromJson) double? get e10;@JsonKey(fromJson: _priceFromJson) double? get e98;@JsonKey(fromJson: _priceFromJson) double? get diesel;@JsonKey(fromJson: _priceFromJson) double? get dieselPremium;@JsonKey(fromJson: _priceFromJson) double? get e85;@JsonKey(fromJson: _priceFromJson) double? get lpg;@JsonKey(fromJson: _priceFromJson) double? get cng; bool get isOpen; String? get updatedAt; String? get openingHoursText;// "Lun 07:00-18:30, Mar 07:00-18:30..."
+ String get id; String get name; String get brand; String get street; String? get houseNumber;@JsonKey(fromJson: _postCodeToString) String get postCode; String get place; double get lat; double get lng; double get dist;@JsonKey(fromJson: _priceFromJson) double? get e5;@JsonKey(fromJson: _priceFromJson) double? get e10;@JsonKey(fromJson: _priceFromJson) double? get e98;@JsonKey(fromJson: _priceFromJson) double? get diesel;@JsonKey(fromJson: _priceFromJson) double? get dieselPremium;@JsonKey(fromJson: _priceFromJson) double? get e85;@JsonKey(fromJson: _priceFromJson) double? get lpg;@JsonKey(fromJson: _priceFromJson) double? get cng;// #3198 — tri-state open flag. `true` / `false` are *known* states (a
+// provider flag, or schedule-derived at fetch time); `null` means the
+// source gave no usable open/closed signal. Six countries used to
+// hard-code `true` because the field was non-nullable, silently
+// presenting possibly-closed stations as open to radar/alerts/cards.
+// The UI renders `null` as "unknown" — never as open or closed.
+// ADDITIVE for every codec (#2777 lesson): older cache/favorites/
+// widget JSON carries an explicit bool (still read as-is); a missing
+// or null key reads as null.
+ bool? get isOpen; String? get updatedAt; String? get openingHoursText;// "Lun 07:00-18:30, Mar 07:00-18:30..."
 // Epic C4 — structured weekly hours from a per-country
 // [OpeningHoursAdapter], carried on the search-result station so a
 // country whose service has no detail endpoint (e.g. AT E-Control)
@@ -64,7 +73,7 @@ abstract mixin class $StationCopyWith<$Res>  {
   factory $StationCopyWith(Station value, $Res Function(Station) _then) = _$StationCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool? isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 
@@ -81,7 +90,7 @@ class _$StationCopyWithImpl<$Res>
 
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = freezed,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -101,8 +110,8 @@ as double?,dieselPremium: freezed == dieselPremium ? _self.dieselPremium : diese
 as double?,e85: freezed == e85 ? _self.e85 : e85 // ignore: cast_nullable_to_non_nullable
 as double?,lpg: freezed == lpg ? _self.lpg : lpg // ignore: cast_nullable_to_non_nullable
 as double?,cng: freezed == cng ? _self.cng : cng // ignore: cast_nullable_to_non_nullable
-as double?,isOpen: null == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
-as bool,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as double?,isOpen: freezed == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
+as bool?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as String?,openingHoursText: freezed == openingHoursText ? _self.openingHoursText : openingHoursText // ignore: cast_nullable_to_non_nullable
 as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
 as WeeklyOpeningHours?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable
@@ -210,7 +219,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool? isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -231,7 +240,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool? isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
 switch (_that) {
 case _Station():
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -251,7 +260,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool? isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -266,7 +275,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 @JsonSerializable()
 
 class _Station implements Station {
-  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, required this.isOpen, this.updatedAt, this.openingHoursText, this.openingHours, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
+  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, this.isOpen, this.updatedAt, this.openingHoursText, this.openingHours, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
   factory _Station.fromJson(Map<String, dynamic> json) => _$StationFromJson(json);
 
 @override final  String id;
@@ -287,7 +296,16 @@ class _Station implements Station {
 @override@JsonKey(fromJson: _priceFromJson) final  double? e85;
 @override@JsonKey(fromJson: _priceFromJson) final  double? lpg;
 @override@JsonKey(fromJson: _priceFromJson) final  double? cng;
-@override final  bool isOpen;
+// #3198 — tri-state open flag. `true` / `false` are *known* states (a
+// provider flag, or schedule-derived at fetch time); `null` means the
+// source gave no usable open/closed signal. Six countries used to
+// hard-code `true` because the field was non-nullable, silently
+// presenting possibly-closed stations as open to radar/alerts/cards.
+// The UI renders `null` as "unknown" — never as open or closed.
+// ADDITIVE for every codec (#2777 lesson): older cache/favorites/
+// widget JSON carries an explicit bool (still read as-is); a missing
+// or null key reads as null.
+@override final  bool? isOpen;
 @override final  String? updatedAt;
 @override final  String? openingHoursText;
 // "Lun 07:00-18:30, Mar 07:00-18:30..."
@@ -373,7 +391,7 @@ abstract mixin class _$StationCopyWith<$Res> implements $StationCopyWith<$Res> {
   factory _$StationCopyWith(_Station value, $Res Function(_Station) _then) = __$StationCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool? isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 
@@ -390,7 +408,7 @@ class __$StationCopyWithImpl<$Res>
 
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = freezed,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
   return _then(_Station(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -410,8 +428,8 @@ as double?,dieselPremium: freezed == dieselPremium ? _self.dieselPremium : diese
 as double?,e85: freezed == e85 ? _self.e85 : e85 // ignore: cast_nullable_to_non_nullable
 as double?,lpg: freezed == lpg ? _self.lpg : lpg // ignore: cast_nullable_to_non_nullable
 as double?,cng: freezed == cng ? _self.cng : cng // ignore: cast_nullable_to_non_nullable
-as double?,isOpen: null == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
-as bool,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as double?,isOpen: freezed == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
+as bool?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as String?,openingHoursText: freezed == openingHoursText ? _self.openingHoursText : openingHoursText // ignore: cast_nullable_to_non_nullable
 as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
 as WeeklyOpeningHours?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable

--- a/lib/features/search/domain/entities/station.g.dart
+++ b/lib/features/search/domain/entities/station.g.dart
@@ -25,7 +25,7 @@ _Station _$StationFromJson(Map<String, dynamic> json) => _Station(
   e85: _priceFromJson(json['e85']),
   lpg: _priceFromJson(json['lpg']),
   cng: _priceFromJson(json['cng']),
-  isOpen: json['isOpen'] as bool,
+  isOpen: json['isOpen'] as bool?,
   updatedAt: json['updatedAt'] as String?,
   openingHoursText: json['openingHoursText'] as String?,
   openingHours: json['openingHours'] == null

--- a/lib/features/search/domain/search_result_filters.dart
+++ b/lib/features/search/domain/search_result_filters.dart
@@ -68,7 +68,11 @@ List<Station> applyAmenityAndStatusFilters(
   }
 
   if (openOnly) {
-    result = result.where((s) => s.isOpen).toList();
+    // #3198 — drop only KNOWN-closed stations. An unknown open state
+    // (`isOpen == null` — the source publishes no signal, e.g. UK/MX/KR)
+    // passes: excluding it would empty the whole result list for those
+    // countries, which is worse than showing a possibly-closed station.
+    result = result.where((s) => s.isOpen != false).toList();
   }
 
   return result;

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -52,6 +52,14 @@ class AllPricesStationCard extends StatelessWidget {
   /// the card keeps that exclusion on top.
   bool get _hasBrand => hasRealBrand(station) && station.brand != 'Autoroute';
 
+  /// #3198 — tri-state status colour: green when known-open, red when
+  /// known-closed, neutral muted when the source gave no signal.
+  Color _statusColor(BuildContext context) => switch (station.isOpen) {
+        true => DarkModeColors.success(context),
+        false => DarkModeColors.error(context),
+        null => DarkModeColors.mutedText(context),
+      };
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -71,15 +79,14 @@ class AllPricesStationCard extends StatelessWidget {
             // Header row: status dot + name + distance + favorite
             Row(
               children: [
-                // Status indicator
+                // Status indicator — #3198 tri-state: unknown renders the
+                // neutral muted dot, never the red "closed" one.
                 Container(
                   width: 12,
                   height: 12,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: station.isOpen
-                        ? DarkModeColors.success(context)
-                        : DarkModeColors.error(context),
+                    color: _statusColor(context),
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -94,30 +101,26 @@ class AllPricesStationCard extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
-                // Status badge
+                // Status badge — #3198 tri-state (Open / Closed / Unknown).
                 Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 6,
                     vertical: 2,
                   ),
                   decoration: BoxDecoration(
-                    color: station.isOpen
-                        ? DarkModeColors.success(
-                            context,
-                          ).withValues(alpha: 0.12)
-                        : DarkModeColors.error(context).withValues(alpha: 0.12),
+                    color: _statusColor(context).withValues(alpha: 0.12),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
-                    station.isOpen
-                        ? (l10n?.open ?? 'Open')
-                        : (l10n?.closed ?? 'Closed'),
+                    switch (station.isOpen) {
+                      true => l10n?.open ?? 'Open',
+                      false => l10n?.closed ?? 'Closed',
+                      null => l10n?.openStateUnknown ?? 'Unknown',
+                    },
                     style: TextStyle(
                       fontSize: 10,
                       fontWeight: FontWeight.w600,
-                      color: station.isOpen
-                          ? DarkModeColors.success(context)
-                          : DarkModeColors.error(context),
+                      color: _statusColor(context),
                     ),
                   ),
                 ),

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -139,9 +139,13 @@ class StationCard extends StatelessWidget {
       currencyOverride: currencyOverride,
     );
     final l10n = AppLocalizations.of(context);
-    final semanticStatus = station.isOpen
-        ? (l10n?.open ?? 'Open')
-        : (l10n?.closed ?? 'Closed');
+    // #3198 — tri-state: an unknown open state is announced as unknown,
+    // never as closed (and never as open).
+    final semanticStatus = switch (station.isOpen) {
+      true => l10n?.open ?? 'Open',
+      false => l10n?.closed ?? 'Closed',
+      null => l10n?.openStateUnknown ?? 'Unknown',
+    };
     final semanticLabel =
         '${_hasBrand ? station.brand : station.name}, ${station.street}, '
         '$formattedPrice, $semanticStatus';

--- a/lib/features/search/presentation/widgets/station_card_price_column.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_column.dart
@@ -135,9 +135,11 @@ class _StationPriceColumn extends StatelessWidget {
                 child: Icon(
                   iconForPriceTier(priceTier!),
                   size: 16,
-                  color: station.isOpen
-                      ? fuelColor
-                      : theme.colorScheme.onSurfaceVariant,
+                  // #3198 — only a KNOWN-closed station greys the price;
+                  // unknown keeps the fuel colour (price data is valid).
+                  color: station.isOpen == false
+                      ? theme.colorScheme.onSurfaceVariant
+                      : fuelColor,
                 ),
               ),
             AnimatedPriceText(
@@ -159,9 +161,10 @@ class _StationPriceColumn extends StatelessWidget {
                     currencyOverride: currencyOverride,
                     baseStyle: theme.textTheme.titleLarge!.copyWith(
                       fontWeight: FontWeight.bold,
-                      color: station.isOpen
-                          ? fuelColor
-                          : theme.colorScheme.onSurfaceVariant,
+                      // #3198 — grey only when known-closed (see above).
+                      color: station.isOpen == false
+                          ? theme.colorScheme.onSurfaceVariant
+                          : fuelColor,
                     ),
                   ),
                 ),

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -3,7 +3,7 @@
 
 part of 'station_card.dart';
 
-/// Status dot (green/red) with optional 24h badge below it.
+/// Status dot (green/red/neutral) with optional 24h badge below it.
 class _StatusColumn extends StatelessWidget {
   final Station station;
 
@@ -20,9 +20,13 @@ class _StatusColumn extends StatelessWidget {
           height: 12,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: station.isOpen
-                ? DarkModeColors.success(context)
-                : DarkModeColors.error(context),
+            // #3198 — tri-state: an unknown open state renders the neutral
+            // muted dot, never the red "closed" one.
+            color: switch (station.isOpen) {
+              true => DarkModeColors.success(context),
+              false => DarkModeColors.error(context),
+              null => DarkModeColors.mutedText(context),
+            },
           ),
         ),
         if (station.is24h)

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/country/country_config.dart';
+import '../../../../core/country/country_time.dart';
 import '../../../../core/widgets/section_header.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
@@ -72,7 +74,18 @@ class StationInfoSection extends StatelessWidget {
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
-          OpeningHoursView(hours: hours),
+          // #3198 — evaluate "open now" on the STATION's wall clock, not
+          // the device's: weekly hours are local to the pump, so browsing
+          // a foreign country from home used to flip every open/closed
+          // status by the timezone gap. Unknown country → device clock.
+          OpeningHoursView(
+            hours: hours,
+            now: nowInCountry(Countries.countryForStation(
+              id: station.id,
+              lat: station.lat,
+              lng: station.lng,
+            )?.code),
+          ),
           const SizedBox(height: 12),
         ],
 

--- a/lib/features/station_detail/presentation/widgets/station_status_row.dart
+++ b/lib/features/station_detail/presentation/widgets/station_status_row.dart
@@ -39,12 +39,21 @@ class StationStatusRow extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final rating = ref.watch(stationRatingProvider(stationId));
 
-    final color = station.isOpen
-        ? DarkModeColors.success(context)
-        : DarkModeColors.error(context);
+    // #3198 — tri-state: an unknown open state renders the neutral muted
+    // dot/text and is announced as unknown, never as open or closed.
+    final color = switch (station.isOpen) {
+      true => DarkModeColors.success(context),
+      false => DarkModeColors.error(context),
+      null => DarkModeColors.mutedText(context),
+    };
 
-    final statusSemantic = l10n?.stationStatusSemantic('${station.isOpen}') ??
-        (station.isOpen ? 'Station is open' : 'Station is closed');
+    final statusSemantic =
+        l10n?.stationOpenStateSemantic('${station.isOpen}') ??
+            switch (station.isOpen) {
+              true => 'Station is open',
+              false => 'Station is closed',
+              null => 'Open state unknown',
+            };
 
     return Row(
       children: [
@@ -109,9 +118,11 @@ class StationStatusRow extends ConsumerWidget {
     ServiceResult<dynamic> result,
     AppLocalizations? l10n,
   ) {
-    final status = station.isOpen
-        ? (l10n?.open ?? 'Open')
-        : (l10n?.closed ?? 'Closed');
+    final status = switch (station.isOpen) {
+      true => l10n?.open ?? 'Open',
+      false => l10n?.closed ?? 'Closed',
+      null => l10n?.openStateUnknown ?? 'Unknown',
+    };
     final agoSuffix = l10n?.freshnessAgo ?? 'ago';
     final freshness = result.freshnessLabel;
     return '$status — $freshness $agoSuffix';

--- a/lib/features/station_services/argentina/argentina_station_service.dart
+++ b/lib/features/station_services/argentina/argentina_station_service.dart
@@ -179,8 +179,10 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
           lat: raw.lat,
           lng: raw.lng,
           dist: roundedDistance(params.lat, params.lng, entry.raw.lat, entry.raw.lng),
+          // #3198 — Nafta súper lives in e5 only; the old e10 mirror
+          // asserted an E10 price the feed never publishes (catalog
+          // change in CountryConfig / registry).
           e5: entry.naftaRegular,
-          e10: entry.naftaRegular,
           e98: entry.naftaPremium,
           diesel: entry.dieselRegular,
           dieselPremium: entry.dieselPremium,

--- a/lib/features/station_services/argentina/argentina_station_service.dart
+++ b/lib/features/station_services/argentina/argentina_station_service.dart
@@ -185,7 +185,9 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
           diesel: entry.dieselRegular,
           dieselPremium: entry.dieselPremium,
           cng: entry.gnc,
-          isOpen: true,
+          // #3198 — the Secretaría feed publishes prices, not hours:
+          // honest unknown instead of the old hard-coded `true`.
+          isOpen: null,
           updatedAt: raw.fechaVigencia,
           region: raw.provincia,
         ));

--- a/lib/features/station_services/austria/econtrol_station_service.dart
+++ b/lib/features/station_services/austria/econtrol_station_service.dart
@@ -158,7 +158,9 @@ class EControlStationService with StationServiceHelpers implements StationServic
       }).where((s) => s.isNotEmpty).join(', ');
 
       final name = r['name']?.toString() ?? '';
-      final isOpen = r['open'] as bool? ?? true;
+      // #3198 — E-Control's `open` flag is authoritative when present;
+      // a missing flag is honest unknown, not `true`.
+      final isOpen = r['open'] as bool?;
 
       // #753 — `at-` prefix so a numeric E-Control id can never collide
       // with another country's numeric id space when widget JSON or

--- a/lib/features/station_services/austria/econtrol_station_service.dart
+++ b/lib/features/station_services/austria/econtrol_station_service.dart
@@ -65,16 +65,14 @@ class EControlStationService with StationServiceHelpers implements StationServic
         final id = int.tryParse(_stripCountryPrefix(s.id)) ?? 0;
         final existing = merged[id];
         if (existing != null) {
-          // Merge e5 from super query into existing diesel station
-          merged[id] = existing.copyWith(
-            e5: s.e5,
-            e10: s.e5, // Austrian "Super 95" maps to both E5 and E10
-          );
+          // Merge e5 from super query into existing diesel station.
+          // #3198 — E-Control publishes ONE petrol grade (SUP); it is no
+          // longer mirrored into e10, which asserted an E10 price the
+          // feed never carries. The fuel catalog (CountryConfig /
+          // registry) drops e10 for AT in the same change.
+          merged[id] = existing.copyWith(e5: s.e5);
         } else {
-          merged[id] = s.copyWith(
-            e5: s.e5,
-            e10: s.e5,
-          );
+          merged[id] = s;
         }
       }
 
@@ -179,7 +177,6 @@ class EControlStationService with StationServiceHelpers implements StationServic
         lng: lng,
         dist: apiDist ?? roundedDistance(searchLat, searchLng, lat, lng),
         e5: fuelType == 'SUP' ? price : null,
-        e10: fuelType == 'SUP' ? price : null,
         diesel: fuelType == 'DIE' ? price : null,
         // #3196 — E-Control's GAS fuel type is CNG (Erdgas/Methan), not LPG.
         cng: fuelType == 'GAS' ? price : null,

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -229,7 +229,9 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
           e10: e5,
           e98: e98,
           diesel: diesel,
-          isOpen: true,
+          // #3198 — the OK feed carries no open/closed signal: honest
+          // unknown instead of the old hard-coded `true`.
+          isOpen: null,
           updatedAt: _formatIsoTime(r['last_updated_time']?.toString()),
         );
       }).whereType<Station>().toList();
@@ -296,7 +298,8 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
           e98: e98,
           diesel: diesel,
           dieselPremium: dieselPremium,
-          isOpen: true,
+          // #3198 — the Shell feed carries no open/closed signal either.
+          isOpen: null,
           updatedAt: _formatIsoTime(
             (prices.isNotEmpty ? prices.first['lastUpdated'] : null)?.toString(),
           ),

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -225,8 +225,10 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
           lat: lat,
           lng: lng,
           dist: 0,
+          // #3198 — the single Danish 95-octane grade lives in e5 only;
+          // the old e10 mirror asserted an E10 price the feed never
+          // publishes (catalog change in CountryConfig / registry).
           e5: e5,
-          e10: e5,
           e98: e98,
           diesel: diesel,
           // #3198 — the OK feed carries no open/closed signal: honest
@@ -293,8 +295,8 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
           lat: lat,
           lng: lng,
           dist: 0,
+          // #3198 — no e10 mirror (single 95-octane grade, see above).
           e5: e5,
-          e10: e5,
           e98: e98,
           diesel: diesel,
           dieselPremium: dieselPremium,

--- a/lib/features/station_services/france/prix_carburants_flux_parser.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_parser.dart
@@ -31,17 +31,19 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:xml/xml.dart';
 
+import '../../../core/country/country_time.dart';
 import '../../search/domain/entities/station.dart';
+import '../opening_hours/open_state_from_hours.dart';
 import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_parsers.dart' as parser;
 
 /// Decode the flux ZIP [bytes], locate the inner XML entry, and parse every
 /// point-of-sale into a [Station] (distance 0 — the caller stamps it per
 /// search). Returns `[]` when the ZIP holds no XML entry or it is empty.
-List<Station> parseFluxZip(List<int> bytes) {
+List<Station> parseFluxZip(List<int> bytes, {DateTime? now}) {
   final xml = extractFluxXml(bytes);
   if (xml == null || xml.isEmpty) return const [];
-  return parseFluxXml(xml);
+  return parseFluxXml(xml, now: now);
 }
 
 /// Pull the inner XML document text out of the flux ZIP. The archive holds a
@@ -71,7 +73,7 @@ String _decodeBytes(Uint8List bytes) {
 
 /// Parse the flux XML document text into [Station]s. Exposed separately so the
 /// XML-shape contract can be tested without zipping a fixture first.
-List<Station> parseFluxXml(String xml) {
+List<Station> parseFluxXml(String xml, {DateTime? now}) {
   final XmlDocument doc;
   try {
     doc = XmlDocument.parse(xml);
@@ -79,9 +81,12 @@ List<Station> parseFluxXml(String xml) {
     return const [];
   }
 
+  // Resolve the open-now reference instant ONCE per document — #3198 clock
+  // seam; defaults to France's wall clock (see [nowInCountry]).
+  final ref = now ?? nowInCountry('FR');
   final stations = <Station>[];
   for (final pdv in doc.findAllElements('pdv')) {
-    final station = parseFluxPdv(pdv);
+    final station = parseFluxPdv(pdv, now: ref);
     if (station != null) stations.add(station);
   }
   return stations;
@@ -89,7 +94,7 @@ List<Station> parseFluxXml(String xml) {
 
 /// Parse a single `<pdv>` element into a [Station], or `null` when it carries
 /// no usable coordinates. Public for direct unit testing.
-Station? parseFluxPdv(XmlElement pdv) {
+Station? parseFluxPdv(XmlElement pdv, {DateTime? now}) {
   final lat = _coord(pdv.getAttribute('latitude'));
   final lng = _coord(pdv.getAttribute('longitude'));
   if (lat == null || lng == null || lat == 0 || lng == 0) return null;
@@ -145,6 +150,14 @@ Station? parseFluxPdv(XmlElement pdv) {
     }
   }
 
+  // #2751 — same structured schedule the instantané path parses (the glued
+  // `rawHoraires` is the shape the adapter handles) so the detail fast path
+  // renders staffed hours.
+  final openingHours = const FranceOpeningHoursAdapter().parse(<String, dynamic>{
+    'horaires_jour': rawHoraires,
+    'horaires_automate_24_24': is24h ? 'Oui' : 'Non',
+  });
+
   // #753 — scope the id with the `fr-` country prefix (matches the legacy
   // JSON parser) so a French numeric id cannot collide with another country.
   return Station(
@@ -163,18 +176,17 @@ Station? parseFluxPdv(XmlElement pdv) {
     diesel: diesel,
     e85: e85,
     lpg: lpg,
-    isOpen: true,
+    // #3198 — schedule-derived instead of the old hard-coded `true`; a
+    // 24/7 automate dispenses fuel regardless of staffed hours. `null`
+    // when the pdv carries no usable hours (the honest "unknown").
+    isOpen: is24h
+        ? true
+        : openStateFromHours(openingHours, now ?? nowInCountry('FR')),
     updatedAt: _formatMaj(mostRecentMaj),
     stationType: pop.isEmpty ? null : pop,
     is24h: is24h,
     openingHoursText: openingHoursText,
-    // #2751 — carry the structured schedule on the search Station (the
-    // glued `rawHoraires` is the same shape the adapter parses on the
-    // instantané path) so the detail fast path renders staffed hours.
-    openingHours: const FranceOpeningHoursAdapter().parse(<String, dynamic>{
-      'horaires_jour': rawHoraires,
-      'horaires_automate_24_24': is24h ? 'Oui' : 'Non',
-    }),
+    openingHours: openingHours,
   );
 }
 

--- a/lib/features/station_services/france/prix_carburants_flux_parser.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_parser.dart
@@ -263,11 +263,15 @@ String? _formatMaj(String? maj) {
   }
 }
 
-/// The flux XML carries no brand column, so reuse the autoroute fallback the
-/// legacy path uses: `pop == 'A'` → highway service area, else the `Independent`
-/// sentinel (#482) rendered as a localised "independent station" row. Address /
-/// ville substring brand detection stays in the legacy enricher path.
-String _brandFor(String pop, String adresse, String ville) {
-  if (pop == 'A') return 'Autoroute';
-  return 'Independent';
-}
+/// The flux XML carries no brand column — delegate to the SAME
+/// [parser.detectPrixCarburantsBrand] the legacy JSON path uses (#3198):
+/// address/ville substring map first, then the `pop == 'A'` autoroute
+/// fallback, then the `Independent` sentinel (#482). Before this the flux
+/// path only knew Autoroute/Independent, so the same station showed a
+/// different brand depending on which path served it.
+String _brandFor(String pop, String adresse, String ville) =>
+    parser.detectPrixCarburantsBrand(
+      adresse,
+      null,
+      <String, dynamic>{'ville': ville, 'pop': pop},
+    );

--- a/lib/features/station_services/france/prix_carburants_parsers.dart
+++ b/lib/features/station_services/france/prix_carburants_parsers.dart
@@ -33,8 +33,10 @@ import 'dart:async';
 
 import '../../search/domain/entities/station.dart';
 import '../../search/domain/entities/station_amenity.dart';
+import '../../../core/country/country_time.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/logging/error_logger.dart';
+import '../opening_hours/open_state_from_hours.dart';
 import 'france_opening_hours_adapter.dart';
 
 /// Extract the `results` list from a Prix-Carburants API envelope.
@@ -66,11 +68,16 @@ List<Map<String, dynamic>> extractPrixCarburantsResults(dynamic data) {
 /// Returns `null` only on a hard [FormatException] inside the body
 /// (the bare minimum invariant — `{}` returns a near-empty Station,
 /// not `null`, mirroring the previous service behaviour).
+///
+/// [now] is the clock seam for the schedule-derived `isOpen` (#3198);
+/// it defaults to France's wall clock so a user browsing FR from another
+/// timezone still gets the open state at the *station*, not at home.
 Station? parsePrixCarburantsStation(
   Map<String, dynamic> r,
   double searchLat,
-  double searchLng,
-) {
+  double searchLng, {
+  DateTime? now,
+}) {
   try {
     final geom = r['geom'] as Map<String, dynamic>?;
     double lat = (geom?['lat'] as num?)?.toDouble() ?? 0;
@@ -101,6 +108,14 @@ Station? parsePrixCarburantsStation(
     // numeric id space. Stripped before any call back out to the
     // Prix-Carburants API by `prix_carburants_station_service.dart`.
     final rawId = r['id']?.toString() ?? '';
+    final automate24h = r['horaires_automate_24_24'] == 'Oui';
+    // #2751 — carry the STRUCTURED schedule on the search Station so the
+    // detail provider's search-cache fast path renders the staffed
+    // boutique hours (+ the 24/7-automate badge) directly, instead of
+    // falling through `legacyOpeningHoursBridge` (which collapses an
+    // automate station to "Open 24 hours" and loses the staffed hours).
+    // Same adapter call the cold `getStationDetail` path already uses.
+    final openingHours = const FranceOpeningHoursAdapter().parse(r);
     return Station(
       id: rawId.isEmpty
           ? ''
@@ -119,17 +134,17 @@ Station? parsePrixCarburantsStation(
       diesel: _toDouble(r['gazole_prix']),
       e85: _toDouble(r['e85_prix']),
       lpg: _toDouble(r['gplc_prix']),
-      isOpen: true,
+      // #3198 — schedule-derived instead of the old hard-coded `true`: a
+      // 24/7 automate dispenses fuel regardless of the staffed hours, so
+      // it counts as open; otherwise the parsed weekly schedule decides
+      // (null when the record carries no usable hours).
+      isOpen: automate24h
+          ? true
+          : openStateFromHours(openingHours, now ?? nowInCountry('FR')),
       updatedAt: parsePrixCarburantsMostRecentUpdate(r),
-      is24h: r['horaires_automate_24_24'] == 'Oui',
+      is24h: automate24h,
       openingHoursText: parsePrixCarburantsOpeningHours(r['horaires_jour']),
-      // #2751 — carry the STRUCTURED schedule on the search Station so the
-      // detail provider's search-cache fast path renders the staffed
-      // boutique hours (+ the 24/7-automate badge) directly, instead of
-      // falling through `legacyOpeningHoursBridge` (which collapses an
-      // automate station to "Open 24 hours" and loses the staffed hours).
-      // Same adapter call the cold `getStationDetail` path already uses.
-      openingHours: const FranceOpeningHoursAdapter().parse(r),
+      openingHours: openingHours,
       services: parsePrixCarburantsServices(r['services_service']),
       amenities: parseAmenitiesFromServices(
         parsePrixCarburantsServices(r['services_service']),

--- a/lib/features/station_services/greece/greece_station_service.dart
+++ b/lib/features/station_services/greece/greece_station_service.dart
@@ -307,7 +307,9 @@ class GreeceStationService
       e98: prices[FuelType.e98],
       diesel: prices[FuelType.diesel],
       lpg: prices[FuelType.lpg],
-      isOpen: true,
+      // #3198 — prefecture-level virtual stations have no open/closed
+      // notion at all: honest unknown.
+      isOpen: null,
       updatedAt: newestDate.isEmpty ? null : newestDate,
     );
   }

--- a/lib/features/station_services/italy/mise_station_service.dart
+++ b/lib/features/station_services/italy/mise_station_service.dart
@@ -108,7 +108,9 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
               prices?.gasolioPremiumSelf ?? prices?.gasolioPremiumServed,
           lpg: prices?.gpl,
           cng: prices?.metano,
-          isOpen: true,
+          // #3198 — the MIMIT dataset carries no open/closed signal:
+          // honest unknown instead of the old hard-coded `true`.
+          isOpen: null,
           updatedAt: prices?.updatedAt,
           stationType: s.type == 'Autostradale' ? 'A' : 'R',
         ));

--- a/lib/features/station_services/italy/mise_station_service.dart
+++ b/lib/features/station_services/italy/mise_station_service.dart
@@ -100,8 +100,10 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
           lat: s.lat,
           lng: s.lng,
           dist: roundedDistance(params.lat, params.lng, s.lat, s.lng),
+          // #3198 — Benzina lives in e5 only; the old e10 mirror asserted
+          // an E10 price MIMIT never publishes (IT's catalog never offered
+          // e10 in the picker, so nothing user-facing is lost).
           e5: prices?.benzinaSelf ?? prices?.benzinaServed,
-          e10: prices?.benzinaSelf ?? prices?.benzinaServed,
           e98: prices?.benzinaPremiumSelf ?? prices?.benzinaPremiumServed,
           diesel: prices?.gasolioSelf ?? prices?.gasolioServed,
           dieselPremium:

--- a/lib/features/station_services/luxembourg/luxembourg_station_service.dart
+++ b/lib/features/station_services/luxembourg/luxembourg_station_service.dart
@@ -262,7 +262,9 @@ class LuxembourgStationService
           e98: prices[FuelType.e98],
           diesel: prices[FuelType.diesel],
           lpg: prices[FuelType.lpg],
-          isOpen: true,
+          // #3198 — the decree publishes prices, not per-station hours:
+          // honest unknown instead of the old hard-coded `true`.
+          isOpen: null,
           updatedAt: effectiveDate,
         ),
     ];

--- a/lib/features/station_services/mexico/mexico_station_service.dart
+++ b/lib/features/station_services/mexico/mexico_station_service.dart
@@ -135,7 +135,7 @@ class MexicoStationService
           e5: c.regular,
           e98: c.premium,
           diesel: c.diesel,
-          isOpen: true,
+          isOpen: null, // #3198 — CRE publishes no open/closed signal.
         ));
       }
 

--- a/lib/features/station_services/opening_hours/open_state_from_hours.dart
+++ b/lib/features/station_services/opening_hours/open_state_from_hours.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../station_detail/domain/open_now.dart';
+import '../../station_detail/domain/opening_hours.dart';
+
+/// Derives the tri-state `Station.isOpen` snapshot from a parsed weekly
+/// schedule at fetch time (#3198).
+///
+/// Returns:
+///  - `true` / `false` when [hours] resolves to a definite open/closed
+///    state at [now] (via [computeOpenNow]);
+///  - `null` when [hours] is absent, carries no usable schedule, or
+///    resolves to [OpenStatus.unknown] — the honest "no data" signal the
+///    UI renders as *unknown* instead of the old hard-coded `true`.
+///
+/// Pure — the caller passes [now] (use the station country's wall clock,
+/// see `nowInCountry`), so services keep an injectable clock seam and the
+/// helper stays deterministic under test. Never throws: [computeOpenNow]
+/// is total over its inputs, and a `null` [hours] short-circuits.
+bool? openStateFromHours(WeeklyOpeningHours? hours, DateTime now) {
+  if (hours == null) return null;
+  return switch (computeOpenNow(hours, now).status) {
+    OpenStatus.open => true,
+    OpenStatus.closed => false,
+    OpenStatus.unknown => null,
+  };
+}

--- a/lib/features/station_services/portugal/portugal_detail_parser.dart
+++ b/lib/features/station_services/portugal/portugal_detail_parser.dart
@@ -53,7 +53,9 @@ abstract final class PortugalDetailParser {
       place: place,
       lat: 0,
       lng: 0,
-      isOpen: true,
+      // #3198 — bare detail fallback (no cached search row): the open
+      // state is stamped by the caller from the parsed weekly hours.
+      isOpen: null,
     );
   }
 

--- a/lib/features/station_services/portugal/portugal_station_service.dart
+++ b/lib/features/station_services/portugal/portugal_station_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/country/country_time.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
@@ -17,6 +18,7 @@ import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../station_detail/domain/opening_hours.dart';
+import '../opening_hours/open_state_from_hours.dart';
 import 'portugal_detail_parser.dart';
 import 'portugal_merged_row.dart';
 import 'portugal_opening_hours_adapter.dart';
@@ -257,7 +259,10 @@ class PortugalStationService
         e98: row.gasolina98,
         diesel: row.gasoleo,
         lpg: row.gpl,
-        isOpen: true,
+        // #3198 — DGEG's search payload carries no open/closed signal and
+        // no hours (they live on the detail endpoint, #2778): honest
+        // unknown instead of the old hard-coded `true`.
+        isOpen: null,
         updatedAt: row.formattedUpdatedAt,
       ));
     }
@@ -332,7 +337,12 @@ class PortugalStationService
 
       return ServiceResult(
         data: StationDetail(
-          station: station,
+          // #3198 — the detail endpoint DOES carry hours: stamp the
+          // schedule-derived open state (on Portugal's wall clock) onto
+          // the station so the detail header renders honestly.
+          station: station.copyWith(
+            isOpen: openStateFromHours(weeklyHours, nowInCountry('PT')),
+          ),
           openingHours: weeklyHours.availability ==
                   OpeningHoursAvailability.notProvided
               ? null

--- a/lib/features/station_services/portugal/portugal_station_service.dart
+++ b/lib/features/station_services/portugal/portugal_station_service.dart
@@ -252,10 +252,10 @@ class PortugalStationService
         lat: row.lat,
         lng: row.lng,
         dist: dist,
+        // #3198 — 95 simples lives in e5 only; the old e10 mirror
+        // asserted an E10 price DGEG never publishes (PT's catalog never
+        // offered e10 in the picker, so nothing user-facing is lost).
         e5: row.gasolina95,
-        // Portugal reports 95 simples as the single "petrol" — mirror it
-        // into e10 so the UI shows something for E10-preferred users.
-        e10: row.gasolina95,
         e98: row.gasolina98,
         diesel: row.gasoleo,
         lpg: row.gpl,

--- a/lib/features/station_services/romania/romania_response_parser.dart
+++ b/lib/features/station_services/romania/romania_response_parser.dart
@@ -157,7 +157,9 @@ class MonitorulStationAccumulator {
       diesel: prices[FuelType.diesel],
       dieselPremium: prices[FuelType.dieselPremium],
       lpg: prices[FuelType.lpg],
-      isOpen: true, // the observatory exposes no open/closed flag
+      // #3198 — the observatory exposes no open/closed flag: honest
+      // unknown instead of the old hard-coded `true`.
+      isOpen: null,
       updatedAt: updatedAt,
     );
   }

--- a/lib/features/station_services/slovenia/slovenia_station_service.dart
+++ b/lib/features/station_services/slovenia/slovenia_station_service.dart
@@ -203,8 +203,10 @@ class SloveniaStationService with StationServiceHelpers implements StationServic
       lat: lat,
       lng: lng,
       dist: distKm,
+      // #3198 — the single NMB-95 grade lives in e5 only; the old e10
+      // mirror asserted an E10 price goriva.si never publishes (catalog
+      // change in CountryConfig / registry).
       e5: nmb95,
-      e10: nmb95, // Slovenia ships a single 95-octane grade; surface as both
       e98: nmb100 ?? nmb98,
       diesel: dizel,
       dieselPremium: dizelPremium,

--- a/lib/features/station_services/slovenia/slovenia_station_service.dart
+++ b/lib/features/station_services/slovenia/slovenia_station_service.dart
@@ -210,11 +210,10 @@ class SloveniaStationService with StationServiceHelpers implements StationServic
       dieselPremium: dizelPremium,
       lpg: lpg,
       cng: cng,
-      // #3196 — open/closed is not reliably derivable here (Station.isOpen
-      // is non-nullable, so "unknown" cannot be expressed without a model
-      // change); keep the optimistic default the other no-signal countries
-      // use and carry the raw hours text alongside.
-      isOpen: true,
+      // #3198 — goriva.si exposes no reliable open/closed flag and only a
+      // free-form hours text: honest unknown (the #3196 optimistic `true`
+      // existed only because the field was non-nullable back then).
+      isOpen: null,
       openingHoursText: openHoursText,
       is24h: openHoursText != null && openHoursText.startsWith('00:00-23:59'),
     );

--- a/lib/features/station_services/south_korea/south_korea_response_parser.dart
+++ b/lib/features/station_services/south_korea/south_korea_response_parser.dart
@@ -137,7 +137,9 @@ class OpinetStationAccumulator {
       e98: prices[FuelType.e98],
       diesel: prices[FuelType.diesel],
       lpg: prices[FuelType.lpg],
-      isOpen: true, // OPINET does not expose a reliable open/closed flag
+      // #3198 — OPINET exposes no reliable open/closed flag: honest
+      // unknown instead of the old hard-coded `true`.
+      isOpen: null,
     );
   }
 }

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/cache/cache_manager.dart';
+import '../../../core/country/country_time.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/cached_dataset_mixin.dart';
@@ -15,8 +16,8 @@ import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/logging/error_logger.dart';
-import '../../station_detail/domain/open_now.dart';
 import '../../station_detail/domain/opening_hours.dart';
+import '../opening_hours/open_state_from_hours.dart';
 import 'spain_opening_hours_adapter.dart';
 import 'spain_provinces.dart';
 
@@ -61,7 +62,10 @@ class MitecoStationService
             ),
         _baseUrl = baseUrl ?? defaultBaseUrl,
         _cache = cache,
-        _now = now ?? DateTime.now,
+        // #3198 — default the clock seam to SPAIN's wall clock, not the
+        // device's, so a user browsing ES from another timezone gets the
+        // open state at the station.
+        _now = now ?? (() => nowInCountry('ES')),
         _parseOpeningHours =
             parseOpeningHours ?? const SpainOpeningHoursAdapter().parse;
 
@@ -293,20 +297,19 @@ class MitecoStationService
   Station _withSearchContext(Station template, double dist) =>
       template.copyWith(dist: dist, isOpen: _isOpenNow(template));
 
-  /// #3189 open-now derivation, computed from the template's already-parsed
-  /// fields: the structured schedule when available (`openingHours` is null
-  /// exactly when the adapter returned `notProvided`), else the legacy
-  /// non-empty-horario heuristic.
-  bool _isOpenNow(Station template) {
-    final horario = template.openingHoursText ?? '';
-    final fallbackOpen = horario.isNotEmpty && horario != 'Cerrado';
-    final weeklyHours = template.openingHours;
-    if (weeklyHours == null) return fallbackOpen;
-    return switch (computeOpenNow(weeklyHours, _now()).status) {
-      OpenStatus.open => true,
-      OpenStatus.closed => false,
-      OpenStatus.unknown => fallbackOpen,
-    };
+  /// #3189/#3198 open-now derivation, computed from the template's
+  /// already-parsed fields: the structured schedule decides when available
+  /// (`openingHours` is null exactly when the adapter returned
+  /// `notProvided`). Without a usable schedule only the explicit `Cerrado`
+  /// marker is a real signal — a non-empty but unparseable horario no
+  /// longer asserts "open" (#3198: that legacy heuristic presented
+  /// possibly-closed stations as open); it is honest unknown (`null`).
+  bool? _isOpenNow(Station template) {
+    final derived = openStateFromHours(template.openingHours, _now());
+    if (derived != null) return derived;
+    final horario = (template.openingHoursText ?? '').trim().toLowerCase();
+    if (horario.startsWith('cerrado')) return false;
+    return null;
   }
 
   /// Parse a number string that uses comma as decimal separator.

--- a/lib/features/station_services/uk/uk_station_service.dart
+++ b/lib/features/station_services/uk/uk_station_service.dart
@@ -237,7 +237,9 @@ class UkStationService with StationServiceHelpers implements StationService {
           // wrongly mapped to e98 (no CMA feed publishes premium petrol).
           diesel: _parsePence(prices['B7'] ?? prices['diesel']),
           dieselPremium: _parsePence(prices['SDV']),
-          isOpen: true,
+          // #3198 — the CMA feed carries no open/closed signal: honest
+          // unknown instead of the old hard-coded `true`.
+          isOpen: null,
         ));
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'UK station parse failed'}));

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -319,7 +319,11 @@ class NearestWidgetDataBuilder {
       'distanceKm': double.parse(station.dist.toStringAsFixed(1)),
       'priceFormatted': priceFormatted,
       'currency': currency,
-      'isOpen': station.isOpen,
+      // #3198 — the Kotlin/Swift widget renderers expect a bool and have
+      // no third state; an unknown open state must not render the "closed"
+      // marker, so it maps to true here (the pre-#3198 value for every
+      // country that publishes no signal).
+      'isOpen': station.isOpen ?? true,
       // Parity fields with the favorites widget so the Kotlin renderer
       // can switch modes without a second JSON shape.
       'preferred_fuel_code': fuel.apiValue,

--- a/lib/l10n/_fragments/opening_hours_display_de.arb
+++ b/lib/l10n/_fragments/opening_hours_display_de.arb
@@ -27,5 +27,7 @@
   "closedLabel": "Geschlossen",
   "openingHoursNotAvailable": "Öffnungszeiten nicht verfügbar",
   "showAllHours": "Alle Zeiten anzeigen",
-  "showLessHours": "Weniger anzeigen"
+  "showLessHours": "Weniger anzeigen",
+  "openStateUnknown": "Unbekannt",
+  "stationOpenStateSemantic": "{open, select, true{Station ist geöffnet} false{Station ist geschlossen} other{Öffnungsstatus unbekannt}}"
 }

--- a/lib/l10n/_fragments/opening_hours_display_en.arb
+++ b/lib/l10n/_fragments/opening_hours_display_en.arb
@@ -140,5 +140,18 @@
   "showLessHours": "Show less",
   "@showLessHours": {
     "description": "Collapse affordance shown when the full opening-hours table is expanded (#2709)."
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "description": "Tri-state open badge/status when the data source publishes no open/closed signal (#3198). Shown instead of Open/Closed on cards and the detail status row."
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "description": "Screen-reader label for the tri-state station open state (#3198). 'true'/'false' are the known states; any other value (the stringified null) means the source gave no signal.",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3176,6 +3176,8 @@
   "openingHoursNotAvailable": "Öffnungszeiten nicht verfügbar",
   "showAllHours": "Alle Zeiten anzeigen",
   "showLessHours": "Weniger anzeigen",
+  "openStateUnknown": "Unbekannt",
+  "stationOpenStateSemantic": "{open, select, true{Station ist geöffnet} false{Station ist geschlossen} other{Öffnungsstatus unbekannt}}",
   "tripRecordingPipEstConsumptionCaption": "gesch. L/100 km",
   "@tripRecordingPipEstConsumptionCaption": {
     "description": "#2393 — unit caption under the big GPS-estimated consumption figure on the PiP tile (the GPS-only branch added by #2390). Marks the value as an estimate ('est.') so it reads distinctly from the OBD2-measured 'L/100 km' caption — the leading '~' on the figure carries the same meaning visually. Short, fits a narrow PiP window."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6160,6 +6160,19 @@
   "@showLessHours": {
     "description": "Collapse affordance shown when the full opening-hours table is expanded (#2709)."
   },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "description": "Tri-state open badge/status when the data source publishes no open/closed signal (#3198). Shown instead of Open/Closed on cards and the detail status row."
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "description": "Screen-reader label for the tri-state station open state (#3198). 'true'/'false' are the known states; any other value (the stringified null) means the source gave no signal.",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
+  },
   "tripRecordingPipEstConsumptionCaption": "est. L/100 km",
   "@tripRecordingPipEstConsumptionCaption": {
     "description": "#2393 — unit caption under the big GPS-estimated consumption figure on the PiP tile (the GPS-only branch added by #2390). Marks the value as an estimate ('est.') so it reads distinctly from the OBD2-measured 'L/100 km' caption — the leading '~' on the figure carries the same meaning visually. Short, fits a narrow PiP window."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1939,6 +1939,8 @@
   "openingHoursNotAvailable": "⟦Óƥéñîñǧ ĥóúřš ñóŧ áṽáîłáƀłé ···········⟧",
   "showAllHours": "⟦Šĥóŵ áłł ĥóúřš ·····⟧",
   "showLessHours": "⟦Šĥóŵ łéšš ····⟧",
+  "openStateUnknown": "⟦Úñķñóŵñ ···⟧",
+  "stationOpenStateSemantic": "⟦{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}⟧",
   "tripRecordingPipEstConsumptionCaption": "⟦éšŧ. Ł/100 ķɱ ···⟧",
   "tripRecordingEstimatedInfo": "⟦Éšŧîɱáŧéđ ṽáłúé (~) — ñó ƒúéł šéñšóř óñ ŧĥîš ŧřîƥ, šó ŧĥé Ł/100 ķɱ ƒîǧúřé îš ɱóđéłłéđ ƒřóɱ ǦƤŠ šƥééđ áñđ ýóúř ṽéĥîçłé'š çáłîƀřáŧîóñ. Îŧ îš áƥƥřóẋîɱáŧé (ŧýƥîçáłłý ±10–30 %, ŧîǧĥŧéñîñǧ áš ŧĥé çáłîƀřáŧîóñ ɱáŧúřéš), ñóŧ á ɱéášúřéđ řéáđîñǧ. ··············································································⟧",
   "tripRecordingPipElapsedCaption": "⟦éłáƥšéđ ···⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4854,5 +4854,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11856,6 +11856,18 @@ abstract class AppLocalizations {
   /// **'Show less'**
   String get showLessHours;
 
+  /// Tri-state open badge/status when the data source publishes no open/closed signal (#3198). Shown instead of Open/Closed on cards and the detail status row.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get openStateUnknown;
+
+  /// Screen-reader label for the tri-state station open state (#3198). 'true'/'false' are the known states; any other value (the stringified null) means the source gave no signal.
+  ///
+  /// In en, this message translates to:
+  /// **'{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}'**
+  String stationOpenStateSemantic(String open);
+
   /// #2393 — unit caption under the big GPS-estimated consumption figure on the PiP tile (the GPS-only branch added by #2390). Marks the value as an estimate ('est.') so it reads distinctly from the OBD2-measured 'L/100 km' caption — the leading '~' on the figure carries the same meaning visually. Short, fits a narrow PiP window.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6863,6 +6863,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String get showLessHours => 'Покажи по-малко';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'прибл. л/100 км';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6817,6 +6817,19 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showLessHours => 'Zobrazit méně';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'odh. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6806,6 +6806,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showLessHours => 'Vis færre';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6843,6 +6843,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showLessHours => 'Weniger anzeigen';
 
   @override
+  String get openStateUnknown => 'Unbekannt';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station ist geöffnet',
+      'false': 'Station ist geschlossen',
+      'other': 'Öffnungsstatus unbekannt',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'gesch. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -6863,6 +6863,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showLessHours => 'Λιγότερες ώρες';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'εκτ. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6772,6 +6772,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showLessHours => 'Show less';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override
@@ -14718,6 +14731,19 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get showLessHours => '⟦Šĥóŵ łéšš ····⟧';
+
+  @override
+  String get openStateUnknown => '⟦Úñķñóŵñ ···⟧';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '⟦$_temp0⟧';
+  }
 
   @override
   String get tripRecordingPipEstConsumptionCaption => '⟦éšŧ. Ł/100 ķɱ ···⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6854,6 +6854,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showLessHours => 'Mostrar menos';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -6803,6 +6803,19 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showLessHours => 'Kuva vähem';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'hinn. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -6804,6 +6804,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showLessHours => 'Näytä vähemmän';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'arv. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6873,6 +6873,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showLessHours => 'Afficher moins';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6829,6 +6829,19 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showLessHours => 'Prikaži manje';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'proci. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -6850,6 +6850,19 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showLessHours => 'Kevesebb megjelenítése';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'becsült L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6844,6 +6844,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showLessHours => 'Mostra meno';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'stim. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -6844,6 +6844,19 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showLessHours => 'Rodyti mažiau';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'įvert. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -6846,6 +6846,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showLessHours => 'Rādīt mazāk';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'aprēķ. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6805,6 +6805,19 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showLessHours => 'Vis mindre';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6828,6 +6828,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showLessHours => 'Minder tonen';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'gesch. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6835,6 +6835,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showLessHours => 'Pokaż mniej';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'szac. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6857,6 +6857,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showLessHours => 'Ver menos';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6855,6 +6855,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showLessHours => 'Afișați mai puțin';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'est. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -6834,6 +6834,19 @@ class AppLocalizationsSk extends AppLocalizations {
   String get showLessHours => 'Zobraziť menej';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'odh. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6815,6 +6815,19 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showLessHours => 'Prikaži manj';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'ocen. L/100 km';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6802,6 +6802,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showLessHours => 'Visa mindre';
 
   @override
+  String get openStateUnknown => 'Unknown';
+
+  @override
+  String stationOpenStateSemantic(String open) {
+    String _temp0 = intl.Intl.selectLogic(open, {
+      'true': 'Station is open',
+      'false': 'Station is closed',
+      'other': 'Open state unknown',
+    });
+    return '$_temp0';
+  }
+
+  @override
   String get tripRecordingPipEstConsumptionCaption => 'uppsk. L/100 km';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4751,5 +4751,20 @@
   "@alertsLastCheckedNever": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "openStateUnknown": "Unknown",
+  "@openStateUnknown": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "stationOpenStateSemantic": "{open, select, true{Station is open} false{Station is closed} other{Open state unknown}}",
+  "@stationOpenStateSemantic": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "open": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/test/core/country/country_fuel_parity_test.dart
+++ b/test/core/country/country_fuel_parity_test.dart
@@ -100,23 +100,29 @@ void main() {
       );
     });
 
-    test('regression: Slovenia exposes e10 + cng in BOTH structures (#2180)',
-        () {
-      // SloveniaStationService surfaces the single 95-octane grade as both
-      // e5 and e10, and maps the goriva.si "cng" key onto Station.cng. The
-      // registry previously omitted both.
-      for (final fuel in const [FuelType.e10, FuelType.cng]) {
-        expect(
-          Countries.slovenia.supportedFuelTypes,
-          contains(fuel),
-          reason: 'SI picker must offer ${fuel.apiValue}',
-        );
-        expect(
-          registrySet('SI'),
-          contains(fuel),
-          reason: 'SI search selector must offer ${fuel.apiValue}',
-        );
-      }
+    test(
+        'regression: Slovenia exposes cng but NOT e10 in BOTH structures '
+        '(#2180/#3198)', () {
+      // SloveniaStationService maps the goriva.si "cng" key onto
+      // Station.cng (#2180). The single NMB-95 grade lives in e5 only:
+      // #3198 removed the e5→e10 mirror, so neither structure may offer
+      // an E10 the feed never publishes.
+      expect(
+        Countries.slovenia.supportedFuelTypes,
+        contains(FuelType.cng),
+        reason: 'SI picker must offer CNG',
+      );
+      expect(
+        registrySet('SI'),
+        contains(FuelType.cng),
+        reason: 'SI search selector must offer CNG',
+      );
+      expect(
+        Countries.slovenia.supportedFuelTypes,
+        isNot(contains(FuelType.e10)),
+        reason: '#3198 — goriva.si publishes no E10 grade',
+      );
+      expect(registrySet('SI'), isNot(contains(FuelType.e10)));
     });
 
     test('regression: Mexico offers e98 (premium grade) not e10 (#2704)', () {
@@ -135,10 +141,23 @@ void main() {
       expect(registrySet('MX'), isNot(contains(FuelType.e10)));
     });
 
-    test('regression: Denmark offers e10 in BOTH structures (#2180)', () {
-      // DenmarkStationService surfaces Blyfri 95 as both e5 and e10.
-      expect(Countries.denmark.supportedFuelTypes, contains(FuelType.e10));
-      expect(registrySet('DK'), contains(FuelType.e10));
+    test(
+        'regression: Denmark offers the real premium grades, NOT e10 '
+        '(#3187/#3198)', () {
+      // #3198 — no DK feed publishes an E10 grade; the old Blyfri-95
+      // mirror is gone. #3187's exact-grade mapping emits Oktan 100 /
+      // V-Power → e98 and V-Power Diesel → dieselPremium instead.
+      expect(
+        Countries.denmark.supportedFuelTypes,
+        isNot(contains(FuelType.e10)),
+      );
+      expect(registrySet('DK'), isNot(contains(FuelType.e10)));
+      for (final fuel in const [FuelType.e98, FuelType.dieselPremium]) {
+        expect(Countries.denmark.supportedFuelTypes, contains(fuel),
+            reason: 'DK picker must offer ${fuel.apiValue}');
+        expect(registrySet('DK'), contains(fuel),
+            reason: 'DK search selector must offer ${fuel.apiValue}');
+      }
     });
 
     test('regression: UK offers e10, drops dieselPremium (#2180)', () {

--- a/test/core/country/country_supported_fuels_test.dart
+++ b/test/core/country/country_supported_fuels_test.dart
@@ -31,10 +31,11 @@ void main() {
       });
     });
 
-    test('Austria — E5, E10, Diesel, Electric (same as default)', () {
+    test('Austria — E5, Diesel, Electric (#3198: no phantom E10)', () {
+      // E-Control publishes exactly one petrol grade (SUP); the catalog
+      // no longer advertises an E10 the feed never carries.
       expect(Countries.austria.supportedFuelTypes, {
         FuelType.e5,
-        FuelType.e10,
         FuelType.diesel,
         FuelType.electric,
       });

--- a/test/core/country/country_time_test.dart
+++ b/test/core/country/country_time_test.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_time.dart';
+
+void main() {
+  // Fixed instants well inside / outside the EU DST window.
+  final summerUtc = DateTime.utc(2026, 6, 10, 12, 0); // June — DST active
+  final winterUtc = DateTime.utc(2026, 1, 15, 12, 0); // January — standard
+
+  group('utcOffsetMinutesFor (#3198)', () {
+    test('CET countries: +60 winter, +120 summer', () {
+      for (final c in ['DE', 'FR', 'AT', 'IT', 'ES', 'DK', 'LU', 'SI']) {
+        expect(utcOffsetMinutesFor(c, winterUtc), 60, reason: c);
+        expect(utcOffsetMinutesFor(c, summerUtc), 120, reason: c);
+      }
+    });
+
+    test('WET countries (PT/GB): 0 winter, +60 summer', () {
+      for (final c in ['PT', 'GB']) {
+        expect(utcOffsetMinutesFor(c, winterUtc), 0, reason: c);
+        expect(utcOffsetMinutesFor(c, summerUtc), 60, reason: c);
+      }
+    });
+
+    test('EET countries (GR/RO): +120 winter, +180 summer', () {
+      for (final c in ['GR', 'RO']) {
+        expect(utcOffsetMinutesFor(c, winterUtc), 120, reason: c);
+        expect(utcOffsetMinutesFor(c, summerUtc), 180, reason: c);
+      }
+    });
+
+    test('fixed-offset countries never shift', () {
+      expect(utcOffsetMinutesFor('KR', winterUtc), 9 * 60);
+      expect(utcOffsetMinutesFor('KR', summerUtc), 9 * 60);
+      expect(utcOffsetMinutesFor('AR', winterUtc), -3 * 60);
+      expect(utcOffsetMinutesFor('AR', summerUtc), -3 * 60);
+      expect(utcOffsetMinutesFor('MX', winterUtc), -6 * 60);
+      expect(utcOffsetMinutesFor('MX', summerUtc), -6 * 60);
+    });
+
+    test('southern-hemisphere DST is inverted (CL, AU)', () {
+      // January is southern summer; June is southern winter.
+      expect(utcOffsetMinutesFor('CL', winterUtc), -3 * 60);
+      expect(utcOffsetMinutesFor('CL', summerUtc), -4 * 60);
+      expect(utcOffsetMinutesFor('AU', winterUtc), 11 * 60);
+      expect(utcOffsetMinutesFor('AU', summerUtc), 10 * 60);
+    });
+
+    test('EU DST boundary: last Sunday of March 2026 at 01:00 UTC', () {
+      // 2026-03-29 is the last Sunday of March.
+      final before = DateTime.utc(2026, 3, 29, 0, 59);
+      final after = DateTime.utc(2026, 3, 29, 1, 0);
+      expect(utcOffsetMinutesFor('DE', before), 60);
+      expect(utcOffsetMinutesFor('DE', after), 120);
+    });
+
+    test('EU DST boundary: last Sunday of October 2026 at 01:00 UTC', () {
+      // 2026-10-25 is the last Sunday of October.
+      final before = DateTime.utc(2026, 10, 25, 0, 59);
+      final after = DateTime.utc(2026, 10, 25, 1, 0);
+      expect(utcOffsetMinutesFor('DE', before), 120);
+      expect(utcOffsetMinutesFor('DE', after), 60);
+    });
+
+    test('unknown / null country code → null (caller falls back)', () {
+      expect(utcOffsetMinutesFor('XX', summerUtc), isNull);
+      expect(utcOffsetMinutesFor(null, summerUtc), isNull);
+    });
+  });
+
+  group('nowInCountry (#3198)', () {
+    test('Seoul is 9h ahead of UTC regardless of season', () {
+      final kr = nowInCountry('KR', utcNow: summerUtc);
+      expect(kr.hour, 21);
+      expect(kr.day, 10);
+    });
+
+    test('Berlin reads 14:00 when UTC is 12:00 in June', () {
+      final de = nowInCountry('DE', utcNow: summerUtc);
+      expect(de.hour, 14);
+    });
+
+    test('weekday rolls over with the offset', () {
+      // 2026-06-10 23:30 UTC is already Thursday 08:30 in Seoul.
+      final lateUtc = DateTime.utc(2026, 6, 10, 23, 30);
+      final kr = nowInCountry('KR', utcNow: lateUtc);
+      expect(kr.weekday, DateTime.thursday);
+      expect(kr.hour, 8);
+    });
+
+    test('unknown country falls back to the device-local instant', () {
+      final local = nowInCountry('XX', utcNow: summerUtc);
+      expect(local, summerUtc.toLocal());
+    });
+  });
+}

--- a/test/core/services/impl/demo_station_service_test.dart
+++ b/test/core/services/impl/demo_station_service_test.dart
@@ -165,7 +165,8 @@ void main() {
 
     test('returns status based on cached isOpen', () async {
       final searchResult = await service.searchStations(defaultParams);
-      final openStation = searchResult.data.firstWhere((s) => s.isOpen);
+      final openStation =
+          searchResult.data.firstWhere((s) => s.isOpen == true);
       final prices = await service.getPrices([openStation.id]);
       expect(prices.data[openStation.id]!.status, 'open');
     });

--- a/test/core/utils/unit_formatter_test.dart
+++ b/test/core/utils/unit_formatter_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/core/utils/unit_formatter.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
 void main() {
   // Ensure every test starts from the default "France" context that
@@ -96,6 +97,32 @@ void main() {
       // $1.859 → 185.9 c/L
       expect(UnitFormatter.formatPricePerUnit(1.859, countryCode: 'AU'),
           '185,9 c/L');
+    });
+
+    test('AR GNC renders the per-fuel \$/m³ suffix override (#3198)', () {
+      // GNC is priced per cubic metre upstream, not per litre.
+      expect(
+        UnitFormatter.formatPricePerUnit(450.0,
+            countryCode: 'AR', fuelType: FuelType.cng),
+        endsWith('\u0024/m\u00b3'),
+      );
+      // Every other AR fuel keeps the country-wide \$/L suffix.
+      expect(
+        UnitFormatter.formatPricePerUnit(980.0,
+            countryCode: 'AR', fuelType: FuelType.e5),
+        endsWith('\u0024/L'),
+      );
+      // Fuel not known at the call site → country-wide suffix.
+      expect(
+        UnitFormatter.formatPricePerUnit(980.0, countryCode: 'AR'),
+        endsWith('\u0024/L'),
+      );
+      // The bare-suffix accessor honours the override too.
+      expect(
+        UnitFormatter.pricePerUnitSuffix(
+            countryCode: 'AR', fuelType: FuelType.cng),
+        '\u0024/m\u00b3',
+      );
     });
 
     test('Denmark uses kr/L suffix', () {

--- a/test/core/widgets/fuel_type_dropdown_test.dart
+++ b/test/core/widgets/fuel_type_dropdown_test.dart
@@ -36,6 +36,25 @@ void main() {
           reason: 'The "all" wildcard must never be pickable as a preference');
     });
 
+    testWidgets(
+        '#3198 — a stored selection missing from the catalog stays '
+        'renderable instead of asserting', (tester) async {
+      // e.g. an e10 preference saved before the phantom-E10 cleanup, in a
+      // country whose catalog no longer offers e10.
+      await pumpApp(
+        tester,
+        FuelTypeDropdown(
+          value: FuelType.e10,
+          onChanged: (_) {},
+          options: const [FuelType.e5, FuelType.diesel],
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text(FuelType.e10.displayName), findsOneWidget,
+          reason: 'the legacy selection must render so the user can '
+              'switch to a real grade');
+    });
+
     testWidgets('selecting a fuel fires onChanged with the FuelType',
         (tester) async {
       FuelType? picked;

--- a/test/features/search/domain/entities/fuel_type_test.dart
+++ b/test/features/search/domain/entities/fuel_type_test.dart
@@ -111,7 +111,8 @@ void main() {
     test('Austria returns correct fuel types', () {
       final types = fuelTypesForCountry('AT');
       expect(types, contains(FuelType.e5));
-      expect(types, contains(FuelType.e10));
+      // #3198 — no e10: E-Control publishes exactly one petrol grade.
+      expect(types, isNot(contains(FuelType.e10)));
       expect(types, contains(FuelType.diesel));
       expect(types, contains(FuelType.electric));
       expect(types, contains(FuelType.all));

--- a/test/features/search/domain/entities/fuel_types_for_country_test.dart
+++ b/test/features/search/domain/entities/fuel_types_for_country_test.dart
@@ -41,12 +41,11 @@ void main() {
       );
     });
 
-    test('AT — E5, E10, Diesel, Electric, All', () {
+    test('AT — E5, Diesel, Electric, All (#3198: no phantom E10)', () {
       expect(
         fuelTypesForCountry('AT'),
         equals(<FuelType>[
           FuelType.e5,
-          FuelType.e10,
           FuelType.diesel,
           FuelType.electric,
           FuelType.all,
@@ -99,17 +98,15 @@ void main() {
       );
     });
 
-    test('SI — NMB-95 (e5+e10)/100, Diesel, Diesel Premium, LPG, CNG '
-        '(#575, #2180)', () {
-      // #2180 — e10 + cng added: SloveniaStationService surfaces the single
-      // 95-octane grade as both e5 and e10, and maps the goriva.si "cng"
-      // key onto Station.cng. The registry now matches what the service
-      // emits and the country's supportedFuelTypes picker set.
+    test('SI — NMB-95 (e5)/100, Diesel, Diesel Premium, LPG, CNG '
+        '(#575, #3198)', () {
+      // #3198 — the single 95-octane grade is e5 only: the #2180 e5→e10
+      // mirror asserted an E10 price goriva.si never publishes, so e10
+      // is gone from the catalog. cng stays (#2180, really emitted).
       expect(
         fuelTypesForCountry('SI'),
         equals(<FuelType>[
           FuelType.e5,
-          FuelType.e10,
           FuelType.e98,
           FuelType.diesel,
           FuelType.dieselPremium,

--- a/test/features/search/domain/entities/station_test.dart
+++ b/test/features/search/domain/entities/station_test.dart
@@ -39,6 +39,37 @@ void main() {
       expect(json['lng'], isA<double>());
       expect(json['isOpen'], isA<bool>());
     });
+
+    // #3198 — tri-state isOpen across the cache/favorites/widget JSON
+    // codec (the #2776/#2777 silent-drop lesson: every state must survive
+    // the real toJson→fromJson round-trip, and legacy payloads written by
+    // older builds must still read).
+    group('tri-state isOpen codec (#3198)', () {
+      test('an unknown open state (null) survives the JSON round-trip', () {
+        final unknown = testStation.copyWith(isOpen: null);
+        final roundtripped = Station.fromJson(unknown.toJson());
+        expect(roundtripped.isOpen, isNull,
+            reason: 'null must round-trip as null — not collapse to a bool');
+      });
+
+      test('a known-closed state survives the JSON round-trip', () {
+        final closed = testStation.copyWith(isOpen: false);
+        expect(Station.fromJson(closed.toJson()).isOpen, isFalse);
+      });
+
+      test('legacy cache JSON with an explicit bool still reads as-is', () {
+        // Payload shape written by pre-#3198 builds: isOpen always a bool.
+        final legacy = Map<String, dynamic>.from(testStation.toJson())
+          ..['isOpen'] = true;
+        expect(Station.fromJson(legacy).isOpen, isTrue);
+      });
+
+      test('cache JSON missing the isOpen key reads as unknown', () {
+        final json = Map<String, dynamic>.from(testStation.toJson())
+          ..remove('isOpen');
+        expect(Station.fromJson(json).isOpen, isNull);
+      });
+    });
   });
 
   group('Station.priceFor', () {

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -58,6 +58,18 @@ void main() {
       expect(find.text('Closed'), findsOneWidget);
     });
 
+    testWidgets(
+        '#3198 — an unknown open state shows the Unknown badge, '
+        'never Closed (and never Open)', (tester) async {
+      final unknownStation = testStation.copyWith(isOpen: null);
+
+      await pumpApp(tester, AllPricesStationCard(station: unknownStation));
+
+      expect(find.text('Unknown'), findsOneWidget);
+      expect(find.text('Closed'), findsNothing);
+      expect(find.text('Open'), findsNothing);
+    });
+
     testWidgets('renders fuel price badges for available fuels', (
       tester,
     ) async {

--- a/test/features/search/presentation/widgets/brand_filter_test.dart
+++ b/test/features/search/presentation/widgets/brand_filter_test.dart
@@ -201,6 +201,33 @@ void main() {
       expect(result.any((s) => s.id == 'b'), isFalse);
     });
 
+    test(
+        '#3198 — openOnly keeps an UNKNOWN open state (only known-closed '
+        'is dropped)', () {
+      // A country whose feed publishes no open/closed signal (UK/MX/KR…)
+      // carries isOpen == null on every station; the open-now filter must
+      // not empty the whole list for it.
+      const unknownState = Station(
+        id: 'u',
+        name: 'U',
+        brand: 'ESSO',
+        street: 'Str',
+        postCode: '10000',
+        place: 'Berlin',
+        lat: 0,
+        lng: 0,
+        isOpen: null,
+      );
+      final result = applyAmenityAndStatusFilters(
+        [wifiShopOpen, wifiOnlyClosed, unknownState],
+        requiredAmenities: const {},
+        openOnly: true,
+      );
+      expect(result.map((s) => s.id), containsAll(['a', 'u']));
+      expect(result.any((s) => s.id == 'b'), isFalse,
+          reason: 'known-closed still drops');
+    });
+
     test('amenity + openOnly combine — wifi AND open', () {
       final result = applyAmenityAndStatusFilters(
         all,

--- a/test/features/station_services/argentina/argentina_station_service_test.dart
+++ b/test/features/station_services/argentina/argentina_station_service_test.dart
@@ -516,7 +516,8 @@ col0,col1,col2,YPF,AV. RIVADAVIA 5000,CABALLITO,Buenos Aires,col7,col8,Nafta pre
       expect(station.lat, closeTo(-34.62, 0.01));
       expect(station.lng, closeTo(-58.43, 0.01));
       expect(station.e98, closeTo(750.0, 0.01));
-      expect(station.isOpen, isTrue);
+      // #3198 — the Secretaría feed publishes no open/closed signal.
+      expect(station.isOpen, isNull);
       expect(station.region, 'Buenos Aires');
       expect(station.updatedAt, '2026-03-20');
     });

--- a/test/features/station_services/argentina/argentina_station_service_test.dart
+++ b/test/features/station_services/argentina/argentina_station_service_test.dart
@@ -504,7 +504,8 @@ col0,col1,col2,YPF,AV. RIVADAVIA 5000,CABALLITO,Buenos Aires,col7,col8,Nafta pre
         e10: null,
         e98: 750.0,
         diesel: null,
-        isOpen: true,
+        // #3198 — mirrors the real service: no upstream open/closed signal.
+        isOpen: null,
         updatedAt: raw.fechaVigencia,
         region: raw.provincia,
       );

--- a/test/features/station_services/austria/econtrol_station_service_test.dart
+++ b/test/features/station_services/austria/econtrol_station_service_test.dart
@@ -177,9 +177,10 @@ void main() {
       expect(s.lat, closeTo(48.2, 0.001));
       expect(s.lng, closeTo(16.37, 0.001));
       expect(s.diesel, closeTo(1.659, 0.001));
-      // Austrian "Super 95" maps to both E5 and E10.
+      // #3198 — E-Control publishes ONE petrol grade (SUP → e5); e10 is
+      // no longer mirrored (the feed has no E10 price).
       expect(s.e5, closeTo(1.549, 0.001));
-      expect(s.e10, closeTo(1.549, 0.001));
+      expect(s.e10, isNull);
       expect(s.isOpen, isTrue);
     });
 
@@ -221,7 +222,8 @@ void main() {
 
       final superOnly = stations.firstWhere((s) => s.id == 'at-300');
       expect(superOnly.e5, closeTo(1.519, 0.001));
-      expect(superOnly.e10, closeTo(1.519, 0.001));
+      expect(superOnly.e10, isNull,
+          reason: '#3198 — no e10 mirror: the feed has no E10 grade');
       expect(superOnly.diesel, isNull);
     });
 

--- a/test/features/station_services/denmark/denmark_station_service_test.dart
+++ b/test/features/station_services/denmark/denmark_station_service_test.dart
@@ -337,7 +337,8 @@ void main() {
         expect(s.e5, closeTo(13.49, 0.01));
         expect(s.e10, closeTo(13.49, 0.01));
         expect(s.diesel, closeTo(11.99, 0.01));
-        expect(s.isOpen, isTrue);
+        // #3198 — the OK feed carries no open/closed signal: honest unknown.
+        expect(s.isOpen, isNull);
       });
 
       test('skips stations with zero coordinates', () {
@@ -825,7 +826,7 @@ class _TestableDenmarkParser {
         e5: e5,
         e10: e5,
         diesel: diesel,
-        isOpen: true,
+        isOpen: null, // #3198 — mirrors the real parser: no signal
         updatedAt: testFormatIsoTime(r['last_updated_time']?.toString()),
       );
     }).whereType<Station>().toList();
@@ -865,7 +866,7 @@ class _TestableDenmarkParser {
         e5: e5,
         e10: e5,
         diesel: diesel,
-        isOpen: true,
+        isOpen: null, // #3198 — mirrors the real parser: no signal
         updatedAt: testFormatIsoTime(
           (prices.isNotEmpty ? prices.first['lastUpdated'] : null)?.toString(),
         ),

--- a/test/features/station_services/denmark/denmark_station_service_test.dart
+++ b/test/features/station_services/denmark/denmark_station_service_test.dart
@@ -335,7 +335,8 @@ void main() {
         expect(s.lat, closeTo(55.6761, 0.001));
         expect(s.lng, closeTo(12.5683, 0.001));
         expect(s.e5, closeTo(13.49, 0.01));
-        expect(s.e10, closeTo(13.49, 0.01));
+        expect(s.e10, isNull,
+            reason: '#3198 — no e10 mirror: no DK feed publishes E10');
         expect(s.diesel, closeTo(11.99, 0.01));
         // #3198 — the OK feed carries no open/closed signal: honest unknown.
         expect(s.isOpen, isNull);
@@ -670,9 +671,9 @@ void main() {
       expect(allStations[0].brand, 'OK');
       expect(allStations[1].brand, 'Shell');
 
-      // Verify OK station has both e5 and e10 set to same value
+      // #3198 — the single 95-octane grade lives in e5 only (no mirror).
       expect(allStations[0].e5, closeTo(13.49, 0.01));
-      expect(allStations[0].e10, closeTo(13.49, 0.01));
+      expect(allStations[0].e10, isNull);
       expect(allStations[0].diesel, closeTo(11.99, 0.01));
 
       // Verify Shell station
@@ -824,7 +825,8 @@ class _TestableDenmarkParser {
         lng: lng,
         dist: 0,
         e5: e5,
-        e10: e5,
+        // #3198 — mirrors the real parser: no e10 mirror.
+
         diesel: diesel,
         isOpen: null, // #3198 — mirrors the real parser: no signal
         updatedAt: testFormatIsoTime(r['last_updated_time']?.toString()),
@@ -864,7 +866,8 @@ class _TestableDenmarkParser {
         lng: lng,
         dist: 0,
         e5: e5,
-        e10: e5,
+        // #3198 — mirrors the real parser: no e10 mirror.
+
         diesel: diesel,
         isOpen: null, // #3198 — mirrors the real parser: no signal
         updatedAt: testFormatIsoTime(

--- a/test/features/station_services/france/prix_carburants_flux_test.dart
+++ b/test/features/station_services/france/prix_carburants_flux_test.dart
@@ -12,6 +12,8 @@ import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/station_services/france/prix_carburants_flux_parser.dart'
     as flux;
+import 'package:tankstellen/features/station_services/france/prix_carburants_parsers.dart'
+    as parser;
 import 'package:tankstellen/features/station_services/france/prix_carburants_flux_station_service.dart';
 
 /// #2277 — the FR *flux instantané* bulk-file path: download the whole-country
@@ -185,6 +187,27 @@ void main() {
         },
       ]);
       expect(flux.parseFluxXml(xml).first.brand, 'Autoroute');
+    });
+
+    test(
+        '#3198 — flux path detects chain brands from adresse/ville like '
+        'the JSON path (no more path-dependent brand)', () {
+      final xml = _fluxXml([
+        _pdv(id: '11', lat: 43.45, lng: 3.52, adresse: 'CC CARREFOUR RN 113'),
+        _pdv(id: '12', lat: 43.46, lng: 3.53, adresse: 'AVENUE TOTALENERGIES'),
+        _pdv(id: '13', lat: 43.47, lng: 3.54, adresse: '1 RUE DES FLEURS',
+            ville: 'PAU'),
+      ]);
+      final byId = {for (final s in flux.parseFluxXml(xml)) s.id: s};
+      // Same substring map the legacy JSON path uses
+      // (detectPrixCarburantsBrand) — and the same value it would return.
+      expect(byId['fr-11']!.brand, 'Carrefour');
+      expect(byId['fr-11']!.brand,
+          parser.detectPrixCarburantsBrand('CC CARREFOUR RN 113', null,
+              <String, dynamic>{'ville': 'CASTELNAU'}));
+      expect(byId['fr-12']!.brand, 'TotalEnergies');
+      // Genuinely unbranded stays the #482 Independent sentinel.
+      expect(byId['fr-13']!.brand, 'Independent');
     });
 
     test('skips a pdv with no/zero coordinates', () {

--- a/test/features/station_services/italy/mise_station_service_test.dart
+++ b/test/features/station_services/italy/mise_station_service_test.dart
@@ -419,7 +419,7 @@ idImpianto|descCarburante|prezzo|isSelf|dtComu
           lng: s.lng,
           dist: 0,
           e5: p?.benzinaSelf ?? p?.benzinaServed,
-          e10: p?.benzinaSelf ?? p?.benzinaServed,
+          // #3198 — mirrors the real parser: no e10 mirror.
           diesel: p?.gasolioSelf ?? p?.gasolioServed,
           lpg: p?.gpl,
           cng: p?.metano,

--- a/test/features/station_services/luxembourg/luxembourg_station_service_test.dart
+++ b/test/features/station_services/luxembourg/luxembourg_station_service_test.dart
@@ -188,12 +188,14 @@ void main() {
         }
       });
 
-      test('all stations report isOpen: true', () async {
+      test('all stations report an unknown open state (#3198)', () async {
+        // The decree publishes prices, not per-station hours — honest
+        // unknown instead of the old hard-coded true.
         const params =
             SearchParams(lat: 49.6116, lng: 6.1319, radiusKm: 100.0);
         final result = await service.searchStations(params);
         for (final s in result.data) {
-          expect(s.isOpen, isTrue);
+          expect(s.isOpen, isNull);
         }
       });
 

--- a/test/features/station_services/mexico/mexico_station_service_test.dart
+++ b/test/features/station_services/mexico/mexico_station_service_test.dart
@@ -188,7 +188,8 @@ void main() {
       expect(s.e98, 24.89, reason: 'CRE premium → e98 (high-octane), not e10');
       expect(s.e10, isNull, reason: 'no European e10 grade in Mexico');
       expect(s.diesel, 23.45);
-      expect(s.isOpen, isTrue);
+      // #3198 — CRE publishes no open/closed signal: honest unknown.
+      expect(s.isOpen, isNull);
     });
 
     test('location.x is longitude and y is latitude (never swapped)',

--- a/test/features/station_services/opening_hours/open_state_from_hours_test.dart
+++ b/test/features/station_services/opening_hours/open_state_from_hours_test.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/opening_hours/open_state_from_hours.dart';
+
+void main() {
+  // Wednesday 2026-06-10; minutes chosen against a 07:00-19:00 day.
+  final wedMorning = DateTime(2026, 6, 10, 10, 0);
+  final wedNight = DateTime(2026, 6, 10, 3, 0);
+
+  WeeklyOpeningHours weekday7to19() => WeeklyOpeningHours(
+        days: [
+          for (final d in kRegularWeekdays)
+            DayHours(
+              day: d,
+              state: DayState.openRanges,
+              ranges: const [
+                TimeRange(startMinutes: 7 * 60, endMinutes: 19 * 60),
+              ],
+            ),
+        ],
+        availability: OpeningHoursAvailability.full,
+      );
+
+  group('openStateFromHours (#3198)', () {
+    test('null hours → null (honest unknown, never true)', () {
+      expect(openStateFromHours(null, wedMorning), isNull);
+    });
+
+    test('inside the schedule → true', () {
+      expect(openStateFromHours(weekday7to19(), wedMorning), isTrue);
+    });
+
+    test('outside the schedule → false', () {
+      expect(openStateFromHours(weekday7to19(), wedNight), isFalse);
+    });
+
+    test('24/7 schedule → true at any instant', () {
+      final allWeek = WeeklyOpeningHours.allWeek24h();
+      expect(openStateFromHours(allWeek, wedNight), isTrue);
+      expect(openStateFromHours(allWeek, wedMorning), isTrue);
+    });
+
+    test('no-data sentinel → null (unknown), not closed', () {
+      expect(
+        openStateFromHours(WeeklyOpeningHours.notAvailable, wedMorning),
+        isNull,
+      );
+    });
+
+    test('all-days-unknown schedule → null', () {
+      final unknownWeek = WeeklyOpeningHours(
+        days: [
+          for (final d in kRegularWeekdays)
+            DayHours(day: d, state: DayState.unknown),
+        ],
+        availability: OpeningHoursAvailability.partial,
+      );
+      expect(openStateFromHours(unknownWeek, wedMorning), isNull);
+    });
+
+    // Fault injection for the documented never-throws contract: feed the
+    // degenerate / adversarial shapes adapters can emit (empty schedule
+    // flagged full, degenerate FR 01:00-01:00 sentinel ranges, a
+    // publicHoliday-only schedule) and assert the call returns normally.
+    test('never throws on degenerate or adversarial schedules', () {
+      final degenerate = WeeklyOpeningHours(
+        days: [
+          DayHours(
+            day: OpeningDay.mon,
+            state: DayState.openRanges,
+            // The FR `01:00-01:00` no-interval sentinel.
+            ranges: const [TimeRange(startMinutes: 60, endMinutes: 60)],
+          ),
+          const DayHours(day: OpeningDay.publicHoliday, state: DayState.closed),
+        ],
+        availability: OpeningHoursAvailability.full,
+      );
+      expect(() => openStateFromHours(degenerate, wedMorning),
+          returnsNormally);
+      const emptyButFull =
+          WeeklyOpeningHours(availability: OpeningHoursAvailability.full);
+      expect(() => openStateFromHours(emptyButFull, wedNight),
+          returnsNormally);
+      expect(openStateFromHours(emptyButFull, wedNight), isNull);
+    });
+
+    test('an overnight wrap from yesterday counts as open', () {
+      // Tue 22:00 - Wed 04:00; probe Wednesday 03:00.
+      final overnight = WeeklyOpeningHours(
+        days: const [
+          DayHours(
+            day: OpeningDay.tue,
+            state: DayState.openRanges,
+            ranges: [TimeRange(startMinutes: 22 * 60, endMinutes: 4 * 60)],
+          ),
+        ],
+        availability: OpeningHoursAvailability.partial,
+      );
+      expect(openStateFromHours(overnight, wedNight), isTrue);
+    });
+  });
+}

--- a/test/features/station_services/opening_hours/open_state_from_hours_test.dart
+++ b/test/features/station_services/opening_hours/open_state_from_hours_test.dart
@@ -66,15 +66,15 @@ void main() {
     // flagged full, degenerate FR 01:00-01:00 sentinel ranges, a
     // publicHoliday-only schedule) and assert the call returns normally.
     test('never throws on degenerate or adversarial schedules', () {
-      final degenerate = WeeklyOpeningHours(
+      const degenerate = WeeklyOpeningHours(
         days: [
           DayHours(
             day: OpeningDay.mon,
             state: DayState.openRanges,
             // The FR `01:00-01:00` no-interval sentinel.
-            ranges: const [TimeRange(startMinutes: 60, endMinutes: 60)],
+            ranges: [TimeRange(startMinutes: 60, endMinutes: 60)],
           ),
-          const DayHours(day: OpeningDay.publicHoliday, state: DayState.closed),
+          DayHours(day: OpeningDay.publicHoliday, state: DayState.closed),
         ],
         availability: OpeningHoursAvailability.full,
       );
@@ -89,8 +89,8 @@ void main() {
 
     test('an overnight wrap from yesterday counts as open', () {
       // Tue 22:00 - Wed 04:00; probe Wednesday 03:00.
-      final overnight = WeeklyOpeningHours(
-        days: const [
+      const overnight = WeeklyOpeningHours(
+        days: [
           DayHours(
             day: OpeningDay.tue,
             state: DayState.openRanges,

--- a/test/features/station_services/portugal/portugal_station_service_test.dart
+++ b/test/features/station_services/portugal/portugal_station_service_test.dart
@@ -243,8 +243,8 @@ void main() {
       final s = result.data.first;
       expect(s.id, 'pt-42');
       expect(s.e5, closeTo(1.719, 0.0001));
-      expect(s.e10, closeTo(1.719, 0.0001),
-          reason: 'PT 95 simples is mirrored into e10 for the UI');
+      expect(s.e10, isNull,
+          reason: '#3198 — no e10 mirror: DGEG publishes no E10 grade');
       expect(s.diesel, closeTo(1.599, 0.0001));
     });
 

--- a/test/features/station_services/slovenia/slovenia_station_service_test.dart
+++ b/test/features/station_services/slovenia/slovenia_station_service_test.dart
@@ -129,10 +129,10 @@ void main() {
         expect(s.postCode, '1000');
         expect(s.lat, closeTo(46.058, 0.001));
         expect(s.lng, closeTo(14.503, 0.001));
-        // NMB-95 -> e5 (and mirrored into e10 as Slovenia sells a
-        // single 95 grade)
+        // NMB-95 -> e5 only (#3198 — the old e10 mirror asserted an E10
+        // price goriva.si never publishes).
         expect(s.e5, closeTo(1.605, 0.001));
-        expect(s.e10, closeTo(1.605, 0.001));
+        expect(s.e10, isNull);
         // NMB-100 -> e98 (premium petrol slot)
         expect(s.e98, closeTo(1.901, 0.001));
         expect(s.diesel, closeTo(1.736, 0.001));

--- a/test/features/station_services/south_korea/south_korea_response_parser_test.dart
+++ b/test/features/station_services/south_korea/south_korea_response_parser_test.dart
@@ -250,7 +250,8 @@ void main() {
       expect(station.diesel, closeTo(1499.0, 1e-9));
       expect(station.e98, isNull);
       expect(station.lpg, isNull);
-      expect(station.isOpen, isTrue);
+      // #3198 — OPINET publishes no open/closed signal: honest unknown.
+      expect(station.isOpen, isNull);
     });
 
     test('falls back to brand label as station name when OS_NM is missing',
@@ -675,7 +676,8 @@ void main() {
       expect(station.e98, closeTo(1900.0, 1e-9));
       expect(station.diesel, closeTo(1499.0, 1e-9));
       expect(station.lpg, closeTo(1099.0, 1e-9));
-      expect(station.isOpen, isTrue);
+      // #3198 — OPINET publishes no open/closed signal: honest unknown.
+      expect(station.isOpen, isNull);
     });
   });
 }

--- a/test/features/station_services/spain/miteco_e85_isopen_margen_test.dart
+++ b/test/features/station_services/spain/miteco_e85_isopen_margen_test.dart
@@ -105,7 +105,7 @@ void main() {
       expect(stations.singleWhere((s) => s.id == 'es-12616').isOpen, isTrue);
     });
 
-    test('an empty horario falls back to the legacy heuristic (closed=false)',
+    test('an empty horario is honest unknown, not closed (#3198)',
         () async {
       final stations = await searchMitecoStations([
         {
@@ -120,7 +120,8 @@ void main() {
           'Horario': '',
         },
       ]);
-      expect(stations.singleWhere((s) => s.id == 'es-77').isOpen, isFalse);
+      expect(stations.singleWhere((s) => s.id == 'es-77').isOpen, isNull,
+          reason: 'no hours data is unknown — neither open nor closed');
     });
   });
 

--- a/test/features/station_services/uk/uk_station_service_test.dart
+++ b/test/features/station_services/uk/uk_station_service_test.dart
@@ -366,7 +366,8 @@ void main() {
       expect(s.e10, closeTo(1.459, 0.0001));
       expect(s.e5, closeTo(1.559, 0.0001));
       expect(s.diesel, closeTo(1.529, 0.0001));
-      expect(s.isOpen, isTrue);
+      // #3198 — the CMA feed carries no open/closed signal: honest unknown.
+      expect(s.isOpen, isNull);
     });
 
     test('keeps prices under 10 as-is (already in pounds)', () {

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -99,7 +99,11 @@ void main() {
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246
     // lines (below the cap). Removed from the snapshot per the shrink
     // ratchet; the extracted files are all new and under 400.
-    'lib/core/country/country_config.dart': 723,
+    // #3198 — re-grandfathered 723 → 751: the per-fuel price-unit
+    // suffix facility (pricePerUnitSuffixByFuel + pricePerUnitSuffixFor)
+    // and the honest per-country fuel-catalog comments (AT/DK/SI/AR no
+    // longer advertise a phantom E10).
+    'lib/core/country/country_config.dart': 751,
     // #2373 — re-grandfathered 868 → 887: one required `sourceUrl` field
     // added to every per-country FuelServicePolicy row (19 data lines) so
     // the country-service header can link the upstream data source.
@@ -131,7 +135,10 @@ void main() {
     // shared #2866 ProviderRequestBudget (import + one param + two call-site
     // args) so foreground + background share ONE per-provider minInterval gate.
     // Decomposing this god-class is tracked separately (#2187/#2188/#2190).
-    'lib/core/services/country_service_registry.dart': 857,
+    // #3198 — re-grandfathered 857 → 864: AT/DK promoted off
+    // _defaultFuelTypes to explicit lists (phantom-E10 removal + DK's
+    // real premium grades).
+    'lib/core/services/country_service_registry.dart': 864,
     // #2969 — re-grandfathered 500 → 522: the `transportForName` inference
     // (matches a stored adapter name against the profile nameMatchers so the
     // transport-aware self-test takes RFCOMM for a Classic-SPP adapter instead


### PR DESCRIPTION
## Country cross-cutting honesty — tri-state isOpen, country wall-clock hours, catalog-driven fuels, FR brand unification

From epic #3186; implements the consolidation principle: per-country provider adapters normalize into ONE shared model, the UI renders only the consolidated view and degrades per field.

- **Tri-state `isOpen`** (`bool` → `bool?`): true/false only when the provider publishes a real signal (schedule-derived for FR/ES/PT/AT via the shared `open_state_from_hours`), `null` when it doesn't (SI/LU/MX/KR/UK/RO/DK/IT/GR/AR) — previously hard-coded `true`. UI renders unknown as a neutral "Unknown" badge (never as closed), prices grey only when known-closed, the open-now filter drops only known-closed, and the codec round-trip is pinned by tests (legacy cached bools read as-is; the #2776 drop class is covered). Favorites sync stores only ids — no Supabase impact.
- **Fuel catalog drives the UI** — the e5/e10 mirroring is gone (AT/DK/SI/AR/PT/IT); DK gains its real premium grades; a stored now-unsupported preference stays renderable. AR's GNC renders `$/m³` via a per-fuel unit-suffix config.
- **Hours evaluate on the station country's clock** (static DST-aware offset table, no paid/IANA dependency) instead of the device clock.
- **FR flux brand detection delegates to the JSON path's detector** — one brand mapping for both FR sources (the optional "brand + ville" display-name composite was deliberately not done; noted in the commit).

2 new ARB keys fanned to all 23 locales + pseudo-locale. 5,082 tests green, zero codegen/l10n drift.

Closes #3198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
