### PR TITLE
feat(android): mechanised FGS restore behind one dart-define — Play-compliant by default (#3173)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import java.util.Base64
 import java.util.Properties
 import java.io.FileInputStream
 
@@ -71,6 +72,52 @@ fun resolveReleaseSigning(): ReleaseSigningConfig? {
 }
 
 val releaseSigning: ReleaseSigningConfig? = resolveReleaseSigning()
+
+// -----------------------------------------------------------------------------
+// #3173 — Foreground-service un-throttle trigger (ships dark until the Google
+// Play "Foreground Service Use" form (#1498) is approved).
+//
+// Flutter forwards every --dart-define to Gradle as the `dart-defines`
+// project property (comma-separated base64 "KEY=VALUE" entries). Decoding it
+// here lets ONE flag flip both halves of the restore in lockstep:
+//
+//   flutter build appbundle --flavor play --dart-define=FGS_FORM_APPROVED=true
+//
+//   * Dart   — kGpsRecordingForegroundServiceEnabled (lib/core/location/
+//              recording_location_settings.dart) turns true, so the trip
+//              recorder requests geolocator's foreground service (the
+//              un-throttle lever against Android's ~5 s background batching).
+//   * Gradle — the flavor manifest overlay (sourceSets below) swaps to the
+//              *FgsApproved variant, which re-declares the FOREGROUND_SERVICE*
+//              permissions and (play flavor) the AutoRecordForegroundService.
+//
+// Without the define (the default, and what every current CI build does) the
+// merged manifest keeps today's Play-compliant shape: ZERO FOREGROUND_SERVICE*
+// permissions, so edits.commit never 403s on the form. FGS_FORM_APPROVED=1 in
+// the environment is accepted as a fallback for plain ./gradlew invocations
+// (e.g. manifest-merge inspection without the Flutter tool in front).
+// -----------------------------------------------------------------------------
+val dartDefines: Map<String, String> =
+    (project.findProperty("dart-defines") as String?)
+        ?.split(",")
+        ?.mapNotNull { encoded ->
+            try {
+                val decoded = String(
+                    Base64.getDecoder().decode(encoded),
+                    Charsets.UTF_8,
+                )
+                val idx = decoded.indexOf('=')
+                if (idx > 0) decoded.take(idx) to decoded.substring(idx + 1) else null
+            } catch (_: IllegalArgumentException) {
+                null // not base64 (defensive) — skip the entry
+            }
+        }
+        ?.toMap()
+        ?: emptyMap()
+
+val fgsFormApproved: Boolean =
+    (dartDefines["FGS_FORM_APPROVED"] ?: System.getenv("FGS_FORM_APPROVED") ?: "false")
+        .let { it.equals("true", ignoreCase = true) || it == "1" }
 
 android {
     namespace = "de.tankstellen.tankstellen"
@@ -183,6 +230,27 @@ android {
             // file is fdroid-scoped: the play flavor keeps the real GMS and the
             // base `-keep com.google.mlkit.**` rule.
             proguardFiles("proguard-rules-fdroid.pro")
+        }
+    }
+
+    // #3173 — see the dart-defines block above. Default (form pending): the
+    // checked-in, Play-compliant manifests, byte-identical to before. With
+    // FGS_FORM_APPROVED set, each flavor's manifest overlay swaps to its
+    // *FgsApproved variant, restoring the FOREGROUND_SERVICE* permissions
+    // (+ AutoRecordForegroundService on play). The flavor overlays are
+    // higher-priority than src/main in the manifest merge, so their plain
+    // permission declarations win over main's tools:node="remove" guards.
+    sourceSets {
+        getByName("play").manifest.srcFile(
+            if (fgsFormApproved) {
+                "src/play/AndroidManifestFgsApproved.xml"
+            } else {
+                "src/play/AndroidManifest.xml"
+            }
+        )
+        if (fgsFormApproved) {
+            getByName("fdroid")
+                .manifest.srcFile("src/fdroid/AndroidManifestFgsApproved.xml")
         }
     }
 }

--- a/android/app/src/fdroid/AndroidManifestFgsApproved.xml
+++ b/android/app/src/fdroid/AndroidManifestFgsApproved.xml
@@ -1,0 +1,33 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+<!-- #3173 — the FGS-APPROVED manifest overlay for the fdroid flavor.
+
+     NOT used by default: the fdroid source set normally has NO manifest
+     overlay at all. android/app/build.gradle.kts wires this file in only
+     when the build carries the FGS_FORM_APPROVED define (see the #3173
+     block there). It exists so that building fdroid with the same define
+     does not recreate error log #17: the Dart flag
+     kGpsRecordingForegroundServiceEnabled is compile-time and
+     flavor-agnostic, so without these permissions an fdroid build made
+     with the define would call startForeground() and hit a Permission
+     Denial that kills the trip-GPS stream.
+
+     The Play "Foreground Service Use" form does not apply to F-Droid, but
+     the flag is kept single and global on purpose — one trigger, both
+     halves (Dart + manifest), every flavor consistent.
+
+     GPS-recording scope only: FOREGROUND_SERVICE (base) +
+     FOREGROUND_SERVICE_LOCATION (API 34+ type-specific permission for
+     geolocator's foregroundServiceType="location" service). No Android
+     Auto components (the Auto host is GMS, absent from the GMS-free fdroid
+     build) and no AutoRecordForegroundService / CONNECTED_DEVICE here —
+     extending hands-free auto-record to fdroid is a separate decision. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,10 +62,26 @@
          Functional impact while disabled:
            * Hands-free trip auto-record (already off because BG location is
              gone) calls invokeMethod('start') and gets a graceful failure.
-           * Android Auto integration is unreachable — the Auto host can't
-             find a CarAppService matching the intent-filter.
-         Restore all five lines below the moment the Foreground Service Use
-         form is approved (#1498). -->
+           * Trip GPS streams foreground-only (~5 s background batching, the
+             #3173 reverse parity gap) because geolocator's foreground
+             service may not be requested.
+           * The Android Auto BOUND POI service is unaffected — it ships in
+             the play flavor overlay since #2951 (bound services need no
+             FOREGROUND_SERVICE).
+         RESTORE TRIGGER (#3173) — the restore is mechanised; do NOT edit
+         this file when the Foreground Service Use form is approved. Build
+         with the single define
+             flutter build appbundle ... [dart-define] FGS_FORM_APPROVED=true
+         and build.gradle.kts swaps the flavor overlay to
+         src/play/AndroidManifestFgsApproved.xml (fdroid:
+         src/fdroid/AndroidManifestFgsApproved.xml), which re-declares the
+         FOREGROUND_SERVICE* permissions and the AutoRecordForegroundService.
+         Flavor overlays outrank src/main in the merge, so the two
+         tools:node="remove" guards below keep stripping library-merged
+         permissions from DEFAULT builds without defeating the overlay. The
+         same define flips kGpsRecordingForegroundServiceEnabled on the Dart
+         side, so flag and manifest can never diverge again (#2787 / error
+         log #17). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"
         tools:node="remove"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
@@ -163,32 +179,16 @@
             </intent-filter>
         </activity>
 
-        <!-- Hands-free trip auto-record foreground service (#1004
-             phase 2b-1) and Android Auto CarAppService — both
-             commented out for the Open Testing release. See the
-             FOREGROUND_SERVICE permission block above for the full
-             rationale (Google Play "Foreground Service Use" form
-             gate); restore alongside the permissions when #1498's
-             form is approved.
-        <service
-            android:name=".autorecord.AutoRecordForegroundService"
-            android:exported="false"
-            android:foregroundServiceType="connectedDevice"/>
-
-        <service
-            android:name=".TankstellenCarAppService"
-            android:exported="true"
-            android:permission="android.permission.FOREGROUND_SERVICE">
-            <intent-filter>
-                <action android:name="androidx.car.app.CarAppService" />
-                <category android:name="androidx.car.app.category.POI" />
-            </intent-filter>
-        </service>
-
-        <meta-data
-            android:name="androidx.car.app.minCarApiLevel"
-            android:value="1" />
-        -->
+        <!-- Hands-free trip auto-record foreground service (#1004 phase
+             2b-1): formerly a commented-out restore point here, now a LIVE
+             declaration in the gated play overlay
+             src/play/AndroidManifestFgsApproved.xml (#3173) — wired in by
+             build.gradle.kts only when the FGS_FORM_APPROVED define is set
+             after the #1498 form clears. See the FOREGROUND_SERVICE
+             permission block above for the trigger. The Android Auto
+             CarAppService that also used to be commented out here shipped
+             independently as a BOUND POI service in the play overlay
+             (#2951) — no FGS needed. -->
 
         <!-- #2413 — re-arm the on-device background price scan after a
              reboot. WorkManager persists periodic work and androidx

--- a/android/app/src/play/AndroidManifestFgsApproved.xml
+++ b/android/app/src/play/AndroidManifestFgsApproved.xml
@@ -1,0 +1,78 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+<!-- #3173 — the FGS-APPROVED variant of the play-flavor manifest overlay.
+
+     NOT used by default. android/app/build.gradle.kts swaps this file in
+     for src/play/AndroidManifest.xml only when the build carries
+     `dash-dash-dart-define FGS_FORM_APPROVED=true` (or env
+     FGS_FORM_APPROVED=1) — i.e. only AFTER Google Play's "Foreground
+     Service Use" form (#1498) has been approved. Until then every build
+     keeps using the sibling manifest and ships with ZERO
+     FOREGROUND_SERVICE* permissions (Play-compliant, no edits.commit 403).
+
+     Keep this file a strict SUPERSET of src/play/AndroidManifest.xml: same
+     Android Auto bound POI service (#2951), PLUS the formerly commented-out
+     restore points from src/main/AndroidManifest.xml:
+
+       * FOREGROUND_SERVICE — base permission for any startForeground();
+         needed by geolocator's GeolocatorLocationService (the trip-GPS
+         un-throttle, #2766) and AutoRecordForegroundService.
+       * FOREGROUND_SERVICE_LOCATION — API 34+ requires the type-specific
+         permission for geolocator's foregroundServiceType="location"
+         service; without it startForeground() throws SecurityException on
+         Android 14+ even with FOREGROUND_SERVICE present.
+       * FOREGROUND_SERVICE_CONNECTED_DEVICE — type-specific permission for
+         AutoRecordForegroundService (foregroundServiceType="connectedDevice",
+         hands-free trip auto-record #1004 phase 2b-1).
+       * AutoRecordForegroundService — the BLE adapter watcher the Dart
+         AndroidBackgroundAdapterListener starts via
+         tankstellen/auto_record/methods.
+
+     These plain declarations are in a flavor overlay, which is
+     HIGHER-priority than src/main in the manifest merge — so they win over
+     main's tools:node="remove" guards (which stay in place to keep the
+     DEFAULT build stripped of library-merged FOREGROUND_SERVICE).
+
+     Deliberately NOT restored here: ACCESS_BACKGROUND_LOCATION. That is a
+     different Play gate (the Sensitive Permissions video declaration, also
+     tracked in #1498) — restore it separately in src/main when that
+     declaration clears. Hands-free auto-record stays Dart-gated on the
+     locationAlways permission either way. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+
+    <application>
+        <!-- Android Auto v1 (#2951) bound POI service: no android:permission
+             (host trust handled by createHostValidator), no FOREGROUND_SERVICE
+             needed for a bound car-app service — unchanged from the default
+             play overlay. -->
+        <service
+            android:name=".TankstellenCarAppService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+                <category android:name="androidx.car.app.category.POI" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="androidx.car.app.minCarApiLevel"
+            android:value="1" />
+
+        <!-- Hands-free trip auto-record foreground service (#1004 phase
+             2b-1), restored from the main manifest's former commented-out
+             block. -->
+        <service
+            android:name=".autorecord.AutoRecordForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice"/>
+    </application>
+</manifest>

--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -23,14 +23,41 @@ import '../language/language_provider.dart';
 ///
 /// While this is `false` the recorder streams **foreground-only**, which is
 /// reliable because the recording screen pins itself (screen-on by default,
-/// #2785). Flip to `true` **together with** re-adding the manifest
-/// `FOREGROUND_SERVICE` permission once #1498's Play form is approved.
+/// #2785).
 ///
-/// Deliberately `final` (not `const`): a non-const flag keeps the analyzer
-/// from marking the gated `ForegroundNotificationConfig` branch as dead code
-/// while the flag is `false`, so the restore path stays compiled + visible.
-// ignore: prefer_const_declarations
-final bool kGpsRecordingForegroundServiceEnabled = false;
+/// ## The un-throttle trigger (#3173)
+///
+/// The restore is a single build flag, so it ships dark and flips the day
+/// the Play form clears — no code change, no forgotten manifest sibling:
+///
+/// ```
+/// flutter build appbundle --flavor play --dart-define=FGS_FORM_APPROVED=true
+/// ```
+///
+/// The SAME define drives BOTH halves of the restore in lockstep:
+///   1. **Dart** — this flag turns `true`, so [recordingLocationSettings]
+///      passes geolocator the [ForegroundNotificationConfig] (the actual
+///      un-throttle lever) and the Android Auto / auto-record Dart side
+///      finds its native service.
+///   2. **Manifest** — `android/app/build.gradle.kts` decodes the
+///      `dart-defines` Gradle property Flutter forwards and, when the flag
+///      is set, swaps the flavor manifest overlay for the `*FgsApproved`
+///      variant that re-declares the `FOREGROUND_SERVICE*` permissions and
+///      the `AutoRecordForegroundService` (restore points formerly
+///      commented in `AndroidManifest.xml`).
+///
+/// Keeping the two halves on one define removes the historical failure
+/// mode (#2787 / error log #17): flag on + permission absent =
+/// `startForeground` Permission Denial = zero GPS fixes. Without the
+/// define every build stays byte-identical to today's Play-compliant
+/// shape (no `FOREGROUND_SERVICE*` permission in the merged manifest, so
+/// the Open-Testing upload never 403s on the #1498 form).
+///
+/// `bool.fromEnvironment` is opaque to the analyzer, so the gated
+/// `ForegroundNotificationConfig` branch stays compiled + visible (the old
+/// `final`-not-`const` trick is no longer needed).
+const bool kGpsRecordingForegroundServiceEnabled =
+    bool.fromEnvironment('FGS_FORM_APPROVED');
 
 /// #2766 — the platform-specific [LocationSettings] used while a trip is
 /// **actively recording**, so the GPS trace stays fine-grained (~1 s) instead
@@ -99,8 +126,14 @@ LocationSettings approachLocationSettings({TargetPlatform? platform}) {
 LocationSettings recordingLocationSettings({
   required AppLocalizations l10n,
   TargetPlatform? platform,
+  bool? foregroundServiceEnabled,
 }) {
   final target = platform ?? defaultTargetPlatform;
+  // #3173 — test seam: production always follows the build-time define
+  // (which the Gradle side mirrors into the manifest), while unit tests
+  // pin both the throttled and the restored branch explicitly.
+  final fgsEnabled =
+      foregroundServiceEnabled ?? kGpsRecordingForegroundServiceEnabled;
   switch (target) {
     case TargetPlatform.android:
       return AndroidSettings(
@@ -112,11 +145,12 @@ LocationSettings recordingLocationSettings({
         distanceFilter: 0,
         // The un-throttle lever: promote geolocator to a foreground service so
         // the OS stops the ~5 s background batching for the trip. Gated by
-        // [kGpsRecordingForegroundServiceEnabled] — OFF while the manifest
+        // [kGpsRecordingForegroundServiceEnabled] (#3173 trigger:
+        // --dart-define=FGS_FORM_APPROVED=true) — OFF while the manifest
         // FOREGROUND_SERVICE permission is removed (#1498), so we pass `null`
         // and stream foreground-only rather than crash on startForeground
         // (error log #17 / #2787). Title/text are the already-merged ARB keys.
-        foregroundNotificationConfig: kGpsRecordingForegroundServiceEnabled
+        foregroundNotificationConfig: fgsEnabled
             ? ForegroundNotificationConfig(
                 notificationTitle: l10n.tripRecordingGpsNotificationTitle,
                 notificationText: l10n.tripRecordingGpsNotificationText,

--- a/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/android_background_adapter_listener.dart
@@ -22,11 +22,13 @@ import 'event_channel_cancel.dart';
 ///
 /// `AutoRecordOrchestrator` selects this listener on Android and binds
 /// the [AutoTripCoordinator] to it (phase 2b-2). Note the Kotlin
-/// `<service>` is currently commented out in the manifest pending the
-/// Google Play "Foreground Service Use" form (#1498), so `start(mac)` is
-/// effectively a no-op in shipped builds until the service is restored;
-/// the foreground-active arming fallback (#2282 concern 1) covers
-/// engine detection while the app is in front.
+/// `<service>` is absent from default-build manifests pending the
+/// Google Play "Foreground Service Use" form (#1498) — it ships in the
+/// gated `AndroidManifestFgsApproved.xml` play overlay enabled by the
+/// `FGS_FORM_APPROVED` define (#3173) — so `start(mac)` is effectively
+/// a no-op in shipped builds until the form clears; the
+/// foreground-active arming fallback (#2282 concern 1) covers engine
+/// detection while the app is in front.
 ///
 /// Channels are constructor-injected so unit tests can swap the names
 /// to per-test channels and exercise the parsing without colliding

--- a/lib/features/consumption/data/obd2/background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/background_adapter_listener.dart
@@ -10,8 +10,10 @@
 /// transitions for the user's paired ELM327 adapter and bridges them
 /// through a `MethodChannel` / `EventChannel` into
 /// [BackgroundAdapterListener.events]. The service `<service>` entry is
-/// currently commented out in the manifest pending the Google Play
-/// "Foreground Service Use" form (#1498); while it is disabled, the
+/// absent from default builds pending the Google Play "Foreground
+/// Service Use" form (#1498) — it lives in the gated
+/// `AndroidManifestFgsApproved.xml` overlay that the
+/// `FGS_FORM_APPROVED` define wires in (#3173). While it is absent, the
 /// foreground-active arming fallback (#2282 concern 1) drives
 /// engine-start detection from the live engine instead. Tests inject a
 /// [FakeBackgroundAdapterListener] from

--- a/test/core/location/recording_location_settings_test.dart
+++ b/test/core/location/recording_location_settings_test.dart
@@ -43,12 +43,75 @@ void main() {
       // #2787 — the foreground service is gated OFF while the manifest
       // FOREGROUND_SERVICE permission is removed (#1498); requesting it threw
       // a startForeground Permission Denial that killed the GPS stream (error
-      // log #17). Foreground-only until the flag + manifest permission return.
+      // log #17). #3173 made the restore a single build define
+      // (FGS_FORM_APPROVED) that flips the Dart flag AND the manifest overlay
+      // together — this test runs WITHOUT the define, so it pins the
+      // ships-dark default: throttled, foreground-only, Play-compliant.
       expect(kGpsRecordingForegroundServiceEnabled, isFalse,
-          reason: 'guards against re-enabling the FGS without the manifest '
-              'permission — flip both together when #1498 lands');
+          reason: 'default builds (no --dart-define=FGS_FORM_APPROVED=true) '
+              'must stay foreground-only until the #1498 Play form clears');
       expect(android.foregroundNotificationConfig, isNull,
           reason: 'no startForeground while FOREGROUND_SERVICE is removed');
+    });
+
+    group('#3173 — FGS_FORM_APPROVED gating (throttled vs restored)', () {
+      test(
+          'throttled (form pending, foregroundServiceEnabled: false) → '
+          'NO foreground service requested', () {
+        final settings = recordingLocationSettings(
+          l10n: l10n,
+          platform: TargetPlatform.android,
+          foregroundServiceEnabled: false,
+        ) as AndroidSettings;
+
+        expect(settings.foregroundNotificationConfig, isNull,
+            reason: 'while the #1498 form is pending the merged manifest has '
+                'no FOREGROUND_SERVICE permission — requesting the service '
+                'would crash startForeground (error log #17)');
+        // The fine cadence stays requested either way; only the
+        // background-batching counter-lever (the FGS) is withheld.
+        expect(settings.intervalDuration, const Duration(seconds: 1));
+        expect(settings.distanceFilter, 0);
+      });
+
+      test(
+          'restored (form approved, foregroundServiceEnabled: true) → '
+          'ForegroundNotificationConfig with ARB copy + wakelock + ongoing',
+          () {
+        final settings = recordingLocationSettings(
+          l10n: l10n,
+          platform: TargetPlatform.android,
+          foregroundServiceEnabled: true,
+        ) as AndroidSettings;
+
+        final config = settings.foregroundNotificationConfig;
+        expect(config, isNotNull,
+            reason: 'with FGS_FORM_APPROVED the foreground service is the '
+                'un-throttle lever against the ~5 s background batching');
+        expect(config!.notificationTitle,
+            l10n.tripRecordingGpsNotificationTitle,
+            reason: 'notification copy must come from ARB, never inline');
+        expect(
+            config.notificationText, l10n.tripRecordingGpsNotificationText);
+        expect(config.enableWakeLock, isTrue,
+            reason: 'CPU must stay awake for the 1 s fixes with screen off');
+        expect(config.setOngoing, isTrue,
+            reason: 'the recording notification must not be swipe-dismissable');
+        // The restored profile keeps the same fine cadence.
+        expect(settings.intervalDuration, const Duration(seconds: 1));
+        expect(settings.distanceFilter, 0);
+      });
+
+      test('iOS ignores the Android FGS flag entirely (no platform fork)', () {
+        final settings = recordingLocationSettings(
+          l10n: l10n,
+          platform: TargetPlatform.iOS,
+          foregroundServiceEnabled: true,
+        );
+        expect(settings, isA<AppleSettings>(),
+            reason: 'the flag is an Android-only lever behind the existing '
+                'platform seam — iOS keeps its full background profile');
+      });
     });
 
     test('iOS → AppleSettings: automotiveNavigation + background updates', () {


### PR DESCRIPTION
## Android FGS un-throttle trigger — ships dark until the Play form clears

From epic #3165: trip GPS sampling and the auto-record foreground service were throttled pending Google Play's "Foreground Service Use" form (#1498). The restore is now mechanised behind ONE switch, so flag and manifest can never diverge:

```
flutter build appbundle --flavor play --dart-define=FGS_FORM_APPROVED=true
```

- **Gradle** decodes the dart-define and swaps the flavor manifest overlay to `AndroidManifestFgsApproved.xml` (play + fdroid variants), which re-declares the `FOREGROUND_SERVICE*` permissions and the `AutoRecordForegroundService`.
- **Dart** flips `kGpsRecordingForegroundServiceEnabled` from the same define, so the trip recorder requests geolocator's foreground service (the lever against Android's ~5 s background batching).
- **Default builds are byte-compatible with today's Play-compliant shape** — verified at the APK level: the default `assemblePlayDebug` carries **zero** `FOREGROUND_SERVICE*` permissions; the define-build carries exactly `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION`, `FOREGROUND_SERVICE_CONNECTED_DEVICE` (aapt2-verified both ways).
- When the form is approved: no code edit — set the define in the beta/release workflow and the restore is live.

Full suite green (4,809 tests).

Closes #3173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
