### PR TITLE
feat(ios): Live Activity for trip recording + approach radar (#3170)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		147DDAF0846E20662D77E04B /* TankstellenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		17D722EB6FFEB5B7EC6BB35D /* LiveActivityBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E789497D95EB8E11317BD40F /* LiveActivityBridge.swift */; };
 		2E07975AC9E60A1BEB9B103C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C4E7855C3D7D6AF8148EDF /* Pods_Runner.framework */; };
 		314AA9FE74D319B7145C3199 /* NearestStationsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C8A9CAC0B84B64CE59171 /* NearestStationsWidgetView.swift */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
@@ -16,8 +17,10 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		595226A68EC384B12AF0A93F /* TankstellenWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5E24927367580828DD745BD3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 53F08202EBE1619234A8ED70 /* Assets.xcassets */; };
+		617A7DBF52F20550E6FAD8F0 /* TripActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
+		976F22DFFA3574104BBF6FEC /* TripActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -25,6 +28,7 @@
 		C1D3C7BC3EE97D07059B912D /* NearestStationsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */; };
 		E05A76E23ACD50B61271D84D /* NearestStationsEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB9171C55A8C662C3106F67 /* NearestStationsEntry.swift */; };
 		E128B0129985B6FE9E2D5787 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE182BA7429614C5B4D896D8 /* Pods_RunnerTests.framework */; };
+		F41E24A56C7842FF0D7B1473 /* TripRecordingLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BDF230A6D8AB196E7C7CA0 /* TripRecordingLiveActivity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +92,7 @@
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearestStationsProvider.swift; sourceTree = "<group>"; };
+		85BDF230A6D8AB196E7C7CA0 /* TripRecordingLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TripRecordingLiveActivity.swift; sourceTree = "<group>"; };
 		8B50DFEEBB486D1837152140 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -103,6 +108,8 @@
 		D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TankstellenWidget.swift; sourceTree = "<group>"; };
 		E1C4E7855C3D7D6AF8148EDF /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6531D801740AA014ACC14D5 /* TankstellenWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = TankstellenWidget.entitlements; sourceTree = "<group>"; };
+		E789497D95EB8E11317BD40F /* LiveActivityBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityBridge.swift; sourceTree = "<group>"; };
+		EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TripActivityAttributes.swift; sourceTree = "<group>"; };
 		FCDDFC2EC66983E39B25D3E3 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -211,6 +218,7 @@
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				AA0B2B41CF68C8C0A67F6D1B /* Runner.entitlements */,
+				E789497D95EB8E11317BD40F /* LiveActivityBridge.swift */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -226,6 +234,8 @@
 				53F08202EBE1619234A8ED70 /* Assets.xcassets */,
 				5B40EDA15C62D6CFC7C19599 /* Info.plist */,
 				E6531D801740AA014ACC14D5 /* TankstellenWidget.entitlements */,
+				EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */,
+				85BDF230A6D8AB196E7C7CA0 /* TripRecordingLiveActivity.swift */,
 			);
 			name = TankstellenWidget;
 			path = TankstellenWidget;
@@ -493,6 +503,8 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+				617A7DBF52F20550E6FAD8F0 /* TripActivityAttributes.swift in Sources */,
+				17D722EB6FFEB5B7EC6BB35D /* LiveActivityBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,6 +517,8 @@
 				E05A76E23ACD50B61271D84D /* NearestStationsEntry.swift in Sources */,
 				314AA9FE74D319B7145C3199 /* NearestStationsWidgetView.swift in Sources */,
 				35A2294918D818734C462990 /* StationRow.swift in Sources */,
+				976F22DFFA3574104BBF6FEC /* TripActivityAttributes.swift in Sources */,
+				F41E24A56C7842FF0D7B1473 /* TripRecordingLiveActivity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -92,6 +92,13 @@ import workmanager_apple
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "StateRestorationBridge") {
       StateRestorationBridge.shared.register(messenger: registrar.messenger())
     }
+    // #3170 — trip-recording / approach-radar Live Activity (Dynamic Island +
+    // lock screen), the iOS answer to the Android PiP driving tile. Serves the
+    // `tankstellen/live_activity` channel; views render in the
+    // TankstellenWidget extension.
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "LiveActivityBridge") {
+      LiveActivityBridge.shared.register(messenger: registrar.messenger())
+    }
   }
 
   /// Handles the `sparkilo-share://receipt` URL the Share Extension opens to

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -104,6 +104,12 @@
 	<string>Sparkilo uses the camera to scan fuel receipts and payment QR codes.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Sparkilo needs access to your photo library so you can attach an existing receipt photo to a fill-up entry.</string>
+	<!-- #3170 — trip-recording / approach-radar Live Activity (Dynamic Island +
+	     lock screen), the iOS answer to the Android PiP driving tile. Views
+	     live in the TankstellenWidget extension; the host requests/updates the
+	     activity via LiveActivityBridge.swift. -->
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/ios/Runner/LiveActivityBridge.swift
+++ b/ios/Runner/LiveActivityBridge.swift
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Host-side bridge for the trip-recording / approach-radar Live Activity
+// (#3170), serving the `tankstellen/live_activity` MethodChannel — the
+// iOS counterpart of Android's `MainActivity` PiP channel
+// (`tankstellen/pip`).
+//
+// The Dart side (`LiveActivityController` in
+// lib/features/consumption/data/live_activity_controller.dart) sends
+// pre-formatted `ContentState` payloads; this bridge owns the ActivityKit
+// lifecycle: request on `start`, push on `update`, immediate dismissal on
+// `end`. The views live in the TankstellenWidget extension
+// (`TripRecordingLiveActivity.swift`); the shared
+// `TripActivityAttributes` type is compiled into both targets (wired by
+// scripts/add_live_activity_sources.rb).
+//
+// Unlike the older ShareIntentBridge/VisionOcrBridge (kept inline in
+// AppDelegate.swift to avoid a pbxproj edit), this lives in its own file:
+// since #3166/PR #3217 the project owns reproducible pbxproj wiring
+// scripts, so new Swift files are first-class.
+
+import ActivityKit
+import Flutter
+import Foundation
+
+final class LiveActivityBridge {
+    static let shared = LiveActivityBridge()
+    private static let channelName = "tankstellen/live_activity"
+
+    /// Content is refreshed at most every ~30 s by the Dart throttle; a
+    /// generous stale horizon dims the surface if the app dies mid-trip
+    /// without ending the activity.
+    private static let staleAfter: TimeInterval = 30 * 60
+
+    private var activity: Activity<TripActivityAttributes>?
+
+    func register(messenger: FlutterBinaryMessenger) {
+        let channel = FlutterMethodChannel(
+            name: Self.channelName, binaryMessenger: messenger)
+        channel.setMethodCallHandler { [weak self] call, result in
+            guard let self else {
+                result(false)
+                return
+            }
+            let args = call.arguments as? [String: Any] ?? [:]
+            switch call.method {
+            case "start":
+                result(self.start(args))
+            case "update":
+                self.update(args)
+                result(nil)
+            case "end":
+                self.end()
+                result(nil)
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+
+    /// Requests a fresh activity (ending any survivor first — at most one
+    /// trip surface exists). Returns false when the user disabled Live
+    /// Activities or ActivityKit vetoed the request; the Dart coordinator
+    /// then stays quiet for the rest of the trip.
+    private func start(_ args: [String: Any]) -> Bool {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            return false
+        }
+        end()
+        do {
+            activity = try Activity.request(
+                attributes: TripActivityAttributes(),
+                content: ActivityContent(
+                    state: Self.contentState(from: args),
+                    staleDate: Date().addingTimeInterval(Self.staleAfter)
+                )
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func update(_ args: [String: Any]) {
+        guard let activity else { return }
+        let content = ActivityContent(
+            state: Self.contentState(from: args),
+            staleDate: Date().addingTimeInterval(Self.staleAfter)
+        )
+        Task { await activity.update(content) }
+    }
+
+    /// Ends EVERY activity of this type, not just the tracked one — a
+    /// previous process may have stranded an activity on the lock screen
+    /// (crash mid-trip); trip end is the reconciliation point.
+    private func end() {
+        let survivors = Activity<TripActivityAttributes>.activities
+        activity = nil
+        guard !survivors.isEmpty else { return }
+        Task {
+            for survivor in survivors {
+                await survivor.end(
+                    survivor.content, dismissalPolicy: .immediate)
+            }
+        }
+    }
+
+    /// Decodes the Dart `LiveActivityContent.toChannelMap()` payload.
+    /// Defaults are defensive — a malformed field degrades the readout,
+    /// never the activity.
+    private static func contentState(
+        from args: [String: Any]
+    ) -> TripActivityAttributes.ContentState {
+        TripActivityAttributes.ContentState(
+            mode: args["mode"] as? String ?? "recording",
+            paused: args["paused"] as? Bool ?? false,
+            startedAtEpochMs: (args["startedAtEpochMs"] as? NSNumber)?
+                .int64Value
+                ?? Int64(Date().timeIntervalSince1970 * 1000),
+            bigFigure: args["bigFigure"] as? String ?? "~",
+            bigCaption: args["bigCaption"] as? String ?? "",
+            isEstimate: args["isEstimate"] as? Bool ?? false,
+            distanceText: args["distanceText"] as? String,
+            pausedLabel: args["pausedLabel"] as? String ?? "Paused",
+            stationName: args["stationName"] as? String,
+            priceText: args["priceText"] as? String,
+            fuelLabel: args["fuelLabel"] as? String,
+            stationDistanceText: args["stationDistanceText"] as? String,
+            progress: (args["progress"] as? NSNumber)?.doubleValue
+        )
+    }
+}

--- a/ios/TankstellenWidget/TankstellenWidget.swift
+++ b/ios/TankstellenWidget/TankstellenWidget.swift
@@ -19,6 +19,10 @@ import WidgetKit
 struct TankstellenWidgetBundle: WidgetBundle {
     var body: some Widget {
         NearestStationsWidget()
+        // #3170 — trip-recording / approach-radar Live Activity
+        // (Dynamic Island + lock screen), driven by the Runner-side
+        // LiveActivityBridge over `tankstellen/live_activity`.
+        TripRecordingLiveActivity()
     }
 }
 

--- a/ios/TankstellenWidget/TripActivityAttributes.swift
+++ b/ios/TankstellenWidget/TripActivityAttributes.swift
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Shared ActivityKit attributes for the trip-recording / approach-radar
+// Live Activity (#3170) — the iOS-native answer to the Android PiP tile.
+//
+// Compiled into BOTH the Runner target (which requests/updates/ends the
+// activity via `LiveActivityBridge`) and the TankstellenWidget extension
+// (which renders it via `TripRecordingLiveActivity`) — ActivityKit
+// matches the two processes on this type, so the single source file must
+// stay in both targets' compile sources (wired by
+// scripts/add_live_activity_sources.rb).
+//
+// Every user-facing string arrives PRE-FORMATTED from Dart
+// (`LiveActivityContent.toChannelMap()` in
+// lib/features/consumption/domain/live_activity_content.dart — keep the
+// keys in lock-step): the Dart side owns the ARB localization pipeline,
+// the Swift views stay dumb renderers, and both surfaces (PiP + Live
+// Activity) share one formatting truth.
+
+import ActivityKit
+import Foundation
+
+struct TripActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        /// "recording" (consumption hero) or "approach" (station-price
+        /// lead) — mirrors the Dart `LiveActivityMode` enum names.
+        var mode: String
+        var paused: Bool
+
+        /// Wall-clock trip start (epoch ms) — drives the NATIVELY ticking
+        /// elapsed timer so the surface stays alive between sparse
+        /// content updates.
+        var startedAtEpochMs: Int64
+
+        /// Consumption hero ("5.8" / "~7.1" / "~") + caption
+        /// ("L/100 km" / "est. L/100 km" / "L/h").
+        var bigFigure: String
+        var bigCaption: String
+        var isEstimate: Bool
+
+        /// "12.3 km" once the trip covered ≥ 0.1 km.
+        var distanceText: String?
+
+        /// Localized "Paused" chip label (rendered while `paused`).
+        var pausedLabel: String
+
+        // Approach-mode fields (nil in recording mode).
+        var stationName: String?
+        var priceText: String?
+        var fuelLabel: String?
+        var stationDistanceText: String?
+
+        /// Radar closeness fill, 0...1 (fuller = closer). nil hides the bar.
+        var progress: Double?
+
+        var isApproach: Bool { mode == "approach" }
+
+        var startedAt: Date {
+            Date(timeIntervalSince1970: Double(startedAtEpochMs) / 1000.0)
+        }
+
+        /// Open-ended interval for `Text(timerInterval:)` — ActivityKit
+        /// needs a closed range; a day is far beyond any single trip.
+        var elapsedInterval: ClosedRange<Date> {
+            let start = startedAt
+            return start...start.addingTimeInterval(24 * 60 * 60)
+        }
+    }
+}

--- a/ios/TankstellenWidget/TripRecordingLiveActivity.swift
+++ b/ios/TankstellenWidget/TripRecordingLiveActivity.swift
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Live Activity views for the trip-recording / approach-radar surface
+// (#3170) — lock-screen banner + Dynamic Island (compact / minimal /
+// expanded). Registered in `TankstellenWidgetBundle`
+// (TankstellenWidget.swift); the Runner side starts/updates/ends the
+// activity via `LiveActivityBridge`.
+//
+// Visual language mirrors the Android PiP tile (#2068 / #2084): a huge
+// consumption figure while driving, flipping to a huge station price +
+// closeness bar when the Fuel Station Radar / approach detector has a
+// target. Elapsed ticks natively via `Text(timerInterval:)` so the
+// surface stays alive between the Dart side's sparse content updates.
+//
+// Localization: every user-facing string arrives pre-localized from the
+// Dart ARB pipeline inside `ContentState`; the only literal here is the
+// brand name (same convention as `NearestStationsWidgetView`).
+
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct TripRecordingLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TripActivityAttributes.self) { context in
+            TripActivityLockScreenView(state: context.state)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "fuelpump.fill")
+                            .foregroundStyle(.green)
+                        Text("Sparkilo")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    TripActivityElapsedView(state: context.state)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: 60)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    TripActivityBodyView(state: context.state)
+                }
+            } compactLeading: {
+                Image(systemName: "fuelpump.fill")
+                    .foregroundStyle(.green)
+            } compactTrailing: {
+                Text(compactFigure(context.state))
+                    .font(.caption2.weight(.semibold).monospacedDigit())
+                    .lineLimit(1)
+            } minimal: {
+                Image(systemName: "fuelpump.fill")
+                    .foregroundStyle(.green)
+            }
+        }
+    }
+
+    /// The one number worth the compact trailing slot: the station price
+    /// during an approach, otherwise the live consumption figure.
+    private func compactFigure(_ state: TripActivityAttributes.ContentState) -> String {
+        if state.isApproach, let price = state.priceText { return price }
+        return state.bigFigure
+    }
+}
+
+/// Lock-screen / banner presentation.
+struct TripActivityLockScreenView: View {
+    let state: TripActivityAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "fuelpump.fill")
+                    .foregroundStyle(.green)
+                Text("Sparkilo")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                TripActivityElapsedView(state: state)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            TripActivityBodyView(state: state)
+        }
+        .padding(14)
+        .activityBackgroundTint(Color(.systemBackground).opacity(0.85))
+    }
+}
+
+/// Elapsed readout: a natively ticking timer while recording, the
+/// localized paused label while paused.
+struct TripActivityElapsedView: View {
+    let state: TripActivityAttributes.ContentState
+
+    var body: some View {
+        if state.paused {
+            Text(state.pausedLabel)
+        } else {
+            Text(timerInterval: state.elapsedInterval, countsDown: false)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+/// Shared body for the lock screen and the island's expanded bottom
+/// region — the approach price lead or the consumption hero.
+struct TripActivityBodyView: View {
+    let state: TripActivityAttributes.ContentState
+
+    var body: some View {
+        if state.isApproach {
+            approachBody
+        } else {
+            recordingBody
+        }
+    }
+
+    /// Station-price lead (mirrors `TripRecordingPipPriceLayout`): huge
+    /// price, fuel label, station + distance, closeness bar.
+    private var approachBody: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(state.priceText ?? "--")
+                    .font(.system(size: 34, weight: .heavy).monospacedDigit())
+                if let fuel = state.fuelLabel {
+                    Text(fuel)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if let dist = state.stationDistanceText {
+                    Text(dist)
+                        .font(.callout.weight(.semibold).monospacedDigit())
+                }
+            }
+            if let station = state.stationName {
+                Text(station)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+            }
+            if let progress = state.progress {
+                ProgressView(value: min(max(progress, 0), 1))
+                    .progressViewStyle(.linear)
+                    .tint(.green)
+            }
+        }
+    }
+
+    /// Consumption hero (mirrors the PiP default layout): huge figure,
+    /// unit caption, distance secondary.
+    private var recordingBody: some View {
+        HStack(alignment: .lastTextBaseline, spacing: 8) {
+            Text(state.bigFigure)
+                .font(.system(size: 34, weight: .heavy).monospacedDigit())
+            Text(state.bigCaption)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Spacer()
+            if let distance = state.distanceText {
+                Text(distance)
+                    .font(.callout.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/lib/features/consumption/data/live_activity_controller.dart
+++ b/lib/features/consumption/data/live_activity_controller.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Dart binding for the app-internal iOS Live Activity channel
+/// `tankstellen/live_activity` (#3170). The Swift side lives in
+/// `ios/Runner/LiveActivityBridge.swift` and mirrors the same channel
+/// name and method set.
+///
+/// Live Activities (Dynamic Island / lock-screen surface) are the
+/// iOS-native answer to the Android PiP driving tile — iOS PiP is
+/// video-only by OS policy ([PipController]). On every other platform
+/// every method here is an inert no-op and [isSupported] is false, so
+/// call sites need no platform branching of their own (the plugin-seam
+/// rule: no `Platform.isIOS` forks in shared code).
+///
+/// None of the methods ever throw — a missing handler (unit-test
+/// engine), a user who disabled Live Activities, or any platform error
+/// degrades to "no activity shown", never to a crashed recorder.
+class LiveActivityController {
+  /// [channel] is injectable so unit tests can supply a mock without a
+  /// live platform binding.
+  LiveActivityController({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel('tankstellen/live_activity');
+
+  final MethodChannel _channel;
+
+  /// Whether the running platform can host a Live Activity at all.
+  /// iOS-only; the OS-level gate (iOS ≥ 16.1 + the user's per-app
+  /// Live Activities toggle) is checked natively by [startActivity].
+  bool get isSupported => defaultTargetPlatform == TargetPlatform.iOS;
+
+  /// Request a new Live Activity rendering [content] (the
+  /// `LiveActivityContent.toChannelMap()` payload). Returns false when
+  /// the activity could not be started (unsupported platform, the user
+  /// disabled Live Activities, or ActivityKit rejected the request) —
+  /// callers treat false as "stay quiet for this trip".
+  Future<bool> startActivity(Map<String, Object?> content) async {
+    if (!isSupported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('start', content) ?? false;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  /// Push fresh [content] onto the running activity. Best-effort: a
+  /// failure (no running activity, platform error) is silently dropped —
+  /// the next update or the trip end will reconcile.
+  Future<void> updateActivity(Map<String, Object?> content) async {
+    if (!isSupported) return;
+    try {
+      await _channel.invokeMethod<void>('update', content);
+    } on PlatformException {
+      // Best-effort: a failed update just leaves stale content briefly.
+    } on MissingPluginException {
+      // No native handler (e.g. a unit-test engine) — silently skip.
+    }
+  }
+
+  /// End and immediately dismiss the activity (trip stopped). Also ends
+  /// any activity left over from a previous process so a crash can't
+  /// strand a stale surface on the lock screen.
+  Future<void> endActivity() async {
+    if (!isSupported) return;
+    try {
+      await _channel.invokeMethod<void>('end');
+    } on PlatformException {
+      // Best-effort: ActivityKit times stranded activities out itself.
+    } on MissingPluginException {
+      // No native handler — nothing to end.
+    }
+  }
+}

--- a/lib/features/consumption/data/live_activity_coordinator.dart
+++ b/lib/features/consumption/data/live_activity_coordinator.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../domain/live_activity_content.dart';
+import 'live_activity_controller.dart';
+
+/// Drives the iOS Live Activity lifecycle off the recorder's emit
+/// stream (#3170): decides start / update / end and enforces the
+/// ActivityKit update cadence.
+///
+/// The recorder emits a full state ~4×/s — pushing every emit through
+/// the channel would hammer ActivityKit far past what its budgets
+/// tolerate (and waste battery re-encoding identical content). The
+/// elapsed timer ticks NATIVELY on the Swift side (off
+/// `startedAtEpochMs`), so the activity stays visibly alive between
+/// sparse content updates. Cadence rules:
+///
+/// * **start** — first non-null content while no activity runs;
+/// * **end** — content goes null (trip stopped / discarded);
+/// * **transition update** (mode flip, station change, price change,
+///   pause toggle) — sent once ≥ [minTransitionGap] since the last send
+///   (the next recorder emit retries, so nothing is lost);
+/// * **routine update** (distance / consumption drift) — at most one
+///   per [minRoutineGap];
+/// * identical content is never re-sent.
+///
+/// A failed start (user disabled Live Activities, OS veto) silences the
+/// coordinator for the REST OF THE TRIP — retrying 4×/s against a
+/// definitive OS "no" is pure channel spam. The next trip tries again.
+///
+/// [apply] never throws — any unexpected failure is logged and
+/// swallowed so the Live Activity can never take the recorder down.
+class LiveActivityCoordinator {
+  LiveActivityCoordinator({
+    required LiveActivityController controller,
+    DateTime Function()? clock,
+  })  : _controller = controller,
+        _clock = clock ?? DateTime.now;
+
+  /// Floor between two sends when the CONTENT meaning changed (a radar
+  /// flip / pause toggle should feel immediate but still debounced).
+  static const Duration minTransitionGap = Duration(seconds: 2);
+
+  /// Floor between two routine drift updates (distance / consumption).
+  /// ~2 updates a minute keeps the surface fresh while staying far
+  /// inside what ActivityKit tolerates for locally-driven activities.
+  static const Duration minRoutineGap = Duration(seconds: 30);
+
+  final LiveActivityController _controller;
+  final DateTime Function() _clock;
+
+  bool _active = false;
+  bool _startVetoed = false;
+  bool _applying = false;
+  LiveActivityContent? _lastSent;
+  DateTime? _lastSentAt;
+
+  /// Whether the platform can host a Live Activity at all — callers use
+  /// this to skip building content entirely off-iOS.
+  bool get isSupported => _controller.isSupported;
+
+  /// Whether an activity is currently believed to be live. Exposed for
+  /// tests; production callers only ever call [apply].
+  @visibleForTesting
+  bool get isActive => _active;
+
+  /// Reconcile the Live Activity with [content] (null = no active trip).
+  ///
+  /// Never throws (#3170): every controller call is best-effort and any
+  /// unexpected raise is logged + swallowed — a Live Activity failure
+  /// must never reach the recording pipeline.
+  Future<void> apply(LiveActivityContent? content) async {
+    if (!isSupported) return;
+    // Re-entrancy guard: emits arrive faster than a channel round-trip;
+    // overlapping applies could double-start. Skipped emits are retried
+    // by the next one (~250 ms later), so nothing is lost.
+    if (_applying) return;
+    _applying = true;
+    try {
+      await _apply(content);
+    } on Object catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: const {
+        'where': 'LiveActivityCoordinator.apply',
+      }));
+    } finally {
+      _applying = false;
+    }
+  }
+
+  Future<void> _apply(LiveActivityContent? content) async {
+    if (content == null) {
+      _startVetoed = false; // a new trip gets a fresh attempt
+      if (!_active) return;
+      _active = false;
+      _lastSent = null;
+      _lastSentAt = null;
+      await _controller.endActivity();
+      return;
+    }
+
+    if (_startVetoed) return;
+
+    final now = _clock();
+    if (!_active) {
+      final started = await _controller.startActivity(content.toChannelMap());
+      if (started) {
+        _active = true;
+        _lastSent = content;
+        _lastSentAt = now;
+      } else {
+        _startVetoed = true;
+      }
+      return;
+    }
+
+    final last = _lastSent;
+    if (content == last) return;
+
+    final significant = last == null ||
+        content.mode != last.mode ||
+        content.paused != last.paused ||
+        content.stationName != last.stationName ||
+        content.priceText != last.priceText;
+    final gap = _lastSentAt == null
+        ? minRoutineGap
+        : now.difference(_lastSentAt!);
+    if (gap < (significant ? minTransitionGap : minRoutineGap)) return;
+
+    _lastSent = content;
+    _lastSentAt = now;
+    await _controller.updateActivity(content.toChannelMap());
+  }
+}

--- a/lib/features/consumption/domain/live_activity_content.dart
+++ b/lib/features/consumption/domain/live_activity_content.dart
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/services/approach_detector.dart';
+import '../../../core/utils/price_formatter.dart';
+import '../../../core/utils/radar_closeness.dart';
+import '../../../core/utils/station_extensions.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../../search/domain/entities/station.dart';
+import '../providers/trip_recording_provider.dart';
+import 'driving_coaching.dart';
+
+/// Which layout the iOS Live Activity leads with (#3170) — mirrors the
+/// Android PiP tile's two faces (`TripRecordingPipView`): the default
+/// consumption hero while driving, flipping to the station-price lead
+/// whenever the Fuel Station Radar / approach detector has a target.
+enum LiveActivityMode { recording, approach }
+
+/// One immutable, fully-FORMATTED snapshot of what the iOS Live Activity
+/// (lock screen + Dynamic Island) should show (#3170).
+///
+/// Every user-facing string is resolved on the Dart side (ARB pipeline /
+/// the same format masks the PiP tile uses) so the Swift views stay
+/// dumb renderers — the extension has no access to the app's ARB
+/// catalogue, and pre-formatted strings keep the two surfaces in
+/// lock-step with zero duplicated formatting logic.
+@immutable
+class LiveActivityContent {
+  final LiveActivityMode mode;
+  final bool paused;
+
+  /// Wall-clock trip start (epoch ms, rounded to the second) — the Swift
+  /// side renders a NATIVELY ticking elapsed timer off this
+  /// (`Text(timerInterval:)`), so the elapsed readout never needs a
+  /// channel update. Rounded so back-computing `now - elapsed` on every
+  /// recorder emit doesn't jitter the content equality.
+  final int startedAtEpochMs;
+
+  /// Consumption hero ("5.8" / "~7.1" / the bare "~" warm-up glyph) +
+  /// its caption ("L/100 km" / "est. L/100 km" / "L/h") — same three
+  /// branches as the PiP default layout (#2601).
+  final String bigFigure;
+  final String bigCaption;
+  final bool isEstimate;
+
+  /// `"12.3 km"` once the trip covered ≥ 0.1 km, else null.
+  final String? distanceText;
+
+  /// Localized "Paused" chip label — always carried so a mid-flight
+  /// pause never needs a string the activity doesn't have.
+  final String pausedLabel;
+
+  // Approach-mode fields (null in recording mode).
+  final String? stationName;
+  final String? priceText;
+  final String? fuelLabel;
+  final String? stationDistanceText;
+
+  /// Radar closeness fill (0..1, fuller = closer) per the canonical
+  /// [RadarCloseness.fillFor] scale. Null collapses the bar.
+  final double? progress;
+
+  const LiveActivityContent({
+    required this.mode,
+    required this.paused,
+    required this.startedAtEpochMs,
+    required this.bigFigure,
+    required this.bigCaption,
+    required this.isEstimate,
+    required this.distanceText,
+    required this.pausedLabel,
+    this.stationName,
+    this.priceText,
+    this.fuelLabel,
+    this.stationDistanceText,
+    this.progress,
+  });
+
+  /// The channel payload (`tankstellen/live_activity` start/update args).
+  /// Keys mirror `TripActivityAttributes.ContentState` in
+  /// `ios/TankstellenWidget/TripActivityAttributes.swift` — keep the two
+  /// in lock-step.
+  Map<String, Object?> toChannelMap() => <String, Object?>{
+        'mode': mode.name,
+        'paused': paused,
+        'startedAtEpochMs': startedAtEpochMs,
+        'bigFigure': bigFigure,
+        'bigCaption': bigCaption,
+        'isEstimate': isEstimate,
+        'distanceText': distanceText,
+        'pausedLabel': pausedLabel,
+        'stationName': stationName,
+        'priceText': priceText,
+        'fuelLabel': fuelLabel,
+        'stationDistanceText': stationDistanceText,
+        'progress': progress,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      other is LiveActivityContent &&
+      other.mode == mode &&
+      other.paused == paused &&
+      other.startedAtEpochMs == startedAtEpochMs &&
+      other.bigFigure == bigFigure &&
+      other.bigCaption == bigCaption &&
+      other.isEstimate == isEstimate &&
+      other.distanceText == distanceText &&
+      other.pausedLabel == pausedLabel &&
+      other.stationName == stationName &&
+      other.priceText == priceText &&
+      other.fuelLabel == fuelLabel &&
+      other.stationDistanceText == stationDistanceText &&
+      other.progress == progress;
+
+  @override
+  int get hashCode => Object.hash(
+        mode,
+        paused,
+        startedAtEpochMs,
+        bigFigure,
+        bigCaption,
+        isEstimate,
+        distanceText,
+        pausedLabel,
+        stationName,
+        priceText,
+        fuelLabel,
+        stationDistanceText,
+        progress,
+      );
+}
+
+/// Build the Live Activity content for one trip/approach snapshot, or
+/// null when no trip is active (→ the coordinator ends the activity).
+///
+/// Mirrors `TripRecordingPipView`'s precedence exactly (#2084 / #2661):
+///
+/// 1. **In-radius / leaving** → station-price lead with a metres caption
+///    + the closeness fill.
+/// 2. **Polling radar hit** ([radarStation]) → station-price lead with a
+///    kilometres caption (the radar surfaces earlier than the fence).
+/// 3. **Otherwise** → the consumption hero (OBD2 L/100 km → GPS `~`
+///    estimate → warm-up `~`), same branch order as the PiP (#2601).
+///
+/// [l] is nullable with the project-wide `l?.key ?? 'English'` fallback
+/// convention so a harness without the l10n graph still renders.
+LiveActivityContent? buildLiveActivityContent({
+  required TripRecordingState state,
+  required ApproachState? approach,
+  required Station? radarStation,
+  required FuelType fuel,
+  required double? radiusMeters,
+  required AppLocalizations? l,
+  required DateTime now,
+}) {
+  if (!state.isActive) return null;
+
+  final live = state.live;
+  final paused = state.phase == TripRecordingPhase.paused;
+  // Round to the second so per-emit recomputation doesn't jitter equality.
+  final startedAtEpochMs =
+      ((now.millisecondsSinceEpoch - (live?.elapsed.inMilliseconds ?? 0)) ~/
+              1000) *
+          1000;
+  final pausedLabel = l?.tripBannerPaused ?? 'Paused';
+  final distance = live?.distanceKmSoFar;
+  final distanceText = (distance != null && distance >= 0.1)
+      ? '${distance.toStringAsFixed(1)} km'
+      : null;
+
+  // Resolve the consumption hero (shared by both modes — the approach
+  // layouts keep it so the island's expanded view can show it secondary).
+  final raw = (live != null && !paused) ? formatInstantConsumption(live) : null;
+  final gpsEstimate =
+      (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
+  final String bigFigure;
+  final String bigCaption;
+  var isEstimate = false;
+  if (raw != null) {
+    final idx = raw.indexOf(' ');
+    bigFigure = idx < 0 ? raw : raw.substring(0, idx);
+    bigCaption = raw.contains('L/100') ? 'L/100 km' : 'L/h';
+  } else if (gpsEstimate != null) {
+    bigFigure = '~${gpsEstimate.toStringAsFixed(1)}';
+    bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+    isEstimate = true;
+  } else {
+    // Warm-up / paused — keep the hero consumption-framed (#2601).
+    bigFigure = '~';
+    bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+    isEstimate = true;
+  }
+
+  LiveActivityContent approachContent(
+    Station station,
+    double? distMeters, {
+    required bool kmCaption,
+  }) {
+    final price = station.priceFor(fuel);
+    final String? stationDistanceText = distMeters == null
+        ? null
+        : kmCaption
+            ? (l?.fuelStationRadarDistanceKm(
+                    (distMeters / 1000.0).toStringAsFixed(1)) ??
+                '${(distMeters / 1000.0).toStringAsFixed(1)} km')
+            : (l?.approachStationDistance(distMeters.toStringAsFixed(0)) ??
+                '${distMeters.toStringAsFixed(0)} m');
+    return LiveActivityContent(
+      mode: LiveActivityMode.approach,
+      paused: paused,
+      startedAtEpochMs: startedAtEpochMs,
+      bigFigure: bigFigure,
+      bigCaption: bigCaption,
+      isEstimate: isEstimate,
+      distanceText: distanceText,
+      pausedLabel: pausedLabel,
+      stationName: station.name.isNotEmpty ? station.name : station.brand,
+      priceText: price != null ? PriceFormatter.formatPrice(price) : '--',
+      fuelLabel: fuel.displayName,
+      stationDistanceText: stationDistanceText,
+      progress: (distMeters != null && radiusMeters != null)
+          ? RadarCloseness.fillFor(distMeters, radiusMeters)
+          : null,
+    );
+  }
+
+  // 1 — in-radius / leaving wins (locked target, metres caption).
+  if (approach is ApproachInRadius) {
+    return approachContent(
+      approach.station,
+      approach.distanceMeters,
+      kmCaption: false,
+    );
+  }
+  if (approach is ApproachLeaving) {
+    return approachContent(approach.lastStation, null, kmCaption: false);
+  }
+
+  // 2 — polling radar hit (km caption — surfaces earlier than the fence).
+  if (radarStation != null) {
+    return approachContent(
+      radarStation,
+      radarStation.dist > 0 ? radarStation.dist * 1000.0 : null,
+      kmCaption: true,
+    );
+  }
+
+  // 3 — default consumption hero.
+  return LiveActivityContent(
+    mode: LiveActivityMode.recording,
+    paused: paused,
+    startedAtEpochMs: startedAtEpochMs,
+    bigFigure: bigFigure,
+    bigCaption: bigCaption,
+    isEstimate: isEstimate,
+    distanceText: distanceText,
+    pausedLabel: pausedLabel,
+  );
+}

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -20,6 +20,7 @@ import '../../domain/driving_coaching.dart';
 import '../../domain/situation_classifier.dart';
 import '../../providers/obd2_connection_state_provider.dart';
 import '../../providers/obd2_reconnect_provider.dart';
+import '../../providers/live_activity_provider.dart';
 import '../../providers/pip_mode_provider.dart';
 import '../../providers/trip_recording_provider.dart';
 import 'gps_degraded_banner.dart';
@@ -47,6 +48,18 @@ class TripRecordingBanner extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(tripRecordingProvider);
     final obd2 = ref.watch(obd2ConnectionStatusProvider);
+
+    // #3170 — arm the iOS Live Activity sync here, where every screen
+    // passes through (MaterialApp.builder), so the lock-screen/Dynamic
+    // Island surface tracks the trip no matter which route was visible
+    // when the user switched to their navigation app. Inert no-op off
+    // iOS (the provider subscribes to nothing); guarded like the PiP
+    // watches below so a harness without the full graph never crashes.
+    try {
+      ref.watch(liveActivitySyncProvider);
+    } on Object {
+      // best-effort surface — never let it take the banner down
+    }
 
     // #1977 — once the OS shrinks the app into a Picture-in-Picture
     // tile, render ONLY the compact trip strip. This wrapper sits above

--- a/lib/features/consumption/providers/live_activity_provider.dart
+++ b/lib/features/consumption/providers/live_activity_provider.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/language/language_provider.dart';
+import '../../../core/services/approach_detector.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../approach/providers/effective_approach_state_provider.dart';
+import '../../approach/providers/nearest_station_radar_provider.dart';
+import '../../profile/providers/effective_fuel_type_provider.dart';
+import '../../profile/providers/profile_provider.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../../search/domain/entities/station.dart';
+import '../data/live_activity_controller.dart';
+import '../data/live_activity_coordinator.dart';
+import '../domain/live_activity_content.dart';
+import 'trip_recording_provider.dart';
+
+part 'live_activity_provider.g.dart';
+
+/// The single app-wide [LiveActivityController] (#3170) — the channel
+/// admits exactly one native counterpart, so one Dart binding mirrors
+/// the [PipController] singleton convention.
+@Riverpod(keepAlive: true)
+LiveActivityController liveActivityController(Ref ref) =>
+    LiveActivityController();
+
+/// The single app-wide [LiveActivityCoordinator] — keepAlive so its
+/// throttle state (last-sent content / timestamps) survives across
+/// [LiveActivitySync] rebuilds, which happen on every recorder emit.
+@Riverpod(keepAlive: true)
+LiveActivityCoordinator liveActivityCoordinator(Ref ref) =>
+    LiveActivityCoordinator(
+      controller: ref.watch(liveActivityControllerProvider),
+    );
+
+/// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
+/// lock-step with the live trip/approach state — the iOS counterpart of
+/// the Android PiP tile's data wiring in `TripRecordingBanner`.
+///
+/// Armed by `TripRecordingBanner` (which wraps every screen via
+/// `MaterialApp.builder`), so the sync runs no matter which route is
+/// visible when the user backgrounds the app for their navigation app.
+///
+/// Watches the SAME sources the PiP tile renders from — the recorder
+/// state, the effective approach state, the polling-radar fallback, the
+/// effective fuel and the profile radius — builds one formatted
+/// [LiveActivityContent] snapshot per emit and hands it to the
+/// [LiveActivityCoordinator], which owns the start/update/end decision
+/// and the ActivityKit cadence budget.
+///
+/// Every auxiliary watch is guarded exactly like the banner's PiP
+/// watches (#2163): under a harness without the full graph the snapshot
+/// degrades (no radar lead, default fuel) instead of crashing.
+@Riverpod(keepAlive: true)
+class LiveActivitySync extends _$LiveActivitySync {
+  @override
+  void build() {
+    final coordinator = ref.watch(liveActivityCoordinatorProvider);
+    // Off-iOS: subscribe to NOTHING — zero extra rebuild traffic on the
+    // platforms that can't host a Live Activity.
+    if (!coordinator.isSupported) return;
+
+    final state = ref.watch(tripRecordingProvider);
+
+    ApproachState? approach;
+    Station? radarStation;
+    var fuel = FuelType.e10;
+    double? radiusMeters;
+    try {
+      approach = ref.watch(effectiveApproachStateProvider);
+    } on Object {
+      // fall back to null — consumption layout
+    }
+    try {
+      fuel = ref.watch(effectiveFuelTypeProvider);
+    } on Object {
+      // keep e10
+    }
+    try {
+      radarStation = ref.watch(nearestStationRadarProvider).value;
+    } on Object {
+      // no radar station
+    }
+    try {
+      final p = ref.watch(activeProfileProvider);
+      if (p != null) radiusMeters = p.approachRadiusKm * 1000.0;
+    } on Object {
+      // no radius — the closeness bar collapses
+    }
+
+    final content = buildLiveActivityContent(
+      state: state,
+      approach: approach,
+      radarStation: radarStation,
+      fuel: fuel,
+      radiusMeters: radiusMeters,
+      l: _l10n(),
+      now: DateTime.now(),
+    );
+    unawaited(coordinator.apply(content));
+  }
+
+  /// Resolve [AppLocalizations] without a `BuildContext` (#2766 pattern
+  /// — `lookupAppLocalizations` is a pure synchronous constructor).
+  /// Guarded twice so a harness without the language graph degrades to
+  /// English, then to the builder's literal fallbacks.
+  AppLocalizations? _l10n() {
+    String code;
+    try {
+      code = ref.read(activeLanguageProvider).code;
+    } on Object {
+      code = 'en';
+    }
+    try {
+      return lookupAppLocalizations(ui.Locale(code));
+    } on Object {
+      try {
+        return lookupAppLocalizations(const ui.Locale('en'));
+      } on Object {
+        return null;
+      }
+    }
+  }
+}

--- a/lib/features/consumption/providers/live_activity_provider.g.dart
+++ b/lib/features/consumption/providers/live_activity_provider.g.dart
@@ -1,0 +1,253 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'live_activity_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The single app-wide [LiveActivityController] (#3170) — the channel
+/// admits exactly one native counterpart, so one Dart binding mirrors
+/// the [PipController] singleton convention.
+
+@ProviderFor(liveActivityController)
+final liveActivityControllerProvider = LiveActivityControllerProvider._();
+
+/// The single app-wide [LiveActivityController] (#3170) — the channel
+/// admits exactly one native counterpart, so one Dart binding mirrors
+/// the [PipController] singleton convention.
+
+final class LiveActivityControllerProvider
+    extends
+        $FunctionalProvider<
+          LiveActivityController,
+          LiveActivityController,
+          LiveActivityController
+        >
+    with $Provider<LiveActivityController> {
+  /// The single app-wide [LiveActivityController] (#3170) — the channel
+  /// admits exactly one native counterpart, so one Dart binding mirrors
+  /// the [PipController] singleton convention.
+  LiveActivityControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'liveActivityControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$liveActivityControllerHash();
+
+  @$internal
+  @override
+  $ProviderElement<LiveActivityController> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  LiveActivityController create(Ref ref) {
+    return liveActivityController(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LiveActivityController value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LiveActivityController>(value),
+    );
+  }
+}
+
+String _$liveActivityControllerHash() =>
+    r'3f8ade6e06fb4c261ca2a54dfb26df691c207f14';
+
+/// The single app-wide [LiveActivityCoordinator] — keepAlive so its
+/// throttle state (last-sent content / timestamps) survives across
+/// [LiveActivitySync] rebuilds, which happen on every recorder emit.
+
+@ProviderFor(liveActivityCoordinator)
+final liveActivityCoordinatorProvider = LiveActivityCoordinatorProvider._();
+
+/// The single app-wide [LiveActivityCoordinator] — keepAlive so its
+/// throttle state (last-sent content / timestamps) survives across
+/// [LiveActivitySync] rebuilds, which happen on every recorder emit.
+
+final class LiveActivityCoordinatorProvider
+    extends
+        $FunctionalProvider<
+          LiveActivityCoordinator,
+          LiveActivityCoordinator,
+          LiveActivityCoordinator
+        >
+    with $Provider<LiveActivityCoordinator> {
+  /// The single app-wide [LiveActivityCoordinator] — keepAlive so its
+  /// throttle state (last-sent content / timestamps) survives across
+  /// [LiveActivitySync] rebuilds, which happen on every recorder emit.
+  LiveActivityCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'liveActivityCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$liveActivityCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<LiveActivityCoordinator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  LiveActivityCoordinator create(Ref ref) {
+    return liveActivityCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LiveActivityCoordinator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LiveActivityCoordinator>(value),
+    );
+  }
+}
+
+String _$liveActivityCoordinatorHash() =>
+    r'9780e89f3a4c8d68537b5d45fa3872dce2e699d8';
+
+/// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
+/// lock-step with the live trip/approach state — the iOS counterpart of
+/// the Android PiP tile's data wiring in `TripRecordingBanner`.
+///
+/// Armed by `TripRecordingBanner` (which wraps every screen via
+/// `MaterialApp.builder`), so the sync runs no matter which route is
+/// visible when the user backgrounds the app for their navigation app.
+///
+/// Watches the SAME sources the PiP tile renders from — the recorder
+/// state, the effective approach state, the polling-radar fallback, the
+/// effective fuel and the profile radius — builds one formatted
+/// [LiveActivityContent] snapshot per emit and hands it to the
+/// [LiveActivityCoordinator], which owns the start/update/end decision
+/// and the ActivityKit cadence budget.
+///
+/// Every auxiliary watch is guarded exactly like the banner's PiP
+/// watches (#2163): under a harness without the full graph the snapshot
+/// degrades (no radar lead, default fuel) instead of crashing.
+
+@ProviderFor(LiveActivitySync)
+final liveActivitySyncProvider = LiveActivitySyncProvider._();
+
+/// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
+/// lock-step with the live trip/approach state — the iOS counterpart of
+/// the Android PiP tile's data wiring in `TripRecordingBanner`.
+///
+/// Armed by `TripRecordingBanner` (which wraps every screen via
+/// `MaterialApp.builder`), so the sync runs no matter which route is
+/// visible when the user backgrounds the app for their navigation app.
+///
+/// Watches the SAME sources the PiP tile renders from — the recorder
+/// state, the effective approach state, the polling-radar fallback, the
+/// effective fuel and the profile radius — builds one formatted
+/// [LiveActivityContent] snapshot per emit and hands it to the
+/// [LiveActivityCoordinator], which owns the start/update/end decision
+/// and the ActivityKit cadence budget.
+///
+/// Every auxiliary watch is guarded exactly like the banner's PiP
+/// watches (#2163): under a harness without the full graph the snapshot
+/// degrades (no radar lead, default fuel) instead of crashing.
+final class LiveActivitySyncProvider
+    extends $NotifierProvider<LiveActivitySync, void> {
+  /// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
+  /// lock-step with the live trip/approach state — the iOS counterpart of
+  /// the Android PiP tile's data wiring in `TripRecordingBanner`.
+  ///
+  /// Armed by `TripRecordingBanner` (which wraps every screen via
+  /// `MaterialApp.builder`), so the sync runs no matter which route is
+  /// visible when the user backgrounds the app for their navigation app.
+  ///
+  /// Watches the SAME sources the PiP tile renders from — the recorder
+  /// state, the effective approach state, the polling-radar fallback, the
+  /// effective fuel and the profile radius — builds one formatted
+  /// [LiveActivityContent] snapshot per emit and hands it to the
+  /// [LiveActivityCoordinator], which owns the start/update/end decision
+  /// and the ActivityKit cadence budget.
+  ///
+  /// Every auxiliary watch is guarded exactly like the banner's PiP
+  /// watches (#2163): under a harness without the full graph the snapshot
+  /// degrades (no radar lead, default fuel) instead of crashing.
+  LiveActivitySyncProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'liveActivitySyncProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$liveActivitySyncHash();
+
+  @$internal
+  @override
+  LiveActivitySync create() => LiveActivitySync();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$liveActivitySyncHash() => r'6b551cc8f221281a76fc2a30cddff113188293f1';
+
+/// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
+/// lock-step with the live trip/approach state — the iOS counterpart of
+/// the Android PiP tile's data wiring in `TripRecordingBanner`.
+///
+/// Armed by `TripRecordingBanner` (which wraps every screen via
+/// `MaterialApp.builder`), so the sync runs no matter which route is
+/// visible when the user backgrounds the app for their navigation app.
+///
+/// Watches the SAME sources the PiP tile renders from — the recorder
+/// state, the effective approach state, the polling-radar fallback, the
+/// effective fuel and the profile radius — builds one formatted
+/// [LiveActivityContent] snapshot per emit and hands it to the
+/// [LiveActivityCoordinator], which owns the start/update/end decision
+/// and the ActivityKit cadence budget.
+///
+/// Every auxiliary watch is guarded exactly like the banner's PiP
+/// watches (#2163): under a harness without the full graph the snapshot
+/// degrades (no radar lead, default fuel) instead of crashing.
+
+abstract class _$LiveActivitySync extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/scripts/add_live_activity_sources.rb
+++ b/scripts/add_live_activity_sources.rb
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# Wires the Live Activity Swift sources (#3170) into ios/Runner.xcodeproj,
+# following the reproducible pbxproj-wiring pattern established by
+# scripts/add_ios_widget_target.rb (#3166 / PR #3217).
+#
+#   1. TankstellenWidget/TripActivityAttributes.swift — compiled into BOTH
+#      the Runner target and the TankstellenWidget extension target.
+#      ActivityKit matches the host process and the rendering extension on
+#      this shared ActivityAttributes type, so the single source file must
+#      be in both targets' compile sources.
+#   2. TankstellenWidget/TripRecordingLiveActivity.swift — the SwiftUI
+#      lock-screen + Dynamic Island views; extension target only.
+#   3. Runner/LiveActivityBridge.swift — the `tankstellen/live_activity`
+#      MethodChannel host; Runner target only.
+#
+# Idempotent: files already referenced / already in a target's sources are
+# skipped, so re-running is a no-op.
+#
+# Usage (from the repo root):
+#   ruby scripts/add_live_activity_sources.rb
+
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../ios/Runner.xcodeproj', __dir__)
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+runner = project.targets.find { |t| t.name == 'Runner' }
+abort 'Runner target not found' unless runner
+widget = project.targets.find { |t| t.name == 'TankstellenWidget' }
+abort 'TankstellenWidget target not found — run scripts/add_ios_widget_target.rb first' unless widget
+
+# Locate the groups the existing sources live in.
+widget_group = project.main_group.children.find do |c|
+  c.is_a?(Xcodeproj::Project::Object::PBXGroup) && c.name == 'TankstellenWidget'
+end
+abort 'TankstellenWidget group not found' unless widget_group
+runner_group = project.main_group.children.find do |c|
+  c.is_a?(Xcodeproj::Project::Object::PBXGroup) &&
+    (c.name == 'Runner' || c.path == 'Runner')
+end
+abort 'Runner group not found' unless runner_group
+
+# Find-or-create a file reference for +path+ inside +group+.
+def file_ref(group, path)
+  group.files.find { |f| f.path == path } || group.new_file(path)
+end
+
+# Add +ref+ to +target+'s compile sources unless already present.
+def compile(target, ref)
+  already = target.source_build_phase.files_references.include?(ref)
+  target.source_build_phase.add_file_reference(ref, true) unless already
+  puts "#{target.name}: #{ref.path} #{already ? 'already compiled' : 'added'}"
+end
+
+attributes_ref = file_ref(widget_group, 'TripActivityAttributes.swift')
+activity_ref   = file_ref(widget_group, 'TripRecordingLiveActivity.swift')
+bridge_ref     = file_ref(runner_group, 'LiveActivityBridge.swift')
+
+compile(runner, attributes_ref)   # shared ActivityAttributes — host side
+compile(widget, attributes_ref)   # shared ActivityAttributes — render side
+compile(widget, activity_ref)     # views: extension only
+compile(runner, bridge_ref)       # channel host: Runner only
+
+project.save
+puts "Saved #{PROJECT_PATH}"

--- a/test/features/consumption/data/live_activity_controller_test.dart
+++ b/test/features/consumption/data/live_activity_controller_test.dart
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/live_activity_controller.dart';
+
+/// Unit coverage for [LiveActivityController] — the Dart side of the
+/// `tankstellen/live_activity` channel (#3170). The Live Activity render
+/// itself is device-verified; these tests pin the channel contract:
+/// method names, payload pass-through, the iOS-only guard, and the
+/// never-throws degradation on platform errors (the fault-injection
+/// sibling for the class's never-throw doccontract).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('tankstellen/live_activity');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('LiveActivityController on iOS', () {
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.iOS);
+
+    test('isSupported is true', () {
+      expect(LiveActivityController().isSupported, isTrue);
+    });
+
+    test('startActivity invokes start with the content payload and returns '
+        'the native result', () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return true;
+      });
+
+      final controller = LiveActivityController();
+      final ok = await controller
+          .startActivity(<String, Object?>{'mode': 'recording', 'paused': false});
+
+      expect(ok, isTrue);
+      expect(calls.single.method, 'start');
+      expect(
+        calls.single.arguments,
+        containsPair('mode', 'recording'),
+      );
+    });
+
+    test('startActivity returns false when the native side declines',
+        () async {
+      messenger.setMockMethodCallHandler(channel, (call) async => false);
+      expect(
+        await LiveActivityController().startActivity(const {}),
+        isFalse,
+      );
+    });
+
+    test('startActivity returns false on a platform error (fault injection)',
+        () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'activitykit');
+      });
+      expect(
+        await LiveActivityController().startActivity(const {}),
+        isFalse,
+      );
+    });
+
+    test('updateActivity invokes update and swallows platform errors',
+        () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        if (calls.length > 1) throw PlatformException(code: 'gone');
+        return null;
+      });
+
+      final controller = LiveActivityController();
+      await controller.updateActivity(<String, Object?>{'bigFigure': '5.8'});
+      // Second call hits the injected fault — must not throw.
+      await controller.updateActivity(<String, Object?>{'bigFigure': '6.0'});
+
+      expect(calls.map((c) => c.method), everyElement('update'));
+      expect(calls.first.arguments, containsPair('bigFigure', '5.8'));
+    });
+
+    test('endActivity invokes end and swallows platform errors', () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        throw PlatformException(code: 'gone');
+      });
+
+      await LiveActivityController().endActivity();
+      expect(calls.single.method, 'end');
+    });
+
+    test('all methods survive a missing native handler '
+        '(MissingPluginException fault)', () async {
+      // No mock handler installed → MissingPluginException path.
+      final controller = LiveActivityController();
+      expect(await controller.startActivity(const {}), isFalse);
+      await controller.updateActivity(const {});
+      await controller.endActivity();
+    });
+  });
+
+  group('LiveActivityController off iOS', () {
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
+
+    test('isSupported is false and calls are inert no-ops', () async {
+      var invoked = false;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        invoked = true;
+        return true;
+      });
+
+      final controller = LiveActivityController();
+      expect(controller.isSupported, isFalse);
+      expect(await controller.startActivity(const {}), isFalse);
+      await controller.updateActivity(const {});
+      await controller.endActivity();
+      expect(invoked, isFalse,
+          reason: 'no channel traffic on a platform without Live Activities');
+    });
+  });
+}

--- a/test/features/consumption/data/live_activity_coordinator_test.dart
+++ b/test/features/consumption/data/live_activity_coordinator_test.dart
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/live_activity_controller.dart';
+import 'package:tankstellen/features/consumption/data/live_activity_coordinator.dart';
+import 'package:tankstellen/features/consumption/domain/live_activity_content.dart';
+
+/// Decision-table coverage for [LiveActivityCoordinator] (#3170):
+/// start / update / end transitions, the ActivityKit cadence throttle
+/// (routine vs transition gaps), the failed-start veto, and the
+/// fault-injection sibling for the `apply` never-throws doccontract.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeLiveActivityController controller;
+  late DateTime now;
+  late LiveActivityCoordinator coordinator;
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    controller = _FakeLiveActivityController();
+    now = DateTime(2026, 6, 10, 12);
+    coordinator =
+        LiveActivityCoordinator(controller: controller, clock: () => now);
+  });
+
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  LiveActivityContent content({
+    LiveActivityMode mode = LiveActivityMode.recording,
+    bool paused = false,
+    String bigFigure = '5.8',
+    String? distanceText,
+    String? stationName,
+    String? priceText,
+  }) =>
+      LiveActivityContent(
+        mode: mode,
+        paused: paused,
+        startedAtEpochMs: 1000000,
+        bigFigure: bigFigure,
+        bigCaption: 'L/100 km',
+        isEstimate: false,
+        distanceText: distanceText,
+        pausedLabel: 'Paused',
+        stationName: stationName,
+        priceText: priceText,
+      );
+
+  group('lifecycle', () {
+    test('null content while idle does nothing', () async {
+      await coordinator.apply(null);
+      expect(controller.calls, isEmpty);
+    });
+
+    test('first content starts the activity once; identical content is '
+        'never re-sent', () async {
+      final c = content();
+      await coordinator.apply(c);
+      now = now.add(const Duration(minutes: 5));
+      await coordinator.apply(c);
+      await coordinator.apply(c);
+
+      expect(controller.calls, ['start']);
+      expect(coordinator.isActive, isTrue);
+    });
+
+    test('null content after a start ends the activity (once)', () async {
+      await coordinator.apply(content());
+      await coordinator.apply(null);
+      await coordinator.apply(null);
+
+      expect(controller.calls, ['start', 'end']);
+      expect(coordinator.isActive, isFalse);
+    });
+
+    test('a new trip after an end starts a fresh activity', () async {
+      await coordinator.apply(content());
+      await coordinator.apply(null);
+      await coordinator.apply(content(bigFigure: '7.0'));
+
+      expect(controller.calls, ['start', 'end', 'start']);
+    });
+  });
+
+  group('cadence throttle', () {
+    test('routine drift (distance/figure) below the 30 s gap is skipped',
+        () async {
+      await coordinator.apply(content(distanceText: '1.0 km'));
+      now = now.add(const Duration(seconds: 29));
+      await coordinator.apply(content(distanceText: '1.2 km'));
+
+      expect(controller.calls, ['start']);
+    });
+
+    test('routine drift at/after the 30 s gap is sent', () async {
+      await coordinator.apply(content(distanceText: '1.0 km'));
+      now = now.add(LiveActivityCoordinator.minRoutineGap);
+      await coordinator.apply(content(distanceText: '1.2 km'));
+
+      expect(controller.calls, ['start', 'update']);
+      expect(
+        controller.lastUpdatePayload,
+        containsPair('distanceText', '1.2 km'),
+      );
+    });
+
+    test('the throttle window restarts from the last SENT update', () async {
+      await coordinator.apply(content(distanceText: '1.0 km'));
+      now = now.add(LiveActivityCoordinator.minRoutineGap);
+      await coordinator.apply(content(distanceText: '1.2 km'));
+      now = now.add(const Duration(seconds: 10));
+      await coordinator.apply(content(distanceText: '1.4 km'));
+
+      expect(controller.calls, ['start', 'update']);
+    });
+
+    test('a transition (pause flip) bypasses the routine gap but honours '
+        'the 2 s floor', () async {
+      await coordinator.apply(content());
+      now = now.add(const Duration(seconds: 1));
+      await coordinator.apply(content(paused: true));
+      expect(controller.calls, ['start'],
+          reason: 'sub-2 s transition is debounced — the next emit retries');
+
+      now = now.add(const Duration(seconds: 1));
+      await coordinator.apply(content(paused: true));
+      expect(controller.calls, ['start', 'update']);
+    });
+
+    test('a mode flip (radar lead) is a transition', () async {
+      await coordinator.apply(content());
+      now = now.add(const Duration(seconds: 3));
+      await coordinator.apply(content(
+        mode: LiveActivityMode.approach,
+        stationName: 'ARAL',
+        priceText: '1.78 €',
+      ));
+
+      expect(controller.calls, ['start', 'update']);
+      expect(controller.lastUpdatePayload, containsPair('mode', 'approach'));
+    });
+
+    test('a station change within approach mode is a transition', () async {
+      await coordinator.apply(content(
+        mode: LiveActivityMode.approach,
+        stationName: 'ARAL',
+        priceText: '1.78 €',
+      ));
+      now = now.add(const Duration(seconds: 3));
+      await coordinator.apply(content(
+        mode: LiveActivityMode.approach,
+        stationName: 'Shell',
+        priceText: '1.75 €',
+      ));
+
+      expect(controller.calls, ['start', 'update']);
+    });
+  });
+
+  group('failed-start veto', () {
+    test('a declined start silences the coordinator for the rest of the '
+        'trip; the next trip retries', () async {
+      controller.startResult = false;
+
+      await coordinator.apply(content());
+      now = now.add(const Duration(minutes: 5));
+      await coordinator.apply(content(bigFigure: '7.0'));
+      expect(controller.calls, ['start'],
+          reason: 'no 4×/s retry spam against a definitive OS "no"');
+      expect(coordinator.isActive, isFalse);
+
+      // Trip ends (nothing to end natively), next trip tries again.
+      await coordinator.apply(null);
+      controller.startResult = true;
+      await coordinator.apply(content());
+      expect(controller.calls, ['start', 'start']);
+    });
+  });
+
+  group('never-throws (fault injection)', () {
+    test('a throwing start is swallowed — apply completes normally',
+        () async {
+      controller.throwOn = 'start';
+      await expectLater(coordinator.apply(content()), completes);
+      expect(coordinator.isActive, isFalse);
+    });
+
+    test('a throwing update is swallowed — apply completes normally',
+        () async {
+      await coordinator.apply(content());
+      controller.throwOn = 'update';
+      now = now.add(const Duration(minutes: 1));
+      await expectLater(
+        coordinator.apply(content(bigFigure: '7.0')),
+        completes,
+      );
+    });
+
+    test('a throwing end is swallowed — apply completes normally', () async {
+      await coordinator.apply(content());
+      controller.throwOn = 'end';
+      await expectLater(coordinator.apply(null), completes);
+      expect(coordinator.isActive, isFalse);
+    });
+  });
+
+  group('off-iOS', () {
+    test('isSupported false → apply is a pure no-op', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final android = LiveActivityCoordinator(
+        controller: _FakeLiveActivityController(supported: false),
+        clock: () => now,
+      );
+      await android.apply(content());
+      await android.apply(null);
+      expect(android.isActive, isFalse);
+    });
+  });
+}
+
+/// Records the call sequence; configurable result + per-method fault
+/// injection so the coordinator's never-throws contract has a real
+/// throwing seam to be tested against.
+class _FakeLiveActivityController extends LiveActivityController {
+  _FakeLiveActivityController({this.supported = true});
+
+  final bool supported;
+  final List<String> calls = [];
+  Map<String, Object?>? lastUpdatePayload;
+  bool startResult = true;
+  String? throwOn;
+
+  @override
+  bool get isSupported => supported;
+
+  @override
+  Future<bool> startActivity(Map<String, Object?> content) async {
+    if (throwOn == 'start') throw StateError('injected start fault');
+    calls.add('start');
+    return startResult;
+  }
+
+  @override
+  Future<void> updateActivity(Map<String, Object?> content) async {
+    if (throwOn == 'update') throw StateError('injected update fault');
+    calls.add('update');
+    lastUpdatePayload = content;
+  }
+
+  @override
+  Future<void> endActivity() async {
+    if (throwOn == 'end') throw StateError('injected end fault');
+    calls.add('end');
+  }
+}

--- a/test/features/consumption/domain/live_activity_content_test.dart
+++ b/test/features/consumption/domain/live_activity_content_test.dart
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
+import 'package:tankstellen/core/utils/radar_closeness.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/domain/live_activity_content.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// Decision-table coverage for [buildLiveActivityContent] (#3170) — the
+/// pure mapper from (recorder state, approach state, radar fallback) to
+/// the Live Activity payload. Mirrors `TripRecordingPipView`'s layout
+/// precedence so the two glanceable surfaces can never disagree.
+void main() {
+  final now = DateTime(2026, 6, 10, 12);
+
+  Station station({
+    String id = 'st1',
+    String name = 'ARAL Hauptstr.',
+    String brand = 'ARAL',
+    double? e10 = 1.789,
+    double dist = 0,
+  }) =>
+      Station(
+        id: id,
+        name: name,
+        brand: brand,
+        street: 'Hauptstr. 1',
+        postCode: '12345',
+        place: 'Teststadt',
+        lat: 50.0,
+        lng: 8.0,
+        dist: dist,
+        e10: e10,
+      );
+
+  TripRecordingState recording({
+    TripRecordingPhase phase = TripRecordingPhase.recording,
+    TripLiveReading? live,
+  }) =>
+      TripRecordingState(
+        phase: phase,
+        live: live ??
+            const TripLiveReading(
+              distanceKmSoFar: 12.34,
+              elapsed: Duration(minutes: 10),
+            ),
+      );
+
+  LiveActivityContent? build({
+    TripRecordingState? state,
+    ApproachState? approach,
+    Station? radarStation,
+    FuelType fuel = FuelType.e10,
+    double? radiusMeters = 3000,
+  }) =>
+      buildLiveActivityContent(
+        state: state ?? recording(),
+        approach: approach,
+        radarStation: radarStation,
+        fuel: fuel,
+        radiusMeters: radiusMeters,
+        l: null, // exercises the English fallbacks (harness convention)
+        now: now,
+      );
+
+  group('no active trip', () {
+    test('idle state yields null (→ coordinator ends the activity)', () {
+      expect(build(state: const TripRecordingState()), isNull);
+    });
+  });
+
+  group('recording mode (consumption hero — PiP branch parity #2601)', () {
+    test('OBD2 fuel rate at speed → measured L/100 km figure', () {
+      final content = build(
+        state: recording(
+          live: const TripLiveReading(
+            distanceKmSoFar: 12.34,
+            elapsed: Duration(minutes: 10),
+            fuelRateLPerHour: 3.0,
+            speedKmh: 50,
+          ),
+        ),
+      )!;
+
+      expect(content.mode, LiveActivityMode.recording);
+      expect(content.bigFigure, '6.0');
+      expect(content.bigCaption, 'L/100 km');
+      expect(content.isEstimate, isFalse);
+      expect(content.distanceText, '12.3 km');
+      expect(content.stationName, isNull);
+    });
+
+    test('near standstill → L/h fallback', () {
+      final content = build(
+        state: recording(
+          live: const TripLiveReading(
+            distanceKmSoFar: 0.5,
+            elapsed: Duration(minutes: 2),
+            fuelRateLPerHour: 1.2,
+            speedKmh: 0,
+          ),
+        ),
+      )!;
+
+      expect(content.bigFigure, '1.2');
+      expect(content.bigCaption, 'L/h');
+    });
+
+    test('GPS-only live estimate → ~figure under the est caption', () {
+      final content = build(
+        state: recording(
+          live: const TripLiveReading(
+            distanceKmSoFar: 5.0,
+            elapsed: Duration(minutes: 6),
+            gpsEstimatedLPer100Km: 7.12,
+          ),
+        ),
+      )!;
+
+      expect(content.bigFigure, '~7.1');
+      expect(content.bigCaption, 'est. L/100 km');
+      expect(content.isEstimate, isTrue);
+    });
+
+    test('warm-up (no rate, no estimate) → bare ~ placeholder', () {
+      final content = build()!;
+      expect(content.bigFigure, '~');
+      expect(content.isEstimate, isTrue);
+    });
+
+    test('paused trip → paused flag set and the measured figure suppressed',
+        () {
+      final content = build(
+        state: recording(
+          phase: TripRecordingPhase.paused,
+          live: const TripLiveReading(
+            distanceKmSoFar: 12.34,
+            elapsed: Duration(minutes: 10),
+            fuelRateLPerHour: 3.0,
+            speedKmh: 50,
+          ),
+        ),
+      )!;
+
+      expect(content.paused, isTrue);
+      expect(content.bigFigure, '~');
+      expect(content.pausedLabel, 'Paused');
+    });
+
+    test('distance under 0.1 km is hidden', () {
+      final content = build(
+        state: recording(
+          live: const TripLiveReading(
+            distanceKmSoFar: 0.05,
+            elapsed: Duration(seconds: 30),
+          ),
+        ),
+      )!;
+      expect(content.distanceText, isNull);
+    });
+
+    test('startedAt back-computes now − elapsed, rounded to the second', () {
+      final content = build(
+        state: recording(
+          live: const TripLiveReading(
+            distanceKmSoFar: 1.0,
+            elapsed: Duration(minutes: 10, milliseconds: 350),
+          ),
+        ),
+      )!;
+
+      final expected = now
+          .subtract(const Duration(minutes: 10, milliseconds: 350))
+          .millisecondsSinceEpoch;
+      expect(content.startedAtEpochMs, (expected ~/ 1000) * 1000);
+      expect(content.startedAtEpochMs % 1000, 0);
+    });
+  });
+
+  group('approach mode — in-radius wins (PiP precedence #2084)', () {
+    test('ApproachInRadius → price lead with metres caption + closeness',
+        () {
+      final content = build(
+        approach: ApproachInRadius(station: station(), distanceMeters: 450),
+        // The radar fallback must NOT win over the locked target.
+        radarStation: station(id: 'other', name: 'Wrong'),
+      )!;
+
+      expect(content.mode, LiveActivityMode.approach);
+      expect(content.stationName, 'ARAL Hauptstr.');
+      expect(content.priceText, PriceFormatter.formatPrice(1.789));
+      expect(content.fuelLabel, FuelType.e10.displayName);
+      expect(content.stationDistanceText, '450 m');
+      expect(content.progress, RadarCloseness.fillFor(450, 3000));
+    });
+
+    test('ApproachLeaving keeps the last station, drops distance + bar', () {
+      final content = build(
+        approach: ApproachLeaving(lastStation: station()),
+      )!;
+
+      expect(content.mode, LiveActivityMode.approach);
+      expect(content.stationDistanceText, isNull);
+      expect(content.progress, isNull);
+    });
+
+    test('a station without a name falls back to the brand', () {
+      final content = build(
+        approach: ApproachInRadius(
+          station: station(name: ''),
+          distanceMeters: 450,
+        ),
+      )!;
+      expect(content.stationName, 'ARAL');
+    });
+
+    test('a station without the fuel price renders the -- placeholder', () {
+      final content = build(
+        approach: ApproachInRadius(
+          station: station(e10: null),
+          distanceMeters: 450,
+        ),
+      )!;
+      expect(content.priceText, '--');
+    });
+  });
+
+  group('approach mode — polling radar fallback (#2661 parity)', () {
+    test('radar station leads with a km caption when nothing is in radius',
+        () {
+      final content = build(radarStation: station(dist: 1.2))!;
+
+      expect(content.mode, LiveActivityMode.approach);
+      expect(content.stationDistanceText, '1.2 km');
+      expect(content.progress, RadarCloseness.fillFor(1200, 3000));
+      // The consumption hero stays populated for the expanded island.
+      expect(content.bigFigure, isNotEmpty);
+    });
+
+    test('a zero radar distance hides the caption + bar', () {
+      final content = build(radarStation: station(dist: 0))!;
+      expect(content.stationDistanceText, isNull);
+      expect(content.progress, isNull);
+    });
+
+    test('no radius collapses the closeness bar only', () {
+      final content = build(
+        radarStation: station(dist: 1.2),
+        radiusMeters: null,
+      )!;
+      expect(content.stationDistanceText, '1.2 km');
+      expect(content.progress, isNull);
+    });
+  });
+
+  group('channel payload', () {
+    test('toChannelMap carries every ContentState key in lock-step', () {
+      final content = build(
+        approach: ApproachInRadius(station: station(), distanceMeters: 450),
+      )!;
+      final map = content.toChannelMap();
+
+      expect(map.keys, <String>{
+        'mode',
+        'paused',
+        'startedAtEpochMs',
+        'bigFigure',
+        'bigCaption',
+        'isEstimate',
+        'distanceText',
+        'pausedLabel',
+        'stationName',
+        'priceText',
+        'fuelLabel',
+        'stationDistanceText',
+        'progress',
+      });
+      expect(map['mode'], 'approach');
+    });
+  });
+}


### PR DESCRIPTION
## Live Activity for trip recording + approach radar — the iOS answer to the Android PiP tile

From epic #3165. While a trip records, the lock screen + Dynamic Island show exactly what the Android PiP tile shows, with the same layout precedence (`buildLiveActivityContent` is a pure tested mapper):

1. **In-radius/leaving**: big station price + fuel + name + metres + the closeness bar.
2. **Polling-radar fallback**: price lead with a km caption.
3. **Default recording**: OBD2 L/100km (L/h at standstill) → GPS estimate → warm-up, plus distance and a natively-ticking elapsed timer (zero updates needed for the clock); paused state localized.

Budget-aware updates: identical content never re-sent, routine drift ≥30 s apart, meaning-transitions fast-pathed with a 2 s floor, user-declined activities veto retries for the trip; never-throws with fault injection. Views ship inside the existing TankstellenWidget extension (no new target — `TripActivityAttributes` compiled into both targets via the reproducible script pattern from #3217); Swift renders only pre-localized strings from existing ARB keys, so no locale fan-out.

Out of scope by design: the no-trip on-search radar variant (iOS suspends the app without the trip's background-location mode) and push-token remote updates (local suffices; remote would touch the no-paid-services constraint).

Verified: 5,607 tests green; device-target `xcodebuild` BUILD SUCCEEDED with the attributes in both targets. Field step: start a trip, background the app, check lock screen/Dynamic Island.

Closes #3170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
