### PR TITLE
feat(ios): widget parity — favorites + predictive variants + AppIntent refresh (#3171)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -15,9 +15,11 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		35A2294918D818734C462990 /* StationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56BA2B737BFEAFAF64046B1 /* StationRow.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		3DFBC3A7D6D2E931C4B535EC /* StationListWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B178E98F93A82662B8ED4165 /* StationListWidgetView.swift */; };
 		595226A68EC384B12AF0A93F /* TankstellenWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5E24927367580828DD745BD3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 53F08202EBE1619234A8ED70 /* Assets.xcassets */; };
 		617A7DBF52F20550E6FAD8F0 /* TripActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */; };
+		69AB881AFDF951061E686013 /* PredictiveStationsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A15DA64CF250BB6FB784375 /* PredictiveStationsWidget.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		976F22DFFA3574104BBF6FEC /* TripActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */; };
@@ -25,10 +27,12 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A1A2A3A41E000001A0000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A2A3A41E000002A0000002 /* PrivacyInfo.xcprivacy */; };
+		B40FD09E966968C1027C08D0 /* WidgetRefreshIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B6E3FDCA71BDEF55ED246F /* WidgetRefreshIntent.swift */; };
 		C1D3C7BC3EE97D07059B912D /* NearestStationsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844ADBBCA2F2A79394B541E8 /* NearestStationsProvider.swift */; };
 		E05A76E23ACD50B61271D84D /* NearestStationsEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB9171C55A8C662C3106F67 /* NearestStationsEntry.swift */; };
 		E128B0129985B6FE9E2D5787 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE182BA7429614C5B4D896D8 /* Pods_RunnerTests.framework */; };
 		F41E24A56C7842FF0D7B1473 /* TripRecordingLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BDF230A6D8AB196E7C7CA0 /* TripRecordingLiveActivity.swift */; };
+		FF0BC870C426C2F4DA1A295F /* FavoriteStationsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF7BD8C44FEF87F0FDD9706 /* FavoriteStationsWidget.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,11 +78,14 @@
 
 /* Begin PBXFileReference section */
 		021C8A9CAC0B84B64CE59171 /* NearestStationsWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearestStationsWidgetView.swift; sourceTree = "<group>"; };
+		0A15DA64CF250BB6FB784375 /* PredictiveStationsWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredictiveStationsWidget.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1DF7BD8C44FEF87F0FDD9706 /* FavoriteStationsWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FavoriteStationsWidget.swift; sourceTree = "<group>"; };
 		2815EFFDECEACD9EAFE42DF1 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		38B6E3FDCA71BDEF55ED246F /* WidgetRefreshIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetRefreshIntent.swift; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		48958D39212C2CFDBF19D6DB /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		4EA6D51155FBB08B992BDCD8 /* TankstellenWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TankstellenWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -104,6 +111,7 @@
 		A1A2A3A41E000002A0000002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA0B2B41CF68C8C0A67F6D1B /* Runner.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		AE182BA7429614C5B4D896D8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B178E98F93A82662B8ED4165 /* StationListWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListWidgetView.swift; sourceTree = "<group>"; };
 		C56BA2B737BFEAFAF64046B1 /* StationRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationRow.swift; sourceTree = "<group>"; };
 		D5BAD308B99CCC0C792854A9 /* TankstellenWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TankstellenWidget.swift; sourceTree = "<group>"; };
 		E1C4E7855C3D7D6AF8148EDF /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -236,6 +244,10 @@
 				E6531D801740AA014ACC14D5 /* TankstellenWidget.entitlements */,
 				EE94E0B255E44A6D24AC543B /* TripActivityAttributes.swift */,
 				85BDF230A6D8AB196E7C7CA0 /* TripRecordingLiveActivity.swift */,
+				B178E98F93A82662B8ED4165 /* StationListWidgetView.swift */,
+				1DF7BD8C44FEF87F0FDD9706 /* FavoriteStationsWidget.swift */,
+				0A15DA64CF250BB6FB784375 /* PredictiveStationsWidget.swift */,
+				38B6E3FDCA71BDEF55ED246F /* WidgetRefreshIntent.swift */,
 			);
 			name = TankstellenWidget;
 			path = TankstellenWidget;
@@ -519,6 +531,10 @@
 				35A2294918D818734C462990 /* StationRow.swift in Sources */,
 				976F22DFFA3574104BBF6FEC /* TripActivityAttributes.swift in Sources */,
 				F41E24A56C7842FF0D7B1473 /* TripRecordingLiveActivity.swift in Sources */,
+				3DFBC3A7D6D2E931C4B535EC /* StationListWidgetView.swift in Sources */,
+				FF0BC870C426C2F4DA1A295F /* FavoriteStationsWidget.swift in Sources */,
+				69AB881AFDF951061E686013 /* PredictiveStationsWidget.swift in Sources */,
+				B40FD09E966968C1027C08D0 /* WidgetRefreshIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/TankstellenWidget/FavoriteStationsWidget.swift
+++ b/ios/TankstellenWidget/FavoriteStationsWidget.swift
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Favorites widget (#3171) — Android parity for the favorites mode of
+// `StationWidgetRenderer.kt`. Renders the user's favorite stations with
+// their current prices from the `stations_json` payload
+// `HomeWidgetService.updateWidget` writes on the same foreground
+// heartbeat as the nearest payload (no extra wake-ups). Same
+// `StationRow` JSON shape, so the shared decode + view do all the work.
+
+import SwiftUI
+import WidgetKit
+
+struct FavoriteStationsProvider: TimelineProvider {
+    typealias Entry = NearestStationsEntry
+
+    func placeholder(in context: Context) -> Entry {
+        NearestStationsEntry.placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
+        completion(currentEntry())
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<Entry>) -> Void
+    ) {
+        completion(StationListPayload.timeline(for: currentEntry()))
+    }
+
+    private func currentEntry() -> Entry {
+        StationListPayload.loadEntry(
+            // The favorites payload (`HomeWidgetService.updateWidget`)
+            // writes no empty-reason / stale keys — an empty list always
+            // means "no favorites yet".
+            jsonKey: "stations_json",
+            emptyReasonKey: nil,
+            staleKey: nil,
+            noDataCopy: "Open Sparkilo to load your favorites",
+            emptyListCopy: "Add favorite stations in Sparkilo to see them here"
+        )
+    }
+}
+
+struct FavoriteStationsWidget: Widget {
+    let kind: String = "FavoriteStationsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: FavoriteStationsProvider()) { entry in
+            StationListWidgetView(
+                entry: entry,
+                emptyFallback: "Add favorite stations in Sparkilo to see them here"
+            )
+        }
+        .configurationDisplayName("Sparkilo — Favorites")
+        .description("Your favorite fuel stations and their current prices.")
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}

--- a/ios/TankstellenWidget/NearestStationsEntry.swift
+++ b/ios/TankstellenWidget/NearestStationsEntry.swift
@@ -1,13 +1,16 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-// TimelineEntry payload for the Nearest-Stations widget.
+// TimelineEntry payload shared by every station-list widget in the bundle
+// (#3171): Nearest reads `nearest_json`, Favorites reads `stations_json`,
+// Predictive reuses the nearest payload.
 //
-// `rows` is the parsed `nearest_json` array (see `StationRow`). `isStale`
+// `rows` is the parsed station array (see `StationRow`). `isStale`
 // reflects the `nearest_is_stale` flag the Dart side sets when the data
 // is older than the freshness budget — the SwiftUI view renders a small
 // "stale" pill when this is true so the user knows the prices may have
-// moved since the last sync.
+// moved since the last sync (always false for the favorites payload,
+// which has no stale concept).
 
 import Foundation
 import WidgetKit
@@ -39,7 +42,10 @@ struct NearestStationsEntry: TimelineEntry {
                 distanceKm: Double(i),
                 isOpen: true,
                 currency: "€",
-                priceFormatted: "—"
+                priceFormatted: "—",
+                isCheapest: false,
+                predictiveBestLabel: nil,
+                predictiveBestPrice: nil
             )
         },
         isStale: false,

--- a/ios/TankstellenWidget/NearestStationsProvider.swift
+++ b/ios/TankstellenWidget/NearestStationsProvider.swift
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 // TimelineProvider that reads the latest Nearest-Stations payload from
-// the shared App Group container.
+// the shared App Group container, plus the shared payload loader the
+// Favorites provider reuses (#3171).
 //
 // Refresh cadence: the host app updates the container whenever a new
 // search resolves (typically every few minutes when the app is open).
@@ -21,6 +22,103 @@ import WidgetKit
 /// strings break together; keep them in lock-step.
 let kTankstellenAppGroupId = "group.de.tankstellen.tankstellen"
 
+/// Shared App-Group payload loader for the station-list widgets (#3171).
+/// The Nearest widget reads the `nearest_*` keys, the Favorites widget the
+/// `stations_json` / favorites keys — same JSON row shape (`StationRow`),
+/// so one decode path serves both providers.
+enum StationListPayload {
+    /// Read + decode one station-list payload from the App Group store.
+    ///
+    /// - `jsonKey`: the UserDefaults key holding the JSON-encoded rows.
+    /// - `emptyReasonKey`: optional key with a Dart-written empty-reason
+    ///   code; nil when the payload has no reason concept (favorites).
+    /// - `staleKey`: optional key with the Dart-written stale flag; nil
+    ///   when the payload has no stale concept (favorites).
+    /// - `noDataCopy` / `emptyListCopy`: the fallback texts for "host app
+    ///   never wrote this key" vs "key exists but the list is empty".
+    static func loadEntry(
+        jsonKey: String,
+        emptyReasonKey: String?,
+        staleKey: String?,
+        noDataCopy: String,
+        emptyListCopy: String
+    ) -> NearestStationsEntry {
+        guard let defaults = UserDefaults(suiteName: kTankstellenAppGroupId) else {
+            return NearestStationsEntry.empty(
+                reason: "App Group not configured"
+            )
+        }
+        // The Dart side writes the rows as a JSON-encoded string (see
+        // `HomeWidgetService` / `NearestWidgetDataBuilder`). A missing key
+        // means the host app has never run / never produced this payload.
+        guard let raw = defaults.string(forKey: jsonKey) else {
+            return NearestStationsEntry.empty(
+                reason: emptyReason(defaults, key: emptyReasonKey)
+                    ?? noDataCopy
+            )
+        }
+        guard let data = raw.data(using: .utf8) else {
+            return NearestStationsEntry.empty(
+                reason: "Couldn't decode widget data"
+            )
+        }
+        do {
+            let rows = try JSONDecoder().decode([StationRow].self, from: data)
+            if rows.isEmpty {
+                return NearestStationsEntry.empty(
+                    reason: emptyReason(defaults, key: emptyReasonKey)
+                        ?? emptyListCopy
+                )
+            }
+            return NearestStationsEntry(
+                date: Date(),
+                rows: rows,
+                isStale: staleKey.map { defaults.bool(forKey: $0) } ?? false,
+                emptyReason: nil
+            )
+        } catch {
+            return NearestStationsEntry.empty(
+                reason: "Couldn't read widget data"
+            )
+        }
+    }
+
+    /// 15-minute `.after` reload policy shared by every provider in the
+    /// bundle — see the cadence note in the file header.
+    static func timeline(for entry: NearestStationsEntry) -> Timeline<NearestStationsEntry> {
+        let nextRefresh = Calendar.current.date(
+            byAdding: .minute,
+            value: 15,
+            to: entry.date
+        ) ?? entry.date.addingTimeInterval(15 * 60)
+        return Timeline(entries: [entry], policy: .after(nextRefresh))
+    }
+
+    /// Map the Dart-written empty-reason CODE to user copy. The Dart side
+    /// writes machine codes (`no_gps`, `no_network`, `no_favorites` — see
+    /// `NearestWidgetDataBuilder` / `HomeWidgetService`); the Android
+    /// renderer maps them the same way. Unknown non-empty values are shown
+    /// verbatim (forward compatibility with future Dart-localized copy).
+    private static func emptyReason(
+        _ defaults: UserDefaults,
+        key: String?
+    ) -> String? {
+        guard let key = key,
+              let code = defaults.string(forKey: key),
+              !code.isEmpty else { return nil }
+        switch code {
+        case "no_gps":
+            return "Turn on location in the app to see nearby stations"
+        case "no_network":
+            return "Open Sparkilo to load nearby prices"
+        case "no_favorites":
+            return "Add favorite stations in Sparkilo to see them here"
+        default:
+            return code
+        }
+    }
+}
+
 struct NearestStationsProvider: TimelineProvider {
     typealias Entry = NearestStationsEntry
 
@@ -36,60 +134,18 @@ struct NearestStationsProvider: TimelineProvider {
         in context: Context,
         completion: @escaping (Timeline<Entry>) -> Void
     ) {
-        let entry = currentEntry()
-        let nextRefresh = Calendar.current.date(
-            byAdding: .minute,
-            value: 15,
-            to: entry.date
-        ) ?? entry.date.addingTimeInterval(15 * 60)
-        completion(
-            Timeline(entries: [entry], policy: .after(nextRefresh))
-        )
+        completion(StationListPayload.timeline(for: currentEntry()))
     }
 
     // MARK: - private
 
     private func currentEntry() -> Entry {
-        let defaults = UserDefaults(suiteName: kTankstellenAppGroupId)
-        guard let defaults = defaults else {
-            return NearestStationsEntry.empty(
-                reason: "App Group not configured"
-            )
-        }
-        // The Dart side writes the rows as a JSON-encoded string under
-        // the `nearest_json` key (see `HomeWidgetService.updateWidget`).
-        // If the key is missing the host app has never run, never
-        // resolved a location, or never had any nearby results — the
-        // empty-reason copy disambiguates the latter two.
-        guard let raw = defaults.string(forKey: "nearest_json") else {
-            return NearestStationsEntry.empty(
-                reason: defaults.string(forKey: "nearest_empty_reason")
-                    ?? "Open Sparkilo to load nearby prices"
-            )
-        }
-        guard let data = raw.data(using: .utf8) else {
-            return NearestStationsEntry.empty(
-                reason: "Couldn't decode widget data"
-            )
-        }
-        do {
-            let rows = try JSONDecoder().decode([StationRow].self, from: data)
-            if rows.isEmpty {
-                return NearestStationsEntry.empty(
-                    reason: defaults.string(forKey: "nearest_empty_reason")
-                        ?? "No nearby stations"
-                )
-            }
-            return NearestStationsEntry(
-                date: Date(),
-                rows: rows,
-                isStale: defaults.bool(forKey: "nearest_is_stale"),
-                emptyReason: nil
-            )
-        } catch {
-            return NearestStationsEntry.empty(
-                reason: "Couldn't read widget data"
-            )
-        }
+        StationListPayload.loadEntry(
+            jsonKey: "nearest_json",
+            emptyReasonKey: "nearest_empty_reason",
+            staleKey: "nearest_is_stale",
+            noDataCopy: "Open Sparkilo to load nearby prices",
+            emptyListCopy: "No nearby stations"
+        )
     }
 }

--- a/ios/TankstellenWidget/NearestStationsWidgetView.swift
+++ b/ios/TankstellenWidget/NearestStationsWidgetView.swift
@@ -1,17 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-// SwiftUI body for the Nearest-Stations widget.
-//
-// Renders one row per station with `widgetURL` set to the
-// `tankstellenwidget://station?id=<id>` deep link so taps follow the
-// same cold-start / warm-click flow Android uses (handled in the
-// Flutter app by `WidgetClickListener` + the router's pending-URI
-// redirect).
-//
-// Visual language deliberately matches the Android renderer: brand /
-// street, price chip, distance pill. Keep both in lock-step so the
-// user sees the same widget on both platforms.
+// SwiftUI body for the Nearest-Stations widget — since #3171 a thin
+// wrapper around the shared `StationListWidgetView` (the Favorites and
+// Predictive variants render the same body off different payloads).
+// Kept as its own type/file so the pbxproj reference and the widget's
+// view name stay stable.
 
 import SwiftUI
 import WidgetKit
@@ -19,125 +13,10 @@ import WidgetKit
 struct NearestStationsWidgetView: View {
     let entry: NearestStationsEntry
 
-    /// `.systemMedium` shows 3 rows, `.systemLarge` shows 5. Configurable
-    /// via the widget family environment so the same body adapts.
-    @Environment(\.widgetFamily) private var family
-
-    private var maxRows: Int {
-        switch family {
-        case .systemLarge: return 5
-        default: return 3
-        }
-    }
-
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            Color(.systemBackground)
-            VStack(alignment: .leading, spacing: 6) {
-                header
-                if entry.rows.isEmpty {
-                    emptyState
-                } else {
-                    ForEach(Array(entry.rows.prefix(maxRows))) { row in
-                        Link(destination: row.deepLink) {
-                            StationRowView(row: row)
-                        }
-                    }
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(12)
-        }
-        .widgetURL(
-            // Fallback tap target for the whole widget (system small +
-            // any tap that misses an individual Link). Routes to the
-            // search screen via a sentinel URI the parser ignores —
-            // the app's redirect chain falls through to its normal
-            // landing without trying to open a station detail.
-            URL(string: "tankstellenwidget://station?id=__widget_root__")
+        StationListWidgetView(
+            entry: entry,
+            emptyFallback: "No data yet"
         )
-        .widgetBackgroundCompat()
-    }
-
-    private var header: some View {
-        HStack(alignment: .center, spacing: 6) {
-            Image(systemName: "fuelpump.fill")
-                .foregroundStyle(.tint)
-            Text("Sparkilo")
-                .font(.caption.weight(.semibold))
-            Spacer()
-            if entry.isStale {
-                Text("stale")
-                    .font(.caption2)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule().fill(Color.orange.opacity(0.18))
-                    )
-                    .foregroundStyle(.orange)
-            }
-        }
-    }
-
-    private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(entry.emptyReason ?? "No data yet")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(3)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct StationRowView: View {
-    let row: StationRow
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(row.displayName)
-                    .font(.callout.weight(.semibold))
-                    .lineLimit(1)
-                if let street = row.street, street != row.displayName {
-                    Text(street)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-            Spacer()
-            VStack(alignment: .trailing, spacing: 2) {
-                if let price = row.priceFormatted, !price.isEmpty {
-                    Text(price)
-                        .font(.callout.weight(.semibold))
-                        .monospacedDigit()
-                }
-                if let distance = row.distanceKm {
-                    Text(String(format: "%.1f km", distance))
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-    }
-}
-
-private extension View {
-    /// iOS 17 requires widgets to adopt `containerBackground(for: .widget)`
-    /// — without it WidgetKit renders a "Please adopt containerBackground
-    /// API" placeholder instead of the widget content. On iOS 16 (our
-    /// deployment target is 16.6) the in-view ZStack background above is
-    /// still the rendering path, so the shim is a no-op there.
-    @ViewBuilder
-    func widgetBackgroundCompat() -> some View {
-        if #available(iOSApplicationExtension 17.0, *) {
-            containerBackground(for: .widget) {
-                Color(.systemBackground)
-            }
-        } else {
-            self
-        }
     }
 }

--- a/ios/TankstellenWidget/PredictiveStationsWidget.swift
+++ b/ios/TankstellenWidget/PredictiveStationsWidget.swift
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Predictive widget (#3171) — Android parity for the `predictive`
+// content variant (#1121, `widget_variants.dart`). Android lets the user
+// flip one widget between variants via the reconfigure activity; iOS
+// `StaticConfiguration` has no such per-widget setting, so the predictive
+// variant ships as its own gallery entry instead — the user picks
+// "Sparkilo — Best time" when adding the widget.
+//
+// Data: reuses the nearest payload (`nearest_json`) — the Dart side
+// attaches the per-row `predictive_*` fields there whenever the on-device
+// price predictor has an actionable forecast, on the same refresh cadence
+// as everything else. Rows without those fields render exactly like the
+// default variant (same graceful fallback as the Kotlin renderer).
+
+import SwiftUI
+import WidgetKit
+
+struct PredictiveStationsWidget: Widget {
+    let kind: String = "PredictiveStationsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: NearestStationsProvider()) { entry in
+            StationListWidgetView(
+                entry: entry,
+                emptyFallback: "No data yet",
+                showPredictive: true
+            )
+        }
+        .configurationDisplayName("Sparkilo — Best time")
+        .description(
+            "Nearby prices plus a hint for the cheapest time to fill up."
+        )
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}

--- a/ios/TankstellenWidget/StationListWidgetView.swift
+++ b/ios/TankstellenWidget/StationListWidgetView.swift
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Shared SwiftUI body for the station-list widgets (#3171): the Nearest,
+// Favorites and Predictive variants all render this view — only the entry
+// source and the `showPredictive` flag differ.
+//
+// Renders one row per station with `widgetURL` set to the
+// `tankstellenwidget://station?id=<id>` deep link so taps follow the
+// same cold-start / warm-click flow Android uses (handled in the
+// Flutter app by `WidgetClickListener` + the router's pending-URI
+// redirect).
+//
+// Visual language deliberately matches the Android renderer: brand /
+// street, price chip (green on the cheapest row, #2600), distance pill,
+// optional predictive "best time to fill" second line (#1121). Keep both
+// in lock-step so the user sees the same widget on both platforms.
+//
+// Localization: dynamic strings arrive pre-localized / pre-formatted from
+// the Dart side via the App-Group payload; the literals here are the
+// brand name and static fallback copy (same convention as
+// `TripRecordingLiveActivity`).
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct StationListWidgetView: View {
+    let entry: NearestStationsEntry
+    /// Copy for the empty state when the entry carries no reason of its own.
+    let emptyFallback: String
+    /// #1121 / #3171 — when true, rows with Dart-attached `predictive_*`
+    /// fields render the compact "best time to fill" second line; rows
+    /// without them keep the default appearance (same per-row fallback as
+    /// the Android VARIANT_PREDICTIVE).
+    var showPredictive: Bool = false
+
+    /// `.systemMedium` shows 3 rows, `.systemLarge` shows 5 (one less in
+    /// predictive mode — the second line costs vertical space).
+    @Environment(\.widgetFamily) private var family
+
+    private var maxRows: Int {
+        let base = family == .systemLarge ? 5 : 3
+        return showPredictive ? max(base - 1, 1) : base
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color(.systemBackground)
+            VStack(alignment: .leading, spacing: 6) {
+                WidgetHeaderView(isStale: entry.isStale)
+                if entry.rows.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(Array(entry.rows.prefix(maxRows))) { row in
+                        Link(destination: row.deepLink) {
+                            StationRowView(
+                                row: row,
+                                showPredictive: showPredictive
+                            )
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+        }
+        .widgetURL(
+            // Fallback tap target for the whole widget (system small +
+            // any tap that misses an individual Link). Routes to the
+            // search screen via a sentinel URI the parser ignores —
+            // the app's redirect chain falls through to its normal
+            // landing without trying to open a station detail.
+            URL(string: "tankstellenwidget://station?id=__widget_root__")
+        )
+        .widgetBackgroundCompat()
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.emptyReason ?? emptyFallback)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Shared header chrome: brand mark, optional stale pill, and — on
+/// iOS 17+ — the interactive AppIntent refresh button (#3171). On iOS 16
+/// the button is simply absent (interactive widgets are an iOS 17
+/// feature; the widget still refreshes on its own timeline policy).
+struct WidgetHeaderView: View {
+    let isStale: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Image(systemName: "fuelpump.fill")
+                .foregroundStyle(.tint)
+            Text("Sparkilo")
+                .font(.caption.weight(.semibold))
+            Spacer()
+            if isStale {
+                Text("stale")
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule().fill(Color.orange.opacity(0.18))
+                    )
+                    .foregroundStyle(.orange)
+            }
+            if #available(iOSApplicationExtension 17.0, *) {
+                Button(intent: WidgetRefreshIntent()) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+struct StationRowView: View {
+    let row: StationRow
+    var showPredictive: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(alignment: .center, spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.displayName)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                    if let street = row.street, street != row.displayName {
+                        Text(street)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    if let price = row.displayPrice {
+                        Text(price)
+                            .font(.callout.weight(.semibold))
+                            .monospacedDigit()
+                            // #2600 parity — the cheapest row's price is
+                            // green, like the Android renderer's
+                            // widget_price_cheap.
+                            .foregroundStyle(
+                                row.isCheapest == true
+                                    ? AnyShapeStyle(.green)
+                                    : AnyShapeStyle(.primary)
+                            )
+                    }
+                    if let distance = row.distanceKm {
+                        Text(String(format: "%.1f km", distance))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+            }
+            if showPredictive, let line = row.predictiveLine {
+                Text(line)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+extension View {
+    /// iOS 17 requires widgets to adopt `containerBackground(for: .widget)`
+    /// — without it WidgetKit renders a "Please adopt containerBackground
+    /// API" placeholder instead of the widget content. On iOS 16 (our
+    /// deployment target is 16.6) the in-view ZStack background above is
+    /// still the rendering path, so the shim is a no-op there.
+    @ViewBuilder
+    func widgetBackgroundCompat() -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            containerBackground(for: .widget) {
+                Color(.systemBackground)
+            }
+        } else {
+            self
+        }
+    }
+}

--- a/ios/TankstellenWidget/StationRow.swift
+++ b/ios/TankstellenWidget/StationRow.swift
@@ -33,6 +33,19 @@ struct StationRow: Codable, Identifiable, Equatable {
     /// convention varies per country and we don't want to duplicate
     /// the rules in Swift.
     let priceFormatted: String?
+    /// #2600 / #3171 — true on the cheapest priced row(s) of the rendered
+    /// set; the views colour that price green (mirrors the Android
+    /// renderer's `widget_price_cheap`).
+    let isCheapest: Bool?
+    /// #1121 / #3171 — predictive "best time to fill" fields the Dart side
+    /// attaches per row when the on-device predictor has an actionable
+    /// forecast (see `buildPredictivePayload` in
+    /// `lib/features/widget/data/predictive_payload.dart`). All nil when
+    /// the prediction isn't actionable — the row then falls back to the
+    /// default price-only appearance, same rule as
+    /// `StationWidgetRenderer.kt`'s VARIANT_PREDICTIVE branch.
+    let predictiveBestLabel: String?
+    let predictiveBestPrice: Double?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -50,6 +63,18 @@ struct StationRow: Codable, Identifiable, Equatable {
         case isOpen
         case currency
         case priceFormatted
+        case isCheapest
+        case predictiveBestLabel = "predictive_best_label"
+        case predictiveBestPrice = "predictive_best_price"
+    }
+
+    /// Decode-only alias (#3171): the nearest real-search payload writes
+    /// the camelCase `distanceKm` while the favorites payload writes the
+    /// legacy snake_case `distance_km` — the Kotlin renderer reads both,
+    /// and so must we (the snake-only decode silently dropped the distance
+    /// pill on every real-search row).
+    private enum LegacyKeys: String, CodingKey {
+        case distanceKm
     }
 
     /// Convenience: best non-empty display label for the row. Mirrors
@@ -68,6 +93,44 @@ struct StationRow: Codable, Identifiable, Equatable {
         return place ?? id
     }
 
+    /// Best displayable price text + the currency symbol, or nil when the
+    /// row has no usable price. Mirrors the Kotlin renderer's fallback
+    /// chain (#3171 favorites parity): the Dart pre-formatted string wins
+    /// (nearest payload), then the raw preferred-fuel double (favorites
+    /// payload), then the e10 fallback.
+    var displayPrice: String? {
+        if let formatted = priceFormatted, !formatted.isEmpty {
+            return appendCurrency(to: formatted)
+        }
+        if let price = preferredFuelPrice {
+            return appendCurrency(to: String(format: "%.3f", price))
+        }
+        if let fallback = e10 {
+            return appendCurrency(to: String(format: "%.3f", fallback))
+        }
+        return nil
+    }
+
+    /// The predictive second line, or nil when the Dart side attached no
+    /// actionable forecast. Format mirrors `StationWidgetRenderer.kt`:
+    /// "now 1.840 € · Prices typically drop Tuesday 6-8 PM ~1.790 €".
+    var predictiveLine: String? {
+        guard
+            let label = predictiveBestLabel, !label.isEmpty,
+            let bestPrice = predictiveBestPrice
+        else { return nil }
+        let best = appendCurrency(to: String(format: "%.3f", bestPrice))
+        if let now = displayPrice {
+            return "now \(now) · \(label) ~\(best)"
+        }
+        return "\(label) ~\(best)"
+    }
+
+    private func appendCurrency(to text: String) -> String {
+        guard let currency = currency, !currency.isEmpty else { return text }
+        return "\(text) \(currency)"
+    }
+
     /// `widgetURL(_:)` target — exact mirror of the Android
     /// `tankstellenwidget://station?id=<id>` PendingIntent URI the
     /// `StationWidgetRenderer` emits. The Flutter app's
@@ -76,5 +139,41 @@ struct StationRow: Codable, Identifiable, Equatable {
     var deepLink: URL {
         URL(string: "tankstellenwidget://station?id=\(id)")
             ?? URL(string: "tankstellenwidget://station")!
+    }
+}
+
+extension StationRow {
+    /// Custom decode so the snake/camel distance aliases both land in
+    /// [distanceKm]. Everything else is a plain `decodeIfPresent` mirror
+    /// of the synthesized decoder. (Lives in an extension so the
+    /// memberwise initializer the placeholder entries use stays
+    /// synthesized.)
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        brand = try c.decodeIfPresent(String.self, forKey: .brand)
+        name = try c.decodeIfPresent(String.self, forKey: .name)
+        street = try c.decodeIfPresent(String.self, forKey: .street)
+        postCode = try c.decodeIfPresent(String.self, forKey: .postCode)
+        place = try c.decodeIfPresent(String.self, forKey: .place)
+        e5 = try c.decodeIfPresent(Double.self, forKey: .e5)
+        e10 = try c.decodeIfPresent(Double.self, forKey: .e10)
+        diesel = try c.decodeIfPresent(Double.self, forKey: .diesel)
+        preferredFuelCode =
+            try c.decodeIfPresent(String.self, forKey: .preferredFuelCode)
+        preferredFuelPrice =
+            try c.decodeIfPresent(Double.self, forKey: .preferredFuelPrice)
+        let legacy = try decoder.container(keyedBy: LegacyKeys.self)
+        distanceKm = try c.decodeIfPresent(Double.self, forKey: .distanceKm)
+            ?? legacy.decodeIfPresent(Double.self, forKey: .distanceKm)
+        isOpen = try c.decodeIfPresent(Bool.self, forKey: .isOpen)
+        currency = try c.decodeIfPresent(String.self, forKey: .currency)
+        priceFormatted =
+            try c.decodeIfPresent(String.self, forKey: .priceFormatted)
+        isCheapest = try c.decodeIfPresent(Bool.self, forKey: .isCheapest)
+        predictiveBestLabel =
+            try c.decodeIfPresent(String.self, forKey: .predictiveBestLabel)
+        predictiveBestPrice =
+            try c.decodeIfPresent(Double.self, forKey: .predictiveBestPrice)
     }
 }

--- a/ios/TankstellenWidget/TankstellenWidget.swift
+++ b/ios/TankstellenWidget/TankstellenWidget.swift
@@ -3,14 +3,17 @@
 
 // Widget extension bundle entry point.
 //
-// Defines the Nearest-Stations widget and registers it with the WidgetKit
-// runtime. Pair widget for the Cheapest / Favourites variant can be added
-// alongside `NearestStationsWidget` inside the `WidgetBundle` body once a
-// dedicated provider lands.
+// Registers the three station-list widgets (#3171 — Nearest, Favorites,
+// Predictive; Android-parity for `StationWidgetRenderer.kt`'s modes +
+// the #1121 predictive variant) and the trip Live Activity (#3170) with
+// the WidgetKit runtime.
 //
-// Shape mirrors the Android `StationWidgetRenderer`'s NearestStations row
-// — same JSON contract under the shared App Group UserDefaults so a single
-// Dart write path (`HomeWidgetService.updateWidget`) feeds both platforms.
+// Shape mirrors the Android `StationWidgetRenderer`'s row — same JSON
+// contract under the shared App Group UserDefaults so a single Dart
+// write path (`HomeWidgetService`) feeds both platforms. The `kind`
+// strings here MUST stay in lock-step with `kIosWidgetKinds` in
+// `lib/features/widget/data/impl/widget_reload_dispatcher.dart` — that
+// list is what the Dart side reloads after every data write.
 
 import SwiftUI
 import WidgetKit
@@ -19,6 +22,9 @@ import WidgetKit
 struct TankstellenWidgetBundle: WidgetBundle {
     var body: some Widget {
         NearestStationsWidget()
+        // #3171 — favorites + predictive variants (Android parity).
+        FavoriteStationsWidget()
+        PredictiveStationsWidget()
         // #3170 — trip-recording / approach-radar Live Activity
         // (Dynamic Island + lock screen), driven by the Runner-side
         // LiveActivityBridge over `tankstellen/live_activity`.

--- a/ios/TankstellenWidget/WidgetRefreshIntent.swift
+++ b/ios/TankstellenWidget/WidgetRefreshIntent.swift
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Interactive AppIntent behind the widgets' refresh button (#3171,
+// iOS 17+ — iOS 16 widgets are render-only, the button is simply not
+// shown there).
+//
+// A widget extension has no network stack and no Dart runtime, so the
+// intent cannot fetch fresh prices itself (unlike the Android
+// ACTION_REFRESH broadcast, which enqueues the `widgetRefreshScan`
+// WorkManager task — an OS capability iOS widgets don't have; see the
+// issue's "refresh-triggered SCAN stays Android-only" note). What it CAN
+// do, and does:
+//
+//   1. Write a manual-refresh request timestamp into the shared App-Group
+//      store (`widget_manual_refresh_requested_at` — same key the Dart
+//      foreground heartbeat reads, see
+//      `lib/features/widget/data/impl/widget_reload_dispatcher.dart`).
+//      The next heartbeat tick lets the request bypass the #3157
+//      freshness/movement gate, so a running/next-opened app re-fetches
+//      immediately — no new background wake-ups are added.
+//   2. Reload every widget timeline so the views re-read whatever is in
+//      the store right now (instant feedback when the host app already
+//      wrote fresher data than the last timeline snapshot).
+
+import AppIntents
+import Foundation
+import WidgetKit
+
+@available(iOS 17.0, *)
+struct WidgetRefreshIntent: AppIntent {
+    static var title: LocalizedStringResource = "Refresh prices"
+    static var description = IntentDescription(
+        "Re-reads the latest synced prices and asks Sparkilo to fetch fresh ones."
+    )
+
+    /// Keep in lock-step with `kWidgetManualRefreshRequestedAtKey` on the
+    /// Dart side (`impl/widget_reload_dispatcher.dart`).
+    static let manualRefreshKey = "widget_manual_refresh_requested_at"
+
+    func perform() async throws -> some IntentResult {
+        if let defaults = UserDefaults(suiteName: kTankstellenAppGroupId) {
+            defaults.set(
+                ISO8601DateFormatter().string(from: Date()),
+                forKey: Self.manualRefreshKey
+            )
+        }
+        WidgetCenter.shared.reloadAllTimelines()
+        return .result()
+    }
+}

--- a/lib/features/widget/data/home_widget_json.dart
+++ b/lib/features/widget/data/home_widget_json.dart
@@ -22,3 +22,29 @@ import 'dart:convert';
 String encodeStationsForWidget(List<Map<String, dynamic>> stations) {
   return jsonEncode(stations);
 }
+
+/// #2600 / #3171 — mark the cheapest priced row(s) with `isCheapest: true`
+/// so the native renderers (Kotlin `StationWidgetRenderer`, Swift
+/// `StationRow`) colour their price green. Operates in place on the
+/// already-built [rows]. Rows with a null/absent `preferred_fuel_price`
+/// are ignored (never the cheapest). When two rows tie at the minimum,
+/// both are flagged — honest, and a rare edge anyway.
+///
+/// Shared between the nearest payload (`NearestWidgetDataBuilder`) and the
+/// favorites payload (`HomeWidgetService._buildStationList`, #3171 — the
+/// iOS favorites variant reads the same flag) so the two JSON shapes stay
+/// in lock-step.
+void flagCheapestRows(List<Map<String, dynamic>> rows) {
+  double? minPrice;
+  for (final row in rows) {
+    final p = (row['preferred_fuel_price'] as num?)?.toDouble();
+    if (p == null) continue;
+    if (minPrice == null || p < minPrice) minPrice = p;
+  }
+  // Always write the key (false when no row is priced) so the field is a
+  // predictable bool the native renderer reads with a `false` default.
+  for (final row in rows) {
+    final p = (row['preferred_fuel_price'] as num?)?.toDouble();
+    row['isCheapest'] = minPrice != null && p != null && p == minPrice;
+  }
+}

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -19,6 +19,7 @@ import '../../../core/utils/geo_utils.dart' as geo;
 import '../../profile/data/models/user_profile.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import 'home_widget_json.dart';
+import 'impl/widget_reload_dispatcher.dart';
 import 'nearest_widget_data_builder.dart';
 import 'predictive_payload.dart';
 import '../../../core/logging/error_logger.dart';
@@ -60,28 +61,10 @@ String get _widgetGroupId =>
 // and nearest modes internally. The old NearestWidgetProvider receiver
 // was dropped from the manifest.
 
-/// #2206 — the AppWidgetProvider lives in the Gradle **namespace**
-/// `de.tankstellen.tankstellen` (the manifest `.FuelPriceWidgetProvider`
-/// receiver), which differs from the **applicationId**
-/// `de.tankstellen.fuelprices`. home_widget's `updateWidget` resolves the
-/// short `androidName` against the applicationId
-/// (`${packageName}.${androidName}`), so it looked for
-/// `de.tankstellen.fuelprices.FuelPriceWidgetProvider` and threw
-/// `ClassNotFoundException` on every update.
-///
-/// home_widget 0.9.2 resolves the provider class as
-/// `Class.forName(qualifiedAndroidName ?? "${packageName}.${androidName}")`
-/// — when `qualifiedAndroidName` is non-null it is used **as-is** and the
-/// short name is ignored for resolution. BUT the plugin's
-/// `ClassNotFoundException` message always prints the SHORT `androidName`
-/// ("No Widget found with Name FuelPriceWidgetProvider"), which made the
-/// device log misleading. We therefore pass ONLY the fully-qualified name
-/// at every call site (no short `androidName`), so the qualified class is
-/// always resolved and a future failure message reports `null` rather
-/// than the wrong short name. (#2207 field follow-up.)
-// i18n-ignore: Android class identifier, not user-facing text.
-const _widgetQualifiedAndroidName =
-    'de.tankstellen.tankstellen.FuelPriceWidgetProvider';
+// #2206 / #3171 — the per-platform "re-render the native widgets" call
+// (fully-qualified Android provider name, per-kind iOS timeline reloads)
+// lives in `impl/widget_reload_dispatcher.dart`; every update path below
+// finishes with `notifyNativeWidgets()`.
 
 /// Maximum number of stations to include in widget data.
 const _maxWidgetStations = 5;
@@ -118,9 +101,7 @@ class HomeWidgetService {
       if (favoriteIds.isEmpty) {
         await HomeWidget.saveWidgetData('station_count', 0);
         await HomeWidget.saveWidgetData('stations_json', '[]');
-        await HomeWidget.updateWidget(
-          qualifiedAndroidName: _widgetQualifiedAndroidName,
-        );
+        await notifyNativeWidgets();
         return;
       }
 
@@ -147,9 +128,7 @@ class HomeWidgetService {
       // backward compatibility.
       await _writeGlobalWidgetDefaults(profileStorage);
 
-      await HomeWidget.updateWidget(
-        qualifiedAndroidName: _widgetQualifiedAndroidName,
-      );
+      await notifyNativeWidgets();
       debugPrint('HomeWidget: favorites updated with ${stations.length} stations');
     } catch (e, st) {
       _logWidgetUpdateFailure(e, st, 'HomeWidget: favorites update failed');
@@ -183,9 +162,7 @@ class HomeWidgetService {
           pricePredictor: pricePredictor,
         );
         final payload = await builder.build();
-        await HomeWidget.updateWidget(
-          qualifiedAndroidName: _widgetQualifiedAndroidName,
-        );
+        await notifyNativeWidgets();
         debugPrint(
           'HomeWidget: nearest (real search) updated — '
           'count=${payload.stations.length} '
@@ -212,9 +189,7 @@ class HomeWidgetService {
           lat == null || lng == null ? 'no_gps' : 'no_favorites',
         );
         await HomeWidget.saveWidgetData('nearest_is_stale', false);
-        await HomeWidget.updateWidget(
-          qualifiedAndroidName: _widgetQualifiedAndroidName,
-        );
+        await notifyNativeWidgets();
         return;
       }
 
@@ -249,9 +224,7 @@ class HomeWidgetService {
       await HomeWidget.saveWidgetData('nearest_lat', lat);
       await HomeWidget.saveWidgetData('nearest_lng', lng);
 
-      await HomeWidget.updateWidget(
-        qualifiedAndroidName: _widgetQualifiedAndroidName,
-      );
+      await notifyNativeWidgets();
       debugPrint('HomeWidget: nearest updated with ${stations.length} stations');
     } catch (e, st) {
       _logWidgetUpdateFailure(e, st, 'HomeWidget: nearest update failed');
@@ -279,6 +252,10 @@ class HomeWidgetService {
         ));
       }
     }
+    // #3171 — parity with the nearest payload: flag the cheapest priced
+    // row(s) so the native renderers can colour their price green in the
+    // favorites variant too.
+    flagCheapestRows(stations);
     return stations;
   }
 

--- a/lib/features/widget/data/impl/widget_reload_dispatcher.dart
+++ b/lib/features/widget/data/impl/widget_reload_dispatcher.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:home_widget/home_widget.dart';
+
+/// Platform dispatch for the "tell the native home-screen widgets to
+/// re-render" step (#3171). Lives in `impl/` per the plugin-pattern rule
+/// (#2350) — this is the one place the widget feature branches on the
+/// runtime platform.
+///
+/// #2206 — the Android AppWidgetProvider lives in the Gradle **namespace**
+/// `de.tankstellen.tankstellen` (the manifest `.FuelPriceWidgetProvider`
+/// receiver), which differs from the **applicationId**
+/// `de.tankstellen.fuelprices`. home_widget's `updateWidget` resolves the
+/// short `androidName` against the applicationId
+/// (`${packageName}.${androidName}`), so it looked for
+/// `de.tankstellen.fuelprices.FuelPriceWidgetProvider` and threw
+/// `ClassNotFoundException` on every update.
+///
+/// home_widget 0.9.2+ resolves the provider class as
+/// `Class.forName(qualifiedAndroidName ?? "${packageName}.${androidName}")`
+/// — when `qualifiedAndroidName` is non-null it is used **as-is** and the
+/// short name is ignored for resolution. BUT the plugin's
+/// `ClassNotFoundException` message always prints the SHORT `androidName`
+/// ("No Widget found with Name FuelPriceWidgetProvider"), which made the
+/// device log misleading. We therefore pass ONLY the fully-qualified name
+/// (no short `androidName`), so the qualified class is always resolved and
+/// a future failure message reports `null` rather than the wrong short
+/// name. (#2207 field follow-up.)
+// i18n-ignore: Android class identifier, not user-facing text.
+const kWidgetQualifiedAndroidName =
+    'de.tankstellen.tankstellen.FuelPriceWidgetProvider';
+
+/// WidgetKit `kind` strings of every widget in the iOS
+/// `TankstellenWidgetBundle` (#3171). MUST stay in lock-step with the
+/// `kind` literals in `ios/TankstellenWidget/TankstellenWidget.swift` —
+/// home_widget's iOS `updateWidget` maps each name straight to
+/// `WidgetCenter.reloadTimelines(ofKind:)`, so a missing/misspelled entry
+/// means that widget silently stops refreshing when the Dart side writes
+/// new data.
+// i18n-ignore: WidgetKit kind identifiers, not user-facing text.
+const kIosWidgetKinds = <String>[
+  'NearestStationsWidget',
+  'FavoriteStationsWidget',
+  'PredictiveStationsWidget',
+];
+
+/// App-Group UserDefaults key the iOS widget's AppIntent refresh button
+/// (iOS 17+, #3171) writes an ISO-8601 timestamp to. The Dart foreground
+/// heartbeat reads it and lets a request newer than the last completed
+/// refresh bypass the #3157 freshness/movement gate — no new wake-ups,
+/// the nudge is consumed by the existing 2-minute tick. Keep in lock-step
+/// with `kWidgetManualRefreshRequestedAtKey` in
+/// `ios/TankstellenWidget/WidgetRefreshIntent.swift`.
+// i18n-ignore: storage key, not user-facing text.
+const kWidgetManualRefreshRequestedAtKey =
+    'widget_manual_refresh_requested_at';
+
+/// Test seam: forces [notifyNativeWidgets] down the iOS (`true`) or
+/// Android (`false`) branch regardless of the host platform, so both
+/// dispatch shapes are assertable from a desktop test runner. Production
+/// never sets it.
+@visibleForTesting
+bool? debugNotifyNativeWidgetsIsIos;
+
+/// Ask the native side to re-render every home-screen widget after the
+/// Dart writers have updated the shared store.
+///
+/// - **Android** — one `updateWidget` with the fully-qualified provider
+///   class (#2206); the single `FuelPriceWidgetProvider` renders every
+///   mode/variant itself.
+/// - **iOS** — one `reloadTimelines(ofKind:)` per WidgetKit kind in
+///   [kIosWidgetKinds] (#3171). The home_widget iOS plugin REQUIRES a
+///   name: the previous Android-only call surfaced as a benign-looking
+///   `PlatformException(-3)` and no iOS widget ever reloaded off a Dart
+///   write — they coasted on their own 15-minute timeline policy.
+Future<void> notifyNativeWidgets() async {
+  final isIos =
+      debugNotifyNativeWidgetsIsIos ?? (!kIsWeb && Platform.isIOS);
+  if (isIos) {
+    for (final kind in kIosWidgetKinds) {
+      await HomeWidget.updateWidget(iOSName: kind);
+    }
+    return;
+  }
+  await HomeWidget.updateWidget(
+    qualifiedAndroidName: kWidgetQualifiedAndroidName,
+  );
+}

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -16,6 +16,7 @@ import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/utils/station_extensions.dart';
+import 'home_widget_json.dart';
 import 'predictive_payload.dart';
 import '../../../core/logging/error_logger.dart';
 
@@ -208,8 +209,9 @@ class NearestWidgetDataBuilder {
       // can colour the price green. Rows are ordered by distance, so the
       // cheapest is not necessarily first; mark every row whose preferred
       // fuel price equals the minimum across the rendered set. Rows with no
-      // price are never the cheapest.
-      _flagCheapest(rows);
+      // price are never the cheapest. (#3171 — moved to the shared
+      // `flagCheapestRows` so the favorites payload carries the same flag.)
+      flagCheapestRows(rows);
 
       final payload = NearestWidgetPayload(
         stations: rows,
@@ -333,26 +335,6 @@ class NearestWidgetDataBuilder {
       'diesel': station.diesel,
       if (predictive != null) ...predictive,
     };
-  }
-
-  /// #2600 — mark the cheapest priced row(s) with `isCheapest: true` so the
-  /// native widget colours their price green. Operates in place on the
-  /// already-built [rows]. Rows with a null/absent `preferred_fuel_price`
-  /// are ignored (never the cheapest). When two rows tie at the minimum,
-  /// both are flagged — honest, and a rare edge anyway.
-  static void _flagCheapest(List<Map<String, dynamic>> rows) {
-    double? minPrice;
-    for (final row in rows) {
-      final p = (row['preferred_fuel_price'] as num?)?.toDouble();
-      if (p == null) continue;
-      if (minPrice == null || p < minPrice) minPrice = p;
-    }
-    // Always write the key (false when no row is priced) so the field is a
-    // predictable bool the native renderer reads with a `false` default.
-    for (final row in rows) {
-      final p = (row['preferred_fuel_price'] as num?)?.toDouble();
-      row['isCheapest'] = minPrice != null && p != null && p == minPrice;
-    }
   }
 
   Future<void> _persist(

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'package:home_widget/home_widget.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/cache/cache_manager.dart' show CacheKey, CacheTtl;
@@ -14,6 +15,7 @@ import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../price_history/providers/price_prediction_provider.dart';
 import '../data/home_widget_service.dart';
+import '../data/impl/widget_reload_dispatcher.dart';
 import '../../../core/logging/error_logger.dart';
 
 part 'nearest_widget_refresh_provider.g.dart';
@@ -113,9 +115,20 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
       // stored position is still inside the same cache-key cell (the same
       // rounding `CacheKey.stationSearch` uses) — the search chain would
       // only re-serve its cached result anyway.
+      //
+      // #3171 — EXCEPT when the iOS widget's AppIntent refresh button has
+      // written a manual-refresh request newer than the last completed
+      // refresh into the shared App-Group store. The nudge is consumed by
+      // this existing tick (no new wake-ups): once the refresh below
+      // completes, `_lastNearestRefreshAt` moves past the request
+      // timestamp, so the same nudge can never bypass the gate twice.
       final posKey = _positionCellKey(storage);
       final last = _lastNearestRefreshAt;
-      if (last != null &&
+      final manualRequestedAt = await _readManualRefreshRequest();
+      final manualPending = manualRequestedAt != null &&
+          (last == null || manualRequestedAt.isAfter(last));
+      if (!manualPending &&
+          last != null &&
           debugNow().difference(last) < CacheTtl.stationSearch &&
           posKey == _lastNearestRefreshPosKey) {
         return;
@@ -138,6 +151,25 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
       _lastNearestRefreshPosKey = posKey;
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'NearestWidgetRefresh: tick failed'}));
+    }
+  }
+
+  /// #3171 — the ISO-8601 timestamp the iOS widget's AppIntent refresh
+  /// button (iOS 17+) last wrote into the shared App-Group store, or null
+  /// when the key is absent/unparsable. Read through the same `home_widget`
+  /// bridge every other widget key uses — no new mechanism. Non-fatal on
+  /// failure: a broken read just means the gate stays in force.
+  Future<DateTime?> _readManualRefreshRequest() async {
+    try {
+      final iso = await HomeWidget.getWidgetData<String>(
+        kWidgetManualRefreshRequestedAtKey,
+      );
+      return iso == null ? null : DateTime.tryParse(iso);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {
+        'where': 'NearestWidgetRefresh: manual refresh request read failed',
+      }));
+      return null;
     }
   }
 

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -102,7 +102,7 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'2f266f61976160afb58de2ba78898124e1aa79e8';
+    r'5fc55400421ae8efc10a112b5e01e85ca36600bf';
 
 /// Foreground heartbeat that rebuilds the home-screen widget — both the
 /// favorites and the nearest variants — every

--- a/scripts/add_widget_variant_sources.rb
+++ b/scripts/add_widget_variant_sources.rb
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# Wires the widget-variant Swift sources (#3171 — favorites + predictive
+# widgets, shared list view, AppIntent refresh) into ios/Runner.xcodeproj,
+# following the reproducible pbxproj-wiring pattern established by
+# scripts/add_ios_widget_target.rb (#3166) and
+# scripts/add_live_activity_sources.rb (#3170).
+#
+# All four files are SwiftUI / AppIntents surfaces rendered inside the
+# widget process, so they are compiled into the TankstellenWidget
+# extension target ONLY:
+#   1. TankstellenWidget/StationListWidgetView.swift — shared list body
+#      (header w/ iOS-17 refresh button, rows, predictive line).
+#   2. TankstellenWidget/FavoriteStationsWidget.swift — favorites variant.
+#   3. TankstellenWidget/PredictiveStationsWidget.swift — predictive variant.
+#   4. TankstellenWidget/WidgetRefreshIntent.swift — iOS-17 AppIntent that
+#      nudges the Dart side through the shared App-Group store.
+#
+# Idempotent: files already referenced / already in the target's sources
+# are skipped, so re-running is a no-op.
+#
+# Usage (from the repo root):
+#   ruby scripts/add_widget_variant_sources.rb
+
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../ios/Runner.xcodeproj', __dir__)
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+widget = project.targets.find { |t| t.name == 'TankstellenWidget' }
+abort 'TankstellenWidget target not found — run scripts/add_ios_widget_target.rb first' unless widget
+
+widget_group = project.main_group.children.find do |c|
+  c.is_a?(Xcodeproj::Project::Object::PBXGroup) && c.name == 'TankstellenWidget'
+end
+abort 'TankstellenWidget group not found' unless widget_group
+
+# Find-or-create a file reference for +path+ inside +group+.
+def file_ref(group, path)
+  group.files.find { |f| f.path == path } || group.new_file(path)
+end
+
+# Add +ref+ to +target+'s compile sources unless already present.
+def compile(target, ref)
+  already = target.source_build_phase.files_references.include?(ref)
+  target.source_build_phase.add_file_reference(ref, true) unless already
+  puts "#{target.name}: #{ref.path} #{already ? 'already compiled' : 'added'}"
+end
+
+%w[
+  StationListWidgetView.swift
+  FavoriteStationsWidget.swift
+  PredictiveStationsWidget.swift
+  WidgetRefreshIntent.swift
+].each do |source|
+  compile(widget, file_ref(widget_group, source))
+end
+
+project.save
+puts "Saved #{PROJECT_PATH}"

--- a/test/features/widget/data/home_widget_json_test.dart
+++ b/test/features/widget/data/home_widget_json_test.dart
@@ -111,4 +111,69 @@ void main() {
       expect(entry.containsKey('closedReason'), isTrue);
     });
   });
+
+  // #2600 / #3171 — shared cheapest-row flagging (moved out of
+  // NearestWidgetDataBuilder so the favorites payload carries the same
+  // `isCheapest` flag the iOS favorites variant + Android renderer read).
+  group('flagCheapestRows', () {
+    test('flags exactly the minimum-priced row, false on the rest', () {
+      final rows = <Map<String, dynamic>>[
+        {'id': 'a', 'preferred_fuel_price': 1.85},
+        {'id': 'b', 'preferred_fuel_price': 1.79},
+        {'id': 'c', 'preferred_fuel_price': 1.92},
+      ];
+
+      flagCheapestRows(rows);
+
+      expect(rows[0]['isCheapest'], isFalse);
+      expect(rows[1]['isCheapest'], isTrue);
+      expect(rows[2]['isCheapest'], isFalse);
+    });
+
+    test('rows without a price are never the cheapest but still get the '
+        'key (predictable bool for the native readers)', () {
+      final rows = <Map<String, dynamic>>[
+        {'id': 'a'},
+        {'id': 'b', 'preferred_fuel_price': 1.79},
+      ];
+
+      flagCheapestRows(rows);
+
+      expect(rows[0]['isCheapest'], isFalse);
+      expect(rows[1]['isCheapest'], isTrue);
+    });
+
+    test('all rows unpriced — every flag is false, none missing', () {
+      final rows = <Map<String, dynamic>>[
+        {'id': 'a'},
+        {'id': 'b'},
+      ];
+
+      flagCheapestRows(rows);
+
+      for (final row in rows) {
+        expect(row['isCheapest'], isFalse);
+      }
+    });
+
+    test('ties at the minimum flag every tied row', () {
+      final rows = <Map<String, dynamic>>[
+        {'id': 'a', 'preferred_fuel_price': 1.79},
+        {'id': 'b', 'preferred_fuel_price': 1.79},
+        {'id': 'c', 'preferred_fuel_price': 1.99},
+      ];
+
+      flagCheapestRows(rows);
+
+      expect(rows[0]['isCheapest'], isTrue);
+      expect(rows[1]['isCheapest'], isTrue);
+      expect(rows[2]['isCheapest'], isFalse);
+    });
+
+    test('empty list is a no-op', () {
+      final rows = <Map<String, dynamic>>[];
+      expect(() => flagCheapestRows(rows), returnsNormally);
+      expect(rows, isEmpty);
+    });
+  });
 }

--- a/test/features/widget/data/widget_reload_dispatcher_test.dart
+++ b/test/features/widget/data/widget_reload_dispatcher_test.dart
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Tests for the per-platform native-widget reload dispatch (#3171).
+//
+// Three concerns:
+//
+//   1. **Dispatch shape** — on iOS the home_widget plugin REQUIRES a
+//      widget name (`reloadTimelines(ofKind:)`), so the dispatcher must
+//      issue one `updateWidget` per WidgetKit kind with the `ios` arg
+//      set. On Android it must keep the single fully-qualified-name call
+//      (#2206/#2207 — short `android` name stays null).
+//
+//   2. **Swift lock-step guards** — `kIosWidgetKinds` must match the
+//      `kind` literals in the widget extension, and the manual-refresh
+//      UserDefaults key must match the one `WidgetRefreshIntent.swift`
+//      writes. Drift on either side silently kills reloads / the refresh
+//      button, so the contract is pinned here.
+//
+//   3. **Favorites payload content** — the favorites snapshot the iOS
+//      Favorites widget renders must carry the `isCheapest` flag
+//      (#2600-parity with the nearest payload).
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/widget/data/home_widget_service.dart';
+import 'package:tankstellen/features/widget/data/impl/widget_reload_dispatcher.dart';
+
+import '../../../fakes/fake_hive_storage.dart';
+import '../../../fakes/fake_storage_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('home_widget');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late List<MethodCall> calls;
+
+  setUp(() {
+    calls = [];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'getInstalledWidgets') return <dynamic>[];
+      return true;
+    });
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    debugNotifyNativeWidgetsIsIos = null;
+  });
+
+  List<MethodCall> updateCalls() =>
+      calls.where((c) => c.method == 'updateWidget').toList();
+
+  group('notifyNativeWidgets dispatch (#3171)', () {
+    test('iOS: one reload per WidgetKit kind, `ios` arg set, no Android '
+        'name', () async {
+      debugNotifyNativeWidgetsIsIos = true;
+
+      await notifyNativeWidgets();
+
+      final updates = updateCalls();
+      expect(updates, hasLength(kIosWidgetKinds.length));
+      final reloadedKinds = updates.map((c) {
+        final args = (c.arguments as Map).cast<String, dynamic>();
+        expect(args['qualifiedAndroidName'], isNull,
+            reason: 'the iOS branch must not carry Android resolution args');
+        expect(args['android'], isNull);
+        return args['ios'] as String?;
+      }).toList();
+      expect(reloadedKinds, kIosWidgetKinds,
+          reason: 'every kind in the bundle must be reloaded — a missing '
+              'kind silently stops that widget from refreshing on writes');
+    });
+
+    test('Android: single call with ONLY the fully-qualified provider name '
+        '(#2206/#2207)', () async {
+      debugNotifyNativeWidgetsIsIos = false;
+
+      await notifyNativeWidgets();
+
+      final updates = updateCalls();
+      expect(updates, hasLength(1));
+      final args = (updates.single.arguments as Map).cast<String, dynamic>();
+      expect(args['qualifiedAndroidName'], kWidgetQualifiedAndroidName);
+      expect(args['android'], isNull,
+          reason: 'the short androidName must stay null so a failure can '
+              'never report the wrong (short) name');
+      expect(args['ios'], isNull);
+    });
+  });
+
+  group('Swift lock-step guards (#3171)', () {
+    // Repo-relative — `flutter test` runs from the package root.
+    final widgetDir = Directory('ios/TankstellenWidget');
+
+    test('kIosWidgetKinds matches the `kind` literals in the widget '
+        'extension', () {
+      final kindPattern =
+          RegExp(r'let kind: String = "([A-Za-z]+)"', multiLine: true);
+      final swiftKinds = <String>{};
+      for (final entity in widgetDir.listSync()) {
+        if (entity is! File || !entity.path.endsWith('.swift')) continue;
+        for (final m in kindPattern.allMatches(entity.readAsStringSync())) {
+          swiftKinds.add(m.group(1)!);
+        }
+      }
+      expect(swiftKinds, kIosWidgetKinds.toSet(),
+          reason: 'kIosWidgetKinds and the Swift `kind` literals break '
+              'together — a drift means a widget that never reloads when '
+              'the Dart side writes new data');
+    });
+
+    test('manual-refresh UserDefaults key matches WidgetRefreshIntent.swift',
+        () {
+      final intentSource =
+          File('ios/TankstellenWidget/WidgetRefreshIntent.swift')
+              .readAsStringSync();
+      expect(
+        intentSource,
+        contains('"$kWidgetManualRefreshRequestedAtKey"'),
+        reason: 'the AppIntent writes — and the Dart heartbeat reads — '
+            'this exact key; a drift makes the refresh button a no-op',
+      );
+    });
+  });
+
+  group('favorites payload content (#3171 — iOS favorites variant)', () {
+    test('stations_json rows carry isCheapest, true only on the '
+        'minimum-priced favorite', () async {
+      final fake = FakeHiveStorage();
+      await fake.saveProfile('p1', const {
+        'id': 'p1',
+        'name': 'Std',
+        'preferredFuelType': 'e10',
+        'defaultSearchRadius': 10.0,
+      });
+      await fake.setActiveProfileId('p1');
+      await fake.addFavorite('de-cheap');
+      await fake.addFavorite('de-pricey');
+      await fake.saveFavoriteStationData('de-cheap', const {
+        'brand': 'Jet',
+        'street': 'A-Str. 1',
+        'lat': 52.5,
+        'lng': 13.4,
+        'e10': 1.799,
+        'isOpen': true,
+      });
+      await fake.saveFavoriteStationData('de-pricey', const {
+        'brand': 'Aral',
+        'street': 'B-Str. 2',
+        'lat': 52.6,
+        'lng': 13.5,
+        'e10': 1.899,
+        'isOpen': true,
+      });
+      final storage = FakeStorageRepository(inner: fake);
+
+      await HomeWidgetService.updateWidget(
+        storage,
+        profileStorage: storage,
+        settingsStorage: storage,
+      );
+
+      final saved = calls
+          .where((c) =>
+              c.method == 'saveWidgetData' &&
+              (c.arguments as Map)['id'] == 'stations_json')
+          .toList();
+      expect(saved, isNotEmpty,
+          reason: 'updateWidget must write the favorites snapshot');
+      final rows = (jsonDecode(
+        (saved.last.arguments as Map)['data'] as String,
+      ) as List)
+          .cast<Map<String, dynamic>>();
+      expect(rows, hasLength(2));
+
+      final byId = {for (final r in rows) r['id'] as String: r};
+      expect(byId['de-cheap']!['isCheapest'], isTrue);
+      expect(byId['de-pricey']!['isCheapest'], isFalse);
+    });
+  });
+}

--- a/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
+++ b/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
@@ -29,6 +29,7 @@ import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/widget/data/impl/widget_reload_dispatcher.dart';
 import 'package:tankstellen/features/widget/providers/nearest_widget_refresh_provider.dart';
 import '../../../helpers/silence_error_logger.dart';
 
@@ -310,6 +311,110 @@ void main() {
             reason: 'leaving the cache-key cell means the cached result no '
                 'longer answers the new position — refresh now even inside '
                 'the TTL');
+      });
+
+      // #3171 — the iOS widget's AppIntent refresh button writes an
+      // ISO-8601 request timestamp into the shared store. A request newer
+      // than the last completed refresh must bypass the gate exactly once
+      // (the completed refresh moves `_lastNearestRefreshAt` past it); a
+      // stale request must not defeat the gate.
+      group('manual refresh nudge (#3171)', () {
+        /// Re-wires the home_widget channel mock so `getWidgetData` on the
+        /// manual-refresh key returns [iso] (null = key absent).
+        void wireManualRefreshRequest(String? iso) {
+          messenger.setMockMethodCallHandler(homeWidgetChannel, (call) async {
+            if (call.method == 'getWidgetData') {
+              final id = (call.arguments as Map)['id'];
+              if (id == kWidgetManualRefreshRequestedAtKey) return iso;
+              return null;
+            }
+            if (call.method == 'getInstalledWidgets') return <dynamic>[];
+            if (call.method == 'updateWidget') return true;
+            return null;
+          });
+        }
+
+        test('a request newer than the last refresh bypasses the gate',
+            () async {
+          final c = makeContainer();
+          addTearDown(c.dispose);
+          final start = DateTime(2026, 6, 10, 12, 0);
+          final notifier = await arm(c, start);
+          final after = countingService.searchCalls;
+
+          // The user taps the widget's refresh button 30s after the last
+          // refresh; the next tick is still inside the TTL + unmoved.
+          wireManualRefreshRequest(
+            start.add(const Duration(seconds: 30)).toIso8601String(),
+          );
+          notifier.debugNow = () => start.add(const Duration(minutes: 1));
+          await notifier.debugTick();
+
+          expect(countingService.searchCalls, after + 1,
+              reason: 'a manual-refresh request newer than the last '
+                  'completed refresh must bypass the freshness/movement '
+                  'gate');
+        });
+
+        test('the same request does not bypass the gate twice (consumed by '
+            'the refresh it triggered)', () async {
+          final c = makeContainer();
+          addTearDown(c.dispose);
+          final start = DateTime(2026, 6, 10, 12, 0);
+          final notifier = await arm(c, start);
+
+          wireManualRefreshRequest(
+            start.add(const Duration(seconds: 30)).toIso8601String(),
+          );
+          notifier.debugNow = () => start.add(const Duration(minutes: 1));
+          await notifier.debugTick();
+          final afterBypass = countingService.searchCalls;
+
+          // Same request still in the store; next tick inside the TTL.
+          notifier.debugNow = () => start.add(const Duration(minutes: 2));
+          await notifier.debugTick();
+
+          expect(countingService.searchCalls, afterBypass,
+              reason: 'the bypass refresh moved the last-refresh stamp past '
+                  'the request, so the unchanged request must not defeat '
+                  'the gate again');
+        });
+
+        test('a request older than the last refresh does NOT bypass the gate',
+            () async {
+          final c = makeContainer();
+          addTearDown(c.dispose);
+          final start = DateTime(2026, 6, 10, 12, 0);
+          final notifier = await arm(c, start);
+          final after = countingService.searchCalls;
+
+          // Request stamped BEFORE the last completed refresh.
+          wireManualRefreshRequest(
+            start.subtract(const Duration(minutes: 5)).toIso8601String(),
+          );
+          notifier.debugNow = () => start.add(const Duration(minutes: 1));
+          await notifier.debugTick();
+
+          expect(countingService.searchCalls, after,
+              reason: 'an already-served request must not keep re-running '
+                  'the search inside the TTL');
+        });
+
+        test('an unparsable request value is ignored (gate stays in force)',
+            () async {
+          final c = makeContainer();
+          addTearDown(c.dispose);
+          final start = DateTime(2026, 6, 10, 12, 0);
+          final notifier = await arm(c, start);
+          final after = countingService.searchCalls;
+
+          wireManualRefreshRequest('not-a-timestamp');
+          notifier.debugNow = () => start.add(const Duration(minutes: 1));
+          await notifier.debugTick();
+
+          expect(countingService.searchCalls, after,
+              reason: 'garbage in the store must fail safe — keep the gate');
+        });
       });
     });
 


### PR DESCRIPTION
## iOS widget parity — favorites + predictive variants + AppIntent refresh

From epic #3165: the iOS home widget now matches Android's variant set.

- **Favorites variant**: the user's favorite stations with current prices from the App-Group snapshot the Dart side already maintains.
- **Predictive variant**: the price-prediction summary (same data contract as the Android predictive widget).
- **AppIntent manual refresh** (iOS 17+, availability-gated like the existing containerBackground shim) nudging the established refresh channel — no new wake mechanism, and the Dart payload writers ride the existing #3157 freshness+movement-gated cadence (no extra background wake-ups).
- New Swift sources added to the extension target via the reproducible script pattern from #3217/#3226.

Validated: analyze clean, 10,546 feature tests green, device-target Swift build succeeded. Field step: add the new widget variants from the widget gallery.

Closes #3171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
