### PR TITLE
fix(ble): iOS UUID-rotation rematch — name-based scan rematch + fresh-id re-persist (#3168)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_adapter_identity.dart
+++ b/lib/features/consumption/data/obd2/obd2_adapter_identity.dart
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'adapter_registry.dart';
+import 'obd2_comm_diagnostics.dart' show redactObd2Mac;
+import 'obd2_connect_trace.dart';
+import 'obd2_connect_trace_log.dart';
+import 'obd2_service.dart';
+import '../../../../core/logging/error_logger.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+
+/// Adapter-identity capture + iOS UUID-rotation rematch (#3168).
+///
+/// On iOS a BLE `deviceId` is Apple's per-app **CBPeripheral UUID** — not the
+/// adapter's MAC — and the OS can ROTATE it (Bluetooth reset, unpair, device
+/// restore, adapter re-provision). Every pinned fast path keys on the stored
+/// id, and the scan fallback used to match strictly on it, so after a
+/// rotation the paired adapter could never re-match again: reconnect was
+/// broken forever with no recovery besides re-running the picker (the
+/// suspected OBDLink CX field signature; the `pinned-id-mismatch` trace step
+/// from #3184(e) is its discriminator). This file is the data-layer seam for
+/// both halves of the fix:
+///
+///  1. **Identity capture** — [Obd2AdapterIdentity.fromCandidate], moved out
+///     of the picker widget (which used an inline `Platform.isIOS`, #2350
+///     debt). Platform-free by construction: [looksLikeIosPeripheralUuid]
+///     tells an iOS CBPeripheral UUID apart from an Android MAC by SHAPE,
+///     so no shared code branches on the runtime platform.
+///  2. **Name-based rematch** — [Obd2UuidRematchDecision.decide] (the pure
+///     decision table) + [connectUuidRematched] (the connect + re-persist
+///     driver the scan fallback calls when the pinned id is absent from a
+///     non-empty scan).
+///
+/// Harmless on Android by construction: a MAC-shaped pinned id is never
+/// rematch-eligible (Android MACs are stable, and a same-named device under
+/// a different MAC there is genuinely a DIFFERENT adapter).
+
+/// Shape of an iOS CBPeripheral identifier: the canonical 36-char UUID
+/// (8-4-4-4-12 hex). Android BLE/Classic deviceIds are colon-separated MACs
+/// and never match.
+final RegExp _iosPeripheralUuidShape = RegExp(
+  r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+  r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+);
+
+/// True when [id] has the SHAPE of an iOS CBPeripheral UUID (8-4-4-4-12
+/// hex). The platform-free discriminator this seam is built on: on iOS
+/// `flutter_blue_plus` surfaces `remoteId.str` as exactly this UUID, on
+/// Android as a `AA:BB:CC:DD:EE:FF` MAC — so shape ≡ platform without any
+/// `Platform.isIOS` in shared code (#2350).
+bool looksLikeIosPeripheralUuid(String id) =>
+    _iosPeripheralUuidShape.hasMatch(id.trim());
+
+/// The friendly name a candidate is persisted/displayed under everywhere
+/// (picker tile, vehicle profile, connect trace headline): the advertised
+/// name, or the matched profile's display label when the advertisement was
+/// anonymous. ONE definition so capture and rematch can never disagree.
+String effectiveCandidateName(ResolvedObd2Candidate c) =>
+    c.candidate.deviceName.isEmpty
+        ? c.profile.displayName
+        : c.candidate.deviceName;
+
+/// Persistable identity of a picked/rematched adapter (#3168) — the three
+/// fields the vehicle profile pins (`obd2AdapterMac`, `obd2AdapterName`,
+/// `pairedAdapterUuidIos`).
+class Obd2AdapterIdentity {
+  /// Platform device id — Android MAC, or the iOS CBPeripheral UUID.
+  final String deviceId;
+
+  /// Friendly adapter name ([effectiveCandidateName]).
+  final String name;
+
+  /// The iOS CoreBluetooth reconnection key (#2282 concern 3): equals
+  /// [deviceId] when it is UUID-shaped (iOS), null when it is a MAC
+  /// (Android) — mirroring what the picker's old `Platform.isIOS` capture
+  /// persisted, without the platform check.
+  final String? uuidIos;
+
+  const Obd2AdapterIdentity({
+    required this.deviceId,
+    required this.name,
+    this.uuidIos,
+  });
+
+  /// Capture the identity to persist for [c] — the single data-layer
+  /// replacement for the picker widget's inline capture.
+  factory Obd2AdapterIdentity.fromCandidate(ResolvedObd2Candidate c) {
+    final id = c.candidate.deviceId;
+    return Obd2AdapterIdentity(
+      deviceId: id,
+      name: effectiveCandidateName(c),
+      uuidIos: looksLikeIosPeripheralUuid(id) ? id : null,
+    );
+  }
+}
+
+/// Re-persist seam fired AFTER a successful UUID-rotation rematch connect
+/// (#3168): [staleId] is the pinned id that no longer matches; [fresh] the
+/// identity the adapter now advertises under. Wired by the provider layer
+/// to update the vehicle profile(s) pinned to the stale id.
+typedef Obd2AdapterIdentityRotated = Future<void> Function({
+  required String staleId,
+  required Obd2AdapterIdentity fresh,
+});
+
+/// Terminal states of the rematch decision table (#3168).
+enum Obd2UuidRematchResult {
+  /// The pinned id is not rotation-prone (Android MAC shape) or there is
+  /// no persisted name to rematch by. Never rematch.
+  notEligible,
+
+  /// Eligible, but no scanned device advertises the persisted name under
+  /// a different id.
+  noCandidate,
+
+  /// Two or more scanned devices advertise the persisted name — picking
+  /// one would be a guess, so the rematch is skipped (the picker fallback
+  /// lets the user disambiguate).
+  ambiguous,
+
+  /// Exactly one scanned device advertises the persisted name under a
+  /// fresh id — the rotated-UUID signature. Connect to it.
+  matched,
+}
+
+/// Outcome of [decide] — the pure, unit-testable rematch decision (#3168).
+class Obd2UuidRematchDecision {
+  final Obd2UuidRematchResult result;
+
+  /// The single rematch candidate; non-null iff [result] is
+  /// [Obd2UuidRematchResult.matched].
+  final ResolvedObd2Candidate? candidate;
+
+  /// How many same-named candidates were in the scan (diagnostic detail
+  /// for the ambiguous trace step).
+  final int candidateCount;
+
+  const Obd2UuidRematchDecision._(
+      this.result, this.candidate, this.candidateCount);
+
+  /// The #3168 decision table. [pinnedId]/[pinnedName] are the persisted
+  /// identity; [ranked] the accumulated scan result. Pure — no IO, no
+  /// trace writes — so the table is exhaustively unit-testable.
+  static Obd2UuidRematchDecision decide({
+    required String pinnedId,
+    required String? pinnedName,
+    required List<ResolvedObd2Candidate> ranked,
+  }) {
+    if (pinnedName == null || pinnedName.trim().isEmpty) {
+      return const Obd2UuidRematchDecision._(
+          Obd2UuidRematchResult.notEligible, null, 0);
+    }
+    // Android MACs are stable — a MAC-shaped pinned id must never rematch
+    // (a same-named device under another MAC is a different adapter there).
+    if (!looksLikeIosPeripheralUuid(pinnedId)) {
+      return const Obd2UuidRematchDecision._(
+          Obd2UuidRematchResult.notEligible, null, 0);
+    }
+    final pinnedUpper = pinnedId.trim().toUpperCase();
+    final candidates = <ResolvedObd2Candidate>[
+      for (final r in ranked)
+        if (effectiveCandidateName(r) == pinnedName &&
+            r.candidate.deviceId.trim().toUpperCase() != pinnedUpper)
+          r,
+    ];
+    if (candidates.isEmpty) {
+      return const Obd2UuidRematchDecision._(
+          Obd2UuidRematchResult.noCandidate, null, 0);
+    }
+    if (candidates.length > 1) {
+      return Obd2UuidRematchDecision._(
+          Obd2UuidRematchResult.ambiguous, null, candidates.length);
+    }
+    return Obd2UuidRematchDecision._(
+        Obd2UuidRematchResult.matched, candidates.single, 1);
+  }
+}
+
+/// Drive the #3168 rematch for a scan fallback that found NO exact-id match:
+/// decide via [Obd2UuidRematchDecision.decide], stamp the decision onto the
+/// active connect trace (`uuid-rematch` step), connect to the rematched
+/// candidate via [connect], and on SUCCESS fire [onIdentityRotated] so the
+/// fresh UUID is re-persisted (`uuid-repersist` step).
+///
+/// Returns null when the decision is anything but matched (the caller falls
+/// back to the picker exactly as before — behaviour is never worse than
+/// today). A connect failure on the rematched candidate propagates like the
+/// exact-id path's would. The re-persist is best-effort: a throwing
+/// [onIdentityRotated] is logged + stamped and never re-thrown, so it can
+/// never derail the connect that just succeeded.
+Future<Obd2Service?> connectUuidRematched({
+  required String pinnedId,
+  required String? pinnedName,
+  required List<ResolvedObd2Candidate> ranked,
+  required Future<Obd2Service> Function(ResolvedObd2Candidate candidate)
+      connect,
+  required Obd2AdapterIdentityRotated? onIdentityRotated,
+}) async {
+  final decision = Obd2UuidRematchDecision.decide(
+    pinnedId: pinnedId,
+    pinnedName: pinnedName,
+    ranked: ranked,
+  );
+  switch (decision.result) {
+    case Obd2UuidRematchResult.notEligible:
+    case Obd2UuidRematchResult.noCandidate:
+      return null;
+    case Obd2UuidRematchResult.ambiguous:
+      Obd2ConnectTraceLog.active?.addStep(
+        label: 'uuid-rematch',
+        status: Obd2ConnectStepStatus.fail,
+        detail: '${decision.candidateCount} scanned devices named '
+            '"$pinnedName" — ambiguous, rematch skipped (#3168)',
+      );
+      return null;
+    case Obd2UuidRematchResult.matched:
+      break;
+  }
+  final candidate = decision.candidate!;
+  final fresh = Obd2AdapterIdentity.fromCandidate(candidate);
+  Obd2ConnectTraceLog.active?.addStep(
+    label: 'uuid-rematch',
+    status: Obd2ConnectStepStatus.ok,
+    detail: 'pinned id ${redactObd2Mac(pinnedId)} absent from scan but '
+        '"$pinnedName" advertises under ${redactObd2Mac(fresh.deviceId)} — '
+        'iOS CBPeripheral UUID rotated; connecting to the fresh id (#3168)',
+  );
+  final service = await connect(candidate);
+  // The connect SUCCEEDED on the fresh id — re-persist it so the next
+  // session's pinned fast path dials the right peripheral. Best-effort.
+  if (onIdentityRotated != null) {
+    try {
+      await onIdentityRotated(staleId: pinnedId, fresh: fresh);
+      Obd2ConnectTraceLog.active?.addStep(
+        label: 'uuid-repersist',
+        status: Obd2ConnectStepStatus.ok,
+        detail: 'pinned identity updated '
+            '${redactObd2Mac(pinnedId)} → ${redactObd2Mac(fresh.deviceId)}',
+      );
+    } catch (e, st) {
+      Obd2ConnectTraceLog.active?.addStep(
+        label: 'uuid-repersist',
+        status: Obd2ConnectStepStatus.fail,
+        detail: e.toString(),
+      );
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'connectUuidRematched: identity re-persist failed (#3168)',
+      }));
+    }
+  }
+  return service;
+}
+
+/// Update every vehicle profile pinned to [staleId] (by `obd2AdapterMac` or
+/// `pairedAdapterUuidIos`, case-insensitively) to the [fresh] identity —
+/// the provider-layer body behind the [Obd2AdapterIdentityRotated] seam.
+///
+/// Only the two IDENTITY fields rotate; the user-facing `obd2AdapterName`
+/// and every other preference on the profile are deliberately left intact
+/// (#3168 — the rematch was keyed on that very name). Never throws: a
+/// failing [save] is logged as a storage error and swallowed, so the
+/// connect that triggered the rotation is never derailed.
+Future<void> repersistRotatedAdapterIdentity({
+  required List<VehicleProfile> profiles,
+  required Future<void> Function(VehicleProfile profile) save,
+  required String staleId,
+  required Obd2AdapterIdentity fresh,
+}) async {
+  try {
+    final stale = staleId.trim().toUpperCase();
+    for (final p in profiles) {
+      final mac = p.obd2AdapterMac?.trim().toUpperCase();
+      final uuid = p.pairedAdapterUuidIos?.trim().toUpperCase();
+      if (mac != stale && uuid != stale) continue;
+      await save(p.copyWith(
+        obd2AdapterMac: fresh.deviceId,
+        pairedAdapterUuidIos: fresh.uuidIos,
+      ));
+    }
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      'where': 'repersistRotatedAdapterIdentity failed (#3168)',
+    }));
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -16,6 +16,7 @@ import 'elm327_adapter.dart';
 import 'elm_byte_channel.dart';
 import 'last_good_adapter_store.dart';
 import 'negotiated_protocol_cache.dart';
+import 'obd2_adapter_identity.dart';
 import 'obd2_adapter_wake_cache.dart';
 import 'obd2_cache_openers.dart';
 import 'obd2_comm_diagnostics.dart' show redactObd2Mac;
@@ -120,6 +121,16 @@ class Obd2ConnectionService {
   /// configs that don't wire it — pairing mode is then never armed.
   final KnownObd2AdaptersStore? knownAdaptersStore;
 
+  /// #3168 — re-persist seam fired when the scan fallback rematches a
+  /// ROTATED iOS CBPeripheral UUID by adapter name (see
+  /// [connectUuidRematched]): the pinned id was absent from a non-empty
+  /// scan, exactly one device advertised the persisted name, and the
+  /// connect to its fresh id SUCCEEDED. The provider wires it to
+  /// [repersistRotatedAdapterIdentity] (vehicle-profile update); null in
+  /// tests / configs that don't wire it — the rematch still connects,
+  /// only the re-persist is skipped.
+  final Obd2AdapterIdentityRotated? onAdapterIdentityRotated;
+
   /// #2906 — settle pause after [_stopScanBeforeConnect] stops the radio and
   /// before a `channel.open()` fires. Android BLE is fragile if a `connect()`
   /// races an active scan still winding down on the radio — a stale scan can
@@ -156,6 +167,7 @@ class Obd2ConnectionService {
     this.activeVehicleKeyFields,
     this.lastGoodAdapterStore,
     this.knownAdaptersStore,
+    this.onAdapterIdentityRotated,
     this.scanSettleDelay = const Duration(milliseconds: 120),
     Obd2ConnectSupervisor? supervisor,
     Obd2ScanGovernor? scanGovernor,
@@ -642,8 +654,12 @@ class Obd2ConnectionService {
         body: () async {
           final stream = scan(timeout: timeout);
           ResolvedObd2Candidate? match;
+          // #3168 — the latest accumulated ranked list, retained for the
+          // UUID-rotation rematch when no exact deviceId match is found.
+          var ranked = const <ResolvedObd2Candidate>[];
           try {
             await for (final batch in stream) {
+              ranked = batch;
               for (final c in batch) {
                 if (c.candidate.deviceId == mac) {
                   match = c;
@@ -656,8 +672,18 @@ class Obd2ConnectionService {
             // No adapters at all in range — fall through to picker.
             return null;
           }
-          if (match == null) return null;
-          return connect(match);
+          if (match != null) return connect(match);
+          // #3168 — exact id absent from a NON-empty scan: on iOS the
+          // pinned CBPeripheral UUID may have ROTATED. Try the name-based
+          // rematch (+ re-persist of the fresh id on success); a no-match
+          // still returns null so the picker fallback is unchanged.
+          return connectUuidRematched(
+            pinnedId: mac,
+            pinnedName: adapterName,
+            ranked: ranked,
+            connect: connect,
+            onIdentityRotated: onAdapterIdentityRotated,
+          );
         },
       ));
 
@@ -889,6 +915,19 @@ Obd2ConnectionService obd2Connection(Ref ref) {
     // start must drain the same bucket. (The default per-instance supervisor
     // is already process-wide here — this provider is a keepAlive singleton.)
     scanGovernor: Obd2ScanGovernor.process,
+    // #3168 — when the scan fallback rematches a ROTATED iOS CBPeripheral
+    // UUID by name, re-persist the fresh id onto every vehicle profile
+    // pinned to the stale one (the user-facing adapter name + every other
+    // preference stay intact). The helper never throws (best-effort), so
+    // the connect that just succeeded can never be derailed.
+    onAdapterIdentityRotated: (
+            {required String staleId, required Obd2AdapterIdentity fresh}) =>
+        repersistRotatedAdapterIdentity(
+      profiles: ref.read(vehicleProfileListProvider),
+      save: ref.read(vehicleProfileListProvider.notifier).save,
+      staleId: staleId,
+      fresh: fresh,
+    ),
     activeVehicleKeyFields: () {
       // Defensive: the vehicle provider must never make a connect throw.
       try {

--- a/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
@@ -54,4 +54,4 @@ final class Obd2ConnectionProvider
   }
 }
 
-String _$obd2ConnectionHash() => r'9ba3605d066d8ef7ce05b25ab1b2156f7626c8f9';
+String _$obd2ConnectionHash() => r'013b94b3ad98ade414b207c603f36d6deeff5224';

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,6 +12,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/adapter_registry.dart';
+import '../../data/obd2/obd2_adapter_identity.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/obd2/obd2_pairing_mode.dart';
@@ -344,26 +344,21 @@ class _Obd2AdapterPickerSheetState
   ) async {
     try {
       if (active == null) return;
-      final mac = candidate.candidate.deviceId;
-      final name = candidate.candidate.deviceName.isEmpty
-          ? candidate.profile.displayName
-          : candidate.candidate.deviceName;
-      // #2282 concern 3 — on iOS the `deviceId` IS the CBPeripheral UUID
-      // (flutter_blue_plus surfaces `remoteId.str`, which on iOS is the
-      // per-app peripheral UUID, not a MAC). Capture it so the later iOS
-      // CoreBluetooth state-restoration path has its reconnection key.
-      // On Android `deviceId` is the MAC already stored in
-      // `obd2AdapterMac`, so we leave the iOS-UUID field null there.
-      final uuidIos = Platform.isIOS ? mac : null;
-      if (active.obd2AdapterMac == mac &&
-          active.obd2AdapterName == name &&
-          active.pairedAdapterUuidIos == uuidIos) {
+      // #2282 concern 3 / #3168 — identity capture lives at the data-layer
+      // [Obd2AdapterIdentity] seam: it stores the iOS CBPeripheral UUID
+      // reconnection key when the deviceId is UUID-shaped (and null for an
+      // Android MAC), so this widget no longer branches on the platform
+      // (#2350 ratchet).
+      final identity = Obd2AdapterIdentity.fromCandidate(candidate);
+      if (active.obd2AdapterMac == identity.deviceId &&
+          active.obd2AdapterName == identity.name &&
+          active.pairedAdapterUuidIos == identity.uuidIos) {
         return; // already persisted — skip the redundant write.
       }
       final updated = active.copyWith(
-        obd2AdapterMac: mac,
-        obd2AdapterName: name,
-        pairedAdapterUuidIos: uuidIos,
+        obd2AdapterMac: identity.deviceId,
+        obd2AdapterName: identity.name,
+        pairedAdapterUuidIos: identity.uuidIos,
       );
       await listNotifier.save(updated);
     } catch (e, st) {

--- a/test/features/consumption/data/obd2/obd2_adapter_identity_test.dart
+++ b/test/features/consumption/data/obd2/obd2_adapter_identity_test.dart
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_adapter_identity.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3168 — iOS CBPeripheral UUID rotation: identity capture, the name-based
+/// rematch decision table, and the fresh-UUID re-persist.
+void main() {
+  silenceErrorLoggerSpool();
+  final registry = Obd2AdapterRegistry.defaults();
+
+  const iosUuid = '12345678-9ABC-4DEF-8012-3456789ABCDE';
+  const iosUuidRotated = 'FEDCBA98-7654-4321-8FED-CBA987654321';
+  const androidMac = 'AA:BB:CC:DD:EE:FF';
+
+  ResolvedObd2Candidate candidate(String id, String name, {int rssi = -55}) {
+    final ranked = registry.rank([
+      Obd2AdapterCandidate(
+        deviceId: id,
+        deviceName: name,
+        advertisedServiceUuids: const [],
+        rssi: rssi,
+      ),
+    ]);
+    expect(ranked, isNotEmpty, reason: 'test candidate "$name" must rank');
+    return ranked.single;
+  }
+
+  group('looksLikeIosPeripheralUuid (#3168)', () {
+    test('matches a canonical iOS CBPeripheral UUID (any case)', () {
+      expect(looksLikeIosPeripheralUuid(iosUuid), isTrue);
+      expect(looksLikeIosPeripheralUuid(iosUuid.toLowerCase()), isTrue);
+      expect(looksLikeIosPeripheralUuid(' $iosUuid '), isTrue,
+          reason: 'tolerates surrounding whitespace');
+    });
+
+    test('rejects an Android MAC and non-UUID shapes', () {
+      expect(looksLikeIosPeripheralUuid(androidMac), isFalse);
+      expect(looksLikeIosPeripheralUuid(''), isFalse);
+      expect(looksLikeIosPeripheralUuid('not-a-uuid'), isFalse);
+      expect(looksLikeIosPeripheralUuid('12345678-9ABC-4DEF-8012'), isFalse,
+          reason: 'truncated UUID must not match');
+      expect(
+          looksLikeIosPeripheralUuid(
+              '12345678-9ABC-4DEF-8012-3456789ABCDE-EXTRA'),
+          isFalse,
+          reason: 'trailing garbage must not match');
+    });
+  });
+
+  group('Obd2AdapterIdentity.fromCandidate (#3168 — picker capture seam)', () {
+    test('UUID-shaped deviceId (iOS) → uuidIos carries the reconnection key',
+        () {
+      final identity =
+          Obd2AdapterIdentity.fromCandidate(candidate(iosUuid, 'OBDLink CX'));
+      expect(identity.deviceId, iosUuid);
+      expect(identity.name, 'OBDLink CX');
+      expect(identity.uuidIos, iosUuid);
+    });
+
+    test('MAC-shaped deviceId (Android) → uuidIos stays null', () {
+      final identity = Obd2AdapterIdentity.fromCandidate(
+          candidate(androidMac, 'OBDLink CX'));
+      expect(identity.deviceId, androidMac);
+      expect(identity.uuidIos, isNull);
+    });
+
+    test('anonymous advertisement → name falls back to the profile label',
+        () {
+      // A nameless candidate matched by service UUID resolves to the
+      // generic FFF0 profile; the persisted name is its display label —
+      // the same fallback the picker used before the capture moved here.
+      final ranked = registry.rank([
+        Obd2AdapterCandidate(
+          deviceId: iosUuid,
+          deviceName: '',
+          advertisedServiceUuids: const [
+            '0000fff0-0000-1000-8000-00805f9b34fb',
+          ],
+          rssi: -55,
+        ),
+      ]);
+      expect(ranked, isNotEmpty);
+      final identity = Obd2AdapterIdentity.fromCandidate(ranked.single);
+      expect(identity.name, ranked.single.profile.displayName);
+      expect(identity.name, isNotEmpty);
+    });
+  });
+
+  group('Obd2UuidRematchDecision.decide — the #3168 decision table', () {
+    test('rotated UUID + exactly one name match → matched', () {
+      final fresh = candidate(iosUuidRotated, 'OBDLink CX');
+      final decision = Obd2UuidRematchDecision.decide(
+        pinnedId: iosUuid,
+        pinnedName: 'OBDLink CX',
+        ranked: [candidate(androidMac, 'vLinker FD'), fresh],
+      );
+      expect(decision.result, Obd2UuidRematchResult.matched);
+      expect(decision.candidate, same(fresh));
+    });
+
+    test('pinned id still present under the SAME id is not a rematch '
+        '(deviceId differs case-insensitively)', () {
+      final decision = Obd2UuidRematchDecision.decide(
+        pinnedId: iosUuid,
+        pinnedName: 'OBDLink CX',
+        ranked: [candidate(iosUuid.toLowerCase(), 'OBDLink CX')],
+      );
+      expect(decision.result, Obd2UuidRematchResult.noCandidate,
+          reason: 'a case-variant of the pinned id is the SAME peripheral — '
+              'the exact-id path owns it, never the rematch');
+    });
+
+    test('name collision — two same-named candidates → ambiguous, no pick',
+        () {
+      final decision = Obd2UuidRematchDecision.decide(
+        pinnedId: iosUuid,
+        pinnedName: 'OBDLink CX',
+        ranked: [
+          candidate(iosUuidRotated, 'OBDLink CX'),
+          candidate('00000000-1111-4222-8333-444455556666', 'OBDLink CX'),
+        ],
+      );
+      expect(decision.result, Obd2UuidRematchResult.ambiguous);
+      expect(decision.candidate, isNull);
+      expect(decision.candidateCount, 2);
+    });
+
+    test('no same-named candidate → noCandidate', () {
+      final decision = Obd2UuidRematchDecision.decide(
+        pinnedId: iosUuid,
+        pinnedName: 'OBDLink CX',
+        ranked: [candidate(iosUuidRotated, 'vLinker FD')],
+      );
+      expect(decision.result, Obd2UuidRematchResult.noCandidate);
+    });
+
+    test('MAC-shaped pinned id (Android) → notEligible even on a name match '
+        '— MACs are stable, a same-named other-MAC device is a DIFFERENT '
+        'adapter', () {
+      final decision = Obd2UuidRematchDecision.decide(
+        pinnedId: androidMac,
+        pinnedName: 'OBDLink CX',
+        ranked: [candidate('11:22:33:44:55:66', 'OBDLink CX')],
+      );
+      expect(decision.result, Obd2UuidRematchResult.notEligible);
+    });
+
+    test('no persisted name → notEligible (nothing to rematch by)', () {
+      for (final name in [null, '', '  ']) {
+        final decision = Obd2UuidRematchDecision.decide(
+          pinnedId: iosUuid,
+          pinnedName: name,
+          ranked: [candidate(iosUuidRotated, 'OBDLink CX')],
+        );
+        expect(decision.result, Obd2UuidRematchResult.notEligible,
+            reason: 'pinnedName=${name == null ? 'null' : '"$name"'}');
+      }
+    });
+  });
+
+  group('repersistRotatedAdapterIdentity (#3168)', () {
+    const fresh = Obd2AdapterIdentity(
+      deviceId: iosUuidRotated,
+      name: 'OBDLink CX',
+      uuidIos: iosUuidRotated,
+    );
+
+    test('rotates the identity fields on every pinned profile and keeps the '
+        'user-facing name + other preferences intact', () async {
+      const pinned = VehicleProfile(
+        id: 'v1',
+        name: 'My BMW',
+        obd2AdapterMac: iosUuid,
+        obd2AdapterName: 'OBDLink CX',
+        pairedAdapterUuidIos: iosUuid,
+        tankCapacityL: 52,
+      );
+      const other = VehicleProfile(
+        id: 'v2',
+        name: 'Other car',
+        obd2AdapterMac: androidMac,
+        obd2AdapterName: 'vLinker FD',
+      );
+      final saved = <VehicleProfile>[];
+      await repersistRotatedAdapterIdentity(
+        profiles: const [pinned, other],
+        save: (p) async => saved.add(p),
+        staleId: iosUuid,
+        fresh: fresh,
+      );
+      expect(saved, hasLength(1), reason: 'only the pinned profile rotates');
+      expect(saved.single.id, 'v1');
+      expect(saved.single.obd2AdapterMac, iosUuidRotated);
+      expect(saved.single.pairedAdapterUuidIos, iosUuidRotated);
+      expect(saved.single.obd2AdapterName, 'OBDLink CX',
+          reason: 'the user-facing adapter name must stay intact');
+      expect(saved.single.tankCapacityL, 52,
+          reason: 'unrelated preferences must stay intact');
+    });
+
+    test('matches a legacy profile pinned only via pairedAdapterUuidIos '
+        '(pre-#3168 persisted state)', () async {
+      const legacy = VehicleProfile(
+        id: 'v1',
+        name: 'My BMW',
+        obd2AdapterMac: 'something-else',
+        obd2AdapterName: 'OBDLink CX',
+        pairedAdapterUuidIos: iosUuid,
+      );
+      final saved = <VehicleProfile>[];
+      await repersistRotatedAdapterIdentity(
+        profiles: const [legacy],
+        save: (p) async => saved.add(p),
+        staleId: iosUuid.toLowerCase(), // case-insensitive match
+        fresh: fresh,
+      );
+      expect(saved, hasLength(1));
+      expect(saved.single.obd2AdapterMac, iosUuidRotated);
+      expect(saved.single.pairedAdapterUuidIos, iosUuidRotated);
+    });
+
+    test('no pinned profile → no writes', () async {
+      const unrelated = VehicleProfile(id: 'v1', name: 'Car');
+      var saves = 0;
+      await repersistRotatedAdapterIdentity(
+        profiles: const [unrelated],
+        save: (_) async => saves++,
+        staleId: iosUuid,
+        fresh: fresh,
+      );
+      expect(saves, 0);
+    });
+
+    test('FAULT INJECTION — a throwing save is swallowed (never throws), '
+        'the connect that triggered the rotation is never derailed',
+        () async {
+      const pinned = VehicleProfile(
+        id: 'v1',
+        name: 'My BMW',
+        obd2AdapterMac: iosUuid,
+        obd2AdapterName: 'OBDLink CX',
+      );
+      await expectLater(
+        repersistRotatedAdapterIdentity(
+          profiles: const [pinned],
+          save: (_) async => throw StateError('hive write failed'),
+          staleId: iosUuid,
+          fresh: fresh,
+        ),
+        completes,
+      );
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_uuid_rematch_test.dart
+++ b/test/features/consumption/data/obd2/obd2_uuid_rematch_test.dart
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_adapter_identity.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3168 — `connectByMac`'s scan fallback rematches a ROTATED iOS
+/// CBPeripheral UUID by the persisted adapter name, re-persists the fresh
+/// id via the `onAdapterIdentityRotated` seam, and stage-tags the whole
+/// thing in the connect trace (`uuid-rematch` / `uuid-repersist`).
+void main() {
+  silenceErrorLoggerSpool();
+
+  const pinnedUuid = '12345678-9ABC-4DEF-8012-3456789ABCDE';
+  const rotatedUuid = 'FEDCBA98-7654-4321-8FED-CBA987654321';
+  const adapterName = 'OBDLink CX';
+
+  setUp(Obd2ConnectTraceLog.clear);
+  tearDown(Obd2ConnectTraceLog.clear);
+
+  Obd2AdapterCandidate cx(String id, {String name = adapterName}) =>
+      Obd2AdapterCandidate(
+        deviceId: id,
+        deviceName: name,
+        advertisedServiceUuids: const [],
+        rssi: -55,
+      );
+
+  List<Obd2ConnectStep> stepsNamed(String label) => [
+        for (final t in Obd2ConnectTraceLog.snapshot())
+          for (final s in t.steps)
+            if (s.label == label) s,
+      ];
+
+  test('rotated UUID + unique name match → connects to the fresh id AND '
+      're-persists it through the rotation seam', () async {
+    final rotations = <({String staleId, Obd2AdapterIdentity fresh})>[];
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx(rotatedUuid)],
+      ]),
+      onRotated: ({required staleId, required fresh}) async =>
+          rotations.add((staleId: staleId, fresh: fresh)),
+    );
+
+    final ready = await svc.connectByMac(pinnedUuid, adapterName: adapterName);
+
+    expect(ready, isNotNull,
+        reason: 'the rotated-UUID adapter must reconnect via the rematch');
+    expect(ready!.adapterMac, rotatedUuid,
+        reason: 'the session must run on the FRESH peripheral id');
+    expect(rotations, hasLength(1));
+    expect(rotations.single.staleId, pinnedUuid);
+    expect(rotations.single.fresh.deviceId, rotatedUuid);
+    expect(rotations.single.fresh.name, adapterName);
+    expect(rotations.single.fresh.uuidIos, rotatedUuid);
+    await ready.disconnect();
+
+    // Stage tags: the field trace must show WHEN the rotation happened.
+    final rematch = stepsNamed('uuid-rematch');
+    expect(rematch, hasLength(1));
+    expect(rematch.single.status, Obd2ConnectStepStatus.ok);
+    final repersist = stepsNamed('uuid-repersist');
+    expect(repersist, hasLength(1));
+    expect(repersist.single.status, Obd2ConnectStepStatus.ok);
+    // The #3184(e) discriminator fires alongside the rematch.
+    expect(stepsNamed('pinned-id-mismatch'), isNotEmpty);
+  });
+
+  test('exact-id hit → NO rematch, NO rotation callback (same-uuid row of '
+      'the decision table)', () async {
+    var rotated = 0;
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx(pinnedUuid)],
+      ]),
+      onRotated: ({required staleId, required fresh}) async => rotated++,
+    );
+
+    final ready = await svc.connectByMac(pinnedUuid, adapterName: adapterName);
+
+    expect(ready, isNotNull);
+    expect(ready!.adapterMac, pinnedUuid);
+    expect(rotated, 0);
+    await ready.disconnect();
+    expect(stepsNamed('uuid-rematch'), isEmpty);
+  });
+
+  test('name collision — two same-named fresh candidates → ambiguous: '
+      'returns null (picker fallback) and stamps the skip', () async {
+    var rotated = 0;
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx(rotatedUuid), cx('00000000-1111-4222-8333-444455556666')],
+      ]),
+      onRotated: ({required staleId, required fresh}) async => rotated++,
+    );
+
+    final ready = await svc.connectByMac(pinnedUuid, adapterName: adapterName);
+
+    expect(ready, isNull, reason: 'an ambiguous rematch must never guess');
+    expect(rotated, 0);
+    final rematch = stepsNamed('uuid-rematch');
+    expect(rematch, hasLength(1));
+    expect(rematch.single.status, Obd2ConnectStepStatus.fail);
+    expect(rematch.single.detail, contains('ambiguous'));
+  });
+
+  test('MAC-shaped pinned id (Android) + same-named other MAC → harmless: '
+      'no rematch, null as before', () async {
+    var rotated = 0;
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx('11:22:33:44:55:66')],
+      ]),
+      onRotated: ({required staleId, required fresh}) async => rotated++,
+    );
+
+    final ready =
+        await svc.connectByMac('AA:BB:CC:DD:EE:FF', adapterName: adapterName);
+
+    expect(ready, isNull);
+    expect(rotated, 0);
+    expect(stepsNamed('uuid-rematch'), isEmpty);
+  });
+
+  test('no persisted adapter name → rematch not eligible, null as before',
+      () async {
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx(rotatedUuid)],
+      ]),
+      onRotated: ({required staleId, required fresh}) async {},
+    );
+
+    final ready = await svc.connectByMac(pinnedUuid);
+
+    expect(ready, isNull);
+    expect(stepsNamed('uuid-rematch'), isEmpty);
+  });
+
+  test('FAULT INJECTION — a THROWING rotation seam is swallowed: the connect '
+      'that just succeeded still returns its service (never throws)',
+      () async {
+    final svc = _build(
+      bt: _FakeFacade(batches: [
+        [cx(rotatedUuid)],
+      ]),
+      onRotated: ({required staleId, required fresh}) =>
+          Future<void>.error(StateError('repersist exploded')),
+    );
+
+    final ready = await svc.connectByMac(pinnedUuid, adapterName: adapterName);
+
+    expect(ready, isNotNull,
+        reason: 'a failed re-persist must never derail the live session');
+    await ready!.disconnect();
+    final repersist = stepsNamed('uuid-repersist');
+    expect(repersist, hasLength(1));
+    expect(repersist.single.status, Obd2ConnectStepStatus.fail);
+  });
+}
+
+Obd2ConnectionService _build({
+  required BluetoothFacade bt,
+  Obd2AdapterIdentityRotated? onRotated,
+}) =>
+    Obd2ConnectionService(
+      registry: Obd2AdapterRegistry.defaults(),
+      permissions: _FakePermissions(),
+      bluetooth: bt,
+      onAdapterIdentityRotated: onRotated,
+      scanSettleDelay: Duration.zero,
+    );
+
+class _FakePermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _FakeFacade implements BluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  _FakeFacade({required this.batches});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      _FakeChannel();
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      _FakeChannel();
+}
+
+/// Answers every write with the canonical ELM327 prompt so the init
+/// sequence completes (mirrors the connection-service test fakes).
+class _FakeChannel implements ElmByteChannel {
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  static const Map<String, String> _respondTo = {
+    'ATZ': 'ELM327 v1.5>',
+    'ATE0': 'OK>',
+    'ATL0': 'OK>',
+    'ATH0': 'OK>',
+    'ATSP0': 'OK>',
+  };
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+
+  @override
+  Future<void> open() async {
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    final cmd = String.fromCharCodes(bytes).trim();
+    final reply = _respondTo[cmd] ?? 'OK>';
+    _ctrl.add(reply.codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ctrl.isClosed) await _ctrl.close();
+  }
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -223,6 +223,12 @@ void main() {
     // iOS UUID-vs-MAC identity-drift discriminator), and the provider
     // registers the adapter-state step-0 probe. The persistence layer
     // lives in the NEW under-cap obd2_connect_trace_persistence.dart.
+    // #3168 — re-grandfathered 826 → 865: the iOS UUID-rotation rematch
+    // wiring (the `onAdapterIdentityRotated` re-persist seam field + its
+    // dartdoc, the `connectByMac` scan-loop handoff to the rematch, and
+    // the provider's repersist wiring). The rematch decision table +
+    // identity capture + re-persist logic all live in the NEW under-cap
+    // obd2_adapter_identity.dart; only the seam plumbing lands here.
     // Decomposition still tracked under #2187/#2188.
     // #3185 — re-grandfathered 826 → 899: the single-flight connect
     // SUPERVISOR + scan GOVERNOR are wired at this chokepoint (the whole
@@ -234,7 +240,9 @@ void main() {
     // themselves live in the NEW under-cap obd2_connect_supervisor.dart /
     // obd2_scan_governor.dart. Decomposition still tracked under
     // #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 899,
+    // (#3168's rematch seam, listed above, adds its 39 lines ON TOP of the
+    // #3185 wiring — combined snapshot below.)
+    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 938,
     // #2969 — grandfathered at 419 (was ~399, right at the cap on master). The
     // scan-path BLE `connect()` timeout bound (FBP could otherwise block ~35 s
     // on a vanished candidate) + the channel-open connect-trace stamp (the one

--- a/test/lint/no_inline_platform_check_test.dart
+++ b/test/lint/no_inline_platform_check_test.dart
@@ -46,7 +46,9 @@ void main() {
     'lib/core/feedback/github_issue_reporter/error_reporter_context.dart',
     'lib/core/sharing/public_file_exporter.dart',
     'lib/core/telemetry/collectors/device_info_collector.dart',
-    'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart',
+    // #3168 — obd2_adapter_picker.dart removed: its identity capture moved
+    // to the data-layer Obd2AdapterIdentity seam (UUID-shape discriminator,
+    // no Platform check).
     'lib/features/widget/data/home_widget_service.dart',
   };
 


### PR DESCRIPTION
## iOS BLE UUID-rotation rematch — reconnect survives CoreBluetooth identifier rotation

From epic #3165, and the prime suspect behind the long-running "OBDLink CX never reconnects on iPhone" field story: iOS peripheral identifiers are per-device random UUIDs that can rotate (re-pairing, iOS updates), after which the persisted adapter identity never matches again — silent permanent reconnect failure.

- New `obd2_adapter_identity.dart`: the rematch decision table (same-id hit → rotated-id + unique name match → ambiguous/no match falls through to normal flow), pure and unit-tested including the two-candidates collision case.
- The scan fallback in `connectByMac` hands unmatched scans to the rematcher; a successful rematch **re-persists the fresh UUID onto every vehicle profile pinned to the stale one** (name and preferences intact, never-throws with fault-injection coverage) via the new `onAdapterIdentityRotated` seam.
- The rotation is **stage-tagged in the persistent connect trace** (`uuid-rematch` step alongside #3184's `pinned-id-mismatch` discriminator), so a field export shows exactly when rotation happened.
- Android is untouched in behavior (stable MACs; the rematch path simply never fires) — no platform forks in shared code.

Closes #3168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
