### PR TITLE
feat(ios): hands-free auto-record Phase 3 — CoreBluetooth state restoration into AutoTripCoordinator (#3167)

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -35,6 +35,15 @@ import workmanager_apple
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // #3167 — capture the Core Bluetooth state-restoration launch signal
+    // FIRST: when iOS relaunches the app in the background because the
+    // paired OBD2 adapter completed a pending connect, `launchOptions`
+    // carries `.bluetoothCentrals` with the restore identifiers of the
+    // central managers being restored. The Dart side queries this via the
+    // `tankstellen/ios_state_restoration` channel to resume hands-free
+    // auto-recording and tag the connect trace origin.
+    StateRestorationBridge.shared.captureLaunchOptions(launchOptions)
+
     // #2414 — Tier-1 background scan on iOS via the workmanager iOS backend
     // (BGTaskScheduler / BGAppRefreshTask).
     //
@@ -77,6 +86,11 @@ import workmanager_apple
     // (replaces Google ML Kit on iOS; Android keeps ML Kit).
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "VisionOcrBridge") {
       VisionOcrBridge.shared.register(messenger: registrar.messenger())
+    }
+    // #3167 — Core Bluetooth state-restoration launch bridge (hands-free
+    // auto-record Phase 3).
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "StateRestorationBridge") {
+      StateRestorationBridge.shared.register(messenger: registrar.messenger())
     }
   }
 
@@ -293,6 +307,59 @@ final class VisionOcrBridge {
         try handler.perform([request])
       } catch {
         DispatchQueue.main.async { result(nil) }
+      }
+    }
+  }
+}
+
+/// #3167 — host-side half of the Core Bluetooth state-restoration wiring
+/// (hands-free auto-record Phase 3, Epic #3165), serving the
+/// `tankstellen/ios_state_restoration` MethodChannel.
+///
+/// When the paired ELM327/OBDLink adapter powers up while the app is
+/// terminated, iOS completes the pending connect flutter_blue_plus queued
+/// (`CBCentralManagerOptionRestoreIdentifierKey` is set via
+/// `setOptions(restoreState: true)` on the Dart side) and relaunches the
+/// app into the background with `.bluetoothCentrals` in `launchOptions` —
+/// the array of central-manager restore identifiers being restored. The
+/// FBP plugin handles `centralManager:willRestoreState:` natively; what it
+/// does NOT surface to Dart is the LAUNCH signal itself. This bridge
+/// captures it so the Dart `IosStateRestorationService` can (a) resume the
+/// auto-record coordinator and (b) stamp `stateRestoration` as the connect
+/// trace origin for field exports.
+///
+/// Inline in AppDelegate.swift (not a separate file) on purpose: a new file
+/// under ios/Runner/ is not in the Runner target's compile sources without
+/// a project.pbxproj edit (see the ShareIntentBridge note above), so
+/// defining it here keeps the build green with zero pbxproj change.
+final class StateRestorationBridge {
+  static let shared = StateRestorationBridge()
+  private static let channelName = "tankstellen/ios_state_restoration"
+
+  /// Restore identifiers from `UIApplication.LaunchOptionsKey.bluetoothCentrals`,
+  /// captured in `didFinishLaunchingWithOptions`. Nil on a normal user launch.
+  /// NOT consumed on read — the Dart service caches + one-shots it itself, and
+  /// an idempotent getter keeps a hot-restart from losing the signal.
+  private var launchBluetoothCentralIds: [String]?
+
+  /// Called first thing in `didFinishLaunchingWithOptions` so the signal is
+  /// stored before any Flutter engine (foreground or headless) spins up.
+  func captureLaunchOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+    if let centrals = launchOptions?[.bluetoothCentrals] as? [String] {
+      launchBluetoothCentralIds = centrals
+    }
+  }
+
+  /// Wires the method channel onto `messenger`. Called once when the Flutter
+  /// engine is ready (see `didInitializeImplicitFlutterEngine`).
+  func register(messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "getLaunchBluetoothCentralIds":
+        result(self?.launchBluetoothCentralIds)
+      default:
+        result(FlutterMethodNotImplemented)
       }
     }
   }

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -44,6 +44,7 @@ import '../core/utils/edge_to_edge.dart';
 import '../features/alerts/providers/alert_provider.dart';
 import '../features/consumption/data/obd2/active_trip_recovery_service.dart';
 import '../features/consumption/data/obd2/active_trip_repository.dart';
+import '../features/consumption/data/obd2/ios_state_restoration_provider.dart';
 import '../features/consumption/data/obd2/obd2_connect_trace_persistence.dart';
 import '../features/consumption/data/obd2/paused_trip_recovery_service.dart';
 import '../features/consumption/data/obd2/paused_trip_repository.dart';
@@ -1002,6 +1003,19 @@ class AppInitializer {
     // bug in `defaultTargetPlatform` resolution or in the listener
     // factory would otherwise crash the whole launch path.
     _deferPostFirstFrame(() async {
+      // #3167 — opt the shared FBP central manager into Core Bluetooth
+      // state restoration BEFORE the orchestrator's first Bluetooth
+      // touch, sequenced in the SAME deferred block so the ordering is
+      // guaranteed. This also drains the host bridge's launch signal
+      // ("relaunched by Core Bluetooth?") that tags the first
+      // auto-record connect trace. No-op off iOS; a failure never
+      // blocks the orchestrator below.
+      try {
+        await container.read(iosStateRestorationServiceProvider).initialize();
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: {'where': 'iosStateRestoration init'}));
+      }
       try {
         container.read(autoRecordOrchestratorProvider);
       } catch (e, st) {

--- a/lib/features/consumption/data/obd2/ios_background_adapter_listener.dart
+++ b/lib/features/consumption/data/obd2/ios_background_adapter_listener.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../../../../core/logging/error_logger.dart';
+import 'background_adapter_listener.dart';
+import 'ios_state_restoration_service.dart';
+
+/// Produces the connected/disconnected stream for one peripheral id.
+/// Production resolves to flutter_blue_plus's `connectionState`; tests
+/// inject a controller-backed stream so no BLE stack is needed.
+typedef IosAdapterConnectionStates = Stream<bool> Function(String deviceId);
+
+/// iOS production [BackgroundAdapterListener] (#3167 — hands-free
+/// auto-record Phase 3, Epic #3165).
+///
+/// Replaces the [UnimplementedBackgroundAdapterListener] the orchestrator
+/// used to construct on iOS, closing the parity gap with Android's
+/// foreground-service bridge. The iOS equivalent of "watch the paired
+/// adapter in the background" is Core Bluetooth State Preservation and
+/// Restoration, already wrapped by [IosStateRestorationService]:
+///
+/// 1. [start] opts the central manager into state restoration
+///    ([IosStateRestorationService.initialize]) and queues the long-lived
+///    `autoConnect` pending connect for the paired peripheral UUID
+///    ([IosStateRestorationService.registerPersistedAdapter]). iOS retains
+///    that pending connect across app termination; flutter_blue_plus also
+///    passes `kCBConnectOptionEnableAutoReconnect` and tracks the device in
+///    its auto-connect set, so a drop re-pends WITHOUT a re-register here.
+/// 2. When the adapter powers up (driver enters the car), iOS completes
+///    the connect — relaunching the app in the background if it was
+///    terminated (the FBP plugin handles `willRestoreState` natively and
+///    rehydrates the peripheral). Either way the device's
+///    `connectionState` stream flips to connected.
+/// 3. This listener maps that stream onto the same
+///    [AdapterConnected] / [AdapterDisconnected] events the Android
+///    bridge emits, so the [AutoTripCoordinator] state machine — session
+///    open via the supervisor-admitted opener, speed watch, threshold
+///    start, debounced disconnect save — runs UNCHANGED on iOS.
+///
+/// On a restoration relaunch the `connectionState` stream replays the
+/// already-connected state to its first subscriber, so the coordinator is
+/// armed immediately after [start] — that immediate session open is the
+/// connect the trace stamps `Obd2ConnectOrigin.stateRestoration` (the
+/// origin tag itself lives on the session-opener seam in
+/// `auto_record_orchestrator_factories.dart`, not here).
+///
+/// ## Contracts
+/// * The MAC slot of every event carries the `CBPeripheral.identifier`
+///   UUID — on iOS `VehicleProfile.obd2AdapterMac` already stores that
+///   UUID (the picker persists `deviceId`, see #2282 concern 3), so the
+///   coordinator's MAC filter matches without translation.
+/// * [start] / [stop] never throw — every restoration-service fault is
+///   logged and the connection-state watch is still armed, because a
+///   broken `setOptions` must not cost the user the foreground-arm path
+///   that works without restoration.
+/// * Late subscribers are tolerated per the [BackgroundAdapterListener]
+///   contract: events emitted before the first subscriber attaches are
+///   buffered and replayed on first listen.
+class IosBackgroundAdapterListener implements BackgroundAdapterListener {
+  IosBackgroundAdapterListener({
+    required IosStateRestorationService restoration,
+    IosAdapterConnectionStates? connectionStates,
+    DateTime Function()? now,
+  })  : _restoration = restoration,
+        _connectionStates = connectionStates ?? _fbpConnectionStates,
+        _now = now ?? DateTime.now;
+
+  /// Production stream source: flutter_blue_plus's per-device
+  /// `connectionState`, which replays the CURRENT state on listen —
+  /// exactly what turns a background relaunch with an already-connected
+  /// peripheral into an immediate [AdapterConnected].
+  static Stream<bool> _fbpConnectionStates(String deviceId) {
+    return BluetoothDevice.fromId(deviceId)
+        .connectionState
+        .map((s) => s == BluetoothConnectionState.connected);
+  }
+
+  final IosStateRestorationService _restoration;
+  final IosAdapterConnectionStates _connectionStates;
+  final DateTime Function() _now;
+
+  late final StreamController<BackgroundAdapterEvent> _events =
+      StreamController<BackgroundAdapterEvent>.broadcast(
+    onListen: _flushPending,
+  );
+
+  /// Events emitted before the first subscriber attached (the
+  /// coordinator subscribes only after `start` returns). Replayed on
+  /// first listen so the initial restored-connect is never dropped.
+  final List<BackgroundAdapterEvent> _pending = <BackgroundAdapterEvent>[];
+
+  StreamSubscription<bool>? _stateSub;
+  String? _watchedId;
+
+  /// Last connected/disconnected value seen, used to (a) de-duplicate
+  /// the replayed current state FBP emits to every new stream listener
+  /// and (b) swallow the initial "disconnected" a normal foreground
+  /// launch starts from (the coordinator must not arm a save timer for
+  /// a car that was never connected this process).
+  bool? _lastConnected;
+
+  @override
+  Stream<BackgroundAdapterEvent> get events => _events.stream;
+
+  /// Arm the watch for [mac] (the paired peripheral UUID on iOS).
+  /// Idempotent for the same id; a different id implicitly stops the
+  /// previous watch. Never throws — restoration-service faults are
+  /// logged and the connection-state watch is armed regardless.
+  @override
+  Future<void> start({required String mac}) async {
+    if (_watchedId == mac) return;
+    if (_watchedId != null) await stop();
+    _watchedId = mac;
+    // Opt into state restoration + queue the long-lived pending connect.
+    // Both are guarded individually: a failed setOptions (restoration
+    // unavailable) must not block the pending connect, and a failed
+    // pending connect must not block the live connection-state watch.
+    //
+    // NOTE on #3185: registerPersistedAdapter only ISSUES a pending
+    // connect — it never tears down a channel or stops a scan, so it
+    // cannot disturb a supervisor-admitted attempt. The actual OBD2
+    // session open this watch triggers enters through the coordinator's
+    // session opener → `Obd2ConnectionService.connectByMac` → supervisor
+    // admission, like every other requester.
+    try {
+      await _restoration.initialize();
+    } catch (e, st) {
+      await errorLogger.log(ErrorLayer.background, e, st, context: {
+        'where': 'IosBackgroundAdapterListener.start initialize',
+        'deviceId': mac,
+      });
+    }
+    try {
+      await _restoration.registerPersistedAdapter(mac);
+    } catch (e, st) {
+      await errorLogger.log(ErrorLayer.background, e, st, context: {
+        'where': 'IosBackgroundAdapterListener.start registerPersistedAdapter',
+        'deviceId': mac,
+      });
+    }
+    _lastConnected = null;
+    _stateSub = _connectionStates(mac).listen(
+      _onConnectionState,
+      onError: (Object e, StackTrace st) {
+        // A stream error must not kill the watch silently — log it; the
+        // subscription itself stays alive (cancelOnError defaults false).
+        unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
+          'where': 'IosBackgroundAdapterListener connectionState error',
+          'deviceId': mac,
+        }));
+      },
+    );
+  }
+
+  void _onConnectionState(bool connected) {
+    final id = _watchedId;
+    if (id == null) return;
+    if (_lastConnected == connected) return; // de-dupe replays
+    final isFirst = _lastConnected == null;
+    _lastConnected = connected;
+    if (isFirst && !connected) {
+      // The replayed initial state on a normal launch is "disconnected"
+      // — not a transition, nothing for the coordinator to debounce.
+      return;
+    }
+    _emit(connected
+        ? AdapterConnected(mac: id, at: _now())
+        : AdapterDisconnected(mac: id, at: _now()));
+  }
+
+  void _emit(BackgroundAdapterEvent event) {
+    if (_events.isClosed) return;
+    if (_events.hasListener) {
+      _events.add(event);
+    } else {
+      _pending.add(event);
+    }
+  }
+
+  void _flushPending() {
+    if (_pending.isEmpty) return;
+    // Microtask: the first subscriber is fully registered by then, so
+    // the replay is guaranteed to be delivered to it.
+    scheduleMicrotask(() {
+      final replay = List<BackgroundAdapterEvent>.of(_pending);
+      _pending.clear();
+      for (final event in replay) {
+        if (!_events.isClosed) _events.add(event);
+      }
+    });
+  }
+
+  /// Stop watching. Cancels the connection-state subscription; the
+  /// pending OS-level connect stays registered on purpose (tearing it
+  /// down belongs to whoever owns the BLE link). Safe to call when no
+  /// watch is active; never throws.
+  @override
+  Future<void> stop() async {
+    _watchedId = null;
+    _lastConnected = null;
+    try {
+      await _stateSub?.cancel();
+    } catch (e, st) {
+      await errorLogger.log(ErrorLayer.background, e, st, context: const {
+        'where': 'IosBackgroundAdapterListener.stop',
+      });
+    } finally {
+      _stateSub = null;
+    }
+  }
+
+  /// Close the event stream. Test/teardown helper — production drops the
+  /// listener with the coordinator entry and lets GC collect it, the same
+  /// lifecycle the Android bridge follows. Safe to call more than once.
+  Future<void> dispose() async {
+    await stop();
+    if (!_events.isClosed) {
+      await _events.close();
+    }
+  }
+}

--- a/lib/features/consumption/data/obd2/ios_state_restoration_service.dart
+++ b/lib/features/consumption/data/obd2/ios_state_restoration_service.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import '../../../../core/logging/error_logger.dart';
@@ -93,6 +94,28 @@ abstract class IosStateRestorationService {
   /// Single-broadcast: multiple listeners are supported.
   Stream<IosRestorationEvent> get events;
 
+  /// The restoration event captured during [initialize] when THIS app
+  /// launch was a Core Bluetooth background relaunch (#3167 — iOS
+  /// passes `UIApplication.LaunchOptionsKey.bluetoothCentrals` to
+  /// `didFinishLaunchingWithOptions`, surfaced through the
+  /// `tankstellen/ios_state_restoration` MethodChannel). Null on a
+  /// normal user launch and on every non-iOS platform.
+  ///
+  /// Cached as a getter (not only on [events]) because consumers wire
+  /// up AFTER app init has already run [initialize] — a broadcast
+  /// stream would have dropped the one-shot launch event by then.
+  IosRestorationWillRestore? get launchRestoration;
+
+  /// One-shot consumption of the [launchRestoration] signal for the
+  /// connect-trace origin stamp (#3167). Returns true exactly ONCE per
+  /// process when this launch was a Core Bluetooth restoration
+  /// relaunch; every later call — and every call on a normal launch or
+  /// a non-iOS platform — returns false. The auto-record session
+  /// opener uses it to tag the first post-relaunch connect with
+  /// `Obd2ConnectOrigin.stateRestoration` so field exports distinguish
+  /// hands-free background resumes from user-driven connects.
+  bool consumeLaunchRestorationTag();
+
   /// Release resources held by the service. Closes the [events]
   /// stream. Safe to call more than once.
   Future<void> dispose();
@@ -120,13 +143,38 @@ class FlutterBluePlusIosStateRestorationService
   @visibleForTesting
   final bool? debugIsIOSOverride;
 
+  /// Test seam: replaces the `FlutterBluePlus.setOptions` call so the
+  /// iOS branch is drivable on the Dart VM (the real call crosses an
+  /// unbound MethodChannel in `flutter_test`). Null in production.
+  @visibleForTesting
+  final Future<void> Function()? debugSetOptionsOverride;
+
+  /// Test seam: replaces the `tankstellen/ios_state_restoration`
+  /// MethodChannel query for the launch-time Bluetooth-central
+  /// restoration identifiers (#3167). Null in production.
+  @visibleForTesting
+  final Future<List<String>?> Function()? debugLaunchCentralIdsFetcher;
+
+  /// Host-side bridge registered inline in `ios/Runner/AppDelegate.swift`
+  /// (#3167). One method: `getLaunchBluetoothCentralIds` returns the
+  /// `UIApplicationLaunchOptionsBluetoothCentralsKey` array captured in
+  /// `didFinishLaunchingWithOptions` (null on a normal launch).
+  static const MethodChannel _restorationChannel =
+      MethodChannel('tankstellen/ios_state_restoration');
+
   final StreamController<IosRestorationEvent> _eventsController =
       StreamController<IosRestorationEvent>.broadcast();
 
   bool _initialized = false;
   bool _disposed = false;
+  IosRestorationWillRestore? _launchRestoration;
+  bool _launchTagConsumed = false;
 
-  FlutterBluePlusIosStateRestorationService({this.debugIsIOSOverride});
+  FlutterBluePlusIosStateRestorationService({
+    this.debugIsIOSOverride,
+    this.debugSetOptionsOverride,
+    this.debugLaunchCentralIdsFetcher,
+  });
 
   /// Resolved platform check. Production reads [Platform.isIOS];
   /// tests pass [debugIsIOSOverride] to drive both branches.
@@ -149,7 +197,8 @@ class FlutterBluePlusIosStateRestorationService
   /// native side. Must run before any scan/connect.
   Future<void> _initializeIOS() async {
     try {
-      await FlutterBluePlus.setOptions(restoreState: true);
+      await (debugSetOptionsOverride ??
+          () => FlutterBluePlus.setOptions(restoreState: true))();
       debugPrint(
         'IosStateRestorationService: setOptions(restoreState: true) ok',
       );
@@ -164,6 +213,57 @@ class FlutterBluePlusIosStateRestorationService
       );
       rethrow;
     }
+    await _captureLaunchRestoration();
+  }
+
+  /// #3167 — ask the host bridge whether THIS launch carried the
+  /// `bluetoothCentrals` launch-options key, i.e. iOS relaunched us in
+  /// the background for Core Bluetooth state restoration. On a hit the
+  /// one-shot [launchRestoration] is cached (for late consumers) and a
+  /// [IosRestorationWillRestore] is published on [events].
+  ///
+  /// Best-effort and NEVER throws: a missing host handler (an old
+  /// native build, a test binding) logs a breadcrumb and leaves the
+  /// launch untagged — exactly the pre-#3167 behaviour.
+  Future<void> _captureLaunchRestoration() async {
+    try {
+      final fetch = debugLaunchCentralIdsFetcher ??
+          () => _restorationChannel
+              .invokeListMethod<String>('getLaunchBluetoothCentralIds');
+      final ids = await fetch();
+      if (ids == null || ids.isEmpty) return;
+      debugPrint(
+        'IosStateRestorationService: launched via Core Bluetooth state '
+        'restoration (centrals: $ids)',
+      );
+      // The launch key carries CENTRAL MANAGER restore identifiers, not
+      // peripheral UUIDs — the paired peripheral UUID is persisted on
+      // the vehicle profile, so the event's peripheral list stays empty
+      // (documented as "restored, no peripheral detail").
+      _launchRestoration = const IosRestorationWillRestore(<String>[]);
+      if (!_eventsController.isClosed) {
+        _eventsController.add(_launchRestoration!);
+      }
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.services,
+        e,
+        st,
+        context: const {
+          'where': 'IosStateRestorationService.captureLaunchRestoration',
+        },
+      );
+    }
+  }
+
+  @override
+  IosRestorationWillRestore? get launchRestoration => _launchRestoration;
+
+  @override
+  bool consumeLaunchRestorationTag() {
+    if (_launchRestoration == null || _launchTagConsumed) return false;
+    _launchTagConsumed = true;
+    return true;
   }
 
   /// Non-iOS path: emit the "not supported" sentinel so listeners

--- a/lib/features/consumption/data/obd2/obd2_connect_trace.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_trace.dart
@@ -29,6 +29,14 @@ enum Obd2ConnectOrigin {
   /// artefact. When a connect entry point opened the trace first, the
   /// scan joins it as a child instead and this origin never appears.
   pickerScan,
+
+  /// The first auto-record connect after iOS relaunched the app via Core
+  /// Bluetooth state restoration (#3167) — the paired adapter came back
+  /// into range while the app was terminated and the OS woke us in the
+  /// background. Distinguishes a hands-free background resume from a
+  /// user-driven first connect in a field export, so "the relaunch path
+  /// connected / failed" is diagnosable without a debugger attached.
+  stateRestoration,
 }
 
 /// The transport a connect step requested / resolved (#2969). `unknown` is the

--- a/lib/features/consumption/data/obd2/obd2_connect_trace.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_trace.g.dart
@@ -109,6 +109,7 @@ const _$Obd2ConnectOriginEnumMap = {
   Obd2ConnectOrigin.firstConnect: 'firstConnect',
   Obd2ConnectOrigin.autoRecord: 'autoRecord',
   Obd2ConnectOrigin.pickerScan: 'pickerScan',
+  Obd2ConnectOrigin.stateRestoration: 'stateRestoration',
 };
 
 const _$Obd2ConnectOutcomeEnumMap = {

--- a/lib/features/consumption/providers/auto_record_orchestrator_factories.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator_factories.dart
@@ -8,6 +8,11 @@ import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/android_background_adapter_listener.dart';
 import '../data/obd2/auto_trip_coordinator.dart';
 import '../data/obd2/background_adapter_listener.dart';
+import '../data/obd2/ios_background_adapter_listener.dart';
+import '../data/obd2/ios_state_restoration_provider.dart';
+import '../data/obd2/ios_state_restoration_service.dart';
+import '../data/obd2/obd2_connect_trace.dart';
+import '../data/obd2/obd2_connect_trace_log.dart';
 import '../data/obd2/obd2_connection_service.dart';
 
 part 'auto_record_orchestrator_factories.g.dart';
@@ -25,7 +30,8 @@ part 'auto_record_orchestrator_factories.g.dart';
 typedef BackgroundAdapterListenerFactory = BackgroundAdapterListener
     Function();
 
-/// Default factory: Android in production, an unimplemented stub
+/// Default factory: Android's foreground-service bridge, iOS's Core
+/// Bluetooth state-restoration listener (#3167), an unimplemented stub
 /// elsewhere. Tests override this provider to inject a
 /// [FakeBackgroundAdapterListener] without touching platform-detection
 /// code.
@@ -34,6 +40,15 @@ BackgroundAdapterListenerFactory autoRecordListenerFactory(Ref ref) {
   return () {
     if (defaultTargetPlatform == TargetPlatform.android) {
       return AndroidBackgroundAdapterListener();
+    }
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      // #3167 — hands-free auto-record Phase 3. The keepAlive singleton
+      // restoration service is shared across coordinators on purpose:
+      // `setOptions(restoreState: true)` and the launch-relaunch tag are
+      // process-wide, while each listener arms its own peripheral UUID.
+      return IosBackgroundAdapterListener(
+        restoration: ref.read(iosStateRestorationServiceProvider),
+      );
     }
     return const UnimplementedBackgroundAdapterListener();
   };
@@ -45,10 +60,49 @@ BackgroundAdapterListenerFactory autoRecordListenerFactory(Ref ref) {
 /// out — the coordinator stays idle for that connect cycle and waits
 /// for the next `AdapterConnected`. Tests override this provider to
 /// inject a fake opener that returns a stub service.
+///
+/// #3167 — wrapped in [wrapStateRestorationOrigin] so the FIRST
+/// auto-record connect after a Core Bluetooth background relaunch is
+/// trace-stamped `Obd2ConnectOrigin.stateRestoration`. A no-op on a
+/// normal launch and on Android (the tag is never set there).
 @Riverpod(keepAlive: true)
 Obd2SessionOpener autoRecordSessionOpenerFactory(Ref ref) {
-  return (String mac) async {
-    return ref.read(obd2ConnectionProvider).connectByMac(mac);
+  return wrapStateRestorationOrigin(
+    inner: (String mac) async {
+      return ref.read(obd2ConnectionProvider).connectByMac(mac);
+    },
+    restoration: ref.read(iosStateRestorationServiceProvider),
+  );
+}
+
+/// #3167 — decorate [inner] so the one-shot launch-restoration tag
+/// (set when iOS relaunched the app via Core Bluetooth state
+/// restoration) stamps `Obd2ConnectOrigin.stateRestoration` on the
+/// connect trace of the FIRST auto-record session open of that launch.
+/// Later opens — and every open on a normal launch — run [inner]
+/// untagged, so the service's own default origin applies.
+///
+/// The origin override scopes the supervisor-admitted connect the
+/// opener performs ([Obd2ConnectionService.connectByMac] →
+/// `supervisor.admit`), so the restoration path enters single-flight
+/// admission like every other requester — only its trace label differs.
+///
+/// Exposed (not private) so the unit test can drive it with a fake
+/// restoration service + a fake inner opener without standing up the
+/// whole connection service.
+@visibleForTesting
+Obd2SessionOpener wrapStateRestorationOrigin({
+  required Obd2SessionOpener inner,
+  required IosStateRestorationService restoration,
+}) {
+  return (String mac) {
+    if (restoration.consumeLaunchRestorationTag()) {
+      return Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.stateRestoration,
+        () => inner(mac),
+      );
+    }
+    return inner(mac);
   };
 }
 

--- a/lib/features/consumption/providers/auto_record_orchestrator_factories.g.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator_factories.g.dart
@@ -8,7 +8,8 @@ part of 'auto_record_orchestrator_factories.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Default factory: Android in production, an unimplemented stub
+/// Default factory: Android's foreground-service bridge, iOS's Core
+/// Bluetooth state-restoration listener (#3167), an unimplemented stub
 /// elsewhere. Tests override this provider to inject a
 /// [FakeBackgroundAdapterListener] without touching platform-detection
 /// code.
@@ -16,7 +17,8 @@ part of 'auto_record_orchestrator_factories.dart';
 @ProviderFor(autoRecordListenerFactory)
 final autoRecordListenerFactoryProvider = AutoRecordListenerFactoryProvider._();
 
-/// Default factory: Android in production, an unimplemented stub
+/// Default factory: Android's foreground-service bridge, iOS's Core
+/// Bluetooth state-restoration listener (#3167), an unimplemented stub
 /// elsewhere. Tests override this provider to inject a
 /// [FakeBackgroundAdapterListener] without touching platform-detection
 /// code.
@@ -29,7 +31,8 @@ final class AutoRecordListenerFactoryProvider
           BackgroundAdapterListenerFactory
         >
     with $Provider<BackgroundAdapterListenerFactory> {
-  /// Default factory: Android in production, an unimplemented stub
+  /// Default factory: Android's foreground-service bridge, iOS's Core
+  /// Bluetooth state-restoration listener (#3167), an unimplemented stub
   /// elsewhere. Tests override this provider to inject a
   /// [FakeBackgroundAdapterListener] without touching platform-detection
   /// code.
@@ -70,7 +73,7 @@ final class AutoRecordListenerFactoryProvider
 }
 
 String _$autoRecordListenerFactoryHash() =>
-    r'3ac9db8a2ce1a0919d0fb75fc9b9906b736d40af';
+    r'5679d42e1a8c6f9453334fab9c982863798be3a3';
 
 /// Default opener: opens a fresh [Obd2Service] for the configured MAC
 /// via [Obd2ConnectionService.connectByMac] (#1004 phase 2b-3).
@@ -78,6 +81,11 @@ String _$autoRecordListenerFactoryHash() =>
 /// out — the coordinator stays idle for that connect cycle and waits
 /// for the next `AdapterConnected`. Tests override this provider to
 /// inject a fake opener that returns a stub service.
+///
+/// #3167 — wrapped in [wrapStateRestorationOrigin] so the FIRST
+/// auto-record connect after a Core Bluetooth background relaunch is
+/// trace-stamped `Obd2ConnectOrigin.stateRestoration`. A no-op on a
+/// normal launch and on Android (the tag is never set there).
 
 @ProviderFor(autoRecordSessionOpenerFactory)
 final autoRecordSessionOpenerFactoryProvider =
@@ -89,6 +97,11 @@ final autoRecordSessionOpenerFactoryProvider =
 /// out — the coordinator stays idle for that connect cycle and waits
 /// for the next `AdapterConnected`. Tests override this provider to
 /// inject a fake opener that returns a stub service.
+///
+/// #3167 — wrapped in [wrapStateRestorationOrigin] so the FIRST
+/// auto-record connect after a Core Bluetooth background relaunch is
+/// trace-stamped `Obd2ConnectOrigin.stateRestoration`. A no-op on a
+/// normal launch and on Android (the tag is never set there).
 
 final class AutoRecordSessionOpenerFactoryProvider
     extends
@@ -104,6 +117,11 @@ final class AutoRecordSessionOpenerFactoryProvider
   /// out — the coordinator stays idle for that connect cycle and waits
   /// for the next `AdapterConnected`. Tests override this provider to
   /// inject a fake opener that returns a stub service.
+  ///
+  /// #3167 — wrapped in [wrapStateRestorationOrigin] so the FIRST
+  /// auto-record connect after a Core Bluetooth background relaunch is
+  /// trace-stamped `Obd2ConnectOrigin.stateRestoration`. A no-op on a
+  /// normal launch and on Android (the tag is never set there).
   AutoRecordSessionOpenerFactoryProvider._()
     : super(
         from: null,
@@ -139,7 +157,7 @@ final class AutoRecordSessionOpenerFactoryProvider
 }
 
 String _$autoRecordSessionOpenerFactoryHash() =>
-    r'bb6af1c2c633c61722cb5329e5ea038cb7c0e33f';
+    r'79e2b0443759a4b43c80c4d32129b2a4d18e7272';
 
 /// Foreground-active opener (#2282 concern 1): a DIRECT connect — NO active
 /// scan — so it wakes ELM327 clones that stop advertising in standby. Used by

--- a/test/features/consumption/data/obd2/ios_background_adapter_listener_test.dart
+++ b/test/features/consumption/data/obd2/ios_background_adapter_listener_test.dart
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_restoration_event.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration_service.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// Unit tests for [IosBackgroundAdapterListener] (#3167 — hands-free
+/// auto-record Phase 3).
+///
+/// The listener is driven entirely through its seams: a fake
+/// [IosStateRestorationService] (recording + fault-injectable) and a
+/// controller-backed `connectionStates` factory, so no flutter_blue_plus
+/// platform channel is touched. The decision table this file covers:
+///
+/// | connectionState transition       | event emitted                  |
+/// |----------------------------------|--------------------------------|
+/// | initial replay `disconnected`    | (nothing — not a transition)   |
+/// | initial replay `connected`       | AdapterConnected (restoration  |
+/// |                                  | relaunch resume case)          |
+/// | connected → disconnected         | AdapterDisconnected            |
+/// | repeated equal states            | (de-duplicated)                |
+/// | events before first subscriber   | buffered, replayed on listen   |
+class _FakeRestorationService implements IosStateRestorationService {
+  final List<String> registeredUuids = <String>[];
+  int initializeCalls = 0;
+  bool throwOnInitialize = false;
+  bool throwOnRegister = false;
+  IosRestorationWillRestore? launchEvent;
+  bool _tagConsumed = false;
+
+  final StreamController<IosRestorationEvent> _events =
+      StreamController<IosRestorationEvent>.broadcast();
+
+  @override
+  Future<void> initialize() async {
+    initializeCalls++;
+    if (throwOnInitialize) {
+      throw StateError('setOptions failed (injected)');
+    }
+  }
+
+  @override
+  Future<void> registerPersistedAdapter(String peripheralUuid) async {
+    if (throwOnRegister) {
+      throw StateError('pending connect failed (injected)');
+    }
+    registeredUuids.add(peripheralUuid);
+  }
+
+  @override
+  Stream<IosRestorationEvent> get events => _events.stream;
+
+  @override
+  IosRestorationWillRestore? get launchRestoration => launchEvent;
+
+  @override
+  bool consumeLaunchRestorationTag() {
+    if (launchEvent == null || _tagConsumed) return false;
+    _tagConsumed = true;
+    return true;
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _events.close();
+  }
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late _FakeRestorationService restoration;
+  late Map<String, StreamController<bool>> stateControllers;
+  late IosBackgroundAdapterListener listener;
+
+  Stream<bool> statesFor(String deviceId) {
+    return stateControllers
+        .putIfAbsent(deviceId, StreamController<bool>.broadcast)
+        .stream;
+  }
+
+  setUp(() {
+    restoration = _FakeRestorationService();
+    stateControllers = <String, StreamController<bool>>{};
+    listener = IosBackgroundAdapterListener(
+      restoration: restoration,
+      connectionStates: statesFor,
+      now: () => DateTime.utc(2026, 6, 10, 12),
+    );
+  });
+
+  tearDown(() async {
+    await listener.dispose();
+    await restoration.dispose();
+    for (final c in stateControllers.values) {
+      await c.close();
+    }
+  });
+
+  const uuid = '0A1B2C3D-0000-1111-2222-333344445555';
+
+  test('start() initializes restoration + registers the persisted adapter',
+      () async {
+    await listener.start(mac: uuid);
+    expect(restoration.initializeCalls, 1);
+    expect(restoration.registeredUuids, [uuid]);
+  });
+
+  test('start() is idempotent for the same uuid', () async {
+    await listener.start(mac: uuid);
+    await listener.start(mac: uuid);
+    expect(restoration.initializeCalls, 1,
+        reason: 're-arming the same adapter must not re-run the chain');
+    expect(restoration.registeredUuids, [uuid]);
+  });
+
+  test('start() with a different uuid re-arms onto the new peripheral',
+      () async {
+    await listener.start(mac: uuid);
+    const other = 'FFFFFFFF-9999-8888-7777-666655554444';
+    await listener.start(mac: other);
+    expect(restoration.registeredUuids, [uuid, other]);
+
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+    // The OLD peripheral's stream is detached — its transitions are
+    // dropped; the NEW one is live.
+    stateControllers[uuid]!.add(true);
+    stateControllers[other]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(events, hasLength(1));
+    expect(events.single, isA<AdapterConnected>());
+    expect(events.single.mac, other);
+    await sub.cancel();
+  });
+
+  test('connected transition emits AdapterConnected with the uuid as mac',
+      () async {
+    await listener.start(mac: uuid);
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+
+    stateControllers[uuid]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, hasLength(1));
+    final event = events.single as AdapterConnected;
+    expect(event.mac, uuid);
+    expect(event.at, DateTime.utc(2026, 6, 10, 12));
+    await sub.cancel();
+  });
+
+  test(
+      'initial replayed "disconnected" is swallowed — a normal launch '
+      'must not arm the disconnect-save debounce', () async {
+    await listener.start(mac: uuid);
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+
+    stateControllers[uuid]!.add(false); // FBP replays current state
+    await Future<void>.delayed(Duration.zero);
+    expect(events, isEmpty);
+
+    // A real transition afterwards flows normally.
+    stateControllers[uuid]!.add(true);
+    stateControllers[uuid]!.add(false);
+    await Future<void>.delayed(Duration.zero);
+    expect(events, hasLength(2));
+    expect(events[0], isA<AdapterConnected>());
+    expect(events[1], isA<AdapterDisconnected>());
+    await sub.cancel();
+  });
+
+  test('repeated equal states are de-duplicated', () async {
+    await listener.start(mac: uuid);
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+
+    stateControllers[uuid]!.add(true);
+    stateControllers[uuid]!.add(true);
+    stateControllers[uuid]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(events, hasLength(1),
+        reason: 'FBP replays the current state to every new stream '
+            'listener — only TRANSITIONS may reach the coordinator');
+    await sub.cancel();
+  });
+
+  test(
+      'events emitted before the first subscriber are buffered and '
+      'replayed on listen (late-subscriber contract)', () async {
+    await listener.start(mac: uuid);
+    // Restoration-relaunch shape: the replayed state is already
+    // "connected" BEFORE the coordinator has subscribed.
+    stateControllers[uuid]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, hasLength(1),
+        reason: 'the restored connect must not be dropped just because '
+            'the coordinator attached after start() returned');
+    expect(events.single, isA<AdapterConnected>());
+    await sub.cancel();
+  });
+
+  test('stop() detaches the watch — later transitions are dropped',
+      () async {
+    await listener.start(mac: uuid);
+    final events = <BackgroundAdapterEvent>[];
+    final sub = listener.events.listen(events.add);
+
+    await listener.stop();
+    stateControllers[uuid]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(events, isEmpty);
+    await sub.cancel();
+  });
+
+  test('stop() without a prior start() completes (never throws)', () async {
+    await expectLater(listener.stop(), completes);
+  });
+
+  group('fault injection (#2349 never-throws contract)', () {
+    test(
+        'a throwing initialize() never throws out of start() and the '
+        'connection watch is still armed', () async {
+      restoration.throwOnInitialize = true;
+      await expectLater(listener.start(mac: uuid), completes);
+      // Restoration is degraded but the live watch still works — the
+      // foreground-arm path must keep functioning.
+      expect(restoration.registeredUuids, [uuid],
+          reason: 'a failed setOptions must not block the pending '
+              'connect registration');
+
+      final events = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(events.add);
+      stateControllers[uuid]!.add(true);
+      await Future<void>.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      await sub.cancel();
+    });
+
+    test(
+        'a throwing registerPersistedAdapter() never throws out of '
+        'start()', () async {
+      restoration.throwOnRegister = true;
+      await expectLater(listener.start(mac: uuid), completes);
+
+      final events = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(events.add);
+      stateControllers[uuid]!.add(true);
+      await Future<void>.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('an error on the connection-state stream is logged, not thrown',
+        () async {
+      await listener.start(mac: uuid);
+      final events = <BackgroundAdapterEvent>[];
+      final sub = listener.events.listen(events.add);
+
+      stateControllers[uuid]!.addError(StateError('BLE stack hiccup'));
+      stateControllers[uuid]!.add(true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1),
+          reason: 'the watch survives a stream error (cancelOnError is '
+              'false) and keeps delivering transitions');
+      await sub.cancel();
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/ios_state_restoration_service_test.dart
+++ b/test/features/consumption/data/obd2/ios_state_restoration_service_test.dart
@@ -3,9 +3,12 @@
 
 import 'dart:async';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/ios_restoration_event.dart';
 import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration_service.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Unit tests for [FlutterBluePlusIosStateRestorationService] (#1295
 /// phase 2).
@@ -25,6 +28,112 @@ import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration
 /// expected sentinel. Phase 5 (device-test acceptance) covers the
 /// real iOS path on hardware.
 void main() {
+  silenceErrorLoggerSpool();
+
+  group(
+      'FlutterBluePlusIosStateRestorationService — launch restoration '
+      'capture (#3167)', () {
+    test(
+        'iOS launch WITH bluetoothCentrals launch options caches '
+        'launchRestoration and emits willRestore', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: true,
+        debugSetOptionsOverride: () async {},
+        debugLaunchCentralIdsFetcher: () async =>
+            <String>['flutterBluePlusRestoreIdentifier'],
+      );
+      final received = <IosRestorationEvent>[];
+      final sub = service.events.listen(received.add);
+
+      await service.initialize();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.launchRestoration, isNotNull,
+          reason: 'the cached getter is what late consumers (the iOS '
+              'listener arms after app init) read');
+      expect(received, [const IosRestorationEvent.willRestore(<String>[])]);
+
+      await sub.cancel();
+      await service.dispose();
+    });
+
+    test('iOS launch WITHOUT the key leaves launchRestoration null',
+        () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: true,
+        debugSetOptionsOverride: () async {},
+        debugLaunchCentralIdsFetcher: () async => null,
+      );
+      await service.initialize();
+      expect(service.launchRestoration, isNull);
+      expect(service.consumeLaunchRestorationTag(), isFalse);
+      await service.dispose();
+    });
+
+    test('empty central-id list counts as a normal launch', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: true,
+        debugSetOptionsOverride: () async {},
+        debugLaunchCentralIdsFetcher: () async => const <String>[],
+      );
+      await service.initialize();
+      expect(service.launchRestoration, isNull);
+      await service.dispose();
+    });
+
+    test('consumeLaunchRestorationTag is one-shot', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: true,
+        debugSetOptionsOverride: () async {},
+        debugLaunchCentralIdsFetcher: () async => <String>['fbp'],
+      );
+      await service.initialize();
+      expect(service.consumeLaunchRestorationTag(), isTrue,
+          reason: 'first consumer gets the stateRestoration origin tag');
+      expect(service.consumeLaunchRestorationTag(), isFalse,
+          reason: 'every later connect of this launch is untagged');
+      // The cached event itself survives consumption — only the trace
+      // tag is one-shot.
+      expect(service.launchRestoration, isNotNull);
+      await service.dispose();
+    });
+
+    test(
+        'fault injection: a throwing channel fetch never throws out of '
+        'initialize() (#2349 never-throws contract)', () async {
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: true,
+        debugSetOptionsOverride: () async {},
+        debugLaunchCentralIdsFetcher: () async =>
+            throw MissingPluginException('no host handler'),
+      );
+      await expectLater(service.initialize(), completes);
+      expect(service.launchRestoration, isNull,
+          reason: 'a failed fetch leaves the launch untagged — exactly '
+              'the pre-#3167 behaviour');
+      expect(service.consumeLaunchRestorationTag(), isFalse);
+      await service.dispose();
+    });
+
+    test('non-iOS never queries the launch channel', () async {
+      var fetched = false;
+      final service = FlutterBluePlusIosStateRestorationService(
+        debugIsIOSOverride: false,
+        debugLaunchCentralIdsFetcher: () async {
+          fetched = true;
+          return <String>['x'];
+        },
+      );
+      await service.initialize();
+      expect(fetched, isFalse,
+          reason: 'Android resolves the platform gate before any '
+              'restoration plumbing runs');
+      expect(service.launchRestoration, isNull);
+      expect(service.consumeLaunchRestorationTag(), isFalse);
+      await service.dispose();
+    });
+  });
+
   group('FlutterBluePlusIosStateRestorationService — non-iOS branch', () {
     test('initialize() returns without throwing on non-iOS', () async {
       final service = FlutterBluePlusIosStateRestorationService(

--- a/test/features/consumption/providers/auto_record_orchestrator_factories_test.dart
+++ b/test/features/consumption/providers/auto_record_orchestrator_factories_test.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/android_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_restoration_event.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/providers/auto_record_orchestrator_factories.dart';
+
+/// #3167 — tests for the auto-record factory seams: per-platform
+/// listener selection (the iOS branch is new) and the
+/// `stateRestoration` connect-trace origin wrapper.
+class _FakeRestorationService implements IosStateRestorationService {
+  _FakeRestorationService({this.tagged = false});
+
+  /// Whether this launch should report the one-shot restoration tag.
+  bool tagged;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> registerPersistedAdapter(String peripheralUuid) async {}
+
+  @override
+  Stream<IosRestorationEvent> get events => const Stream.empty();
+
+  @override
+  IosRestorationWillRestore? get launchRestoration =>
+      tagged ? const IosRestorationWillRestore(<String>[]) : null;
+
+  @override
+  bool consumeLaunchRestorationTag() {
+    if (!tagged) return false;
+    tagged = false;
+    return true;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  group('autoRecordListenerFactory platform selection', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    BackgroundAdapterListener buildFor(TargetPlatform platform) {
+      debugDefaultTargetPlatformOverride = platform;
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      return container.read(autoRecordListenerFactoryProvider)();
+    }
+
+    test('Android gets the foreground-service bridge', () {
+      expect(
+        buildFor(TargetPlatform.android),
+        isA<AndroidBackgroundAdapterListener>(),
+      );
+    });
+
+    test('iOS gets the Core Bluetooth state-restoration listener (#3167)',
+        () {
+      expect(
+        buildFor(TargetPlatform.iOS),
+        isA<IosBackgroundAdapterListener>(),
+      );
+    });
+
+    test('other platforms keep the loud unimplemented stub', () {
+      expect(
+        buildFor(TargetPlatform.linux),
+        isA<UnimplementedBackgroundAdapterListener>(),
+      );
+    });
+  });
+
+  group('wrapStateRestorationOrigin (#3167)', () {
+    setUp(Obd2ConnectTraceLog.clear);
+    tearDown(Obd2ConnectTraceLog.clear);
+
+    /// Inner opener standing in for `connectByMac`: opens + ends a trace
+    /// the way the connection service does, so the test observes which
+    /// origin the trace was stamped with.
+    Future<Obd2Service?> tracingInner(String mac) async {
+      final trace = Obd2ConnectTraceLog.beginTrace(
+        origin: Obd2ConnectOrigin.firstConnect,
+        mac: mac,
+      );
+      Obd2ConnectTraceLog.endTrace(trace);
+      return null;
+    }
+
+    test(
+        'restoration launch: the FIRST session open is stamped '
+        'stateRestoration, the second falls back to the default origin',
+        () async {
+      final opener = wrapStateRestorationOrigin(
+        inner: tracingInner,
+        restoration: _FakeRestorationService(tagged: true),
+      );
+
+      await opener('AA');
+      await opener('BB');
+
+      final traces = Obd2ConnectTraceLog.snapshot();
+      expect(traces, hasLength(2));
+      // snapshot() is newest-first.
+      expect(traces[1].origin, Obd2ConnectOrigin.stateRestoration,
+          reason: 'the connect triggered by the Core Bluetooth relaunch '
+              'must be distinguishable in a field export');
+      expect(traces[0].origin, Obd2ConnectOrigin.firstConnect,
+          reason: 'the tag is one-shot — later connects keep the '
+              'service default');
+    });
+
+    test('normal launch: the wrapper is a transparent pass-through',
+        () async {
+      final opener = wrapStateRestorationOrigin(
+        inner: tracingInner,
+        restoration: _FakeRestorationService(),
+      );
+
+      await opener('AA');
+
+      final traces = Obd2ConnectTraceLog.snapshot();
+      expect(traces, hasLength(1));
+      expect(traces.single.origin, Obd2ConnectOrigin.firstConnect);
+    });
+  });
+}

--- a/test/features/consumption/providers/auto_record_restoration_decision_test.dart
+++ b/test/features/consumption/providers/auto_record_restoration_decision_test.dart
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_trip_coordinator.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_background_adapter_listener.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_restoration_event.dart';
+import 'package:tankstellen/features/consumption/data/obd2/ios_state_restoration_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/auto_record_orchestrator.dart';
+import 'package:tankstellen/features/consumption/providers/auto_record_orchestrator_factories.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3167 — decision-table test for the iOS Core Bluetooth
+/// state-restoration → [AutoTripCoordinator] wiring (hands-free
+/// auto-record Phase 3, Epic #3165).
+///
+/// Drives the REAL [IosBackgroundAdapterListener] (injected through the
+/// orchestrator's listener-factory seam, exactly the production wiring
+/// shape) with a fake restoration service + controller-backed
+/// connection-state streams, and asserts the coordinator's decisions:
+///
+/// | active vehicle? | auto-record? | already recording? | restored connect → |
+/// |-----------------|--------------|--------------------|--------------------|
+/// | paired uuid     | enabled      | no                 | session opens, trip starts on speed |
+/// | paired uuid     | DISABLED     | —                  | nothing armed, nothing starts        |
+/// | NO paired id    | enabled      | —                  | no coordinator at all                |
+/// | paired uuid     | enabled      | YES                | no second session / second start     |
+class _FakeVehicleProfileList extends VehicleProfileList {
+  _FakeVehicleProfileList(this._initial);
+
+  final List<VehicleProfile> _initial;
+
+  @override
+  List<VehicleProfile> build() => _initial;
+}
+
+class _FakeTripRecording extends TripRecording {
+  int startCalls = 0;
+  final List<bool> startAutomaticFlags = <bool>[];
+
+  @override
+  TripRecordingState build() => const TripRecordingState();
+
+  @override
+  Future<void> start(Obd2Service service, {bool automatic = false}) async {
+    startCalls++;
+    startAutomaticFlags.add(automatic);
+  }
+
+  @override
+  Future<void> stopAndSaveAutomatic() async {}
+}
+
+class _CountingPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags(this._initial);
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() => {..._initial};
+}
+
+class _FakeRestorationService implements IosStateRestorationService {
+  final List<String> registeredUuids = <String>[];
+  IosRestorationWillRestore? launchEvent;
+  bool _tagConsumed = false;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> registerPersistedAdapter(String peripheralUuid) async {
+    registeredUuids.add(peripheralUuid);
+  }
+
+  @override
+  Stream<IosRestorationEvent> get events => const Stream.empty();
+
+  @override
+  IosRestorationWillRestore? get launchRestoration => launchEvent;
+
+  @override
+  bool consumeLaunchRestorationTag() {
+    if (launchEvent == null || _tagConsumed) return false;
+    _tagConsumed = true;
+    return true;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+/// Canned `41 0D <hex>` speed transport (mirrors the helper in
+/// `auto_record_orchestrator_test.dart`).
+class _FakeTransport implements Obd2Transport {
+  _FakeTransport(this.speedQueue);
+
+  final Queue<int?> speedQueue;
+  bool _connected = true;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async {
+    _connected = true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+  }
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (command == Elm327Protocol.vehicleSpeedCommand) {
+      if (speedQueue.isEmpty) return 'NO DATA';
+      final value = speedQueue.removeFirst();
+      if (value == null) return 'NO DATA';
+      return '41 0D ${value.toRadixString(16).padLeft(2, '0').toUpperCase()}';
+    }
+    return '';
+  }
+}
+
+const String _uuid = '0A1B2C3D-0000-1111-2222-333344445555';
+
+VehicleProfile _profile({
+  bool autoRecord = true,
+  String? adapterId = _uuid,
+}) {
+  return VehicleProfile(
+    id: 'v1',
+    name: 'Restored car',
+    type: VehicleType.combustion,
+    autoRecord: autoRecord,
+    obd2AdapterMac: adapterId,
+    movementStartThresholdKmh: 5.0,
+    disconnectSaveDelaySec: 60,
+  );
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late _FakeTripRecording fakeTripRecording;
+  late _FakeRestorationService restoration;
+  late Map<String, StreamController<bool>> stateControllers;
+  late List<String> openedMacs;
+  late Map<String, Queue<int?>> speedById;
+
+  setUp(() {
+    AutoRecordTraceLog.clear();
+    fakeTripRecording = _FakeTripRecording();
+    restoration = _FakeRestorationService()
+      // Every test here models the Core Bluetooth background relaunch.
+      ..launchEvent = const IosRestorationWillRestore(<String>[]);
+    stateControllers = <String, StreamController<bool>>{};
+    openedMacs = <String>[];
+    speedById = <String, Queue<int?>>{};
+  });
+
+  tearDown(() async {
+    for (final c in stateControllers.values) {
+      await c.close();
+    }
+  });
+
+  Stream<bool> statesFor(String deviceId) {
+    return stateControllers
+        .putIfAbsent(deviceId, StreamController<bool>.broadcast)
+        .stream;
+  }
+
+  Obd2SessionOpener fakeOpener() {
+    return (String mac) async {
+      openedMacs.add(mac);
+      final queue = speedById.putIfAbsent(mac, () => Queue<int?>());
+      return Obd2Service(_FakeTransport(queue));
+    };
+  }
+
+  ProviderContainer makeContainer(List<VehicleProfile> profiles) {
+    return ProviderContainer(
+      overrides: [
+        vehicleProfileListProvider
+            .overrideWith(() => _FakeVehicleProfileList(profiles)),
+        tripRecordingProvider.overrideWith(() => fakeTripRecording),
+        // Production wiring shape: a REAL IosBackgroundAdapterListener per
+        // coordinator, fed by the fake restoration service + fake streams.
+        autoRecordListenerFactoryProvider.overrideWithValue(
+          () => IosBackgroundAdapterListener(
+            restoration: restoration,
+            connectionStates: statesFor,
+          ),
+        ),
+        autoRecordSessionOpenerFactoryProvider.overrideWithValue(fakeOpener()),
+        autoRecordForegroundSessionOpenerFactoryProvider
+            .overrideWithValue((String mac) async => null),
+        obd2PermissionsProvider.overrideWithValue(_CountingPermissions()),
+        featureFlagsProvider.overrideWith(
+          () => _TestFeatureFlags({
+            ...FeatureManifest.defaultManifest.defaultEnabledSet(),
+            Feature.obd2TripRecording,
+          }),
+        ),
+      ],
+    );
+  }
+
+  test(
+      'restored connect on an eligible vehicle opens a session and '
+      'starts the trip on sustained speed', () async {
+    // 3 supra-threshold samples at the 1 Hz production poll.
+    speedById[_uuid] = Queue<int?>.of(<int?>[30, 32, 35, 40]);
+    final container = makeContainer([_profile()]);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(restoration.registeredUuids, [_uuid],
+        reason: 'arming must queue the long-lived pending connect for '
+            'the paired peripheral');
+
+    // The restoration relaunch left the peripheral already connected —
+    // FBP replays that state to the fresh subscription.
+    stateControllers[_uuid]!.add(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(openedMacs, [_uuid],
+        reason: 'the restored connect must open an OBD2 session through '
+            'the (supervisor-admitted) session opener');
+
+    // Production 1 Hz speed poll: 3 consecutive supra-threshold samples.
+    await Future<void>.delayed(const Duration(milliseconds: 3500));
+    expect(fakeTripRecording.startCalls, 1,
+        reason: 'sustained movement after the restored connect must '
+            'start exactly one automatic trip');
+    expect(fakeTripRecording.startAutomaticFlags, [true]);
+  });
+
+  test('auto-record disabled on the vehicle → nothing armed, nothing starts',
+      () async {
+    final container = makeContainer([_profile(autoRecord: false)]);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(restoration.registeredUuids, isEmpty,
+        reason: 'no coordinator → no pending-connect registration');
+    expect(stateControllers, isEmpty,
+        reason: 'no connection-state watch is opened either');
+    expect(fakeTripRecording.startCalls, 0);
+  });
+
+  test('no paired adapter id → no coordinator at all', () async {
+    final container = makeContainer([_profile(adapterId: null)]);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      container
+          .read(autoRecordOrchestratorProvider.notifier)
+          .activeVehicleIdsForTest,
+      isEmpty,
+    );
+    expect(restoration.registeredUuids, isEmpty);
+  });
+
+  test(
+      'already recording: a reconnect within the drive opens no second '
+      'session and starts no second trip', () async {
+    speedById[_uuid] = Queue<int?>.of(<int?>[30, 32, 35]);
+    final container = makeContainer([_profile()]);
+    addTearDown(container.dispose);
+
+    container.read(autoRecordOrchestratorProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    stateControllers[_uuid]!.add(true);
+    await Future<void>.delayed(const Duration(milliseconds: 3500));
+    expect(fakeTripRecording.startCalls, 1);
+
+    // Tunnel bounce: disconnect then reconnect while the trip is live.
+    stateControllers[_uuid]!.add(false);
+    await Future<void>.delayed(Duration.zero);
+    stateControllers[_uuid]!.add(true);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(openedMacs, [_uuid],
+        reason: 'while the recorder owns the live session the '
+            'coordinator must not open a competing one');
+    expect(fakeTripRecording.startCalls, 1,
+        reason: 'the in-flight trip continues — no double start');
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -86,7 +86,14 @@ void main() {
     // #3146 — re-grandfathered 1087 → 1090: `HealthCounters.init()` joins
     // the storage-phase `Future.wait` (+ its import) so the always-on
     // counter box opens in the foreground isolate only.
-    'lib/app/app_initializer.dart': 1090,
+    // #3167 — re-grandfathered 1090 → 1104: the guarded
+    // `iosStateRestorationServiceProvider.initialize()` call (+ import +
+    // rationale comment) sequenced INSIDE the auto-record orchestrator's
+    // deferred block, so Core Bluetooth state restoration is opted in
+    // before the orchestrator's first FBP touch. The restoration logic
+    // itself lives in the under-cap ios_state_restoration_service.dart /
+    // NEW ios_background_adapter_listener.dart; this is launch glue only.
+    'lib/app/app_initializer.dart': 1104,
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
     // deletion-tombstone fix threads a tombstoned-id set through `merge` and
     // `mergeRows` (fetch + dual-side filter so a delete on another device


### PR DESCRIPTION
## Hands-free auto-record Phase 3 — CoreBluetooth state restoration wired into AutoTripCoordinator

From epic #3165: the Phase-2 `IosStateRestorationService` existed with zero call sites. Now, when iOS relaunches the terminated app because the OBD adapter came in range, auto-record arms and the trip records hands-free:

- A small Swift bridge in the AppDelegate captures the `bluetoothCentrals` launch option (the signal FBP never surfaces to Dart) and serves it over a method channel; the service drains it at init and registers the persisted adapter UUID with FBP's restored central (no second CBCentralManager — reuses FBP's restore identifier).
- New `IosBackgroundAdapterListener` implements the existing `BackgroundAdapterListener` seam, so `AutoTripCoordinator` runs unchanged and Android is byte-identical; the platform pick lives in the factory. Bonus fix: the foreground arm (#2282) previously died on the unimplemented iOS stub — it works now.
- Restoration-triggered connects enter through the #3185 supervisor like every requester and the first session open after a restoration relaunch is stage-tagged `stateRestoration` in the persistent connect trace.
- Decision table fully tested (paired×enabled×already-recording), with fault injection on every never-throws claim. 4,742 tests green; `flutter build ios --config-only` exit 0.

On-device validation (real adapter, OS-terminated relaunch) needs hardware — that's the remaining field step.

Closes #3167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
