### PR TITLE
chore(lint): strictness wave — strict modes, fatal infos, evasion holes closed (#3160 #3161 #3163 #3164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,10 @@ jobs:
       # outputs are committed and kept honest by the `codegen-drift` job
       # below, so `analyze` trusts the checked-in generated files instead
       # of paying a redundant codegen pass.
-      - run: flutter analyze --no-fatal-infos
+      # #3161 — fatal infos: the lint phase-in is over, the tree is
+      # info-clean, and every deliberate exception carries an explicit
+      # `// ignore:` with a reason. A new info is a build failure.
+      - run: flutter analyze
       - name: Check feature-module boundaries
         run: bash scripts/check_module_boundaries.sh
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,6 +34,14 @@ plugins:
       provider_parameters: false
 
 analyzer:
+  # Strict language modes (#3160) — the project paid for implicit-dynamic
+  # casts twice (#2296, #2311 in the Hive/JSON codec layer); these make
+  # implicit downcasts, raw generic types and uninferable invocations
+  # compile-time diagnostics instead of runtime surprises.
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
   errors:
     # freezed uses @JsonKey on constructor parameters, which the analyzer
     # flags as invalid. This is a known false positive with freezed.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,13 +25,24 @@ plugins:
     # these four rules (several in files owned by in-flight branches, the
     # rest pre-existing patterns like `ref.keepAlive()` inside autoDispose
     # rebuild-throttles and the bootstrap-owned ProviderScope). Re-enable
-    # rule by rule as the burn-down lands. Info-level rules (e.g.
-    # avoid_public_notifier_properties) stay on — they don't fail CI.
+    # rule by rule as the burn-down lands.
     diagnostics:
       missing_provider_scope: false
       only_use_keep_alive_inside_keep_alive: false
       scoped_providers_should_specify_dependencies: false
       provider_parameters: false
+      # #3161 — CI analyze is now fatal on infos, which would make this
+      # info-level rule a build breaker. All 38 findings were audited:
+      # the 7 lib sites are deliberate, documented seams (test-override
+      # function fields in InAppReviewService, the cross-provider read
+      # getters on TripRecording (#888), the broadcast event/bus stream
+      # getters in HapticEcoCoachLifecycle (#1273) and LiveHarshEventBus)
+      # and the 31 test sites are fake-notifier probe fields. riverpod_lint
+      # 3.1.3's native plugin does NOT honor `// ignore:` /
+      # `// ignore_for_file:` comments (verified empirically), so per-site
+      # opt-outs are impossible — disabling the rule is the only lever.
+      # Re-enable once the plugin honors ignore comments.
+      avoid_public_notifier_properties: false
 
 analyzer:
   # Strict language modes (#3160) — the project paid for implicit-dynamic
@@ -60,17 +71,28 @@ analyzer:
     unawaited_futures: error
     cancel_subscriptions: error
     close_sinks: error
-    # Phase in at info so existing code isn't a wall of red; tighten once clean.
+    # #3161 — the "phase in at info" era is over: the codebase is clean,
+    # CI runs `flutter analyze` with fatal infos, and the correctness
+    # subset is promoted to error so a violation is unmistakably a build
+    # failure (not a fatal-info side effect that a future flag tweak
+    # could silently un-fatal).
+    avoid_slow_async_io: error
+    avoid_type_to_string: error
+    no_logic_in_create_state: error
+    prefer_void_to_null: error
+    test_types_in_equals: error
+    throw_in_finally: error
+    unnecessary_statements: error
+    unrelated_type_equality_checks: error
+    valid_regexps: error
+    # Style-leaning; stays info (still fatal in CI since #3161, but an
+    # IDE shows it in proportion to its weight).
     avoid_print: info
-    avoid_slow_async_io: info
-    avoid_type_to_string: info
-    no_logic_in_create_state: info
-    prefer_void_to_null: info
-    test_types_in_equals: info
-    throw_in_finally: info
-    unnecessary_statements: info
-    unrelated_type_equality_checks: info
-    valid_regexps: info
+    # #3161 — sync-context fire-and-forget (dispose, constructors,
+    # non-async callbacks) was previously unchecked; `unawaited_futures`
+    # only covers async bodies. Deliberate fire-and-forget wraps in
+    # `unawaited(...)`.
+    discarded_futures: error
 
 linter:
   rules:
@@ -85,6 +107,7 @@ linter:
     - avoid_type_to_string
     - cancel_subscriptions
     - close_sinks
+    - discarded_futures
     - no_adjacent_strings_in_list
     - no_logic_in_create_state
     - prefer_void_to_null

--- a/integration_test/golden_flow_integration_test.dart
+++ b/integration_test/golden_flow_integration_test.dart
@@ -465,7 +465,7 @@ void main() {
       // The fake notifier records every show() call so the test can
       // assert "exactly one" notification with the expected payload.
       // -----------------------------------------------------------------
-      await Hive.openBox(HiveBoxes.alerts);
+      await Hive.openBox<dynamic>(HiveBoxes.alerts);
       final radiusStore = RadiusAlertStore();
       final radiusDedup = RadiusAlertDedup();
       final fakeNotifier = _CapturingNotificationService();
@@ -585,7 +585,7 @@ void main() {
               'prices do not cross the threshold');
 
       // Tidy up.
-      await Hive.box(HiveBoxes.alerts).clear();
+      await Hive.box<dynamic>(HiveBoxes.alerts).clear();
     },
     timeout: const Timeout(Duration(seconds: 60)),
   );

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -895,7 +895,7 @@ class AppInitializer {
           isBenignStreamCancel(details.exception)) {
         return;
       }
-      errorLogger.log(
+      unawaited(errorLogger.log(
         ErrorLayer.ui,
         details.exception,
         details.stack ?? StackTrace.current,
@@ -904,15 +904,15 @@ class AppInitializer {
           'library': details.library,
           'context': details.context?.toString(),
         },
-      );
+      ));
     };
     // Capture async / platform errors that escape the framework.
     PlatformDispatcher.instance.onError = (error, stack) {
       if (_isTileFetchNoise(error) || isBenignStreamCancel(error)) return true;
       // #3150 — context so a dispatcher-caught trace is distinguishable
       // from a bare errorLogger call site.
-      errorLogger.log(ErrorLayer.other, error, stack,
-          context: const {'where': 'PlatformDispatcher.onError'});
+      unawaited(errorLogger.log(ErrorLayer.other, error, stack,
+          context: const {'where': 'PlatformDispatcher.onError'}));
       return true;
     };
   }

--- a/lib/app/routes/station_routes.dart
+++ b/lib/app/routes/station_routes.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/data/storage_repository.dart';
+import '../../core/logging/error_logger.dart';
 import '../../core/storage/storage_providers.dart';
 import '../../features/ev/data/repositories/ev_station_repository.dart';
 import '../../features/ev/domain/entities/charging_station.dart';
@@ -103,7 +106,10 @@ ChargingStation? hydrateEvStationById(
   if (raw != null) {
     try {
       return ChargingStation.fromJson(raw);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'hydrateEvStationById: corrupt EV favorite payload'
+      }));
       // A corrupt favorites payload shouldn't block a valid cache hit.
     }
   }

--- a/lib/app/shell/search_fab_tap.dart
+++ b/lib/app/shell/search_fab_tap.dart
@@ -90,13 +90,13 @@ void _pushSearchCriteria(NavigatorState nav, int slot) {
     override(nav);
     return;
   }
-  nav.push<void>(
+  unawaited(nav.push<void>(
     MaterialPageRoute<void>(
       builder: (_) => const SearchCriteriaScreen(),
       fullscreenDialog: true,
       settings: const RouteSettings(name: kSearchCriteriaRouteName),
     ),
-  );
+  ));
 }
 
 /// Default centre-FAB behaviour (#2113), the three-branch matrix:

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -83,7 +83,7 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
       ref.read(currentShellBranchProvider.notifier).set(_currentIndex);
       // #1690 — one-time first-run hint that the tabs can be swiped
       // between (the gesture is otherwise undiscoverable).
-      _maybeShowSwipeHint();
+      unawaited(_maybeShowSwipeHint());
     });
 
     _iconControllers = List.generate(
@@ -133,13 +133,12 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     _transitionController.value = 0.0;
 
     // Play icon bounce
-    _iconControllers[index]
-      ..reset()
-      ..forward();
+    _iconControllers[index].reset();
+    unawaited(_iconControllers[index].forward());
 
-    _transitionController.forward().then((_) {
+    unawaited(_transitionController.forward().then((_) {
       _isTransitioning = false;
-    });
+    }));
 
     setState(() => _currentIndex = index);
     // Publish the new branch index so observers (e.g. MapScreen for its

--- a/lib/app/widgets/animated_splash.dart
+++ b/lib/app/widgets/animated_splash.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../core/theme/app_motion.dart';
@@ -101,7 +103,7 @@ class _AnimatedSplashState extends State<AnimatedSplash>
     // jump the controller straight to its end (logo full-size, fully opaque)
     // instead of running the 650 ms scale+fade reveal.
     if (AppMotion.enabled(context)) {
-      _controller.forward();
+      unawaited(_controller.forward());
     } else {
       _controller.value = 1.0;
     }

--- a/lib/core/background/alert_scan_journal.dart
+++ b/lib/core/background/alert_scan_journal.dart
@@ -41,10 +41,10 @@ class AlertScanJournal {
   /// week?" while staying tiny in the alerts box and the export.
   static const int maxEntries = 20;
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
-      return Hive.box(HiveBoxes.alerts);
+      return Hive.box<dynamic>(HiveBoxes.alerts);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
         'where': 'AlertScanJournal: alerts box unavailable',
@@ -98,7 +98,7 @@ class AlertScanJournal {
       final raw = _boxOrNull()?.get(journalKey);
       if (raw is! List) return <Map<String, Object?>>[];
       return raw
-          .whereType<Map>()
+          .whereType<Map<dynamic, dynamic>>()
           .map((row) => row.map((k, v) => MapEntry('$k', v as Object?)))
           .toList();
     } catch (e, st) {

--- a/lib/core/background/background_retry.dart
+++ b/lib/core/background/background_retry.dart
@@ -1,8 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+
+import '../logging/error_logger.dart';
 
 /// Retry configuration for background network requests.
 class BackgroundRetryConfig {
@@ -33,9 +37,13 @@ Future<Map<String, dynamic>?> fetchWithRetry({
         return response.data as Map<String, dynamic>;
       }
       return null;
-    } on DioException catch (e, st) { // ignore: unused_catch_stack
+    } on DioException catch (e, st) {
       final isLastAttempt = attempt == config.maxAttempts - 1;
       if (isLastAttempt || !isRetryable(e)) {
+        unawaited(errorLogger.log(ErrorLayer.background, e, st,
+            context: const {
+              'where': 'fetchWithRetry: giving up after retries'
+            }));
         debugPrint(
           'BackgroundRetry: failed after ${attempt + 1} '
           'attempt(s): ${e.type} - ${e.message}',

--- a/lib/core/background/background_retry.dart
+++ b/lib/core/background/background_retry.dart
@@ -25,7 +25,7 @@ Future<Map<String, dynamic>?> fetchWithRetry({
 }) async {
   for (var attempt = 0; attempt < config.maxAttempts; attempt++) {
     try {
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         url,
         queryParameters: queryParameters,
       );

--- a/lib/core/background/background_scan_dedup_store.dart
+++ b/lib/core/background/background_scan_dedup_store.dart
@@ -45,7 +45,7 @@ class BackgroundScanDedupStore {
   /// recent refresh.
   static const String lastTriggerKey = 'bg_scan_last_trigger';
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
       return Hive.box(HiveBoxes.alerts);

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -182,7 +182,7 @@ class BackgroundService {
     try {
       hasRadiusAlert = (await RadiusAlertStore().list()).any((a) => a.enabled);
     } catch (_) {
-      // Radius store unreadable (e.g. box not open) — treat as none.
+      // ignore: silent_catch — Radius store unreadable (e.g. box not open) — treat as none.
     }
     return hasPriceAlert || hasRadiusAlert;
   }

--- a/lib/core/background/hive_isolate_lock.dart
+++ b/lib/core/background/hive_isolate_lock.dart
@@ -146,7 +146,7 @@ class HiveIsolateLock {
       try {
         handle?.closeSync();
       } catch (_) {
-        // Best-effort close; nothing actionable if it fails.
+        // ignore: silent_catch — Best-effort close; nothing actionable if it fails.
       }
       return null;
     } catch (e, st) {
@@ -154,7 +154,7 @@ class HiveIsolateLock {
       try {
         handle?.closeSync();
       } catch (_) {
-        // Best-effort close.
+        // ignore: silent_catch — Best-effort close.
       }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'HiveIsolateLock: lock attempt failed, retrying'}));
       return null;
@@ -208,7 +208,7 @@ class HiveIsolateLock {
       try {
         handle.unlockSync();
       } catch (_) {
-        // Best-effort unlock; closing the handle releases it anyway.
+        // ignore: silent_catch — Best-effort unlock; closing the handle releases it anyway.
       }
       try {
         handle.closeSync();

--- a/lib/core/country/country_detection_provider.dart
+++ b/lib/core/country/country_detection_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../location/user_position_provider.dart';
 import '../services/service_providers.dart';
@@ -17,7 +19,7 @@ class DetectedCountry extends _$DetectedCountry {
   String? build() {
     final position = ref.watch(userPositionProvider);
     if (position != null) {
-      _detectCountry(position.lat, position.lng);
+      unawaited(_detectCountry(position.lat, position.lng));
     }
     return null;
   }

--- a/lib/core/country/country_detection_provider.g.dart
+++ b/lib/core/country/country_detection_provider.g.dart
@@ -47,7 +47,7 @@ final class DetectedCountryProvider
   }
 }
 
-String _$detectedCountryHash() => r'964c768179655a56dc2e11604370590e9710e5a5';
+String _$detectedCountryHash() => r'4e070d98a0ae947883d185b04a3fa6d427c3bb64';
 
 /// Detects the user's country from their GPS position via reverse geocoding.
 /// Watches [userPositionProvider] and updates when position changes.

--- a/lib/core/country/country_switch_listener.dart
+++ b/lib/core/country/country_switch_listener.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/profile/providers/profile_provider.dart';
@@ -51,9 +53,9 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
         case CountrySwitchAction.autoSwitch:
           _handleAutoSwitch(next);
         case CountrySwitchAction.suggest:
-          _handleSuggest(next);
+          unawaited(_handleSuggest(next));
         case CountrySwitchAction.noProfile:
-          _handleNoProfile(next);
+          unawaited(_handleNoProfile(next));
       }
     });
 
@@ -62,7 +64,7 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
 
   void _handleAutoSwitch(CountrySwitchEvent event) {
     final profile = event.matchingProfile!;
-    ref.read(activeProfileProvider.notifier).switchProfile(profile.id);
+    unawaited(ref.read(activeProfileProvider.notifier).switchProfile(profile.id));
 
     final l = AppLocalizations.of(context);
     final countryName =

--- a/lib/core/export/data_exporter.dart
+++ b/lib/core/export/data_exporter.dart
@@ -266,7 +266,7 @@ class DataExporter {
     final raw = _storage.getSetting('fillUps');
     if (raw is List) {
       return raw
-          .whereType<Map>()
+          .whereType<Map<dynamic, dynamic>>()
           .map((e) => e.cast<String, dynamic>())
           .toList(growable: false);
     }

--- a/lib/core/location/user_position_provider.dart
+++ b/lib/core/location/user_position_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../storage/storage_providers.dart';
 import '../storage/storage_keys.dart';
@@ -65,20 +67,20 @@ class UserPosition extends _$UserPosition {
 
   void clear() {
     final storage = ref.read(storageRepositoryProvider);
-    storage.putSetting(StorageKeys.userPositionLat, null);
-    storage.putSetting(StorageKeys.userPositionLng, null);
-    storage.putSetting(StorageKeys.userPositionTimestamp, null);
-    storage.putSetting(StorageKeys.userPositionSource, null);
+    unawaited(storage.putSetting(StorageKeys.userPositionLat, null));
+    unawaited(storage.putSetting(StorageKeys.userPositionLng, null));
+    unawaited(storage.putSetting(StorageKeys.userPositionTimestamp, null));
+    unawaited(storage.putSetting(StorageKeys.userPositionSource, null));
     state = null;
   }
 
   void _persist(double lat, double lng, String source) {
     final now = DateTime.now();
     final storage = ref.read(storageRepositoryProvider);
-    storage.putSetting(StorageKeys.userPositionLat, lat);
-    storage.putSetting(StorageKeys.userPositionLng, lng);
-    storage.putSetting(StorageKeys.userPositionTimestamp, now.millisecondsSinceEpoch);
-    storage.putSetting(StorageKeys.userPositionSource, source);
+    unawaited(storage.putSetting(StorageKeys.userPositionLat, lat));
+    unawaited(storage.putSetting(StorageKeys.userPositionLng, lng));
+    unawaited(storage.putSetting(StorageKeys.userPositionTimestamp, now.millisecondsSinceEpoch));
+    unawaited(storage.putSetting(StorageKeys.userPositionSource, source));
     state = UserPositionData(lat: lat, lng: lng, updatedAt: now, source: source);
   }
 }

--- a/lib/core/location/user_position_provider.g.dart
+++ b/lib/core/location/user_position_provider.g.dart
@@ -41,7 +41,7 @@ final class UserPositionProvider
   }
 }
 
-String _$userPositionHash() => r'05edbca12d5ad7b8fbda4d65c48f71f0dde7cc0d';
+String _$userPositionHash() => r'd015a8737bd661e4c8b5944318a4431b09986bc8';
 
 abstract class _$UserPosition extends $Notifier<UserPositionData?> {
   UserPositionData? build();

--- a/lib/core/notifications/notification_launch_listener.dart
+++ b/lib/core/notifications/notification_launch_listener.dart
@@ -41,7 +41,7 @@ class NotificationLaunchHandler {
     );
     if (path == null) return;
     try {
-      _router.push(path);
+      unawaited(_router.push(path));
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'NotificationLaunchHandler: push failed for $rawPayload → $path'}));
     }
@@ -95,14 +95,14 @@ class _NotificationLaunchListenerState
   @override
   void initState() {
     super.initState();
-    _handleColdLaunch();
+    unawaited(_handleColdLaunch());
     _subscription =
         NotificationTapDispatcher.instance.stream.listen(_dispatch);
   }
 
   @override
   void dispose() {
-    _subscription?.cancel();
+    unawaited(_subscription?.cancel());
     super.dispose();
   }
 

--- a/lib/core/sensors/imu_sensor_source.dart
+++ b/lib/core/sensors/imu_sensor_source.dart
@@ -99,7 +99,7 @@ class ImuSensorSource {
             },
           );
         } catch (_) {
-          // Sensors unavailable — leave the stream quiet.
+          // ignore: silent_catch — Sensors unavailable — leave the stream quiet.
         }
       },
       onCancel: () async {
@@ -107,7 +107,7 @@ class ImuSensorSource {
           await accelSub?.cancel();
           await gyroSub?.cancel();
         } catch (_) {
-          // A subscription that failed to set up cleanly may also throw on
+          // ignore: silent_catch — A subscription that failed to set up cleanly may also throw on
           // cancel; nothing to recover.
         }
         if (!out.isClosed) await out.close();

--- a/lib/core/services/conditional_get_interceptor.dart
+++ b/lib/core/services/conditional_get_interceptor.dart
@@ -66,7 +66,7 @@ class ConditionalGetInterceptor extends Interceptor {
   }
 
   @override
-  void onResponse(Response response, ResponseInterceptorHandler handler) {
+  void onResponse(Response<dynamic> response, ResponseInterceptorHandler handler) {
     final options = response.requestOptions;
     if (!_isGet(options)) {
       handler.next(response);
@@ -127,7 +127,7 @@ class ConditionalGetInterceptor extends Interceptor {
   }
 
   /// Cache a 2xx GET response that carries an ETag and/or Last-Modified.
-  void _cacheIfValidated(Response response) {
+  void _cacheIfValidated(Response<dynamic> response) {
     final status = response.statusCode ?? 0;
     if (status < 200 || status >= 300) return;
     final etag = response.headers.value('etag');
@@ -146,7 +146,8 @@ class ConditionalGetInterceptor extends Interceptor {
 
   /// Build the replay response for a 304, or null when nothing is cached for
   /// this URI (header survived a store eviction).
-  Response? _replay304(RequestOptions options, {Map<String, dynamic>? extra}) {
+  Response<dynamic>? _replay304(RequestOptions options,
+      {Map<String, dynamic>? extra}) {
     final key = _keyFor(options);
     final cached = _store[key];
     if (cached == null) return null;
@@ -160,7 +161,7 @@ class ConditionalGetInterceptor extends Interceptor {
     );
   }
 
-  Response _synthetic(
+  Response<dynamic> _synthetic(
     RequestOptions options,
     _CachedResponse cached, {
     required String tag,

--- a/lib/core/services/geocoding_chain.dart
+++ b/lib/core/services/geocoding_chain.dart
@@ -100,6 +100,8 @@ class GeocodingChain {
         );
 
         return result;
+      // #3164 — kept: the error is captured into the chain's ServiceError
+      // aggregate and surfaces in the result.
       } catch (e, st) { // ignore: unused_catch_stack
         errors.add(ServiceError(
           source: provider.source,
@@ -163,6 +165,8 @@ class GeocodingChain {
           fetchedAt: DateTime.now(),
           errors: errors,
         );
+      // #3164 — kept: the error is captured into the chain's ServiceError
+      // aggregate and surfaces in the result.
       } catch (e, st) { // ignore: unused_catch_stack
         errors.add(ServiceError(
           source: provider.source,

--- a/lib/core/services/impl/native_geocoding_provider.dart
+++ b/lib/core/services/impl/native_geocoding_provider.dart
@@ -49,10 +49,13 @@ class NativeGeocodingProvider implements GeocodingProvider {
       }
       final location = locations.first;
       return (lat: location.latitude, lng: location.longitude);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
       if (e is LocationException) rethrow;
-      throw LocationException(
-        message: 'Geräte-Geocodierung fehlgeschlagen: $e',
+      Error.throwWithStackTrace(
+        LocationException(
+          message: 'Geräte-Geocodierung fehlgeschlagen: $e',
+        ),
+        st,
       );
     }
   }

--- a/lib/core/services/impl/nominatim_geocoding_provider.dart
+++ b/lib/core/services/impl/nominatim_geocoding_provider.dart
@@ -96,9 +96,12 @@ class NominatimGeocodingProvider implements GeocodingProvider {
       }
 
       return (lat: lat, lng: lng);
-    } on DioException catch (e, st) { // ignore: unused_catch_stack
-      throw LocationException(
-        message: 'Nominatim geocoding failed: ${e.message}',
+    } on DioException catch (e, st) {
+      Error.throwWithStackTrace(
+        LocationException(
+          message: 'Nominatim geocoding failed: ${e.message}',
+        ),
+        st,
       );
     }
   }

--- a/lib/core/services/impl/osm_brand_enricher.dart
+++ b/lib/core/services/impl/osm_brand_enricher.dart
@@ -73,7 +73,7 @@ class OsmBrandEnricher {
       minLat -= 0.01; maxLat += 0.01;
       minLng -= 0.01; maxLng += 0.01;
 
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         'https://nominatim.openstreetmap.org/search',
         queryParameters: {
           'format': 'json',

--- a/lib/core/services/location_search_service.dart
+++ b/lib/core/services/location_search_service.dart
@@ -107,7 +107,7 @@ class LocationSearchService {
 
     // Rate-limiting is handled by DioFactory's RateLimitInterceptor (#2315).
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         '/search',
         queryParameters: {
           'q': query,

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import '../persistent_dataset.dart';
 
 /// Mixin for services that download a full national dataset and cache it
@@ -308,7 +310,7 @@ mixin KeyedCachedDatasetMixin {
       // Only clear if it's still our future (a later refetch may have
       // replaced it).
       if (identical(_keyedPendingLoads[key], started)) {
-        _keyedPendingLoads.remove(key);
+        unawaited(_keyedPendingLoads.remove(key));
       }
     });
   }

--- a/lib/core/services/rate_limit_interceptor.dart
+++ b/lib/core/services/rate_limit_interceptor.dart
@@ -112,7 +112,7 @@ class RateLimitInterceptor extends Interceptor {
   }
 
   @override
-  void onResponse(Response response, ResponseInterceptorHandler handler) {
+  void onResponse(Response<dynamic> response, ResponseInterceptorHandler handler) {
     _applyCooldownIfRateLimited(
       response.statusCode,
       response.headers,

--- a/lib/core/services/report_service.dart
+++ b/lib/core/services/report_service.dart
@@ -73,10 +73,13 @@ class ReportService {
         success: true,
         message: data is Map ? data['message']?.toString() : null,
       );
-    } on DioException catch (e, st) { // ignore: unused_catch_stack
-      throw ApiException(
-        message: e.message ?? 'Network error submitting report',
-        statusCode: e.response?.statusCode,
+    } on DioException catch (e, st) {
+      Error.throwWithStackTrace(
+        ApiException(
+          message: e.message ?? 'Network error submitting report',
+          statusCode: e.response?.statusCode,
+        ),
+        st,
       );
     }
   }

--- a/lib/core/services/report_service.dart
+++ b/lib/core/services/report_service.dart
@@ -51,7 +51,7 @@ class ReportService {
     }
 
     try {
-      final response = await _dio.post(
+      final response = await _dio.post<dynamic>(
         ApiConstants.complaintEndpoint,
         data: {
           'id': stationId,

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -392,7 +392,7 @@ class StationServiceChain implements StationService {
         .map((e) => e.key)
         .toList();
     for (final key in staleKeys) {
-      _inFlight.remove(key);
+      unawaited(_inFlight.remove(key));
       _inFlightTimestamps.remove(key);
       debugPrint('StationServiceChain: evicted stale in-flight entry: $key');
     }

--- a/lib/core/services/voice_announcement_providers.dart
+++ b/lib/core/services/voice_announcement_providers.dart
@@ -40,7 +40,7 @@ VoiceAnnouncementService voiceAnnouncementService(Ref ref) {
   try {
     unawaited(service.setAppLocale(ref.read(activeLanguageProvider).code));
   } catch (_) {
-    // Profile store not ready yet; keep the device-default voice until the
+    // ignore: silent_catch — Profile store not ready yet; keep the device-default voice until the
     // listener below fires once the language resolves.
   }
 

--- a/lib/core/services/widgets/freshness_badge.dart
+++ b/lib/core/services/widgets/freshness_badge.dart
@@ -16,7 +16,7 @@ import '../service_result.dart';
 /// matches the badge's `warning_amber_rounded` icon (#2492) and gives users
 /// an at-a-glance sense of data quality without the full [ServiceStatusBanner].
 class FreshnessBadge extends StatelessWidget {
-  final ServiceResult result;
+  final ServiceResult<dynamic> result;
 
   const FreshnessBadge({super.key, required this.result});
 

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../error/error_localizer.dart';
@@ -184,7 +186,7 @@ class ServiceChainErrorWidget extends StatelessWidget {
       searchContext: searchContext,
       stackTrace: stackTrace,
     );
-    (reporter ?? const ErrorReporter()).reportError(context, payload);
+    unawaited((reporter ?? const ErrorReporter()).reportError(context, payload));
   }
 
   @override

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -12,7 +12,7 @@ import '../service_result.dart';
 
 /// Displays a banner when data comes from cache or fallback services.
 class ServiceStatusBanner extends StatelessWidget {
-  final ServiceResult result;
+  final ServiceResult<dynamic> result;
 
   const ServiceStatusBanner({super.key, required this.result});
 
@@ -58,7 +58,8 @@ class ServiceStatusBanner extends StatelessWidget {
 
 /// Builds the "X unavailable. Using Y." banner message using the active
 /// localization, falling back to the untranslated [ServiceResult.fallbackSummary].
-String _localizedFallbackSummary(ServiceResult result, AppLocalizations? l10n) {
+String _localizedFallbackSummary(
+    ServiceResult<dynamic> result, AppLocalizations? l10n) {
   if (result.errors.isEmpty) return '';
   final failedNames = result.errors.map((e) => e.source.displayName).join(', ');
   final current = result.source.displayName;
@@ -161,7 +162,7 @@ class ServiceChainErrorWidget extends StatelessWidget {
           // technical-details section, intentionally raw for debugging.
           return '${e.source.displayName}: ${e.message}';
         }
-        return render(e);
+        return render(e as Object);
       }).toList();
     }
     return [render(error)];

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -272,12 +272,12 @@ class HiveBoxes {
   static Future<void> initInIsolate() async {
     await Hive.initFlutter();
     final cipher = await HiveCipherLoader.loadGuarded();
-    await Hive.openBox(settings, encryptionCipher: cipher);
-    await Hive.openBox(favorites, encryptionCipher: cipher);
-    await Hive.openBox(profiles, encryptionCipher: cipher); // #2205 BG widget
-    await Hive.openBox(alerts, encryptionCipher: cipher);
-    await Hive.openBox(cache, encryptionCipher: cipher);
-    await Hive.openBox(priceHistory, encryptionCipher: cipher);
+    await Hive.openBox<dynamic>(settings, encryptionCipher: cipher);
+    await Hive.openBox<dynamic>(favorites, encryptionCipher: cipher);
+    await Hive.openBox<dynamic>(profiles, encryptionCipher: cipher); // #2205 BG widget
+    await Hive.openBox<dynamic>(alerts, encryptionCipher: cipher);
+    await Hive.openBox<dynamic>(cache, encryptionCipher: cipher);
+    await Hive.openBox<dynamic>(priceHistory, encryptionCipher: cipher);
     // #579 — velocity detector reads/writes snapshots from the BG
     // isolate, mirroring the main-isolate open above.
     await Hive.openBox<String>(priceSnapshots);
@@ -308,7 +308,7 @@ class HiveBoxes {
       if (HiveIsolateOwnership.isOwned(name)) continue;
       try {
         if (Hive.isBoxOpen(name)) {
-          await Hive.box(name).close();
+          await Hive.box<dynamic>(name).close();
         }
       } catch (e, st) {
         debugPrint('HiveBoxes: failed to close box "$name": $e\n$st');
@@ -318,12 +318,12 @@ class HiveBoxes {
 
   @visibleForTesting
   static Future<void> initForTest() async {
-    await Hive.openBox(settings);
-    await Hive.openBox(favorites);
-    await Hive.openBox(cache);
-    await Hive.openBox(profiles);
-    await Hive.openBox(priceHistory);
-    await Hive.openBox(alerts);
+    await Hive.openBox<dynamic>(settings);
+    await Hive.openBox<dynamic>(favorites);
+    await Hive.openBox<dynamic>(cache);
+    await Hive.openBox<dynamic>(profiles);
+    await Hive.openBox<dynamic>(priceHistory);
+    await Hive.openBox<dynamic>(alerts);
     // #584 — service reminders live in their own box so tests that
     // exercise the vehicle feature can open it without pulling in the
     // rest of the app. String-typed to match runtime.

--- a/lib/core/storage/hive_legacy_migration.dart
+++ b/lib/core/storage/hive_legacy_migration.dart
@@ -24,7 +24,7 @@ class HiveLegacyMigration {
   static Future<void> migrateLegacyPlaintextBox(
       String boxName, HiveAesCipher cipher) async {
     try {
-      final box = await Hive.openBox(boxName, encryptionCipher: cipher);
+      final box = await Hive.openBox<dynamic>(boxName, encryptionCipher: cipher);
       await box.close();
       return; // Already encrypted, or a fresh install.
     } catch (_) {
@@ -56,7 +56,7 @@ class HiveLegacyMigration {
 
     await Hive.deleteBoxFromDisk(boxName);
     final encryptedBox =
-        await Hive.openBox(boxName, encryptionCipher: cipher);
+        await Hive.openBox<dynamic>(boxName, encryptionCipher: cipher);
     if (entries.isNotEmpty) {
       await encryptedBox.putAll(entries);
     }

--- a/lib/core/storage/hive_legacy_migration.dart
+++ b/lib/core/storage/hive_legacy_migration.dart
@@ -32,7 +32,7 @@ class HiveLegacyMigration {
       await box.close();
       return; // Already encrypted, or a fresh install.
     } catch (_) {
-      // Fall through — the box may be a pre-encryption plaintext box.
+      // ignore: silent_catch — Fall through — the box may be a pre-encryption plaintext box.
     }
 
     Box<dynamic> plain;

--- a/lib/core/storage/hive_legacy_migration.dart
+++ b/lib/core/storage/hive_legacy_migration.dart
@@ -1,8 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+
+import '../logging/error_logger.dart';
 
 /// One-time migration of pre-encryption plaintext Hive boxes into their
 /// encrypted equivalents (#1686).
@@ -34,7 +38,10 @@ class HiveLegacyMigration {
     Box<dynamic> plain;
     try {
       plain = await Hive.openBox(boxName);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'HiveLegacyMigration: plaintext probe failed for $boxName'
+      }));
       debugPrint('Hive: "$boxName" unreadable during the migration probe '
           '— left on disk for Phase 2 to surface.');
       return;

--- a/lib/core/storage/hive_schema_migration.dart
+++ b/lib/core/storage/hive_schema_migration.dart
@@ -88,7 +88,7 @@ class HiveSchemaMigration {
   /// Called only from [ensureSchemaVersions] after the cache box is open.
   static Future<void> evictStaleCacheOnUpgrade({required String cacheBox}) async {
     if (!Hive.isBoxOpen(cacheBox)) return;
-    final box = Hive.box(cacheBox);
+    final box = Hive.box<dynamic>(cacheBox);
     // Snapshot the keys first — deleting while iterating box.keys is unsafe.
     final stale = box.keys
         .whereType<String>()

--- a/lib/core/storage/hive_storage.dart
+++ b/lib/core/storage/hive_storage.dart
@@ -321,7 +321,7 @@ class HiveStorage implements StorageRepository {
   }
 
   int _boxSizeBytes(String boxName, {required int fallbackPerEntry}) {
-    final box = Hive.box(boxName);
+    final box = Hive.box<dynamic>(boxName);
     if (kIsWeb) return box.length * fallbackPerEntry;
     final path = box.path;
     if (path == null) return box.length * fallbackPerEntry;

--- a/lib/core/storage/stores/alerts_hive_store.dart
+++ b/lib/core/storage/stores/alerts_hive_store.dart
@@ -10,7 +10,7 @@ import '../hive_boxes.dart';
 ///
 /// Manages user-configured price alerts for specific stations.
 class AlertsHiveStore implements AlertStorage {
-  Box get _alerts => Hive.box(HiveBoxes.alerts);
+  Box<dynamic> get _alerts => Hive.box(HiveBoxes.alerts);
 
   @override
   List<Map<String, dynamic>> getAlerts() {

--- a/lib/core/storage/stores/cache_hive_store.dart
+++ b/lib/core/storage/stores/cache_hive_store.dart
@@ -24,7 +24,7 @@ import '../hive_boxes.dart';
 /// `VelocityAlertCooldown`). The root close-site is fixed in
 /// [HiveBoxes.closeIsolateBoxes]; this is the belt-and-braces reader guard.
 class CacheHiveStore implements CacheStorage, ItineraryStorage {
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.cache)) return null;
       return Hive.box(HiveBoxes.cache);

--- a/lib/core/storage/stores/favorites_hive_store.dart
+++ b/lib/core/storage/stores/favorites_hive_store.dart
@@ -20,7 +20,7 @@ import '../storage_keys.dart';
 /// ignored station IDs, and station ratings.
 class FavoritesHiveStore
     implements FavoriteStorage, EvFavoriteStorage, IgnoredStorage, RatingStorage {
-  Box get _favorites => Hive.box(HiveBoxes.favorites);
+  Box<dynamic> get _favorites => Hive.box(HiveBoxes.favorites);
 
   // Favorites
   @override

--- a/lib/core/storage/stores/price_history_hive_store.dart
+++ b/lib/core/storage/stores/price_history_hive_store.dart
@@ -11,7 +11,7 @@ import '../hive_boxes.dart';
 /// Manages 30-day price history records per station for trend analysis
 /// and "best time to fill" predictions.
 class PriceHistoryHiveStore implements PriceHistoryStorage {
-  Box get _priceHistory => Hive.box(HiveBoxes.priceHistory);
+  Box<dynamic> get _priceHistory => Hive.box(HiveBoxes.priceHistory);
 
   @override
   Future<void> savePriceRecords(

--- a/lib/core/storage/stores/profiles_hive_store.dart
+++ b/lib/core/storage/stores/profiles_hive_store.dart
@@ -12,8 +12,8 @@ import '../storage_keys.dart';
 /// Manages user search profiles (country, fuel type, radius, etc.).
 /// Profile data is stored in an encrypted Hive box.
 class ProfilesHiveStore implements ProfileStorage {
-  Box get _profiles => Hive.box(HiveBoxes.profiles);
-  Box get _settings => Hive.box(HiveBoxes.settings);
+  Box<dynamic> get _profiles => Hive.box(HiveBoxes.profiles);
+  Box<dynamic> get _settings => Hive.box(HiveBoxes.settings);
 
   @override
   String? getActiveProfileId() =>

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -13,7 +13,7 @@ import '../storage_keys.dart';
 /// Manages app settings (plain Hive) and API keys (FlutterSecureStorage
 /// with in-memory cache for synchronous reads).
 class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
-  Box get _settings => Hive.box(HiveBoxes.settings);
+  Box<dynamic> get _settings => Hive.box(HiveBoxes.settings);
 
   // API Key — stored in platform secure enclave, NOT in plain Hive.
   static const _secureStorage = FlutterSecureStorage();
@@ -104,7 +104,7 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
     if (_supabaseAnonKeyCache != null) return;
 
     // One-time migration from plain Hive settings.
-    final box = Hive.box(HiveBoxes.settings);
+    final box = Hive.box<dynamic>(HiveBoxes.settings);
     final legacy = box.get(StorageKeys.supabaseAnonKey) as String?;
     if (legacy != null && legacy.isNotEmpty) {
       await _secureStorage.write(

--- a/lib/core/sync/pending_deletions_journal.dart
+++ b/lib/core/sync/pending_deletions_journal.dart
@@ -49,12 +49,12 @@ class PendingDeletionsJournal {
   static Future<void> Function(String json) persist = _persistToSettings;
 
   static String? _loadFromSettings() => Hive.isBoxOpen(HiveBoxes.settings)
-      ? Hive.box(HiveBoxes.settings).get(settingsKey) as String?
+      ? Hive.box<dynamic>(HiveBoxes.settings).get(settingsKey) as String?
       : null;
 
   static Future<void> _persistToSettings(String json) async {
     if (!Hive.isBoxOpen(HiveBoxes.settings)) return;
-    await Hive.box(HiveBoxes.settings).put(settingsKey, json);
+    await Hive.box<dynamic>(HiveBoxes.settings).put(settingsKey, json);
   }
 
   /// Restore the real Hive-backed seams after a test injected fakes.

--- a/lib/core/sync/supabase_client.dart
+++ b/lib/core/sync/supabase_client.dart
@@ -152,6 +152,8 @@ class TankSyncClient {
       try {
         await c.from('users').upsert({'id': userId}, onConflict: 'id');
         return; // success
+      // #3164 — kept: transient retry loop; the final error propagates
+      // after exhaustion.
       } catch (e, st) { // ignore: unused_catch_stack
         lastError = e;
         debugPrint(

--- a/lib/core/sync/sync_device_identity.dart
+++ b/lib/core/sync/sync_device_identity.dart
@@ -45,7 +45,7 @@ class SyncDeviceIdentity {
     String? id;
     try {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        final box = Hive.box(HiveBoxes.settings);
+        final box = Hive.box<dynamic>(HiveBoxes.settings);
         id = box.get(settingsKey) as String?;
         if (id == null) {
           id = const Uuid().v4();

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -297,7 +297,7 @@ class SyncState extends _$SyncState {
   }
 
   void _performInitialSync(StorageRepository storage) {
-    Future.microtask(() async {
+    unawaited(Future.microtask(() async {
       try {
         // #3126 — one run id threads every per-table merge of this sync
         // pass through the breadcrumb trace.
@@ -314,7 +314,7 @@ class SyncState extends _$SyncState {
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));
       }
-    });
+    }));
   }
 
   /// Bidirectionally sync favorites + ignored stations and **persist the

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'd5d6a7aad6e920b76d75d090f7c66cc8ce072f76';
+String _$syncStateHash() => r'92e15215a89b95a4fabf218fe485e091f581709f';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/core/sync/trip_shares_sync.dart
+++ b/lib/core/sync/trip_shares_sync.dart
@@ -112,7 +112,7 @@ class TripSharesSync {
       return TripShareResult.notAuthenticated;
     }
     try {
-      final resolved = await client.rpc(
+      final resolved = await client.rpc<dynamic>(
         'resolve_share_recipient',
         params: {'recipient_email': recipientEmail},
       );
@@ -178,7 +178,7 @@ class TripSharesSync {
       return false;
     }
     try {
-      final claimed = await client.rpc(
+      final claimed = await client.rpc<dynamic>(
         'claim_trip_share',
         params: {'token': token},
       );

--- a/lib/core/sync/trips_sync_json.dart
+++ b/lib/core/sync/trips_sync_json.dart
@@ -27,7 +27,7 @@ Map<String, dynamic> compactSummaryJson(TripHistoryEntry entry) {
 Map<String, dynamic> tripDetailsJson(TripHistoryEntry entry) {
   final json = entry.toJson();
   return {
-    'samples': json['samples'] ?? const [],
-    'gpsd': json['gpsd'] ?? const [],
+    'samples': json['samples'] ?? const <dynamic>[],
+    'gpsd': json['gpsd'] ?? const <dynamic>[],
   };
 }

--- a/lib/core/telemetry/health_counters.dart
+++ b/lib/core/telemetry/health_counters.dart
@@ -59,7 +59,7 @@ class HealthCounters {
   /// Open the counter box. Foreground-only, called once from
   /// AppInitializer's storage phase alongside `TraceStorage.init()`.
   static Future<void> init() async {
-    await Hive.openBox(boxName);
+    await Hive.openBox<dynamic>(boxName);
   }
 
   /// Whether a debounced flush is currently scheduled (test hook).
@@ -106,7 +106,7 @@ class HealthCounters {
       _flushTimer = null;
       if (_pending.isEmpty) return;
       if (!Hive.isBoxOpen(boxName)) return; // keep pending — see docstring
-      final box = Hive.box(boxName);
+      final box = Hive.box<dynamic>(boxName);
       final today = _dayKey(_clock());
       final row = _rowFrom(box.get(today));
       for (final entry in _pending.entries) {
@@ -128,7 +128,7 @@ class HealthCounters {
     try {
       final days = <String, Map<String, int>>{};
       if (Hive.isBoxOpen(boxName)) {
-        final box = Hive.box(boxName);
+        final box = Hive.box<dynamic>(boxName);
         for (final key in box.keys) {
           days['$key'] = _rowFrom(box.get(key));
         }
@@ -148,7 +148,7 @@ class HealthCounters {
 
   /// Delete rows older than [retainDays] before [today]'s date. Day
   /// keys sort lexicographically, so a plain string compare suffices.
-  Future<void> _prune(Box box, String today) async {
+  Future<void> _prune(Box<dynamic> box, String today) async {
     final cutoff = _dayKey(_clock().subtract(const Duration(days: retainDays)));
     final stale =
         box.keys.where((k) => '$k'.compareTo(cutoff) < 0).toList(growable: false);

--- a/lib/core/telemetry/integrations/dio_trace_interceptor.dart
+++ b/lib/core/telemetry/integrations/dio_trace_interceptor.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../logging/error_logger.dart';
@@ -27,7 +29,7 @@ class DioTraceInterceptor extends Interceptor {
     // #1104 — route through the unified logger so service-layer Dio
     // failures land in the same pipeline as foreground / background
     // errors. Fire-and-forget: the interceptor contract is sync.
-    errorLogger.log(
+    unawaited(errorLogger.log(
       ErrorLayer.services,
       err,
       err.stackTrace,
@@ -37,7 +39,7 @@ class DioTraceInterceptor extends Interceptor {
         'statusCode': err.response?.statusCode,
         'dioType': err.type.name,
       },
-    );
+    ));
     handler.next(err);
   }
 }

--- a/lib/core/telemetry/integrations/riverpod_trace_observer.dart
+++ b/lib/core/telemetry/integrations/riverpod_trace_observer.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../logging/error_logger.dart';
 
@@ -25,8 +27,8 @@ final class RiverpodTraceObserver extends ProviderObserver {
     // the future is fine because `errorLogger.log` never throws.
     // #3150 — name the failing provider: a bare `[providers]` trace was
     // un-triageable without it.
-    errorLogger.log(ErrorLayer.providers, error, stackTrace, context: {
+    unawaited(errorLogger.log(ErrorLayer.providers, error, stackTrace, context: {
       'provider': context.provider.toString(),
-    });
+    }));
   }
 }

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -32,10 +32,10 @@ class TraceStorage {
   static final Map<String, Object? Function()> extraExportSections = {};
 
   static Future<void> init() async {
-    await Hive.openBox(_boxName);
+    await Hive.openBox<dynamic>(_boxName);
   }
 
-  Box get _box => Hive.box(_boxName);
+  Box<dynamic> get _box => Hive.box(_boxName);
 
   Future<void> store(ErrorTrace trace) async {
     await _box.put(trace.id, trace.toJson());
@@ -135,7 +135,7 @@ class TraceStorage {
   /// (and every nested `_$XFromJson`) throws `TypeError` on the first
   /// `as Map<String, dynamic>` cast against a Hive-shaped nested map —
   /// see #1388.
-  Map<String, dynamic> _jsonMapFrom(Map raw) {
+  Map<String, dynamic> _jsonMapFrom(Map<dynamic, dynamic> raw) {
     final result = <String, dynamic>{};
     raw.forEach((key, value) {
       result[key.toString()] = _coerceJsonValue(value);

--- a/lib/core/telemetry/upload/trace_uploader.dart
+++ b/lib/core/telemetry/upload/trace_uploader.dart
@@ -74,7 +74,7 @@ class TraceUploader {
       // breadcrumb payloads so the user-configured trace endpoint sees
       // the same scrubbed surface Sentry does.
       final scrubbed = PiiScrubber.scrubErrorTrace(trace);
-      await dio.post(
+      await dio.post<dynamic>(
         config.serverUrl!,
         data: scrubbed.toJson(),
         options: Options(headers: {

--- a/lib/core/theme/theme_mode_provider.dart
+++ b/lib/core/theme/theme_mode_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -44,7 +46,7 @@ class ThemeModeSetting extends _$ThemeModeSetting {
 
   @override
   AppThemeChoice build() {
-    _load();
+    unawaited(_load());
     return AppThemeChoice.system;
   }
 

--- a/lib/core/theme/theme_mode_provider.g.dart
+++ b/lib/core/theme/theme_mode_provider.g.dart
@@ -68,7 +68,7 @@ final class ThemeModeSettingProvider
   }
 }
 
-String _$themeModeSettingHash() => r'3a434cc7afb6cd8664151d3d5fee6458df9392c5';
+String _$themeModeSettingHash() => r'a31a377f69c08674f0d53d90f83868c8b3ed5277';
 
 /// Persisted theme preference (#752; Eco theme added #1712).
 ///

--- a/lib/core/utils/edge_to_edge.dart
+++ b/lib/core/utils/edge_to_edge.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -27,7 +29,7 @@ class EdgeToEdge {
   ///
   /// Call once during app startup after [WidgetsFlutterBinding.ensureInitialized].
   static void enable() {
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    unawaited(SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge));
     SystemChrome.setSystemUIOverlayStyle(overlayStyle);
   }
 }

--- a/lib/core/widgets/animated_favorite_star.dart
+++ b/lib/core/widgets/animated_favorite_star.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 /// A filled/unfilled star icon that bounces (scale 1.0 → 1.3 → 1.0) and
@@ -70,9 +72,8 @@ class _AnimatedFavoriteStarState extends State<AnimatedFavoriteStar>
   void didUpdateWidget(covariant AnimatedFavoriteStar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.isFavorite != widget.isFavorite) {
-      _controller
-        ..reset()
-        ..forward();
+      _controller.reset();
+      unawaited(_controller.forward());
     }
   }
 

--- a/lib/core/widgets/animated_price_text.dart
+++ b/lib/core/widgets/animated_price_text.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../theme/app_motion.dart';
@@ -104,9 +106,8 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
     setState(() {
       _flashIsDrop = newPrice < oldPrice;
     });
-    _controller
-      ..reset()
-      ..forward();
+    _controller.reset();
+    unawaited(_controller.forward());
   }
 
   @override

--- a/lib/core/widgets/help_banner.dart
+++ b/lib/core/widgets/help_banner.dart
@@ -42,7 +42,7 @@ class _HelpBannerState extends ConsumerState<HelpBanner> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(_checkIfShouldShow);
+    unawaited(Future.microtask(_checkIfShouldShow));
   }
 
   void _checkIfShouldShow() {

--- a/lib/features/achievements/providers/achievements_provider.dart
+++ b/lib/features/achievements/providers/achievements_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -78,7 +80,7 @@ class Achievements extends _$Achievements {
     );
     // Fire-and-forget persistence so the build is synchronous.
     // The repository merges idempotently — re-runs are cheap.
-    repo.mergeEarned(earnedIds, now: DateTime.now());
+    unawaited(repo.mergeEarned(earnedIds, now: DateTime.now()));
     return repo.loadAll();
   }
 

--- a/lib/features/achievements/providers/achievements_provider.g.dart
+++ b/lib/features/achievements/providers/achievements_provider.g.dart
@@ -173,7 +173,7 @@ final class AchievementsProvider
   }
 }
 
-String _$achievementsHash() => r'3825e61016915e7fdfd88e4317a2c3ad82fa3e4f';
+String _$achievementsHash() => r'9b7655096f50c916ce14e224d5faf89277810abc';
 
 /// Earned badges, newest-first. Watches the trip-history and
 /// fill-up providers so that adding a trip or fill-up naturally

--- a/lib/features/alerts/data/radius_alert_dedup.dart
+++ b/lib/features/alerts/data/radius_alert_dedup.dart
@@ -65,7 +65,7 @@ class RadiusAlertDedup {
   /// and suppressed within the dedup window.
   static const double priceDropEpsilon = 0.001;
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
       return Hive.box(HiveBoxes.alerts);
@@ -240,7 +240,7 @@ class _LastFire {
   final DateTime firedAt;
   const _LastFire({required this.price, required this.firedAt});
 
-  factory _LastFire.fromJson(Map raw) {
+  factory _LastFire.fromJson(Map<dynamic, dynamic> raw) {
     final priceRaw = raw['price'];
     final tsRaw = raw['firedAt'];
     final price = priceRaw is num ? priceRaw.toDouble() : null;

--- a/lib/features/alerts/data/radius_alert_store.dart
+++ b/lib/features/alerts/data/radius_alert_store.dart
@@ -37,7 +37,7 @@ class RadiusAlertStore {
   /// here.
   static const String lastEvalKeyPrefix = 'radius_alert_last_eval:';
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.alerts)) return null;
       return Hive.box(HiveBoxes.alerts);

--- a/lib/features/alerts/data/radius_alert_store.dart
+++ b/lib/features/alerts/data/radius_alert_store.dart
@@ -107,7 +107,11 @@ class RadiusAlertStore {
     if (raw is String) {
       try {
         return DateTime.parse(raw);
-      } catch (e, st) { // ignore: unused_catch_stack
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+          'where': 'RadiusAlertStore.getLastEvaluatedAt: bad timestamp '
+              'for $alertId'
+        }));
         debugPrint(
             'RadiusAlertStore.getLastEvaluatedAt: bad ISO timestamp '
             'for $alertId: $e');

--- a/lib/features/alerts/data/velocity_alert_cooldown.dart
+++ b/lib/features/alerts/data/velocity_alert_cooldown.dart
@@ -25,7 +25,7 @@ class VelocityAlertCooldown {
   /// Key prefix in the settings box — one entry per fuel apiValue.
   static const String keyPrefix = 'velocity_cooldown:';
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
       return Hive.box(HiveBoxes.settings);

--- a/lib/features/alerts/data/velocity_alert_runner.dart
+++ b/lib/features/alerts/data/velocity_alert_runner.dart
@@ -137,7 +137,7 @@ class VelocityAlertRunner {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) {
         return VelocityAlertConfig.defaults();
       }
-      final raw = Hive.box(HiveBoxes.settings).get(configKey);
+      final raw = Hive.box<dynamic>(HiveBoxes.settings).get(configKey);
       if (raw is String && raw.isNotEmpty) {
         final decoded = jsonDecode(raw);
         if (decoded is Map) {
@@ -160,7 +160,7 @@ class VelocityAlertRunner {
       debugPrint('VelocityAlertRunner.saveConfig: settings box closed');
       return;
     }
-    await Hive.box(HiveBoxes.settings)
+    await Hive.box<dynamic>(HiveBoxes.settings)
         .put(configKey, jsonEncode(config.toJson()));
   }
 

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -234,7 +236,7 @@ class _AlertListTile extends ConsumerWidget {
         child: const Icon(Icons.delete, color: Colors.white),
       ),
       onDismissed: (_) {
-        ref.read(alertProvider.notifier).removeAlert(alert.id);
+        unawaited(ref.read(alertProvider.notifier).removeAlert(alert.id));
         SnackBarHelper.show(context, l10n?.alertDeleted(alert.stationName) ?? 'Alert "${alert.stationName}" deleted');
       },
       child: ListTile(
@@ -255,7 +257,7 @@ class _AlertListTile extends ConsumerWidget {
         trailing: Switch.adaptive(
           value: alert.isActive,
           onChanged: (_) {
-            ref.read(alertProvider.notifier).toggleAlert(alert.id);
+            unawaited(ref.read(alertProvider.notifier).toggleAlert(alert.id));
           },
         ),
       ),
@@ -349,7 +351,7 @@ class _RadiusAlertListTile extends ConsumerWidget {
         // unusable; the Undo callback must close over the notifier, not
         // re-read it through the dead tile's `ref`.
         final notifier = ref.read(radiusAlertsProvider.notifier);
-        notifier.remove(alert.id);
+        unawaited(notifier.remove(alert.id));
         SnackBarHelper.showWithUndo(
           context,
           l10n?.radiusAlertDeleted(alert.label) ??
@@ -377,7 +379,7 @@ class _RadiusAlertListTile extends ConsumerWidget {
         trailing: Switch.adaptive(
           value: alert.enabled,
           onChanged: (_) {
-            ref.read(radiusAlertsProvider.notifier).toggle(alert.id);
+            unawaited(ref.read(radiusAlertsProvider.notifier).toggle(alert.id));
           },
         ),
       ),

--- a/lib/features/calculator/presentation/screens/calculator_screen.dart
+++ b/lib/features/calculator/presentation/screens/calculator_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -60,9 +62,9 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
 
     if (hasRoutePrice) {
       _priceApplied = true;
-      Future.microtask(() {
+      unawaited(Future.microtask(() {
         ref.read(calculatorProvider.notifier).setPrice(routePrice);
-      });
+      }));
     }
   }
 

--- a/lib/features/car/car_data_service.dart
+++ b/lib/features/car/car_data_service.dart
@@ -240,7 +240,7 @@ class CarDataService {
       try {
         await HiveStorage.closeIsolateBoxes();
       } catch (_) {
-        // Best-effort close — a stray fault here is never actionable.
+        // ignore: silent_catch — Best-effort close — a stray fault here is never actionable.
       }
       lock?.release();
     }

--- a/lib/features/car/car_data_service.dart
+++ b/lib/features/car/car_data_service.dart
@@ -386,6 +386,7 @@ class CarDataService {
     if (key != null) {
       try {
         fuel = FuelType.fromString(key);
+      // #3164 — kept: preference validation; unknown fuel key falls back.
       } catch (e, st) { // ignore: unused_catch_stack
         debugPrint('CarDataService: unknown preferred fuel "$key": $e');
       }

--- a/lib/features/consumption/data/baseline_store.dart
+++ b/lib/features/consumption/data/baseline_store.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../domain/baseline_rolling_state.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/situation_classifier.dart';
@@ -71,7 +72,10 @@ class BaselineStore {
         }
       });
       _cache[vehicleId] = m;
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'BaselineStore.loadVehicle: corrupt payload for $vehicleId'
+      }));
       debugPrint('BaselineStore.loadVehicle: corrupt payload '
           'for $vehicleId — starting fresh: $e');
       _cache[vehicleId] = {};

--- a/lib/features/consumption/data/baseline_sync.dart
+++ b/lib/features/consumption/data/baseline_sync.dart
@@ -93,7 +93,7 @@ Map<String, dynamic>? _tryDecode(String? raw) {
     if (decoded is Map<String, dynamic>) return decoded;
     if (decoded is Map) return Map<String, dynamic>.from(decoded);
   } catch (_) {
-    // Fall through — caller treats as null.
+    // ignore: silent_catch — Fall through — caller treats as null.
   }
   return null;
 }

--- a/lib/features/consumption/data/charging_log_store.dart
+++ b/lib/features/consumption/data/charging_log_store.dart
@@ -36,7 +36,7 @@ class ChargingLogStore {
   /// without importing this class.
   static const String keyPrefix = 'charging_log:';
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
       return Hive.box(HiveBoxes.settings);

--- a/lib/features/consumption/data/maintenance_snooze_repository.dart
+++ b/lib/features/consumption/data/maintenance_snooze_repository.dart
@@ -42,7 +42,7 @@ class MaintenanceSnoozeRepository {
   /// provider read the same value.
   static const Duration defaultSnoozeDuration = Duration(days: 30);
 
-  Box? _boxOrNull() {
+  Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
       return Hive.box(HiveBoxes.settings);

--- a/lib/features/consumption/data/obd2/ble_adapter_state_gate.dart
+++ b/lib/features/consumption/data/obd2/ble_adapter_state_gate.dart
@@ -38,7 +38,7 @@ Future<void> waitForAdapterOn({
     // (the caller's dispatch surfaces the typed Obd2BluetoothOff) or a slow
     // platform; either way the caller proceeds.
   } catch (_) {
-    // Best-effort gate: a failing adapterState probe — a platform-channel
+    // ignore: silent_catch — Best-effort gate: a failing adapterState probe — a platform-channel
     // quirk, a missing plugin in a test harness, or the state stream ending
     // without an `on` (StateError from `.first`) — must never block or fail
     // the scan/connect that follows; the dispatch's own error mapping owns

--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -265,7 +265,7 @@ class PluginBluetoothFacade implements BluetoothFacade {
       try {
         await FlutterBluePlus.stopScan();
       } catch (_) {
-        // Best-effort — a stopScan that throws (no scan in flight, plugin
+        // ignore: silent_catch — Best-effort — a stopScan that throws (no scan in flight, plugin
         // quirk) must not block the connect that follows.
       }
       if (!completer.isCompleted) completer.complete(sawMac);

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -185,7 +185,7 @@ class BluetoothObd2Transport
     }
     _subscription = _channel.incoming.listen(
       _onBytes,
-      onError: (e, st) {
+      onError: (Object e, StackTrace st) {
         debugPrint('BluetoothObd2Transport: channel error: $e');
         _failPending(e);
       },

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -158,7 +158,7 @@ class BluetoothObd2Transport
         try {
           await _channel.close();
         } catch (_) {
-          // best-effort teardown of a half-open link before retrying
+          // ignore: silent_catch — best-effort teardown of a half-open link before retrying
         }
         // #3014 — GATT-133 recovery: on a 133 (cache-poisoned device — a clone
         // whose GATT table mutated, or a stale cache from the aborted attempt),
@@ -171,7 +171,7 @@ class BluetoothObd2Transport
             try {
               await (ch as Obd2GattRecoverable).refreshGattCache();
             } catch (_) {
-              // OEM-variable reflection; swallow — the retry proceeds anyway.
+              // ignore: silent_catch — OEM-variable reflection; swallow — the retry proceeds anyway.
             }
           }
         }

--- a/lib/features/consumption/data/obd2/classic_method_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_method_channel.dart
@@ -29,7 +29,7 @@ class Obd2ClassicMethodChannel {
     final raw = await _methodChannel.invokeListMethod<dynamic>('bondedDevices')
         ?? const [];
     return raw
-        .whereType<Map>()
+        .whereType<Map<dynamic, dynamic>>()
         .map((m) => ClassicBondedDevice(
               address: m['address'] as String? ?? '',
               name: m['name'] as String? ?? '',

--- a/lib/features/consumption/data/obd2/dropped_session_repo_resolver.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_repo_resolver.dart
@@ -65,7 +65,7 @@ class DroppedSessionRepoResolver {
     final repo = resolvePaused();
     final id = host.sessionId;
     if (repo == null || id == null) return;
-    repo.save(PausedTripEntry(
+    unawaited(repo.save(PausedTripEntry(
       id: id,
       vehicleId: host.vehicleId,
       vin: host.vin,
@@ -77,14 +77,14 @@ class DroppedSessionRepoResolver {
       // service knows whether to bump the launcher-icon badge if the app
       // is killed before the grace timer fires.
       automatic: host.automatic,
-    ));
+    )));
   }
 
   /// Delete this session's paused-trips row — best-effort, no-op when
   /// the session has no id.
   void deletePausedRow(String? sessionId) {
     if (sessionId == null) return;
-    resolvePaused()?.delete(sessionId);
+    unawaited(resolvePaused()?.delete(sessionId));
   }
 
   /// Grace-window finalisation persistence (#797): write the partial into

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -526,7 +526,7 @@ class FlutterBluePlusElmChannel
     await enableNotify();
     _subscription = _notifyChar!.lastValueStream.listen(
       handleNotifyBytes,
-      onError: (e, st) {
+      onError: (Object e, StackTrace st) {
         // #2900 — a mid-session disconnect can surface here too (the GATT/ATT
         // stack errors the notify stream when the adapter drops). Clear the
         // session and forward the RECLASSIFIED recoverable disconnect (not the
@@ -680,7 +680,7 @@ class FlutterBluePlusElmChannel
         }
         _dropDebouncer.noteConnectionState(disconnected: disconnected);
       },
-      onError: (e, st) {
+      onError: (Object e, StackTrace st) {
         debugPrint('FlutterBluePlusElmChannel connectionState error: $e');
       },
     );

--- a/lib/features/consumption/data/obd2/obd2_connect_trace_persistence.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_trace_persistence.dart
@@ -116,7 +116,7 @@ class Obd2ConnectTracePersistence {
         try {
           started = (jsonDecode(raw) as Map<String, dynamic>)['st'] as int?;
         } catch (_) {
-          // unreadable — treated as aged-out below.
+          // ignore: silent_catch — unreadable — treated as aged-out below.
         }
       }
       if (started == null || started < cutoff) {

--- a/lib/features/consumption/data/obd2/obd2_connect_trace_persistence.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_trace_persistence.dart
@@ -47,7 +47,7 @@ class Obd2ConnectTracePersistence {
   Obd2ConnectTracePersistence({DateTime Function()? clock})
       : _now = clock ?? DateTime.now;
 
-  Box get _box => Hive.box(boxName);
+  Box<dynamic> get _box => Hive.box(boxName);
 
   /// Open the box, hydrate the in-memory ring, and register the persist
   /// hook + the error-log export section. Called once from
@@ -55,7 +55,7 @@ class Obd2ConnectTracePersistence {
   /// degrades to the pre-#3184 in-memory-only behaviour.
   static Future<void> init() async {
     try {
-      await Hive.openBox(boxName);
+      await Hive.openBox<dynamic>(boxName);
       final persistence = Obd2ConnectTracePersistence();
       Obd2ConnectTraceLog.hydrateFromPersisted(persistence.load());
       Obd2ConnectTraceLog.onTracePersist =

--- a/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
+++ b/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
@@ -370,7 +370,7 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
     try {
       await service?.disconnect();
     } catch (_) {
-      // Disconnect is best-effort; the session is finalised regardless.
+      // ignore: silent_catch — Disconnect is best-effort; the session is finalised regardless.
     }
     diag.endSession();
     diag.enabled = priorEnabled;

--- a/lib/features/consumption/data/obd2/obd2_self_test_steps.dart
+++ b/lib/features/consumption/data/obd2/obd2_self_test_steps.dart
@@ -196,7 +196,7 @@ Future<({Obd2SelfTestStepResult result, Obd2Service? service})> _reconnectStep(
   try {
     await service.disconnect();
   } catch (_) {
-    // A failed deliberate drop still proceeds to attempt reconnect.
+    // ignore: silent_catch — A failed deliberate drop still proceeds to attempt reconnect.
   }
   diag.noteConnectionEvent(drop: true);
   if (mac == null) {

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -634,7 +634,7 @@ class Obd2Service implements Obd2RawCommandPort {
         // back-to-back command can race the reset. The adapter still
         // owns the actual settle duration via [postResetDelay].
         if (_isResetCommand(sequence[i])) {
-          await Future.delayed(adapter.postResetDelay);
+          await Future<void>.delayed(adapter.postResetDelay);
         }
       }
 

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1497,7 +1497,7 @@ class Obd2Service implements Obd2RawCommandPort {
             if (!controller.isClosed) controller.addError(e, st);
           },
           onDone: () {
-            if (!controller.isClosed) controller.close();
+            if (!controller.isClosed) unawaited(controller.close());
           },
         );
       } catch (e, st) {

--- a/lib/features/consumption/data/obd2/obd2_speed_stream.dart
+++ b/lib/features/consumption/data/obd2/obd2_speed_stream.dart
@@ -103,7 +103,7 @@ class Obd2SpeedStream {
     // sample within `pollPeriod` of subscribe rather than after.
     // `Timer.periodic` only fires AFTER its first interval, so we
     // bridge with an explicit kick.
-    _tick();
+    unawaited(_tick());
     _timer = Timer.periodic(pollPeriod, (_) => _tick());
   }
 

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -1076,6 +1076,7 @@ class TripRecordingController {
         final response = await _sendOrShortCircuit(command);
         _dropDetector.registerSuccess();
         return response;
+      // #3164 — kept: `rethrow` preserves the original stack.
       } catch (e, st) { // ignore: unused_catch_stack
         _registerTransportError(e);
         rethrow;

--- a/lib/features/consumption/data/ocr/pump_ocr_config.dart
+++ b/lib/features/consumption/data/ocr/pump_ocr_config.dart
@@ -312,7 +312,10 @@ class PumpOcrConfig {
     dynamic decoded;
     try {
       decoded = json.decode(raw);
-    } on FormatException catch (e, st) { // ignore: unused_catch_stack
+    } on FormatException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'PumpOcrConfig._ingest: malformed JSON in $_assetPath'
+      }));
       debugPrint('PumpOcrConfig: malformed JSON in $_assetPath: $e');
       return;
     }

--- a/lib/features/consumption/data/ocr/receipt_pdf_rasterizer.dart
+++ b/lib/features/consumption/data/ocr/receipt_pdf_rasterizer.dart
@@ -125,7 +125,7 @@ class ReceiptPdfRasterizer {
           'where': 'ReceiptPdfRasterizer.rasterize',
         }));
       } catch (_) {
-        // best-effort logging; swallow so `null` is always returned
+        // ignore: silent_catch — best-effort logging; swallow so `null` is always returned
       }
       return null;
     } finally {

--- a/lib/features/consumption/data/pip_controller.dart
+++ b/lib/features/consumption/data/pip_controller.dart
@@ -96,6 +96,6 @@ class PipController {
     if (isSupported) {
       _channel.setMethodCallHandler(null);
     }
-    _modeController.close();
+    unawaited(_modeController.close());
   }
 }

--- a/lib/features/consumption/data/receipt_override_registry.dart
+++ b/lib/features/consumption/data/receipt_override_registry.dart
@@ -39,6 +39,8 @@ class OverrideFieldSpec {
     // Validate the regex compiles so the parser doesn't throw later.
     try {
       RegExp(pattern);
+    // #3164 — kept: per-entry config validation; the invalid entry is
+    // skipped by design.
     } on FormatException catch (e, st) { // ignore: unused_catch_stack
       debugPrint(
         'ReceiptOverrideRegistry: invalid regex "$pattern" skipped: $e',
@@ -198,7 +200,11 @@ class ReceiptOverrideRegistry {
     dynamic decoded;
     try {
       decoded = json.decode(raw);
-    } on FormatException catch (e, st) { // ignore: unused_catch_stack
+    } on FormatException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where':
+            'ReceiptOverrideRegistry._ingest: malformed JSON in $_assetPath'
+      }));
       debugPrint(
         'ReceiptOverrideRegistry: malformed JSON in $_assetPath: $e',
       );

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -295,7 +295,7 @@ class TripHistoryRepository {
   List<TripHistoryEntry> loadAll({bool dedupe = true}) {
     final result = <TripHistoryEntry>[];
     for (final key in _box.keys) {
-      final entry = _decode(key);
+      final entry = _decode(key as Object);
       if (entry != null) result.add(entry);
     }
     result.sort((a, b) {

--- a/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
+++ b/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
@@ -81,12 +81,12 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
     _orientation = widget.initialOrientation;
     // #2477 — force landscape so the wide pump display fills the frame
     // with large, upright digits. Restored in dispose + every early-return.
-    SystemChrome.setPreferredOrientations(const [
+    unawaited(SystemChrome.setPreferredOrientations(const [
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
-    ]);
+    ]));
     WidgetsBinding.instance.addObserver(this);
-    _setUpCamera();
+    unawaited(_setUpCamera());
   }
 
   @override
@@ -95,19 +95,19 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
     _restoreOrientations();
     WidgetsBinding.instance.removeObserver(this);
     _stopStream();
-    _controller?.dispose();
+    unawaited(_controller?.dispose());
     super.dispose();
   }
 
   /// Restores the app's full orientation set after a forced-landscape
   /// session. Safe to call more than once and from any teardown path.
   void _restoreOrientations() {
-    SystemChrome.setPreferredOrientations(const [
+    unawaited(SystemChrome.setPreferredOrientations(const [
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
-    ]);
+    ]));
   }
 
   @override
@@ -116,9 +116,9 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
     if (ctrl == null || !ctrl.value.isInitialized) return;
     if (state == AppLifecycleState.inactive) {
       _stopStream();
-      ctrl.dispose();
+      unawaited(ctrl.dispose());
     } else if (state == AppLifecycleState.resumed) {
-      _setUpCamera();
+      unawaited(_setUpCamera());
     }
   }
 
@@ -191,7 +191,7 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
     if (_streamRunning) return;
     try {
       _streamRunning = true;
-      ctrl.startImageStream(_onCameraFrame);
+      unawaited(ctrl.startImageStream(_onCameraFrame));
     } catch (_) {
       _streamRunning = false;
     }

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -198,7 +198,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         ),
       );
     }
-    _coachEventsSub?.cancel();
+    unawaited(_coachEventsSub?.cancel());
     _coachEventsSub = null;
     // #1458 phase 2 — cancel any pending unpinned-warning fire so the
     // SnackBar never lands in the next route's messenger after the
@@ -486,7 +486,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   /// effect is visible without waiting for the next drive.
   void _showPinHelp() {
     final l = AppLocalizations.of(context);
-    showModalBottomSheet<void>(
+    unawaited(showModalBottomSheet<void>(
       context: context,
       builder: (ctx) {
         return SafeArea(
@@ -542,7 +542,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           ),
         );
       },
-    );
+    ));
   }
 
   /// #1273 — handle the back-press. If the trip is still recording
@@ -679,7 +679,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final wantAutoPip = stopped == null && state.isActive;
     if (wantAutoPip != _autoPipRequested) {
       _autoPipRequested = wantAutoPip;
-      _pip.setAutoEnterEnabled(wantAutoPip);
+      unawaited(_pip.setAutoEnterEnabled(wantAutoPip));
     }
 
     // #1977 — when the OS shrinks the app into a PiP tile, the compact

--- a/lib/features/consumption/presentation/widgets/charging_tab.dart
+++ b/lib/features/consumption/presentation/widgets/charging_tab.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -71,7 +73,7 @@ class ChargingTab extends ConsumerWidget {
                 child: const Icon(Icons.delete, color: Colors.white),
               ),
               onDismissed: (_) {
-                ref.read(chargingLogsProvider.notifier).remove(log.id);
+                unawaited(ref.read(chargingLogsProvider.notifier).remove(log.id));
               },
               child: ChargingLogCard(log: log),
             );

--- a/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
@@ -141,11 +141,11 @@ class ConsumptionAppBarActions extends ConsumerWidget {
             tooltip: l?.trajetsViewAllOnMap ?? 'View all on map',
             icon: const Icon(Icons.map_outlined),
             onPressed: () {
-              Navigator.of(context).push(
+              unawaited(Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => TrajetsMapScreen(tripIds: ids),
                 ),
-              );
+              ));
             },
           ),
         PopupMenuButton<_OverflowAction>(

--- a/lib/features/consumption/presentation/widgets/diesel_rev_prompt.dart
+++ b/lib/features/consumption/presentation/widgets/diesel_rev_prompt.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../../../l10n/app_localizations.dart';
@@ -54,8 +56,8 @@ class _DieselRevPromptState extends State<DieselRevPrompt>
     _controller = AnimationController(vsync: this, duration: widget.window)
       ..addStatusListener((status) {
         if (status == AnimationStatus.completed) _finish(revved: false);
-      })
-      ..forward();
+      });
+    unawaited(_controller.forward());
   }
 
   @override

--- a/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/feedback/github_issue_reporter.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
@@ -27,10 +30,10 @@ import 'pump_scan_failure_sheet.dart';
 /// `_lastScan`, `_date`, `_vehicleId`, `_fuelType`, and the
 /// `_scanService` — and passes them in via the `state` parameter.
 ///
-/// Lifting these flows out of the screen halves its line count and
-/// drops the ad-hoc `// ignore: unused_catch_stack` noise from the
-/// orchestration layer; the catches stay here, contained alongside
-/// the user-facing snackbars they emit.
+/// Lifting these flows out of the screen halves its line count; the
+/// catches stay here, contained alongside the user-facing snackbars
+/// they emit, and route their stack traces through `errorLogger`
+/// (#3164).
 
 /// Mutable surface the host screen exposes to the scan helpers. The
 /// helpers only read/write through this struct so the screen can
@@ -137,7 +140,10 @@ Future<void> runReceiptScan(
     if (state.isMounted() && context.mounted) {
       SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
     }
-  } catch (e, st) { // ignore: unused_catch_stack
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+      'where': 'runReceiptScan: receipt scan failed'
+    }));
     if (state.isMounted() && context.mounted) {
       SnackBarHelper.showError(
         context,
@@ -227,7 +233,10 @@ Future<void> runPumpDisplayScan(
         l?.scanPumpSuccess ?? 'Pump display scanned — verify the values.',
       );
     }
-  } catch (e, st) { // ignore: unused_catch_stack
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+      'where': 'runPumpDisplayScan: pump display scan failed'
+    }));
     if (state.isMounted() && context.mounted) {
       SnackBarHelper.showError(
         context,

--- a/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
@@ -135,7 +135,10 @@ Future<void> runSharedReceiptScan(
     if (state.isMounted() && context.mounted) {
       SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
     }
-  } catch (e, st) { // ignore: unused_catch_stack
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+      'where': 'runSharedReceiptScan: shared receipt scan failed'
+    }));
     if (state.isMounted() && context.mounted) {
       SnackBarHelper.showError(
         context,

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -94,7 +96,7 @@ class FuelTab extends ConsumerWidget {
           child: const Icon(Icons.delete, color: Colors.white),
         ),
         onDismissed: (_) {
-          ref.read(fillUpListProvider.notifier).remove(fillUp.id);
+          unawaited(ref.read(fillUpListProvider.notifier).remove(fillUp.id));
         },
         child: FillUpCard(
           fillUp: fillUp,
@@ -146,11 +148,11 @@ class FuelTab extends ConsumerWidget {
   }
 
   void _openCorrectionEditor(BuildContext context, FillUp fillUp) {
-    showModalBottomSheet<void>(
+    unawaited(showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
       builder: (_) => EditCorrectionFillUpSheet(fillUp: fillUp),
-    );
+    ));
   }
 }

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -311,7 +311,10 @@ class _Obd2AdapterPickerSheetState
       } else {
         Navigator.of(context).pop(service);
       }
-    } on Obd2ConnectionError catch (e, st) { // ignore: unused_catch_stack
+    } on Obd2ConnectionError catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': '_Obd2AdapterPicker._connect: adapter connect failed'
+      }));
       if (!mounted) return;
       setState(() {
         _error = e;

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -246,7 +246,7 @@ class _Obd2AdapterPickerSheetState
           if (list.isNotEmpty) _phase = _Phase.selecting;
         });
       },
-      onError: (e, _) {
+      onError: (Object e, _) {
         if (!mounted || e is! Obd2ConnectionError) return;
         setState(() {
           _error = e;

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -225,7 +225,7 @@ class _Obd2AdapterPickerSheetState
 
   @override
   void dispose() {
-    _sub?.cancel();
+    unawaited(_sub?.cancel());
     super.dispose();
   }
 
@@ -237,7 +237,7 @@ class _Obd2AdapterPickerSheetState
     });
     final connection = ref.read(obd2ConnectionProvider);
     _supportsClassicDiscovery = connection.supportsClassicDiscovery;
-    _sub?.cancel();
+    unawaited(_sub?.cancel());
     _sub = connection.scan().listen(
       (list) {
         if (!mounted) return;

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -277,9 +277,9 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
                       ),
                       TextButton(
                         onPressed: () {
-                          ref
+                          unawaited(ref
                               .read(obd2DebugOverlayProvider.notifier)
-                              .disable();
+                              .disable());
                         },
                         style: TextButton.styleFrom(
                           foregroundColor: Colors.white,

--- a/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -82,7 +84,7 @@ class Obd2StatusDot extends ConsumerWidget {
     final name = snapshot.adapterName ??
         (l?.obd2StatusNoAdapter ?? 'No adapter paired');
     final mac = snapshot.adapterMac;
-    showModalBottomSheet<void>(
+    unawaited(showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
       builder: (ctx) {
@@ -129,7 +131,7 @@ class Obd2StatusDot extends ConsumerWidget {
           ),
         );
       },
-    );
+    ));
   }
 
   String _description(Obd2ConnectionState s, AppLocalizations? l) {

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
@@ -181,7 +181,7 @@ class ShareReceiptHandler {
 
   void _push(String path) {
     try {
-      _ref.read(routerProvider).push(path);
+      unawaited(_ref.read(routerProvider).push(path));
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {
         'where': 'ShareReceiptHandler: push failed for $path',

--- a/lib/features/consumption/presentation/widgets/share_receipt_listener.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_listener.dart
@@ -65,7 +65,7 @@ class _ShareReceiptListenerState extends ConsumerState<ShareReceiptListener> {
   @override
   void initState() {
     super.initState();
-    _handleColdShare();
+    unawaited(_handleColdShare());
     _listenWarmShares();
   }
 

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -105,7 +107,7 @@ class TripRecordingBanner extends ConsumerWidget {
       // off Android, so the tile stays safe on every other platform.
       void onBodyTap() {
         try {
-          ref.read(pipControllerProvider).bringToFront();
+          unawaited(ref.read(pipControllerProvider).bringToFront());
         } on Object {
           // Best-effort: a failed reorder just leaves the tile in PiP.
         }

--- a/lib/features/consumption/providers/pending_shared_receipt_provider.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'pending_shared_receipt_provider.g.dart';
@@ -57,7 +59,7 @@ class PendingSharedReceipt extends _$PendingSharedReceipt {
   String? consumeDeferred() {
     final pending = state;
     if (pending != null) {
-      Future.microtask(() => state = null);
+      unawaited(Future.microtask(() => state = null));
     }
     return pending;
   }

--- a/lib/features/consumption/providers/pending_shared_receipt_provider.g.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_provider.g.dart
@@ -114,7 +114,7 @@ final class PendingSharedReceiptProvider
 }
 
 String _$pendingSharedReceiptHash() =>
-    r'a5e987b04e4827446e20bad9aae17d8e3c16a364';
+    r'e1546bc9b9dc120716f57cea15060976f154aaf8';
 
 /// One-shot stash for the file path of a receipt image an external app
 /// shared into Sparkilo via the OS share sheet (#2735 / Epic #2687).

--- a/lib/features/consumption/providers/pending_shared_receipt_text_provider.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_text_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../data/receipt_parser.dart';
@@ -38,7 +40,7 @@ class PendingSharedReceiptText extends _$PendingSharedReceiptText {
   ReceiptParseResult? consumeDeferred() {
     final pending = state;
     if (pending != null) {
-      Future.microtask(() => state = null);
+      unawaited(Future.microtask(() => state = null));
     }
     return pending;
   }

--- a/lib/features/consumption/providers/pending_shared_receipt_text_provider.g.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_text_provider.g.dart
@@ -87,7 +87,7 @@ final class PendingSharedReceiptTextProvider
 }
 
 String _$pendingSharedReceiptTextHash() =>
-    r'b8e66951cc26c0ca44d1bd4624bc500a3127d212';
+    r'4f0e8897226e19299f3ca0a62ddb4944ab481b88';
 
 /// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
 /// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).

--- a/lib/features/consumption/providers/trip_haptic_controller.dart
+++ b/lib/features/consumption/providers/trip_haptic_controller.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 import '../domain/cold_start_baselines.dart';
@@ -39,10 +41,10 @@ class TripHapticController {
     switch (hapticForBandTransition(previous, current)) {
       case HapticIntensity.light:
         _lightCount++;
-        HapticFeedback.lightImpact();
+        unawaited(HapticFeedback.lightImpact());
       case HapticIntensity.medium:
         _mediumCount++;
-        HapticFeedback.mediumImpact();
+        unawaited(HapticFeedback.mediumImpact());
       case HapticIntensity.none:
         break;
     }

--- a/lib/features/driving/haptic_eco_coach.dart
+++ b/lib/features/driving/haptic_eco_coach.dart
@@ -239,18 +239,18 @@ class HapticEcoCoach {
   /// so a vibration-channel hiccup doesn't kill the trip subscription;
   /// the live-reading stream MUST keep flowing for the rest of the app.
   void _fireHaptic() {
-    // ignore: discarded_futures — fire-and-forget by design; we don't
-    // want to block the next reading on the platform channel reply.
-    haptic().catchError((Object e, StackTrace st) {
-      errorLogger.log(
+    // Fire-and-forget by design; we don't want to block the next
+    // reading on the platform channel reply.
+    unawaited(haptic().catchError((Object e, StackTrace st) {
+      unawaited(errorLogger.log(
         ErrorLayer.ui,
         e,
         st,
         context: <String, Object?>{
           'where': 'HapticEcoCoach.fire',
         },
-      );
-    });
+      ));
+    }));
   }
 
   /// Fire the visual / event-stream subscriber (#1273). The callback
@@ -265,14 +265,14 @@ class HapticEcoCoach {
     try {
       cb(CoachEvent(triggeredAt: triggeredAt));
     } catch (e, st) {
-      errorLogger.log(
+      unawaited(errorLogger.log(
         ErrorLayer.ui,
         e,
         st,
         context: <String, Object?>{
           'where': 'HapticEcoCoach.onFire',
         },
-      );
+      ));
     }
   }
 }

--- a/lib/features/driving/presentation/screens/driving_mode_screen.dart
+++ b/lib/features/driving/presentation/screens/driving_mode_screen.dart
@@ -126,7 +126,7 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
     Station station,
     FuelType fuelType,
   ) {
-    showModalBottomSheet(
+    showModalBottomSheet<void>(
       context: context,
       builder: (_) => DrivingStationSheet(
         station: station,

--- a/lib/features/driving/presentation/screens/driving_mode_screen.dart
+++ b/lib/features/driving/presentation/screens/driving_mode_screen.dart
@@ -48,7 +48,7 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
     _mapController = MapController();
     _resetInactivityTimer();
     // Enter immersive full-screen mode — hides status bar and nav bar
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    unawaited(SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky));
   }
 
   @override
@@ -56,10 +56,10 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
     _inactivityTimer?.cancel();
     _mapController.dispose();
     // Restore normal system UI when leaving driving mode
-    SystemChrome.setEnabledSystemUIMode(
+    unawaited(SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.manual,
       overlays: SystemUiOverlay.values,
-    );
+    ));
     super.dispose();
   }
 
@@ -126,13 +126,13 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
     Station station,
     FuelType fuelType,
   ) {
-    showModalBottomSheet<void>(
+    unawaited(showModalBottomSheet<void>(
       context: context,
       builder: (_) => DrivingStationSheet(
         station: station,
         fuelType: fuelType,
       ),
-    );
+    ));
   }
 
   void _recenter(List<Station> stations) {

--- a/lib/features/driving/presentation/widgets/driving_station_sheet.dart
+++ b/lib/features/driving/presentation/widgets/driving_station_sheet.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/utils/price_formatter.dart';
@@ -107,7 +109,7 @@ class DrivingStationSheet extends StatelessWidget {
     final uri = Uri.parse(
       'geo:${station.lat},${station.lng}?q=${station.lat},${station.lng}(${Uri.encodeComponent(station.displayName)})',
     );
-    launchUrl(uri);
+    unawaited(launchUrl(uri));
     if (context.mounted) {
       Navigator.of(context).pop();
     }

--- a/lib/features/driving/providers/haptic_eco_coach_provider.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.dart
@@ -154,7 +154,7 @@ class HapticEcoCoachLifecycle extends _$HapticEcoCoachLifecycle {
       // provider itself is being disposed permanently (e.g. test
       // ProviderContainer.dispose).
       if (!_coachEventsController.isClosed) {
-        _coachEventsController.close();
+        unawaited(_coachEventsController.close());
       }
     });
   }
@@ -165,9 +165,9 @@ class HapticEcoCoachLifecycle extends _$HapticEcoCoachLifecycle {
   }
 
   void _teardown() {
-    _coachSub?.cancel();
+    unawaited(_coachSub?.cancel());
     _coachSub = null;
-    _bridge?.close();
+    unawaited(_bridge?.close());
     _bridge = null;
     _lastForwardedReading = null;
   }

--- a/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
@@ -199,7 +199,7 @@ final class HapticEcoCoachLifecycleProvider
 }
 
 String _$hapticEcoCoachLifecycleHash() =>
-    r'9d4641838f1297884dff3cde9478d3765e256a3d';
+    r'd86b0d9d862133fa9974d1c2afde60fcd22da9d8';
 
 /// Active subscription that bridges the trip-recording state stream
 /// to a [HapticEcoCoach]. Held by Riverpod for the duration of an

--- a/lib/features/driving/providers/voice_announcement_settings_provider.dart
+++ b/lib/features/driving/providers/voice_announcement_settings_provider.dart
@@ -59,7 +59,7 @@ class VoiceAnnouncementSettings extends _$VoiceAnnouncementSettings {
 
   @override
   AnnouncementConfig build() {
-    _load();
+    unawaited(_load());
     // Pre-load frame: the engine's own defaults, but gated off until the
     // feature flag + persisted toggle resolve.
     return const AnnouncementConfig();

--- a/lib/features/driving/providers/voice_announcement_settings_provider.g.dart
+++ b/lib/features/driving/providers/voice_announcement_settings_provider.g.dart
@@ -117,7 +117,7 @@ final class VoiceAnnouncementSettingsProvider
 }
 
 String _$voiceAnnouncementSettingsHash() =>
-    r'17337690219582d9e3905048b8cd0d8c3699603b';
+    r'8c2f48be1713a522129b2351b510dcde58556d28';
 
 /// Persisted user settings for voice announcements while driving (#2569).
 ///

--- a/lib/features/driving/providers/voice_coaching_enabled_provider.dart
+++ b/lib/features/driving/providers/voice_coaching_enabled_provider.dart
@@ -39,7 +39,7 @@ class VoiceCoachingEnabled extends _$VoiceCoachingEnabled {
 
   @override
   bool build() {
-    _load();
+    unawaited(_load());
     // Pre-load frame: default ON. `_load` only overrides it if the user
     // has explicitly persisted a value (i.e. opted out).
     return true;

--- a/lib/features/driving/providers/voice_coaching_enabled_provider.g.dart
+++ b/lib/features/driving/providers/voice_coaching_enabled_provider.g.dart
@@ -105,7 +105,7 @@ final class VoiceCoachingEnabledProvider
 }
 
 String _$voiceCoachingEnabledHash() =>
-    r'98dec33a6236fc820c8715f6f35a8c0427315721';
+    r'15d87dcf5c85192b9e732da85214b81df3538e32';
 
 /// Persisted user toggle for spoken driving coaching (#2663).
 ///

--- a/lib/features/ev/providers/ev_providers.dart
+++ b/lib/features/ev/providers/ev_providers.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_keys.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../search/providers/ev_search_provider.dart';
@@ -217,7 +220,10 @@ Future<List<ChargingStation>> evStations(
       radiusKm: viewport.radiusKm,
     );
     await repo.saveAll(stations);
-  } catch (e, st) { // ignore: unused_catch_stack
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.services, e, st, context: const {
+      'where': 'evStations: fetchStations failed, using cache'
+    }));
     // Fall back to whatever we have cached if the service fails.
     stations = repo.getAll();
   }

--- a/lib/features/ev/providers/ev_providers.g.dart
+++ b/lib/features/ev/providers/ev_providers.g.dart
@@ -333,7 +333,7 @@ final class EvStationsProvider
   }
 }
 
-String _$evStationsHash() => r'8cafa106900a85ce445bb9be57aeddbc5342ae0b';
+String _$evStationsHash() => r'1d22131a2eb49dc23a112bce6b26404c937a6769';
 
 /// Fetches charging stations for the given [viewport] and writes them
 /// through the local repository cache. Applies the current

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -46,9 +46,9 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     // when the user is on the Alerts tab (Share v1 only supports the
     // Favorites tab — see #1344).
     _tabController.addListener(_handleTabChange);
-    Future.microtask(() {
-      ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
-    });
+    unawaited(Future.microtask(() {
+      unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
+    }));
   }
 
   void _handleTabChange() {
@@ -81,7 +81,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
       syncStateProvider.select((s) => s.userId),
       (prev, next) {
         if (prev != next) {
-          ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
+          unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
         }
       },
     );
@@ -100,7 +100,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: () {
-              ref.read(favoriteStationsProvider.notifier).loadAndRefresh();
+              unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
             },
             tooltip: l10n?.refreshPrices ?? 'Refresh prices',
           ),

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -87,7 +89,7 @@ class AlertsTab extends StatelessWidget {
               ),
             ),
             onDismissed: (_) {
-              ref.read(alertProvider.notifier).removeAlert(alert.id);
+              unawaited(ref.read(alertProvider.notifier).removeAlert(alert.id));
               SnackBarHelper.show(
                   context,
                   l10n?.alertDeleted(alert.stationName) ??

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -114,7 +116,7 @@ class FavoriteStationDismissible extends ConsumerWidget {
         profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
         onTap: () => context.push('/station/${station.id}'),
         onFavoriteTap: () {
-          ref.read(favoritesProvider.notifier).remove(station.id);
+          unawaited(ref.read(favoritesProvider.notifier).remove(station.id));
         },
       ),
     );

--- a/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../../../core/widgets/shimmer_placeholder.dart';
@@ -28,7 +30,8 @@ class _FavoritesLoadingViewState extends State<FavoritesLoadingView>
     _pulseController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1500),
-    )..repeat(reverse: true);
+    );
+    unawaited(_pulseController.repeat(reverse: true));
     _pulseAnimation = Tween<double>(begin: 0.6, end: 1.0).animate(
       CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
     );

--- a/lib/features/favorites/presentation/widgets/swipe_tutorial_banner.dart
+++ b/lib/features/favorites/presentation/widgets/swipe_tutorial_banner.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/data/storage_repository.dart';
@@ -27,7 +29,7 @@ class _SwipeTutorialBannerState extends ConsumerState<SwipeTutorialBanner> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(_checkIfShouldShow);
+    unawaited(Future.microtask(_checkIfShouldShow));
   }
 
   void _checkIfShouldShow() {

--- a/lib/features/favorites/providers/favorites_provider.dart
+++ b/lib/features/favorites/providers/favorites_provider.dart
@@ -89,6 +89,8 @@ class Favorites extends _$Favorites {
         StationService? stationService;
         try {
           stationService = ref.read(stationServiceProvider);
+        // #3164 — kept: expected fallback when the provider isn't
+        // initialized yet; degraded path is logged via debugPrint.
         } catch (e, st) { // ignore: unused_catch_stack
           debugPrint(
             'Favorites._refreshWidget: stationService unavailable, '

--- a/lib/features/feature_management/application/app_profile_provider.dart
+++ b/lib/features/feature_management/application/app_profile_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -59,7 +61,7 @@ class ActiveAppProfile extends _$ActiveAppProfile {
     // them to `custom` so we never silently change their flag set.
     final flagsRepo = ref.read(featureFlagsRepositoryProvider);
     if (flagsRepo == null || flagsRepo.isEmpty) return null;
-    repo.save(AppProfile.custom);
+    unawaited(repo.save(AppProfile.custom));
     return AppProfile.custom;
   }
 

--- a/lib/features/feature_management/application/app_profile_provider.g.dart
+++ b/lib/features/feature_management/application/app_profile_provider.g.dart
@@ -160,7 +160,7 @@ final class ActiveAppProfileProvider
   }
 }
 
-String _$activeAppProfileHash() => r'12488e4871dca36942cbe08f555511c2606c05be';
+String _$activeAppProfileHash() => r'01668de419f3429cf006592cf6c0234eb3d41ae2';
 
 /// Active "use mode" profile (#1517).
 ///

--- a/lib/features/glide_coach/data/osm_traffic_signal_client.dart
+++ b/lib/features/glide_coach/data/osm_traffic_signal_client.dart
@@ -121,7 +121,7 @@ class OsmTrafficSignalClient {
 
     try {
       return elements
-          .whereType<Map>()
+          .whereType<Map<dynamic, dynamic>>()
           .map(_parseElement)
           .whereType<TrafficSignal>()
           .toList(growable: false);
@@ -135,7 +135,7 @@ class OsmTrafficSignalClient {
   /// Convert one Overpass element into a [TrafficSignal]. Returns null
   /// when the element is missing a coordinate so a single bad row
   /// doesn't poison the whole batch — the caller filters nulls out.
-  TrafficSignal? _parseElement(Map element) {
+  TrafficSignal? _parseElement(Map<dynamic, dynamic> element) {
     final lat = element['lat'];
     final lon = element['lon'];
     if (lat is! num || lon is! num) return null;

--- a/lib/features/glide_coach/data/traffic_signal_repository.dart
+++ b/lib/features/glide_coach/data/traffic_signal_repository.dart
@@ -129,7 +129,7 @@ class TrafficSignalRepository {
 
     try {
       return signalsRaw
-          .whereType<Map>()
+          .whereType<Map<dynamic, dynamic>>()
           .map((e) => TrafficSignal.fromJson(e.cast<String, dynamic>()))
           .toList(growable: false);
     } catch (e, st) {

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -53,7 +55,7 @@ class GlideCoachSettingsNotifier extends _$GlideCoachSettingsNotifier {
 
   @override
   GlideCoachSettings build() {
-    _load();
+    unawaited(_load());
     return const GlideCoachSettings();
   }
 

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
@@ -144,7 +144,7 @@ final class GlideCoachSettingsNotifierProvider
 }
 
 String _$glideCoachSettingsNotifierHash() =>
-    r'047aa18bb08487db2c21a3c8e4e589ce862fa20e';
+    r'ed5bac993239b9880db2d8867926b44d5f9e5daa';
 
 /// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
 ///

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -61,7 +63,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
                   return SwipeToDelete(
                     dismissKey: ValueKey(it.id),
                     onDismissed: () {
-                      ref.read(itineraryProvider.notifier).delete(it.id);
+                      unawaited(ref.read(itineraryProvider.notifier).delete(it.id));
                       SnackBarHelper.show(context, AppLocalizations.of(context)?.itineraryDeleted(it.name) ?? '${it.name} deleted');
                     },
                     child: ListTile(
@@ -105,11 +107,11 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     final fuelType = FuelType.fromString(it.fuelType as String);
     final detourBudgetKm =
         ref.read(activeProfileProvider)?.routeDetourBudgetKm ?? 5.0;
-    ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
+    unawaited(ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
       waypoints: waypoints,
       fuelType: fuelType,
       searchRadiusKm: detourBudgetKm,
-    );
+    ));
 
     // Navigate to search screen
     context.go('/');

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -102,7 +102,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
 
     // Trigger route search with saved waypoints. #1602 — the search
     // corridor is the active profile's detour budget.
-    final fuelType = FuelType.fromString(it.fuelType);
+    final fuelType = FuelType.fromString(it.fuelType as String);
     final detourBudgetKm =
         ref.read(activeProfileProvider)?.routeDetourBudgetKm ?? 5.0;
     ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
@@ -114,7 +114,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     // Navigate to search screen
     context.go('/');
 
-    SnackBarHelper.show(context, AppLocalizations.of(context)?.loadingRoute(it.name) ?? 'Loading route: ${it.name}');
+    SnackBarHelper.show(context, AppLocalizations.of(context)?.loadingRoute(it.name as String) ?? 'Loading route: ${it.name}');
   }
 
   String _formatDate(DateTime dt) {

--- a/lib/features/itinerary/providers/itinerary_provider.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.dart
@@ -30,7 +30,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
     final storage = ref.read(storageRepositoryProvider);
     final local = _fromStorage(storage);
     // Kick off async merge in background
-    Future.microtask(() => _loadAndMerge());
+    unawaited(Future.microtask(() => _loadAndMerge()));
     return local;
   }
 

--- a/lib/features/itinerary/providers/itinerary_provider.g.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.g.dart
@@ -53,7 +53,7 @@ final class ItineraryNotifierProvider
   }
 }
 
-String _$itineraryNotifierHash() => r'bbd216c85b49e9bcf871571d2d59c4b0ba2e4087';
+String _$itineraryNotifierHash() => r'4a5c6997824931860f26be26987c3c927538939c';
 
 /// Manages saved itineraries with local-first strategy:
 /// - Save locally first, then sync to DB

--- a/lib/features/map/data/sparkilo_tile_layer.dart
+++ b/lib/features/map/data/sparkilo_tile_layer.dart
@@ -136,7 +136,7 @@ class _SparkiloTileLayerState extends State<SparkiloTileLayer> {
 
   @override
   void dispose() {
-    _tileProvider.dispose();
+    unawaited(_tileProvider.dispose());
     super.dispose();
   }
 

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -7,11 +7,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/presentation/widgets/ev_map_overlay.dart';
 import '../../../ev/providers/ev_providers.dart';
+import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
 import 'station_map_layers.dart';
@@ -26,7 +28,7 @@ import 'station_map_layers.dart';
 /// the map whenever a fallback fired — a permanent ~32 dp tax on
 /// every "stations were fetched via the secondary API" session.
 class NearbyMapView extends ConsumerStatefulWidget {
-  final AsyncValue searchState;
+  final AsyncValue<dynamic> searchState;
   final dynamic selectedFuel;
   final double searchRadiusKm;
   final MapController mapController;
@@ -139,7 +141,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
                     center: center,
                     zoom: zoom,
                     searchRadiusKm: searchRadiusKm,
-                    selectedFuel: selectedFuel,
+                    selectedFuel: selectedFuel as FuelType,
                     sortMode: sortMode,
                     // #2998 — adopt the maintainer-loved radar grammar
                     // (#2939): proximity-cluster EVERY result set with the
@@ -189,7 +191,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
   Widget _buildInfoBar(
     BuildContext context,
     AppLocalizations? l10n,
-    List stations,
+    List<dynamic> stations,
     dynamic result,
   ) {
     final theme = Theme.of(context);
@@ -218,7 +220,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
           ),
           const Spacer(),
           Text(
-            result.freshnessLabel,
+            result.freshnessLabel as String,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -253,7 +255,7 @@ class _OverlayBanner extends StatelessWidget {
         elevation: 4,
         borderRadius: BorderRadius.circular(8),
         clipBehavior: Clip.antiAlias,
-        child: ServiceStatusBanner(result: result),
+        child: ServiceStatusBanner(result: result as ServiceResult<dynamic>),
       ),
     );
   }

--- a/lib/features/map/presentation/widgets/route_best_stops_list.dart
+++ b/lib/features/map/presentation/widgets/route_best_stops_list.dart
@@ -44,7 +44,9 @@ class RouteBestStopsList extends StatelessWidget {
           final station = stations[index];
           final isSelected = selectedStationIds.contains(station.id);
           final price = station.priceFor(
-              fuelResolver != null ? fuelResolver!(station) : selectedFuel);
+              fuelResolver != null
+                  ? fuelResolver!(station)
+                  : selectedFuel as FuelType);
           final stopNumber = index + 1;
           return RouteStationChip(
             key: ValueKey('route-station-${station.id}'),

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -314,11 +316,11 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         return aIdx.compareTo(bIdx);
       });
 
-    NavigationUtils.openRouteInMaps(
+    unawaited(NavigationUtils.openRouteInMaps(
       origin: '${start.latitude},${start.longitude}',
       destination: '${end.latitude},${end.longitude}',
       waypoints: selectedStations.map((s) => '${s.lat},${s.lng}').toList(),
-    );
+    ));
   }
   int _nearestPolylineIndex(double lat, double lng, List<LatLng> polyline) {
     int bestIdx = 0;

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -164,7 +164,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             center: center,
             zoom: zoom,
             searchRadiusKm: 5,
-            selectedFuel: widget.selectedFuel,
+            selectedFuel: widget.selectedFuel as FuelType,
             showRecenterButton: true,
             // #2755 — recenter refits to the same full-route bounds the
             // camera was framed to, never the (changing) station subset.

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
@@ -409,7 +410,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
     final onTap = widget.onStationTap == null
         ? null
         : (String id) {
-            HapticFeedback.selectionClick();
+            unawaited(HapticFeedback.selectionClick());
             widget.onStationTap!(id);
           };
     _markerMeta.clear();

--- a/lib/features/price_history/presentation/screens/price_history_screen.dart
+++ b/lib/features/price_history/presentation/screens/price_history_screen.dart
@@ -66,7 +66,7 @@ class PriceHistoryScreen extends ConsumerWidget {
 class _FuelTypeSection extends ConsumerWidget {
   final String stationId;
   final FuelType fuelType;
-  final List records;
+  final List<dynamic> records;
 
   const _FuelTypeSection({
     required this.stationId,

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
@@ -290,7 +290,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
         base64: base64Encode(bytes),
       );
     } catch (_) {
-      // Image attach is best-effort; the trace JSON is still useful.
+      // ignore: silent_catch — Image attach is best-effort; the trace JSON is still useful.
     }
   }
 

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -331,7 +331,7 @@ class _PrivacyDashboardScreenState
     await storageMgmt.clearPriceHistory();
     await storageMgmt.deleteApiKey();
     for (final boxName in ['settings', 'favorites', 'profiles']) {
-      final box = Hive.box(boxName);
+      final box = Hive.box<dynamic>(boxName);
       await box.clear();
     }
     if (mounted) {

--- a/lib/features/profile/presentation/widgets/config_verification_widget.dart
+++ b/lib/features/profile/presentation/widgets/config_verification_widget.dart
@@ -147,7 +147,7 @@ class ConfigVerificationWidget extends ConsumerWidget {
             'Email account enables cross-device access')
         : (l?.configAuthNoteAnonymous ??
             'Anonymous account — data tied to this device');
-    final summaryBody = syncConfig.isConfigured
+    final summaryBody = syncConfig.isConfigured as bool
         ? (l?.configPrivacySummarySynced(authNote) ??
             '• Favorites, alerts, and ignored stations are synced to your '
                 'private database\n'

--- a/lib/features/profile/presentation/widgets/feedback_token_section.dart
+++ b/lib/features/profile/presentation/widgets/feedback_token_section.dart
@@ -47,7 +47,7 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
   @override
   void initState() {
     super.initState();
-    _refresh();
+    unawaited(_refresh());
   }
 
   Future<void> _refresh() async {

--- a/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
+++ b/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -48,7 +50,7 @@ class GamificationSettingsTile extends ConsumerWidget {
         style: theme.textTheme.bodySmall,
       ),
       onChanged: (v) {
-        ref.read(gamificationEnabledProvider.notifier).set(v);
+        unawaited(ref.read(gamificationEnabledProvider.notifier).set(v));
       },
       contentPadding: EdgeInsets.zero,
     );

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -10,6 +10,7 @@ import '../../../../core/logging/error_logger.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/user_profile.dart';
 import '../../providers/profile_provider.dart';
 
 /// GPS position management section for the profile/settings screen.
@@ -107,7 +108,7 @@ class LocationSectionWidget extends ConsumerWidget {
   }
 
   Widget _buildAutoUpdateToggle(WidgetRef ref, ThemeData theme,
-      dynamic activeProfile, AppLocalizations? l) {
+      UserProfile? activeProfile, AppLocalizations? l) {
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
       title: Text(
@@ -123,7 +124,8 @@ class LocationSectionWidget extends ConsumerWidget {
       value: activeProfile?.autoUpdatePosition ?? false,
       onChanged: (value) {
         if (activeProfile != null) {
-          final updated = activeProfile.copyWith(autoUpdatePosition: value);
+          final updated =
+              activeProfile.copyWith(autoUpdatePosition: value);
           ref.read(profileRepositoryProvider).updateProfile(updated);
           ref.invalidate(allProfilesProvider);
           ref.invalidate(activeProfileProvider);

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -126,7 +126,7 @@ class LocationSectionWidget extends ConsumerWidget {
         if (activeProfile != null) {
           final updated =
               activeProfile.copyWith(autoUpdatePosition: value);
-          ref.read(profileRepositoryProvider).updateProfile(updated);
+          unawaited(ref.read(profileRepositoryProvider).updateProfile(updated));
           ref.invalidate(allProfilesProvider);
           ref.invalidate(activeProfileProvider);
         }
@@ -153,7 +153,7 @@ class LocationSectionWidget extends ConsumerWidget {
       ),
       value: autoSwitch,
       onChanged: (value) {
-        ref.read(autoSwitchProfileProvider.notifier).set(value);
+        unawaited(ref.read(autoSwitchProfileProvider.notifier).set(value));
       },
     );
   }

--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -152,7 +152,7 @@ class ProfileListSection extends ConsumerWidget {
     final profileNotifier = ref.read(activeProfileProvider.notifier);
     final repo = ref.read(profileRepositoryProvider);
 
-    await showModalBottomSheet(
+    await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       // `_` (not `context`) so the mounted guards below check the section's

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -300,7 +300,7 @@ class StorageSection extends ConsumerWidget {
       PaintingBinding.instance.imageCache.clear();
       PaintingBinding.instance.imageCache.clearLiveImages();
       for (final boxName in ['settings', 'favorites', 'profiles']) {
-        final box = Hive.box(boxName);
+        final box = Hive.box<dynamic>(boxName);
         await box.clear();
       }
       if (!ctx.mounted) return; // #3159 — see _clearCache.

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -272,7 +272,7 @@ class TankSyncSection extends ConsumerWidget {
   }
 
   void _showQrShare(BuildContext context) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (ctx) => Dialog(
         child: Padding(

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -272,7 +272,7 @@ class TankSyncSection extends ConsumerWidget {
   }
 
   void _showQrShare(BuildContext context) {
-    showDialog<void>(
+    unawaited(showDialog<void>(
       context: context,
       builder: (ctx) => Dialog(
         child: Padding(
@@ -290,6 +290,6 @@ class TankSyncSection extends ConsumerWidget {
           ),
         ),
       ),
-    );
+    ));
   }
 }

--- a/lib/features/report/presentation/screens/report_submit_handler.dart
+++ b/lib/features/report/presentation/screens/report_submit_handler.dart
@@ -1,12 +1,15 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/error/exceptions.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/feedback/github_issue_reporter/error_report_payload.dart';
 import '../../../../core/feedback/github_issue_reporter/error_reporter.dart';
 import '../../../../core/feedback/github_issue_reporter/error_reporter_context.dart';
@@ -155,7 +158,10 @@ class ReportSubmitHandler {
         );
         context.pop();
       }
-    } on ApiException catch (e, st) { // ignore: unused_catch_stack
+    } on ApiException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'ReportSubmitHandler.submit: report submission failed'
+      }));
       if (context.mounted) {
         SnackBarHelper.showError(
           context,

--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -199,6 +199,8 @@ StationQueryFunction buildCorridorQueryFunction(
         raw = result.data
             .map((s) => FuelStationResult(s) as SearchResultItem)
             .toList();
+      // #3164 — kept: #2703 breadcrumb-not-ERROR decision; recoverable leg
+      // outage is recorded as a diagnostic breadcrumb.
       } catch (e, st) { // ignore: unused_catch_stack
         // #2621 — degrade to the other legs rather than aborting the whole
         // route; never silently swallow. #2703 — a single country's feed

--- a/lib/features/route_search/data/services/routing_service.dart
+++ b/lib/features/route_search/data/services/routing_service.dart
@@ -121,10 +121,13 @@ class RoutingService {
         source: ServiceSource.osrmRouting,
         fetchedAt: DateTime.now(),
       );
-    } on DioException catch (e, st) { // ignore: unused_catch_stack
-      throw ApiException(
-        message: e.message ?? 'Route calculation failed',
-        statusCode: e.response?.statusCode,
+    } on DioException catch (e, st) {
+      Error.throwWithStackTrace(
+        ApiException(
+          message: e.message ?? 'Route calculation failed',
+          statusCode: e.response?.statusCode,
+        ),
+        st,
       );
     }
   }

--- a/lib/features/route_search/data/services/routing_service.dart
+++ b/lib/features/route_search/data/services/routing_service.dart
@@ -46,7 +46,7 @@ class RoutingService {
 
       if (avoidHighways) {
         // Try with exclude=motorway first; fall back if unsupported
-        final response = await _dio.get(
+        final response = await _dio.get<dynamic>(
           '$_baseUrl/route/v1/driving/$coords',
           queryParameters: {
             'overview': 'full',
@@ -59,7 +59,7 @@ class RoutingService {
 
         if (data['code'] != 'Ok') {
           debugPrint('RouteSearch: exclude=motorway not supported, falling back to normal route');
-          final fallback = await _dio.get(
+          final fallback = await _dio.get<dynamic>(
             '$_baseUrl/route/v1/driving/$coords',
             queryParameters: {
               'overview': 'full',
@@ -70,7 +70,7 @@ class RoutingService {
           data = fallback.data as Map<String, dynamic>;
         }
       } else {
-        final response = await _dio.get(
+        final response = await _dio.get<dynamic>(
           '$_baseUrl/route/v1/driving/$coords',
           queryParameters: {
             'overview': 'full',

--- a/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -163,14 +165,14 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
       return out;
     } catch (e, st) {
       // Never silent — route selection failing must surface.
-      errorLogger.log(
+      unawaited(errorLogger.log(
         ErrorLayer.services,
         e,
         st,
         context: <String, Object?>{
           'where': 'EcoRouteSearchStrategy.parseOsrmAlternatives',
         },
-      );
+      ));
       return const <EcoRouteCandidate>[];
     }
   }

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -266,7 +266,7 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       try {
         notifier.setSearching(false);
       } catch (_) {
-        // Provider disposed — state is gone anyway.
+        // ignore: silent_catch — Provider disposed — state is gone anyway.
       }
     }
   }

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -61,7 +61,7 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       ref.read(routeInputControllerProvider.notifier).reset();
       if (!_autoGpsTriggered) {
         _autoGpsTriggered = true;
-        _useGpsForStart();
+        unawaited(_useGpsForStart());
       }
     });
   }

--- a/lib/features/search/data/services/ev_charging_service.dart
+++ b/lib/features/search/data/services/ev_charging_service.dart
@@ -51,7 +51,7 @@ class EVChargingService with StationServiceHelpers {
     CancelToken? cancelToken,
   }) async {
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         _baseUrl,
         queryParameters: {
           'output': 'json',

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -50,7 +50,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
     // tap (the only seam that was enriched before #2632), so the free /
     // paid badge surfaces wherever the detail screen is opened.
     _station = widget.station;
-    _enrichOnOpen();
+    unawaited(_enrichOnOpen());
   }
 
   /// One-shot enrich of the opened station with the country-authoritative
@@ -116,8 +116,8 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   }
 
   void _navigateToStation() {
-    NavigationUtils.openInMaps(_station.lat, _station.lng,
-        label: _station.name);
+    unawaited(NavigationUtils.openInMaps(_station.lat, _station.lng,
+        label: _station.name));
   }
 
   /// Open the add-charging-log form pre-filled with this station
@@ -312,9 +312,9 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
                     StarRating(
                       rating: rating,
                       onRatingChanged: (stars) {
-                        ref
+                        unawaited(ref
                             .read(stationRatingsProvider.notifier)
-                            .rate(station.id, stars);
+                            .rate(station.id, stars));
                       },
                     ),
                     if (rating != null) ...[

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -103,7 +103,10 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showError(context, l10n?.evStationNotFound ?? 'Could not refresh — station not found nearby');
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'EVStationDetailScreen._refreshStation: refresh failed',
+      }));
       if (mounted) {
         SnackBarHelper.showError(context, AppLocalizations.of(context)?.refreshFailed ?? 'Refresh failed. Please try again.');
       }

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -91,13 +91,13 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       // #2139 — microtask fires before any frame; addPostFrameCallback
       // can be skipped if no frame is scheduled, leaving a stale
       // action that makes the FAB look enabled but no-op.
-      Future.microtask(() {
+      unawaited(Future.microtask(() {
         try {
           notifier.clearFor(this); // #2553 — clear by owner, not action.
         } catch (_) {
           // ignore: silent_catch — ProviderContainer torn down (e.g. test teardown) — no-op.
         }
-      });
+      }));
     }
     super.dispose();
   }
@@ -154,7 +154,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
 
   void _onFabRouteTap() {
     if (_bailIfStale()) return;
-    _routeInputKey.currentState?.resolveAndSearch();
+    unawaited(_routeInputKey.currentState?.resolveAndSearch());
   }
 
   void _onFabNearbyTap() {
@@ -200,11 +200,11 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    ref.read(searchStateProvider.notifier).searchByZipCode(
+    unawaited(ref.read(searchStateProvider.notifier).searchByZipCode(
           zipCode: zip,
           fuelType: fuelType,
           radiusKm: radius,
-        );
+        ));
     Navigator.of(context).pop();
   }
 
@@ -213,14 +213,14 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    ref.read(searchStateProvider.notifier).searchByCoordinates(
+    unawaited(ref.read(searchStateProvider.notifier).searchByCoordinates(
           lat: city.lat,
           lng: city.lng,
           postalCode: city.postcode,
           locationName: city.name,
           fuelType: fuelType,
           radiusKm: radius,
-        );
+        ));
     Navigator.of(context).pop();
   }
 
@@ -235,13 +235,13 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final segmentKm = ref.read(routeSegmentSearchParamProvider);
     final minSaving = ref.read(minRouteSavingSearchParamProvider);
     ref.read(activeSearchModeProvider.notifier).set(SearchMode.route);
-    ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
+    unawaited(ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
           waypoints: waypoints,
           fuelType: fuelType,
           searchRadiusKm: detourBudgetKm,
           segmentKm: segmentKm,
           minSavingPerLiter: minSaving,
-        );
+        ));
     Navigator.of(context).pop();
   }
 

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -95,7 +95,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
         try {
           notifier.clearFor(this); // #2553 — clear by owner, not action.
         } catch (_) {
-          // ProviderContainer torn down (e.g. test teardown) — no-op.
+          // ignore: silent_catch — ProviderContainer torn down (e.g. test teardown) — no-op.
         }
       });
     }

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -100,7 +100,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   void _tryGpsSearchIfConsented() {
     final settings = ref.read(settingsStorageProvider);
     if (!LocationConsentDialog.hasConsent(settings)) return;
-    _performGpsSearch();
+    unawaited(_performGpsSearch());
   }
 
   Future<void> _performGpsSearch() async {

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../../../core/country/country_config.dart';
@@ -142,7 +144,7 @@ class AllPricesStationCard extends StatelessWidget {
                     onPressed: onFavoriteTap == null
                         ? null
                         : () {
-                            HapticFeedback.selectionClick();
+                            unawaited(HapticFeedback.selectionClick());
                             onFavoriteTap!();
                           },
                     tooltip: isFavorite

--- a/lib/features/search/presentation/widgets/fuel_type_selector.dart
+++ b/lib/features/search/presentation/widgets/fuel_type_selector.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -45,9 +47,9 @@ class FuelTypeSelector extends ConsumerWidget {
 
     // If selected type isn't available in this country, reset to 'all'
     if (!types.contains(selected)) {
-      Future.microtask(() {
+      unawaited(Future.microtask(() {
         ref.read(selectedFuelTypeProvider.notifier).select(FuelType.all);
-      });
+      }));
     }
 
     return SingleChildScrollView(
@@ -78,7 +80,7 @@ class FuelTypeSelector extends ConsumerWidget {
                   // matching the everyday tap-surface haptics. selectionClick
                   // only (never heavyImpact); never fires on scroll because
                   // ChoiceChip.onSelected is a discrete tap, not a drag.
-                  HapticFeedback.selectionClick();
+                  unawaited(HapticFeedback.selectionClick());
                   ref.read(selectedFuelTypeProvider.notifier).select(type);
                 },
                 visualDensity: VisualDensity.compact,

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -70,7 +70,7 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
     if (type == LocationInputType.city) {
       _debounce?.cancel();
       _debounce = Timer(const Duration(milliseconds: 1000), () {
-        _fetchSuggestions(value);
+        unawaited(_fetchSuggestions(value));
       });
     }
   }

--- a/lib/features/search/presentation/widgets/radar_pin_help_sheet.dart
+++ b/lib/features/search/presentation/widgets/radar_pin_help_sheet.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -18,7 +20,7 @@ void showRadarPinHelp(
   required Future<void> Function() onEnableNow,
 }) {
   final l = AppLocalizations.of(context);
-  showModalBottomSheet<void>(
+  unawaited(showModalBottomSheet<void>(
     context: context,
     builder: (ctx) {
       return SafeArea(
@@ -86,5 +88,5 @@ void showRadarPinHelp(
         ),
       );
     },
-  );
+  ));
 }

--- a/lib/features/search/presentation/widgets/radar_search_fab.dart
+++ b/lib/features/search/presentation/widgets/radar_search_fab.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -43,7 +45,7 @@ class RadarSearchFab extends ConsumerWidget {
         if (active) {
           notifier.dismiss();
         } else {
-          notifier.runRadar();
+          unawaited(notifier.runRadar());
         }
       },
       icon: Icon(active ? Icons.stop_circle : Icons.radar),

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -73,7 +75,8 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     _fadeController = AnimationController(
       vsync: this,
       duration: StaggeredFadeIn.timelineDuration,
-    )..forward();
+    );
+    unawaited(_fadeController.forward());
   }
 
   @override
@@ -81,7 +84,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     super.didUpdateWidget(oldWidget);
     // A fresh search → replay the staggered cascade from the top.
     if (!identical(oldWidget.result, widget.result)) {
-      _fadeController.forward(from: 0);
+      unawaited(_fadeController.forward(from: 0));
     }
   }
 
@@ -317,7 +320,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
           if (isWideScreen(context)) {
             ref.read(selectedStationProvider.notifier).select(station.id);
           } else {
-            context.push('/station/${station.id}');
+            unawaited(context.push('/station/${station.id}'));
           }
         },
         onFavoriteTap: () => ref
@@ -372,7 +375,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
         // captured reference is safe across that gap.
         final ignoredNotifier =
             ref.read(ignoredStationsProvider.notifier);
-        ignoredNotifier.add(station.id);
+        unawaited(ignoredNotifier.add(station.id));
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showWithUndo(
           context,
@@ -385,7 +388,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
         if (isWideScreen(context)) {
           ref.read(selectedStationProvider.notifier).select(station.id);
         } else {
-          context.push('/station/${station.id}');
+          unawaited(context.push('/station/${station.id}'));
         }
       },
       onFavoriteTap: () => ref

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../../../core/country/country_config.dart';

--- a/lib/features/search/presentation/widgets/station_card_price_column.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_column.dart
@@ -90,7 +90,7 @@ class _StationPriceColumn extends StatelessWidget {
             onPressed: onFavoriteTap == null
                 ? null
                 : () {
-                    HapticFeedback.selectionClick();
+                    unawaited(HapticFeedback.selectionClick());
                     onFavoriteTap!();
                   },
             tooltip: isFavorite

--- a/lib/features/setup/data/api_key_validator.dart
+++ b/lib/features/setup/data/api_key_validator.dart
@@ -29,7 +29,7 @@ class ApiKeyValidator {
 
   Future<ApiKeyValidationResult> validate(String apiKey) async {
     try {
-      final response = await _dio.get('/list.php', queryParameters: {
+      final response = await _dio.get<dynamic>('/list.php', queryParameters: {
         'lat': ApiConstants.testLatitude,
         'lng': ApiConstants.testLongitude,
         'rad': 1,

--- a/lib/features/setup/data/api_key_validator.dart
+++ b/lib/features/setup/data/api_key_validator.dart
@@ -44,6 +44,8 @@ class ApiKeyValidator {
         );
       }
       return const ApiKeyValidationResult(isValid: true);
+    // #3164 — kept: genuine user-input validation; the failure surfaces
+    // in the returned ApiKeyValidationResult.
     } on DioException catch (e, st) { // ignore: unused_catch_stack
       return ApiKeyValidationResult(
         isValid: false,

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,6 +13,7 @@ import '../../../feature_management/application/app_profile_provider.dart';
 import '../../../feature_management/domain/app_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../providers/api_key_validator_provider.dart';
+import '../../providers/onboarding_platform_steps_provider.dart';
 import '../../providers/onboarding_wizard_provider.dart';
 import '../widgets/api_key_step.dart';
 import '../widgets/completion_step.dart';
@@ -89,7 +89,7 @@ class _OnboardingWizardScreenState
     if (profile != AppProfile.full && profile != AppProfile.custom) return -1;
     // Welcome+Profile (0), Country (1), Vehicle (2), [iOS standby (3)],
     // OBD2 (3 or 4 depending on platform).
-    return defaultTargetPlatform == TargetPlatform.iOS ? 4 : 3;
+    return ref.read(onboardingIncludesIosStandbyStepProvider) ? 4 : 3;
   }
 
   /// Zero-based index of the optional API key step.
@@ -274,9 +274,11 @@ class _OnboardingWizardScreenState
     // compromises (open once after reboot, don't force-quit, grant
     // Always location). Same gating as `showObd2`: an iOS user who
     // skipped OBD2 doesn't need to be warned about a flow they're
-    // not setting up.
+    // not setting up. Platform resolution lives in the dedicated
+    // dispatch-seam provider (#3163) so this screen stays free of
+    // inline `defaultTargetPlatform` branching.
     final showIosStandby = showObd2 &&
-        defaultTargetPlatform == TargetPlatform.iOS;
+        ref.watch(onboardingIncludesIosStandbyStepProvider);
     return [
       ProfileChoiceStep(onProfilePicked: _onProfilePicked),
       const CountryLanguageStep(),

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -112,11 +114,11 @@ class _OnboardingWizardScreenState
 
   void _goToStep(int step) {
     ref.read(onboardingWizardControllerProvider.notifier).setStep(step);
-    _pageController.animateToPage(
+    unawaited(_pageController.animateToPage(
       step,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
-    );
+    ));
   }
 
   void _next(int currentStep) {
@@ -134,7 +136,7 @@ class _OnboardingWizardScreenState
       return;
     }
     if (_isLastStep(currentStep)) {
-      _finishOnboarding();
+      unawaited(_finishOnboarding());
     } else {
       _goToStep(currentStep + 1);
     }

--- a/lib/features/setup/presentation/widgets/country_language_step.dart
+++ b/lib/features/setup/presentation/widgets/country_language_step.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/country/country_config.dart';
@@ -52,7 +54,7 @@ class CountryLanguageStep extends ConsumerWidget {
                   label: Text(lang.nativeName),
                   selected: isSelected,
                   onSelected: (_) {
-                    ref.read(activeLanguageProvider.notifier).select(lang);
+                    unawaited(ref.read(activeLanguageProvider.notifier).select(lang));
                   },
                   visualDensity: VisualDensity.compact,
                 ),
@@ -81,7 +83,7 @@ class CountryLanguageStep extends ConsumerWidget {
                   label: Text('${c.flag} ${c.name}'),
                   selected: isSelected,
                   onSelected: (_) {
-                    ref.read(activeCountryProvider.notifier).select(c);
+                    unawaited(ref.read(activeCountryProvider.notifier).select(c));
                   },
                 ),
               );

--- a/lib/features/setup/providers/onboarding_platform_steps_provider.dart
+++ b/lib/features/setup/providers/onboarding_platform_steps_provider.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Platform-resolved onboarding step composition (#3163).
+///
+/// The onboarding wizard used to branch on `defaultTargetPlatform`
+/// inline in shared presentation code — a hole in the plugin-pattern
+/// lint guard (`test/lint/no_inline_platform_check_test.dart`), which
+/// only matched `Platform.isXxx`. This provider is the sanctioned
+/// dispatch seam: it resolves whether the iOS-only standby explainer
+/// step (#1542 phase 6) is part of the wizard, so the screen itself
+/// stays platform-agnostic.
+///
+/// Widget tests either override this provider or set
+/// `debugDefaultTargetPlatformOverride` before the wizard's first
+/// build (the existing tests do the latter; the provider reads the
+/// platform lazily on first access within each test's fresh
+/// `ProviderScope`, so both seams keep working).
+final onboardingIncludesIosStandbyStepProvider = Provider<bool>(
+  (ref) => defaultTargetPlatform == TargetPlatform.iOS,
+);

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -38,7 +38,7 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
   @override
   void initState() {
     super.initState();
-    _recordAndLoad();
+    unawaited(_recordAndLoad());
   }
 
   Future<void> _recordAndLoad() async {

--- a/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -54,11 +56,11 @@ class StationDetailAppBarActions extends ConsumerWidget {
           onPressed: () {
             final s = station;
             if (s != null) {
-              NavigationUtils.openInMaps(
+              unawaited(NavigationUtils.openInMaps(
                 s.lat,
                 s.lng,
                 label: hasRealBrand(s) ? s.brand : s.street,
-              );
+              ));
             }
           },
           tooltip: l10n?.navigate ?? 'Navigate',
@@ -89,9 +91,9 @@ class StationDetailAppBarActions extends ConsumerWidget {
         IconButton(
           icon: AnimatedFavoriteStar(isFavorite: isFav),
           onPressed: () {
-            ref
+            unawaited(ref
                 .read(favoritesProvider.notifier)
-                .toggle(stationId, stationData: station);
+                .toggle(stationId, stationData: station));
           },
           tooltip: isFav ? 'Remove from favorites' : 'Add to favorites',
         ),

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -113,7 +115,7 @@ class LogFillUpButton extends ConsumerWidget {
         };
         if (pricedFuel != null) extra['fuelType'] = pricedFuel;
         if (pricePerLiter != null) extra['pricePerLiter'] = pricePerLiter;
-        context.push('/consumption/add', extra: extra);
+        unawaited(context.push('/consumption/add', extra: extra));
       },
       icon: const Icon(Icons.local_gas_station_outlined),
       label: Text(

--- a/lib/features/station_detail/presentation/widgets/station_rating_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_rating_section.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -33,7 +35,7 @@ class StationRatingSection extends StatelessWidget {
             StarRating(
               rating: rating,
               onRatingChanged: (stars) {
-                ref.read(stationRatingsProvider.notifier).rate(stationId, stars);
+                unawaited(ref.read(stationRatingsProvider.notifier).rate(stationId, stars));
               },
             ),
             if (rating != null) ...[

--- a/lib/features/station_services/austria/econtrol_station_service.dart
+++ b/lib/features/station_services/austria/econtrol_station_service.dart
@@ -91,7 +91,7 @@ class EControlStationService with StationServiceHelpers implements StationServic
   Future<List<Station>> _queryByCoordinates(
     double lat, double lng, String fuelType, {CancelToken? cancelToken}
   ) async {
-    final response = await _dio.get(
+    final response = await _dio.get<dynamic>(
       '$_baseUrl/search/gas-stations/by-address',
       queryParameters: {
         'latitude': lat,
@@ -106,7 +106,8 @@ class EControlStationService with StationServiceHelpers implements StationServic
 
     final stations = <Station>[];
     for (final r in response.data as List) {
-      final station = _parseStation(r, lat, lng, fuelType);
+      final station =
+          _parseStation(r as Map<String, dynamic>, lat, lng, fuelType);
       if (station != null) stations.add(station);
     }
     return stations;

--- a/lib/features/station_services/chile/chile_response_parser.dart
+++ b/lib/features/station_services/chile/chile_response_parser.dart
@@ -108,7 +108,7 @@ List<Station> parseChileStationsResponse(
 // ──────────────────────────────────────────────────────────────────────
 
 Station? _parseOneStation(
-  Map raw, {
+  Map<dynamic, dynamic> raw, {
   required double fromLat,
   required double fromLng,
 }) {
@@ -167,7 +167,7 @@ Station? _parseOneStation(
   );
 }
 
-Map<FuelType, double> _parsePrices(Map raw) {
+Map<FuelType, double> _parsePrices(Map<dynamic, dynamic> raw) {
   final out = <FuelType, double>{};
   final precios = raw['precios'];
   if (precios is! Map) return out;
@@ -231,14 +231,14 @@ double? _parseDouble(dynamic raw) {
   return null;
 }
 
-Map? _coerceMap(dynamic data) {
+Map<dynamic, dynamic>? _coerceMap(dynamic data) {
   if (data is Map) return data;
   return null;
 }
 
 /// CNE nests the distributor under `distribuidor.nombre`; older
 /// payloads use a flat `distribuidor` string. Accept both.
-String _parseBrand(Map raw) {
+String _parseBrand(Map<dynamic, dynamic> raw) {
   final dist = raw['distribuidor'];
   if (dist is Map) {
     final n = dist['nombre']?.toString().trim();
@@ -251,7 +251,7 @@ String _parseBrand(Map raw) {
   return 'Independent';
 }
 
-String _joinStreet(Map raw) {
+String _joinStreet(Map<dynamic, dynamic> raw) {
   final calle = raw['direccion_calle']?.toString().trim() ?? '';
   final numero = raw['direccion_numero']?.toString().trim() ?? '';
   if (calle.isEmpty && numero.isEmpty) return '';
@@ -264,7 +264,7 @@ String _joinStreet(Map raw) {
 /// `horario_atencion` field often reads `"24_horas"` or a free-text
 /// schedule. We treat stations as open by default and fall back to
 /// `false` only when the field explicitly says `cerrado`.
-bool _isOpen(Map raw) {
+bool _isOpen(Map<dynamic, dynamic> raw) {
   final h = raw['horario_atencion']?.toString().toLowerCase().trim();
   if (h == null || h.isEmpty) return true;
   if (h.contains('cerrado')) return false;

--- a/lib/features/station_services/chile/chile_station_service.dart
+++ b/lib/features/station_services/chile/chile_station_service.dart
@@ -156,7 +156,7 @@ class ChileStationService
       // No query parameters: we pull everything and filter locally so
       // the radius / sort semantics from [StationServiceHelpers] stay
       // consistent with every other country.
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         _baseUrl,
         cancelToken: cancelToken,
       );

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -181,7 +181,7 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
   /// OK — https://mobility-prices.ok.dk/api/v1/fuel-prices
   Future<List<Station>> _fetchOk({CancelToken? cancelToken}) async {
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         'https://mobility-prices.ok.dk/api/v1/fuel-prices',
         cancelToken: cancelToken,
       );
@@ -249,7 +249,7 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
   /// Shell — https://shellpumpepriser.geoapp.me/v1/prices
   Future<List<Station>> _fetchShell({CancelToken? cancelToken}) async {
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         'https://shellpumpepriser.geoapp.me/v1/prices',
         cancelToken: cancelToken,
       );

--- a/lib/features/station_services/france/prix_carburants_parsers.dart
+++ b/lib/features/station_services/france/prix_carburants_parsers.dart
@@ -276,15 +276,14 @@ Map<String, dynamic> parsePrixCarburantsHoursInput(Map<String, dynamic> r) {
   final automate24h = automateRaw == '1' || automateRaw == 'oui';
 
   final jourRaw = decoded['jour'];
-  final jours = jourRaw is List ? jourRaw : [if (jourRaw != null) jourRaw];
+  final jours = jourRaw is List ? jourRaw : [?jourRaw];
   final parts = <String>[];
   for (final jour in jours) {
     if (jour is! Map) continue;
     final nom = jour['@nom']?.toString().trim() ?? '';
     if (nom.isEmpty) continue;
     final horaireRaw = jour['horaire'];
-    final horaires =
-        horaireRaw is List ? horaireRaw : [if (horaireRaw != null) horaireRaw];
+    final horaires = horaireRaw is List ? horaireRaw : [?horaireRaw];
     for (final h in horaires) {
       if (h is! Map) continue;
       final open = h['@ouverture']?.toString().trim() ?? '';

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -134,7 +134,7 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
 
   Future<List<Map<String, dynamic>>> _queryByPostalCode(String cp, {CancelToken? cancelToken}) async {
     try {
-      final response = await _dio.get(_baseUrl, queryParameters: {
+      final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
         'where': "cp='$cp'",
         'limit': 50,
       }, cancelToken: cancelToken);
@@ -176,7 +176,7 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     // by the unchanged `within_distance` filter).
     final point = "geom'POINT($lng $lat)'";
     try {
-      final response = await _dio.get(_baseUrl, queryParameters: {
+      final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
         'where': 'within_distance(geom,$point,${radiusStr}km)',
         'order_by': 'distance(geom,$point)',
         'limit': 50,
@@ -248,7 +248,7 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     // unprefixed favorites.
     final upstreamId =
         stationId.startsWith('fr-') ? stationId.substring(3) : stationId;
-    final response = await _dio.get(_baseUrl, queryParameters: {
+    final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
       'where': 'id=$upstreamId',
       'limit': 1,
     });
@@ -354,7 +354,7 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     }
 
     try {
-      final response = await _dio.get(_baseUrl, queryParameters: {
+      final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
         'where': whereClauses.join(' OR '),
         'limit': batch.length,
       });

--- a/lib/features/station_services/germany/tankerkoenig_station_service.dart
+++ b/lib/features/station_services/germany/tankerkoenig_station_service.dart
@@ -55,7 +55,7 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
     CancelToken? cancelToken,
   }) async {
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         ApiConstants.listEndpoint,
         queryParameters: {
           'lat': params.lat,
@@ -109,7 +109,7 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
     String stationId,
   ) async {
     try {
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         ApiConstants.detailEndpoint,
         // #753 — accept either `de-<uuid>` (new prefix) or a bare UUID
         // (legacy favorite from before the prefix scheme); the upstream

--- a/lib/features/station_services/greece/greece_station_service.dart
+++ b/lib/features/station_services/greece/greece_station_service.dart
@@ -174,7 +174,7 @@ class GreeceStationService
 
     for (final pref in candidates) {
       try {
-        final response = await _dio.get(
+        final response = await _dio.get<dynamic>(
           '$_baseUrl/data/daily/prefecture/${pref.apiName}',
           cancelToken: cancelToken,
         );
@@ -276,7 +276,7 @@ class GreeceStationService
     // Prefer the newest entry. The community API documents "most recent
     // first" but we defend against order drift by picking the entry with
     // the greatest `date` string (ISO-8601 lexicographic order works).
-    Map? newest;
+    Map<dynamic, dynamic>? newest;
     String newestDate = '';
     for (final item in data) {
       if (item is! Map) continue;

--- a/lib/features/station_services/luxembourg/luxembourg_station_service.dart
+++ b/lib/features/station_services/luxembourg/luxembourg_station_service.dart
@@ -192,8 +192,10 @@ class LuxembourgStationService
 
     try {
       final responses = await Future.wait([
-        _dio.get('$_baseUrl/$essenceFlow/$_query', cancelToken: cancelToken),
-        _dio.get('$_baseUrl/$dieselFlow/$_query', cancelToken: cancelToken),
+        _dio.get<dynamic>('$_baseUrl/$essenceFlow/$_query',
+            cancelToken: cancelToken),
+        _dio.get<dynamic>('$_baseUrl/$dieselFlow/$_query',
+            cancelToken: cancelToken),
       ]);
 
       final latest = <String, LustatObservation>{};

--- a/lib/features/station_services/romania/romania_response_parser.dart
+++ b/lib/features/station_services/romania/romania_response_parser.dart
@@ -101,7 +101,7 @@ class MonitorulStationAccumulator {
 
   /// Pull the base fields off the first product-call payload that
   /// carries them; later calls for the same station only add prices.
-  void absorbStation(Map raw) {
+  void absorbStation(Map<dynamic, dynamic> raw) {
     name ??= raw['name']?.toString().trim();
 
     final network = raw['network'];

--- a/lib/features/station_services/romania/romania_station_service.dart
+++ b/lib/features/station_services/romania/romania_station_service.dart
@@ -165,7 +165,7 @@ class RomaniaStationService
 
       final responses = await Future.wait([
         for (final entry in entries)
-          _dio.get(
+          _dio.get<dynamic>(
             '$_baseUrl$searchPath',
             queryParameters: {
               'lon': params.lng,

--- a/lib/features/station_services/slovenia/slovenia_station_service.dart
+++ b/lib/features/station_services/slovenia/slovenia_station_service.dart
@@ -97,7 +97,7 @@ class SloveniaStationService with StationServiceHelpers implements StationServic
           .clamp(1000, 200 * 1000)
           .round();
 
-      final response = await _dio.get(
+      final response = await _dio.get<dynamic>(
         _baseUrl,
         queryParameters: {
           'format': 'json',
@@ -148,7 +148,7 @@ class SloveniaStationService with StationServiceHelpers implements StationServic
     return parsed;
   }
 
-  Station? _parseStation(Map raw) {
+  Station? _parseStation(Map<dynamic, dynamic> raw) {
     final lat = (raw['lat'] as num?)?.toDouble();
     final lng = (raw['lng'] as num?)?.toDouble();
     if (lat == null || lng == null) return null;
@@ -239,7 +239,7 @@ class SloveniaStationService with StationServiceHelpers implements StationServic
   /// goriva.si stores missing prices as JSON `null` and present prices
   /// as numeric EUR-per-litre values. Anything else (empty string, bad
   /// number) is treated as missing.
-  double? _priceFor(Map prices, String key) {
+  double? _priceFor(Map<dynamic, dynamic> prices, String key) {
     final v = prices[key];
     if (v == null) return null;
     if (v is num) return v.toDouble();

--- a/lib/features/station_services/south_korea/south_korea_response_parser.dart
+++ b/lib/features/station_services/south_korea/south_korea_response_parser.dart
@@ -80,7 +80,7 @@ class OpinetStationAccumulator {
   /// Korea sit in [124, 132] × [33, 39], so the magnitude check below
   /// distinguishes the two unambiguously and keeps the parser tolerant
   /// of any OPINET endpoint that *does* serve WGS84.
-  void absorbBase(Map raw) {
+  void absorbBase(Map<dynamic, dynamic> raw) {
     brandCode ??= raw['POLL_DIV_CD']?.toString();
     name ??= raw['OS_NM']?.toString().trim();
     address ??= raw['NEW_ADR']?.toString().trim();
@@ -232,7 +232,7 @@ double? _parseDouble(dynamic raw) {
   return null;
 }
 
-Map? _coerceMap(dynamic data) {
+Map<dynamic, dynamic>? _coerceMap(dynamic data) {
   if (data is Map) return data;
   return null;
 }

--- a/lib/features/station_services/south_korea/south_korea_station_service.dart
+++ b/lib/features/station_services/south_korea/south_korea_station_service.dart
@@ -165,7 +165,7 @@ class SouthKoreaStationService
 
       final responses = await Future.wait([
         for (final entry in entries)
-          _dio.get(
+          _dio.get<dynamic>(
             _baseUrl,
             queryParameters: {
               'code': _apiKey,

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -196,7 +196,7 @@ class MitecoStationService
     String provinceId, {
     CancelToken? cancelToken,
   }) async {
-    final response = await _dio.get(
+    final response = await _dio.get<dynamic>(
       '$_baseUrl/EstacionesTerrestres/FiltroProvincia/$provinceId',
       cancelToken: cancelToken,
     );

--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/sync/supabase_client.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -84,7 +87,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 'Connected as guest');
         context.pop();
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'AuthScreen._continueAsGuest: guest sign-in failed'
+      }));
       if (mounted) {
         form.setError(
             friendlyAuthError(e, AppLocalizations.of(context)));
@@ -148,7 +154,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         }
         context.pop();
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'AuthScreen._submitEmail: email auth failed'
+      }));
       if (mounted) {
         form.setError(
             friendlyAuthError(e, AppLocalizations.of(context)));
@@ -171,7 +180,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 'Switched to anonymous session');
         context.pop();
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'AuthScreen._switchToAnonymous: switch failed'
+      }));
       if (mounted) {
         form.setError(
             friendlyAuthError(e, AppLocalizations.of(context)));

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -29,7 +29,7 @@ class DataTransparencyScreen extends ConsumerWidget {
     Map<String, dynamic> data,
   ) async {
     final json = _prettyJson(data);
-    await showDialog(
+    await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: Text(AppLocalizations.of(context)?.rawDataJson ?? 'Raw data (JSON)'),

--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -122,7 +122,10 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
 
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'SyncSetupScreen._onAuthSubmit: connect/sign-in failed'
+      }));
       if (mounted) {
         ctrl.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
@@ -160,7 +163,10 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
 
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'SyncSetupScreen._onAdopt: adopt connect/sign-in failed'
+      }));
       if (mounted) {
         ctrl.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -262,7 +262,10 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
           );
       if (!mounted) return;
       await _verifySchemaAfterConnect();
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'SyncWizardScreen._adopt: adopt connect/sign-in failed'
+      }));
       if (mounted) {
         wizard.adoptFailed('Connection failed: $e');
       }
@@ -280,7 +283,10 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
       final key = _sanitizeKey(_keyController.text);
       await TankSyncClient.init(url: url, anonKey: key);
       if (mounted) wizard.testSucceeded('Connection successful!');
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'SyncWizardScreen._testConnection: test failed'
+      }));
       if (mounted) wizard.testFailed('Connection failed:\n$e');
     }
   }
@@ -321,7 +327,10 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
 
       if (!mounted) return;
       await _verifySchemaAfterConnect();
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'SyncWizardScreen._connect: connect/sign-in failed'
+      }));
       if (mounted) {
         notifier.connectFailed('Connection failed: $e');
       }

--- a/lib/features/sync/presentation/widgets/auth_form_widget.dart
+++ b/lib/features/sync/presentation/widgets/auth_form_widget.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -83,12 +85,12 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
       SnackBarHelper.showError(context, error);
       return;
     }
-    widget.onSubmit(
+    unawaited(widget.onSubmit(
       isEmail: form.useEmail,
       email: form.useEmail ? _emailController.text.trim() : null,
       password: form.useEmail ? _passwordController.text : null,
       isSignUp: form.isSignUp,
-    );
+    ));
   }
 
   @override

--- a/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -72,7 +74,7 @@ class LinkDeviceThisDeviceCard extends StatelessWidget {
                       tooltip:
                           l10n?.linkDeviceCopyCodeTooltip ?? 'Copy code',
                       onPressed: () {
-                        Clipboard.setData(ClipboardData(text: myId!));
+                        unawaited(Clipboard.setData(ClipboardData(text: myId!)));
                         SnackBarHelper.show(
                           context,
                           AppLocalizations.of(context)?.deviceCodeCopied ??

--- a/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
+++ b/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
@@ -78,7 +78,7 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
       _controller = MobileScannerController();
       _ownsController = true;
     }
-    _probePermission();
+    unawaited(_probePermission());
   }
 
   Future<void> _probePermission() async {
@@ -124,7 +124,7 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
   void dispose() {
     _timeoutTimer?.cancel();
     if (_ownsController) {
-      _controller.dispose();
+      unawaited(_controller.dispose());
     }
     super.dispose();
   }
@@ -205,7 +205,7 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
     _timeoutTimer?.cancel();
     // Medium impact — noticeable but not startling. Gives the user
     // a tactile "yes, we got it" before the navigation animation.
-    HapticFeedback.mediumImpact();
+    unawaited(HapticFeedback.mediumImpact());
     Navigator.pop(context, value);
   }
 }

--- a/lib/features/sync/presentation/widgets/qr_share_widget.dart
+++ b/lib/features/sync/presentation/widgets/qr_share_widget.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -66,7 +68,7 @@ class QrShareWidget extends ConsumerWidget {
         const SizedBox(height: 12),
         OutlinedButton.icon(
           onPressed: () {
-            Clipboard.setData(ClipboardData(text: qrData));
+            unawaited(Clipboard.setData(ClipboardData(text: qrData)));
             SnackBarHelper.show(context, AppLocalizations.of(context)?.connectionDataCopied ?? 'Connection data copied');
           },
           icon: const Icon(Icons.copy, size: 16),

--- a/lib/features/sync/presentation/widgets/wizard_schema_step.dart
+++ b/lib/features/sync/presentation/widgets/wizard_schema_step.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -114,7 +116,7 @@ class WizardSchemaStep extends StatelessWidget {
           const SizedBox(height: 12),
           FilledButton.icon(
             onPressed: () {
-              Clipboard.setData(ClipboardData(text: migrationSql ?? ''));
+              unawaited(Clipboard.setData(ClipboardData(text: migrationSql ?? '')));
               SnackBarHelper.show(context,
                   l10n?.sqlCopied ?? 'SQL copied to clipboard');
             },

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -54,7 +54,7 @@ class DataTransparencyController extends _$DataTransparencyController {
   @override
   DataTransparencyState build() {
     // Kick off initial load.
-    Future.microtask(load);
+    unawaited(Future.microtask(load));
     return const DataTransparencyState();
   }
 

--- a/lib/features/sync/providers/data_transparency_provider.dart
+++ b/lib/features/sync/providers/data_transparency_provider.dart
@@ -88,7 +88,10 @@ class DataTransparencyController extends _$DataTransparencyController {
       } else {
         state = DataTransparencyState(data: data, loading: false);
       }
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'DataTransparencyController.load: fetchAll failed'
+      }));
       state = state.copyWith(loading: false, error: e.toString());
     }
   }
@@ -169,7 +172,10 @@ class DataTransparencyController extends _$DataTransparencyController {
     try {
       await UserDataSync.deleteAll();
       await load();
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'DataTransparencyController.deleteAllData: delete failed'
+      }));
       state = state.copyWith(loading: false, error: e.toString());
     }
   }

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -44,7 +44,7 @@ final class DataTransparencyControllerProvider
 }
 
 String _$dataTransparencyControllerHash() =>
-    r'b4f45ab05014413fcd7dd9c68fdd7430b0fd0f1a';
+    r'85523f801ec9831a6645d6e64889fa00137adb06';
 
 abstract class _$DataTransparencyController
     extends $Notifier<DataTransparencyState> {

--- a/lib/features/sync/providers/data_transparency_provider.g.dart
+++ b/lib/features/sync/providers/data_transparency_provider.g.dart
@@ -44,7 +44,7 @@ final class DataTransparencyControllerProvider
 }
 
 String _$dataTransparencyControllerHash() =>
-    r'6f7412b55b4b699795210784a8d93fc316b9c835';
+    r'b4f45ab05014413fcd7dd9c68fdd7430b0fd0f1a';
 
 abstract class _$DataTransparencyController
     extends $Notifier<DataTransparencyState> {

--- a/lib/features/sync/providers/link_device_provider.dart
+++ b/lib/features/sync/providers/link_device_provider.dart
@@ -182,7 +182,10 @@ class LinkDeviceController extends _$LinkDeviceController {
             'Linked! Imported $addedFavorites favorites, $addedAlerts alerts, '
             '$addedVehicles vehicles, $addedFillUps fill-ups.',
       );
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+        'where': 'LinkDeviceController: device link failed'
+      }));
       state = LinkDeviceState(result: 'Link failed: $e');
     }
   }

--- a/lib/features/sync/providers/link_device_provider.g.dart
+++ b/lib/features/sync/providers/link_device_provider.g.dart
@@ -42,7 +42,7 @@ final class LinkDeviceControllerProvider
 }
 
 String _$linkDeviceControllerHash() =>
-    r'e7534bc5edc0aaf95d99bd2d861866065f37d4c3';
+    r'b97e4144a61dbab0713cbc9baa16f3924648979b';
 
 abstract class _$LinkDeviceController extends $Notifier<LinkDeviceState> {
   LinkDeviceState build();

--- a/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
@@ -99,7 +99,7 @@ class _CatalogReresolveSnackbarHostState
               GoRouter.of(context)
                   .push('/vehicles/edit', extra: candidate.vehicleId);
             } catch (_) {
-              // Best-effort — if the router isn't available (widget
+              // ignore: silent_catch — Best-effort — if the router isn't available (widget
               // tests without a router) we still want the flag write
               // below to fire so the nudge does not loop.
             }

--- a/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -96,8 +98,8 @@ class _CatalogReresolveSnackbarHostState
             // through to the global router. The vehicle-edit route
             // expects the vehicle id as `extra` (see profile_routes.dart).
             try {
-              GoRouter.of(context)
-                  .push('/vehicles/edit', extra: candidate.vehicleId);
+              unawaited(GoRouter.of(context)
+                  .push('/vehicles/edit', extra: candidate.vehicleId));
             } catch (_) {
               // ignore: silent_catch — Best-effort — if the router isn't available (widget
               // tests without a router) we still want the flag write
@@ -112,7 +114,7 @@ class _CatalogReresolveSnackbarHostState
     // again for this vehicle. Done after `showSnackBar` so a failure
     // in the messenger doesn't leave the user permanently un-
     // nudgeable.
-    Future<void>(() async {
+    unawaited(Future<void>(() async {
       // #3159 — this future is detached, so the host can unmount before it
       // runs; both the helper's ref.read and the invalidate below would
       // then throw a StateError. Skipping is safe: the candidate provider
@@ -126,7 +128,7 @@ class _CatalogReresolveSnackbarHostState
         // build.
         if (mounted) ref.invalidate(catalogReresolveCandidatesProvider);
       }
-    });
+    }));
   }
 }
 

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
@@ -92,11 +94,11 @@ class ServiceReminderSection extends ConsumerWidget {
       intervalKm: intervalKm,
       lastServiceOdometerKm: currentOdometerKm,
     );
-    ref.read(serviceReminderListProvider.notifier).save(reminder);
+    unawaited(ref.read(serviceReminderListProvider.notifier).save(reminder));
   }
 
   void _delete(WidgetRef ref, String id) {
-    ref.read(serviceReminderListProvider.notifier).remove(id);
+    unawaited(ref.read(serviceReminderListProvider.notifier).remove(id));
   }
 
   Future<void> _markDone(

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -237,7 +237,12 @@ class NearestWidgetDataBuilder {
             await _persist(payload, userLat: lat, userLng: lng);
             return payload;
           }
-        } catch (decodeErr, st) { // ignore: unused_catch_stack
+        } catch (decodeErr, st) {
+          unawaited(errorLogger.log(ErrorLayer.storage, decodeErr, st,
+              context: const {
+                'where': 'NearestWidgetDataBuilder: stale-fallback '
+                    'previous JSON decode failed'
+              }));
           debugPrint(
             'NearestWidgetDataBuilder: previous JSON decode failed: '
             '$decodeErr',
@@ -269,6 +274,8 @@ class NearestWidgetDataBuilder {
     if (key != null) {
       try {
         fuel = FuelType.fromString(key);
+      // #3164 — kept: stored-preference validation; unknown fuel key is
+      // expected and falls back.
       } catch (e, st) { // ignore: unused_catch_stack
         debugPrint(
           'NearestWidgetDataBuilder: unknown preferred fuel "$key": $e',

--- a/lib/features/widget/presentation/widget_click_listener.dart
+++ b/lib/features/widget/presentation/widget_click_listener.dart
@@ -48,7 +48,7 @@ class WidgetLaunchHandler {
     );
     if (path == null) return;
     try {
-      _router.push(path);
+      unawaited(_router.push(path));
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {'where': 'WidgetLaunchHandler: push failed for $uri → $path'}));
     }

--- a/lib/features/widget/presentation/widget_help_section.dart
+++ b/lib/features/widget/presentation/widget_help_section.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -164,7 +166,7 @@ class _WidgetDefaultsEditor extends ConsumerWidget {
     // Riverpod listeners watching activeProfileProvider repaint as
     // soon as Hive returns. Errors are surfaced via the provider's
     // own logging.
-    ref.read(activeProfileProvider.notifier).updateProfile(next);
+    unawaited(ref.read(activeProfileProvider.notifier).updateProfile(next));
   }
 
   static String _localizedSchemeLabel(

--- a/lib/features/widget/providers/pending_widget_uri_provider.dart
+++ b/lib/features/widget/providers/pending_widget_uri_provider.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'pending_widget_uri_provider.g.dart';
@@ -53,7 +55,7 @@ class PendingWidgetUri extends _$PendingWidgetUri {
   Uri? consumeDeferred() {
     final pending = state;
     if (pending != null) {
-      Future.microtask(() => state = null);
+      unawaited(Future.microtask(() => state = null));
     }
     return pending;
   }

--- a/lib/features/widget/providers/pending_widget_uri_provider.g.dart
+++ b/lib/features/widget/providers/pending_widget_uri_provider.g.dart
@@ -101,7 +101,7 @@ final class PendingWidgetUriProvider
   }
 }
 
-String _$pendingWidgetUriHash() => r'c6f9435f44a1ab9dcf183bc4be69410215c4ce9e';
+String _$pendingWidgetUriHash() => r'ac09e8785e713755c741e78d06bfb73860862b6f';
 
 /// One-shot stash for the URI a home-screen widget tap delivered to the
 /// app on cold start.

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -141,14 +141,13 @@ if ! git diff --exit-code -- lib/l10n/; then
 fi
 
 # --- 4. Static analysis --------------------------------------------------
-# Match CI exactly: CI runs `flutter analyze --no-fatal-infos`, so info-level
-# lints (e.g. a stray unnecessary_import) are NON-fatal there. A bare
-# `flutter analyze` here is fatal on infos, so a pre-existing info anywhere in
-# the tree blocked EVERY push's gate and forced SKIP_PREPUSH (#3031). Stay
-# fatal on warnings + errors (what CI fails on); let infos through.
-echo "pre-push [4/5]: flutter analyze (--no-fatal-infos, matching CI)..."
-if ! flutter analyze --no-fatal-infos; then
-  fail "flutter analyze reported warnings/errors" "Fix the analyzer output above."
+# Match CI exactly: since #3161 CI runs a bare `flutter analyze` (fatal on
+# infos too — the lint phase-in is over and the tree is info-clean). A new
+# info is a CI failure, so it must block the push here as well; deliberate
+# exceptions carry an explicit `// ignore:` with a reason.
+echo "pre-push [4/5]: flutter analyze (fatal infos, matching CI)..."
+if ! flutter analyze; then
+  fail "flutter analyze reported errors/warnings/infos" "Fix the analyzer output above."
 fi
 
 # --- 5. Lint + l10n contract tests (cheap, network-free) -----------------

--- a/test/core/background/alert_scan_journal_test.dart
+++ b/test/core/background/alert_scan_journal_test.dart
@@ -21,9 +21,9 @@ void main() {
 
   setUp(() async {
     if (!Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.openBox(HiveBoxes.alerts);
+      await Hive.openBox<dynamic>(HiveBoxes.alerts);
     }
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {
@@ -133,7 +133,7 @@ void main() {
   group('never-throws contract (fault injection)', () {
     test('append/entries degrade to a no-op when the alerts box is closed',
         () async {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
       final journal = AlertScanJournal();
 
       await expectLater(
@@ -144,12 +144,12 @@ void main() {
       expect(journal.entries(), isEmpty);
       expect(AlertScanJournal.exportSection, returnsNormally);
 
-      await Hive.openBox(HiveBoxes.alerts); // restore for the next test
+      await Hive.openBox<dynamic>(HiveBoxes.alerts); // restore for the next test
     });
 
     test('a malformed persisted value is ignored, then overwritten',
         () async {
-      final box = Hive.box(HiveBoxes.alerts);
+      final box = Hive.box<dynamic>(HiveBoxes.alerts);
       await box.put(AlertScanJournal.journalKey, 'not-a-list');
       final journal = AlertScanJournal();
 

--- a/test/core/background/background_price_history_writer_test.dart
+++ b/test/core/background/background_price_history_writer_test.dart
@@ -27,10 +27,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.priceHistory)) {
-      await Hive.box(HiveBoxes.priceHistory).close();
+      await Hive.box<dynamic>(HiveBoxes.priceHistory).close();
     }
-    await Hive.openBox(HiveBoxes.priceHistory);
-    await Hive.box(HiveBoxes.priceHistory).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.priceHistory);
+    await Hive.box<dynamic>(HiveBoxes.priceHistory).clear();
   });
 
   tearDownAll(() async {

--- a/test/core/background/background_retry_test.dart
+++ b/test/core/background/background_retry_test.dart
@@ -164,7 +164,7 @@ void main() {
 
     test('returns data on first success', () async {
       adapter.responses = [
-        _MockResponse(data: {'ok': true, 'prices': {}}, statusCode: 200),
+        _MockResponse(data: {'ok': true, 'prices': <dynamic, dynamic>{}}, statusCode: 200),
       ];
 
       final result = await fetchWithRetry(

--- a/test/core/background/background_scan_dedup_store_test.dart
+++ b/test/core/background/background_scan_dedup_store_test.dart
@@ -21,10 +21,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {
@@ -71,7 +71,7 @@ void main() {
       final store = BackgroundScanDedupStore();
       await store.recordScan(now: t0, trigger: 'ios_bg_refresh');
       expect(await store.lastScanAt(), t0);
-      final box = Hive.box(HiveBoxes.alerts);
+      final box = Hive.box<dynamic>(HiveBoxes.alerts);
       expect(box.get(BackgroundScanDedupStore.lastTriggerKey), 'ios_bg_refresh');
     });
 

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -176,7 +176,7 @@ void main() {
 
       final entry = cache.get('nested');
       expect(entry, isNotNull);
-      expect(entry!.payload['station'], isA<Map>());
+      expect(entry!.payload['station'], isA<Map<dynamic, dynamic>>());
     });
   });
 
@@ -483,7 +483,7 @@ void main() {
   group('CacheManager - concurrent access patterns', () {
     test('multiple puts to same key resolve to last write', () async {
       // Simulate concurrent puts
-      final futures = <Future>[];
+      final futures = <Future<dynamic>>[];
       for (int i = 0; i < 10; i++) {
         futures.add(cache.put(
           'concurrent-key',

--- a/test/core/country/country_provider_test.dart
+++ b/test/core/country/country_provider_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
@@ -32,7 +34,7 @@ void main() {
   }) {
     if (savedCountryCode != null) {
       // Seed the persisted country setting so the provider can read it.
-      fakeStorage.putSetting('active_country_code', savedCountryCode);
+      unawaited(fakeStorage.putSetting('active_country_code', savedCountryCode));
     }
 
     final c = ProviderContainer(overrides: [

--- a/test/core/country/country_switch_event_test.dart
+++ b/test/core/country/country_switch_event_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
@@ -167,7 +169,7 @@ void main() {
       // Pin auto-switch OFF so the recompute lands on the deterministic
       // `suggest` action (the default is ON since #2597); this test is about
       // the watch-driven recompute, not the auto-switch policy.
-      fakeStorage.putSetting(StorageKeys.autoSwitchProfile, false);
+      unawaited(fakeStorage.putSetting(StorageKeys.autoSwitchProfile, false));
       // Backing store the overridden allProfilesProvider WATCHES, so a change
       // here must invalidate countrySwitchEvent without a new GPS fix.
       final c = ProviderContainer(overrides: [

--- a/test/core/export/data_exporter_test.dart
+++ b/test/core/export/data_exporter_test.dart
@@ -81,7 +81,7 @@ void main() {
       expect((json['alerts'] as List).length, 1);
       expect((json['fillUps'] as List).length, 1);
       expect((json['fillUps'] as List).first['liters'], 42.5);
-      expect((json['priceHistory'] as Map)['s1'], isA<List>());
+      expect((json['priceHistory'] as Map)['s1'], isA<List<dynamic>>());
     });
   });
 

--- a/test/core/location/movement_detection_provider_test.dart
+++ b/test/core/location/movement_detection_provider_test.dart
@@ -43,7 +43,7 @@ class _FakeGeolocator extends GeolocatorWrapper {
 
   void dispose() {
     if (!controller.isClosed) {
-      controller.close();
+      unawaited(controller.close());
     }
   }
 }
@@ -501,7 +501,7 @@ class _ThrowingFakeGeolocator extends GeolocatorWrapper {
       // Detach the throwing onCancel before disposing — tearDown must
       // not be the path that triggers the test's expected throw.
       c.onCancel = null;
-      c.close();
+      unawaited(c.close());
     }
   }
 }

--- a/test/core/location/movement_detection_test.dart
+++ b/test/core/location/movement_detection_test.dart
@@ -72,7 +72,7 @@ class _FakeGeolocatorWrapper extends GeolocatorWrapper {
   }
 
   void dispose() {
-    positionController.close();
+    unawaited(positionController.close());
   }
 }
 

--- a/test/core/providers/app_state_provider_test.dart
+++ b/test/core/providers/app_state_provider_test.dart
@@ -63,7 +63,7 @@ void main() {
       await fakeStorage.setIgnoredIds(['c']);
       await fakeStorage.setRating('d', 4);
       for (var i = 0; i < 10; i++) {
-        await fakeStorage.cacheData('k$i', {});
+        await fakeStorage.cacheData('k$i', <dynamic, dynamic>{});
       }
       await fakeStorage.savePriceRecords('s1', [
         {'a': 1},

--- a/test/core/services/api_connectivity_test.dart
+++ b/test/core/services/api_connectivity_test.dart
@@ -38,7 +38,7 @@ void main() {
     test('Germany — Tankerkoenig API is reachable', () async {
       // The list endpoint requires an API key, but the status endpoint is open
       // We test that the server responds (even with an auth error = server is up)
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         'https://creativecommons.tankerkoenig.de/json/list.php',
         queryParameters: {
           'lat': 52.52,
@@ -52,13 +52,13 @@ void main() {
 
       // Server responds (200 with error message about invalid key, or 200 with data)
       expect(response.statusCode, 200);
-      expect(response.data, isA<Map>());
+      expect(response.data, isA<Map<dynamic, dynamic>>());
       // The API returns ok:false for invalid keys, which proves the server is reachable
       expect(response.data.containsKey('ok'), isTrue);
     });
 
     test('France — Prix-Carburants API is reachable and returns stations', () async {
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets'
         '/prix-des-carburants-en-france-flux-instantane-v2/records',
         queryParameters: {
@@ -68,8 +68,8 @@ void main() {
       );
 
       expect(response.statusCode, 200);
-      expect(response.data, isA<Map>());
-      expect(response.data['results'], isA<List>());
+      expect(response.data, isA<Map<dynamic, dynamic>>());
+      expect(response.data['results'], isA<List<dynamic>>());
 
       // The Paris 75001 query intermittently returns 0 rows as the open-data
       // endpoint rebuilds its index. Reachability + schema is the goal — only
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('Austria — E-Control API is reachable and returns stations', () async {
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         'https://api.e-control.at/sprit/1.0/search/gas-stations/by-address',
         queryParameters: {
           'latitude': 48.2082,
@@ -96,7 +96,7 @@ void main() {
       );
 
       expect(response.statusCode, 200);
-      expect(response.data, isA<List>());
+      expect(response.data, isA<List<dynamic>>());
       expect((response.data as List).length, greaterThan(0));
 
       // Verify key fields exist
@@ -113,25 +113,25 @@ void main() {
 
     test('Spain — MITECO API is reachable and returns stations', () async {
       // Fetch province list first
-      final provincesResponse = await dio.get(
+      final provincesResponse = await dio.get<dynamic>(
         'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
         '/PreciosCarburantes/Listados/Provincias/',
       );
 
       expect(provincesResponse.statusCode, 200);
-      expect(provincesResponse.data, isA<List>());
+      expect(provincesResponse.data, isA<List<dynamic>>());
       expect((provincesResponse.data as List).length, greaterThan(40));
 
       // Fetch stations for Madrid (province 28)
-      final stationsResponse = await dio.get(
+      final stationsResponse = await dio.get<dynamic>(
         'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
         '/PreciosCarburantes/EstacionesTerrestres/FiltroProvincia/28',
       );
 
       expect(stationsResponse.statusCode, 200);
-      expect(stationsResponse.data, isA<Map>());
+      expect(stationsResponse.data, isA<Map<dynamic, dynamic>>());
       expect(stationsResponse.data['ResultadoConsulta'], 'OK');
-      expect(stationsResponse.data['ListaEESSPrecio'], isA<List>());
+      expect(stationsResponse.data['ListaEESSPrecio'], isA<List<dynamic>>());
       expect(
         (stationsResponse.data['ListaEESSPrecio'] as List).length,
         greaterThan(100),
@@ -214,13 +214,13 @@ void main() {
     });
 
     test('Denmark — OK API is reachable and returns stations', () async {
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         'https://mobility-prices.ok.dk/api/v1/fuel-prices',
       );
 
       expect(response.statusCode, 200);
-      expect(response.data, isA<Map>());
-      expect(response.data['items'], isA<List>());
+      expect(response.data, isA<Map<dynamic, dynamic>>());
+      expect(response.data['items'], isA<List<dynamic>>());
       expect((response.data['items'] as List).length, greaterThan(0));
 
       final station = (response.data['items'] as List).first;
@@ -230,12 +230,12 @@ void main() {
     });
 
     test('Denmark — Shell API is reachable and returns stations', () async {
-      final response = await dio.get(
+      final response = await dio.get<dynamic>(
         'https://shellpumpepriser.geoapp.me/v1/prices',
       );
 
       expect(response.statusCode, 200);
-      expect(response.data, isA<List>());
+      expect(response.data, isA<List<dynamic>>());
       expect((response.data as List).length, greaterThan(0));
 
       final station = (response.data as List).first;
@@ -283,7 +283,7 @@ void main() {
       };
 
       for (final entry in testCases.entries) {
-        final response = await dio.get(
+        final response = await dio.get<dynamic>(
           'https://nominatim.openstreetmap.org/search',
           queryParameters: {
             'q': entry.value,
@@ -295,7 +295,7 @@ void main() {
 
         expect(response.statusCode, 200,
             reason: '${entry.key}: Nominatim returned non-200');
-        expect(response.data, isA<List>(),
+        expect(response.data, isA<List<dynamic>>(),
             reason: '${entry.key}: Response is not a list');
         expect((response.data as List).length, greaterThan(0),
             reason: '${entry.key}: No results for ${entry.value}');

--- a/test/core/services/approach_detector_test.dart
+++ b/test/core/services/approach_detector_test.dart
@@ -262,9 +262,9 @@ void main() {
             reason: 'must target the cheapest DIESEL station (A=1.849), not '
                 'the cheapest-any-fuel station (B, by its 1.659 e10)');
 
-        sub.cancel();
-        det.dispose();
-        gps.close();
+        unawaited(sub.cancel());
+        unawaited(det.dispose());
+        unawaited(gps.close());
       });
     });
   });
@@ -308,9 +308,9 @@ void main() {
         expect(emitted.last, isA<ApproachPolling>(),
             reason: 'with no priced station in radius the detector polls');
 
-        sub.cancel();
-        det.dispose();
-        gps.close();
+        unawaited(sub.cancel());
+        unawaited(det.dispose());
+        unawaited(gps.close());
       });
     });
 
@@ -346,9 +346,9 @@ void main() {
                 'surface');
         expect(inRadius.last.station.id, 'A');
 
-        sub.cancel();
-        det.dispose();
-        gps.close();
+        unawaited(sub.cancel());
+        unawaited(det.dispose());
+        unawaited(gps.close());
       });
     });
   });
@@ -407,9 +407,9 @@ void main() {
         expect(fetchCount, fetchesAfterPoll,
             reason: 'the live recompute must NOT poll the data service');
 
-        sub.cancel();
-        det.dispose();
-        gps.close();
+        unawaited(sub.cancel());
+        unawaited(det.dispose());
+        unawaited(gps.close());
       });
     });
   });

--- a/test/core/services/conditional_get_interceptor_test.dart
+++ b/test/core/services/conditional_get_interceptor_test.dart
@@ -17,11 +17,11 @@ void main() {
       ]);
       final dio = _dioWith(adapter);
 
-      final first = await dio.get<Map>('https://x.test/data');
+      final first = await dio.get<Map<dynamic, dynamic>>('https://x.test/data');
       expect(first.statusCode, 200);
       expect(first.data, {'price': 1.5});
 
-      final second = await dio.get<Map>('https://x.test/data');
+      final second = await dio.get<Map<dynamic, dynamic>>('https://x.test/data');
       // 304 is transparently turned into a 200 carrying the cached body.
       expect(second.statusCode, 200);
       expect(second.data, {'price': 1.5});
@@ -39,8 +39,8 @@ void main() {
       ]);
       final dio = _dioWith(adapter);
 
-      await dio.get<Map>('https://x.test/feed');
-      final second = await dio.get<Map>('https://x.test/feed');
+      await dio.get<Map<dynamic, dynamic>>('https://x.test/feed');
+      final second = await dio.get<Map<dynamic, dynamic>>('https://x.test/feed');
 
       expect(adapter.requests[1].headers['If-Modified-Since'], lastMod);
       expect(second.data, {'n': 1});
@@ -53,8 +53,8 @@ void main() {
       ]);
       final dio = _dioWith(adapter);
 
-      final a = await dio.get<Map>('https://x.test/s?q=a');
-      final b = await dio.get<Map>('https://x.test/s?q=b');
+      final a = await dio.get<Map<dynamic, dynamic>>('https://x.test/s?q=a');
+      final b = await dio.get<Map<dynamic, dynamic>>('https://x.test/s?q=b');
       expect(a.data, {'q': 'a'});
       expect(b.data, {'q': 'b'});
       // Neither request revalidated the other's entry.
@@ -70,12 +70,12 @@ void main() {
       ]);
       final dio = _dioWith(adapter);
 
-      final first = await dio.get<Map>('https://x.test/data');
+      final first = await dio.get<Map<dynamic, dynamic>>('https://x.test/data');
       expect(first.data, {'price': 2.0});
 
       // Network drops on the next call — the cached body is served instead of
       // throwing.
-      final second = await dio.get<Map>('https://x.test/data');
+      final second = await dio.get<Map<dynamic, dynamic>>('https://x.test/data');
       expect(second.statusCode, 200);
       expect(second.data, {'price': 2.0});
       expect(second.extra['tankstellen.conditionalGet'], 'offline');
@@ -86,7 +86,7 @@ void main() {
       final dio = _dioWith(adapter);
 
       await expectLater(
-        dio.get<Map>('https://x.test/cold'),
+        dio.get<Map<dynamic, dynamic>>('https://x.test/cold'),
         throwsA(isA<DioException>()),
       );
     });
@@ -98,9 +98,9 @@ void main() {
       ]);
       final dio = _dioWith(adapter);
 
-      await dio.get<Map>('https://x.test/data');
+      await dio.get<Map<dynamic, dynamic>>('https://x.test/data');
       await expectLater(
-        dio.get<Map>('https://x.test/data'),
+        dio.get<Map<dynamic, dynamic>>('https://x.test/data'),
         throwsA(isA<DioException>()),
       );
     });
@@ -123,9 +123,9 @@ void main() {
         ..httpClientAdapter = adapter
         ..interceptors.add(interceptor);
 
-      await dio.get<Map>('https://x.test/a');
-      await dio.get<Map>('https://x.test/b');
-      await dio.get<Map>('https://x.test/c');
+      await dio.get<Map<dynamic, dynamic>>('https://x.test/a');
+      await dio.get<Map<dynamic, dynamic>>('https://x.test/b');
+      await dio.get<Map<dynamic, dynamic>>('https://x.test/c');
       expect(interceptor.cacheSize, 2);
     });
   });

--- a/test/core/services/location_search_service_test.dart
+++ b/test/core/services/location_search_service_test.dart
@@ -289,7 +289,7 @@ void main() {
 
     void stubResponse(List<Map<String, dynamic>> raw) {
       when(
-        () => mockDio.get(
+        () => mockDio.get<dynamic>(
           any(),
           queryParameters: any(named: 'queryParameters'),
           cancelToken: any(named: 'cancelToken'),

--- a/test/core/services/rate_limit_retry_after_test.dart
+++ b/test/core/services/rate_limit_retry_after_test.dart
@@ -15,7 +15,7 @@ import 'package:tankstellen/core/services/rate_limit_interceptor.dart';
 class _CapturingResponseHandler extends ResponseInterceptorHandler {
   bool called = false;
   @override
-  void next(Response response) {
+  void next(Response<dynamic> response) {
     called = true;
   }
 }
@@ -69,7 +69,7 @@ void main() {
   group('RateLimitInterceptor 429 / Retry-After cooldown (#2255)', () {
     RequestOptions opts() => RequestOptions(path: '/test');
 
-    Response resp429(RequestOptions o, {String? retryAfter}) => Response(
+    Response<dynamic> resp429(RequestOptions o, {String? retryAfter}) => Response(
           requestOptions: o,
           statusCode: 429,
           headers: retryAfter == null

--- a/test/core/storage/cache_schema_guard_test.dart
+++ b/test/core/storage/cache_schema_guard_test.dart
@@ -158,14 +158,14 @@ void main() {
     setUp(() async {
       tmp = await Directory.systemTemp.createTemp('cache_evict_test');
       Hive.init(tmp.path);
-      await Hive.openBox(HiveBoxes.cache);
+      await Hive.openBox<dynamic>(HiveBoxes.cache);
       await Hive.openBox<int>(HiveBoxes.boxSchema);
       // The other encrypted-box stamps the migration loop touches.
-      await Hive.openBox(HiveBoxes.settings);
-      await Hive.openBox(HiveBoxes.favorites);
-      await Hive.openBox(HiveBoxes.profiles);
-      await Hive.openBox(HiveBoxes.priceHistory);
-      await Hive.openBox(HiveBoxes.alerts);
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
+      await Hive.openBox<dynamic>(HiveBoxes.favorites);
+      await Hive.openBox<dynamic>(HiveBoxes.profiles);
+      await Hive.openBox<dynamic>(HiveBoxes.priceHistory);
+      await Hive.openBox<dynamic>(HiveBoxes.alerts);
     });
 
     tearDown(() async {
@@ -176,7 +176,7 @@ void main() {
     test('an OLD-format cached search blob stamped at the old version is '
         'evicted (reads as a miss) after the bump, while saved itineraries '
         'and other user data survive', () async {
-      final cacheBox = Hive.box(HiveBoxes.cache);
+      final cacheBox = Hive.box<dynamic>(HiveBoxes.cache);
       final schema = Hive.box<int>(HiveBoxes.boxSchema);
 
       // Pre-#2922 on-disk state: the cache stamped at the OLD schema version,
@@ -223,11 +223,11 @@ void main() {
         {'id': 'i1', 'name': 'Summer trip'},
       ]);
       // User data in OTHER boxes — MUST survive.
-      final favorites = Hive.box(HiveBoxes.favorites);
+      final favorites = Hive.box<dynamic>(HiveBoxes.favorites);
       await favorites.put('fav1', {'id': 'station-7'});
-      final settings = Hive.box(HiveBoxes.settings);
+      final settings = Hive.box<dynamic>(HiveBoxes.settings);
       await settings.put('theme', 'dark');
-      final profiles = Hive.box(HiveBoxes.profiles);
+      final profiles = Hive.box<dynamic>(HiveBoxes.profiles);
       await profiles.put('p1', {'name': 'Me'});
 
       // Run the migration the same way init() does.
@@ -253,7 +253,7 @@ void main() {
 
     test('a fresh install (no stamps) is stamped at the current version and '
         'evicts nothing', () async {
-      final cacheBox = Hive.box(HiveBoxes.cache);
+      final cacheBox = Hive.box<dynamic>(HiveBoxes.cache);
       final schema = Hive.box<int>(HiveBoxes.boxSchema);
 
       // No stamps yet (fresh install). A search entry already in the cache
@@ -270,7 +270,7 @@ void main() {
 
     test('an up-to-date cache (already at current version) is left untouched',
         () async {
-      final cacheBox = Hive.box(HiveBoxes.cache);
+      final cacheBox = Hive.box<dynamic>(HiveBoxes.cache);
       final schema = Hive.box<int>(HiveBoxes.boxSchema);
 
       await schema.put(HiveBoxes.cache, HiveBoxes.currentSchemaVersion);

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -374,7 +374,7 @@ void main() {
 
     test('migrates a plaintext box into an encrypted box, preserving '
         'every entry', () async {
-      final plain = await Hive.openBox('mig_data');
+      final plain = await Hive.openBox<dynamic>('mig_data');
       await plain.put('city', 'Lyon');
       await plain.put('count', 7);
 
@@ -382,19 +382,19 @@ void main() {
 
       // The box is now encrypted and the data survived intact.
       final encrypted =
-          await Hive.openBox('mig_data', encryptionCipher: cipher);
+          await Hive.openBox<dynamic>('mig_data', encryptionCipher: cipher);
       expect(encrypted.get('city'), 'Lyon');
       expect(encrypted.get('count'), 7);
       await encrypted.close();
     });
 
     test('an empty plaintext box migrates without error', () async {
-      final plain = await Hive.openBox('mig_empty');
+      final plain = await Hive.openBox<dynamic>('mig_empty');
 
       await HiveBoxes.migrateToEncryptedForTest('mig_empty', plain, cipher);
 
       final encrypted =
-          await Hive.openBox('mig_empty', encryptionCipher: cipher);
+          await Hive.openBox<dynamic>('mig_empty', encryptionCipher: cipher);
       expect(encrypted.isEmpty, isTrue);
       await encrypted.close();
     });

--- a/test/core/storage/hive_storage_test.dart
+++ b/test/core/storage/hive_storage_test.dart
@@ -204,7 +204,7 @@ void main() {
 
     test('getCachedData returns null when maxAge is exceeded', () async {
       // Manually insert an entry with old timestamp
-      final box = Hive.box('cache');
+      final box = Hive.box<dynamic>('cache');
       await box.put('old-key', {
         'data': {'hello': 'world'},
         'timestamp': DateTime.now()
@@ -229,7 +229,7 @@ void main() {
     });
 
     test('getCachedData without maxAge ignores age', () async {
-      final box = Hive.box('cache');
+      final box = Hive.box<dynamic>('cache');
       await box.put('ancient-key', {
         'data': {'old': true},
         'timestamp': 0, // epoch start
@@ -242,7 +242,7 @@ void main() {
     test('getCachedData returns null when data is not a Map', () async {
       // cacheData wraps in {data: ..., timestamp: ...}
       // If someone stored a non-map as 'data', getCachedData should return null
-      final box = Hive.box('cache');
+      final box = Hive.box<dynamic>('cache');
       await box.put('string-data', {
         'data': 'just a string',
         'timestamp': DateTime.now().millisecondsSinceEpoch,
@@ -721,7 +721,7 @@ void main() {
     // real-bytes implementation the reported value should track
     // `File(box.path).lengthSync()` to within rounding.
     test('storageStats matches File.lengthSync of the underlying box', () {
-      final cacheBox = Hive.box('cache');
+      final cacheBox = Hive.box<dynamic>('cache');
       final cachePath = cacheBox.path;
       expect(cachePath, isNotNull,
           reason: 'native Hive box should expose a path');

--- a/test/core/storage/storage_providers_test.dart
+++ b/test/core/storage/storage_providers_test.dart
@@ -95,7 +95,7 @@ void main() {
       await fakeStorage.saveProfile('p3', {});
       await fakeStorage.setFavoriteIds(List.generate(12, (i) => 's$i'));
       for (var i = 0; i < 87; i++) {
-        await fakeStorage.cacheData('k$i', {});
+        await fakeStorage.cacheData('k$i', <dynamic, dynamic>{});
       }
       await fakeStorage.savePriceRecords('s1', [
         {'a': 1},

--- a/test/core/storage/storage_repository_provider_test.dart
+++ b/test/core/storage/storage_repository_provider_test.dart
@@ -159,7 +159,7 @@ void main() {
       await fake.saveProfile('p2', {});
       await fake.setFavoriteIds(['a', 'b', 'c', 'd', 'e']);
       for (var i = 0; i < 10; i++) {
-        await fake.cacheData('k$i', {});
+        await fake.cacheData('k$i', <dynamic, dynamic>{});
       }
       await fake.savePriceRecords('s1', [
         {'a': 1},

--- a/test/core/storage/stores/cache_hive_store_test.dart
+++ b/test/core/storage/stores/cache_hive_store_test.dart
@@ -106,7 +106,7 @@ void main() {
       expect(store.getCachedData('k1'), isNotNull);
 
       // Simulate closeIsolateBoxes() closing the live handle.
-      await Hive.box(HiveBoxes.cache).close();
+      await Hive.box<dynamic>(HiveBoxes.cache).close();
 
       expect(() => store.getCachedData('k1'), returnsNormally);
       expect(store.getCachedData('k1'), isNull);
@@ -120,7 +120,7 @@ void main() {
       await store.saveItineraries([
         {'id': 'i1', 'name': 'Trip'},
       ]);
-      await Hive.box(HiveBoxes.cache).close();
+      await Hive.box<dynamic>(HiveBoxes.cache).close();
 
       expect(() => store.getItineraries(), returnsNormally);
       expect(store.getItineraries(), isEmpty);
@@ -130,7 +130,7 @@ void main() {
 
     test('cacheData is a silent no-op on a closed box (never throws)',
         () async {
-      await Hive.box(HiveBoxes.cache).close();
+      await Hive.box<dynamic>(HiveBoxes.cache).close();
 
       await expectLater(store.cacheData('k', {'x': 1}), completes);
 
@@ -139,7 +139,7 @@ void main() {
 
     test('saveItineraries / clearCache / deleteCacheEntry no-op on a '
         'closed box', () async {
-      await Hive.box(HiveBoxes.cache).close();
+      await Hive.box<dynamic>(HiveBoxes.cache).close();
 
       await expectLater(store.saveItineraries(const []), completes);
       await expectLater(store.clearCache(), completes);

--- a/test/core/sync/deletions_sync_test.dart
+++ b/test/core/sync/deletions_sync_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/deletions_sync.dart';
 
@@ -14,14 +16,14 @@ import 'package:tankstellen/core/sync/deletions_sync.dart';
 void main() {
   group('DeletionsSync never-throws fault path (#3078)', () {
     test('record completes silently when the client is uninitialised', () {
-      expectLater(DeletionsSync.record('favorites', 'st-X'), completes);
+      unawaited(expectLater(DeletionsSync.record('favorites', 'st-X'), completes));
     });
 
     test('recordAll completes silently on the fault path', () {
-      expectLater(
+      unawaited(expectLater(
         DeletionsSync.recordAll('fill_ups', const ['a', 'b']),
         completes,
-      );
+      ));
     });
 
     test('recordAll on an empty list returns normally (no round-trip)', () {

--- a/test/core/sync/sync_data_models_test.dart
+++ b/test/core/sync/sync_data_models_test.dart
@@ -559,8 +559,8 @@ void main() {
       const dynamic favorites = 'unexpected';
       const dynamic alerts = null;
 
-      final favList = favorites is List ? favorites : [];
-      final alertList = alerts is List ? alerts : [];
+      final favList = favorites is List ? favorites : <dynamic>[];
+      final alertList = alerts is List ? alerts : <dynamic>[];
 
       expect(favList, isEmpty);
       expect(alertList, isEmpty);

--- a/test/core/sync/trips_sync_enabled_provider_test.dart
+++ b/test/core/sync/trips_sync_enabled_provider_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
@@ -29,8 +31,8 @@ void main() {
     required bool syncTrips,
   }) {
     final storage = FakeHiveStorage();
-    storage.putSetting(StorageKeys.consentCloudSync, cloudSync);
-    storage.putSetting(StorageKeys.consentSyncTrips, syncTrips);
+    unawaited(storage.putSetting(StorageKeys.consentCloudSync, cloudSync));
+    unawaited(storage.putSetting(StorageKeys.consentSyncTrips, syncTrips));
     final c = ProviderContainer(overrides: [
       hiveStorageProvider.overrideWithValue(storage),
       syncStateProvider.overrideWith(

--- a/test/core/telemetry/health_counters_test.dart
+++ b/test/core/telemetry/health_counters_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       await c.flush();
 
-      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      final row = Hive.box<dynamic>(HealthCounters.boxName).get('2026-06-10') as Map;
       expect(row['api.de.ok'], 2);
       expect(row['sync.favorites.failures'], 3);
     });
@@ -52,7 +52,7 @@ void main() {
       c.increment('ble.connect.successes');
       await c.flush();
 
-      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      final row = Hive.box<dynamic>(HealthCounters.boxName).get('2026-06-10') as Map;
       expect(row['ble.connect.attempts'], 2);
       expect(row['ble.connect.successes'], 1);
     });
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('flush prunes day rows older than the retention window', () async {
-      final box = Hive.box(HealthCounters.boxName);
+      final box = Hive.box<dynamic>(HealthCounters.boxName);
       await box.put('2026-01-01', {'api.de.ok': 9});
       await box.put('2026-06-09', {'api.de.ok': 1});
 
@@ -129,14 +129,14 @@ void main() {
         () async {
       final c = counters();
       c.increment('api.de.ok');
-      await Hive.box(HealthCounters.boxName).close();
+      await Hive.box<dynamic>(HealthCounters.boxName).close();
 
       await expectLater(c.flush(), completes);
 
       // Re-open: the pending delta survives to the next flush.
       await HealthCounters.init();
       await c.flush();
-      final row = Hive.box(HealthCounters.boxName).get('2026-06-10') as Map;
+      final row = Hive.box<dynamic>(HealthCounters.boxName).get('2026-06-10') as Map;
       expect(row['api.de.ok'], 1);
     });
 
@@ -148,7 +148,7 @@ void main() {
     });
 
     test('flush skips malformed persisted rows without throwing', () async {
-      final box = Hive.box(HealthCounters.boxName);
+      final box = Hive.box<dynamic>(HealthCounters.boxName);
       await box.put('2026-06-10', 'not-a-map');
 
       final c = counters();

--- a/test/core/telemetry/storage/trace_storage_test.dart
+++ b/test/core/telemetry/storage/trace_storage_test.dart
@@ -66,7 +66,7 @@ void main() {
       final json = _makePlainJson(id: 'trace-1');
       final trace = ErrorTrace.fromJson(json);
       // Store the plain JSON directly in Hive box (bypassing toJson issue)
-      await Hive.box('error_traces').put(trace.id, json);
+      await Hive.box<dynamic>('error_traces').put(trace.id, json);
 
       final retrieved = storage.getById('trace-1');
       expect(retrieved, isNotNull);
@@ -82,7 +82,7 @@ void main() {
       final olderJson = _makePlainJson(id: 'old', timestamp: DateTime(2025, 1, 1));
       final newerJson = _makePlainJson(id: 'new', timestamp: DateTime(2025, 6, 1));
 
-      final box = Hive.box('error_traces');
+      final box = Hive.box<dynamic>('error_traces');
       await box.put('old', olderJson);
       await box.put('new', newerJson);
 
@@ -95,7 +95,7 @@ void main() {
 
     test('delete removes a trace', () async {
       final json = _makePlainJson(id: 'to-delete');
-      await Hive.box('error_traces').put('to-delete', json);
+      await Hive.box<dynamic>('error_traces').put('to-delete', json);
       expect(storage.getById('to-delete'), isNotNull);
 
       await storage.delete('to-delete');
@@ -103,7 +103,7 @@ void main() {
     });
 
     test('clearAll removes all traces', () async {
-      final box = Hive.box('error_traces');
+      final box = Hive.box<dynamic>('error_traces');
       await box.put('a', _makePlainJson(id: 'a'));
       await box.put('b', _makePlainJson(id: 'b'));
       expect(storage.count, 2);
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('count reflects number of stored traces', () async {
-      final box = Hive.box('error_traces');
+      final box = Hive.box<dynamic>('error_traces');
       expect(storage.count, 0);
       await box.put('1', _makePlainJson(id: '1'));
       expect(storage.count, 1);
@@ -123,7 +123,7 @@ void main() {
     });
 
     test('prune removes entries beyond maxTraces', () async {
-      final box = Hive.box('error_traces');
+      final box = Hive.box<dynamic>('error_traces');
       // Store more than maxTraces (50)
       for (var i = 0; i < 55; i++) {
         final json = _makePlainJson(
@@ -206,7 +206,7 @@ void main() {
 
       test('parsed traces match getAll and unparsed match getUnparsedRaw',
           () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put(
             'v1', _makePlainJson(id: 'v1', timestamp: DateTime(2025, 1, 1)));
         await box.put(
@@ -237,7 +237,7 @@ void main() {
       });
 
       test('exported traces are sorted newest-first', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put(
             'old', _makePlainJson(id: 'old', timestamp: DateTime(2024, 1, 1)));
         await box.put(
@@ -254,7 +254,7 @@ void main() {
 
     test('getAll parses stored JSON back into ErrorTrace objects', () async {
       final json = _makePlainJson(id: 'parse-test');
-      await Hive.box('error_traces').put('parse-test', json);
+      await Hive.box<dynamic>('error_traces').put('parse-test', json);
 
       final traces = storage.getAll();
       expect(traces, hasLength(1));
@@ -274,11 +274,11 @@ void main() {
 
       test('serialises every persisted trace into the traces array',
           () async {
-        await Hive.box('error_traces')
+        await Hive.box<dynamic>('error_traces')
             .put('e1', _makePlainJson(id: 'e1'));
-        await Hive.box('error_traces')
+        await Hive.box<dynamic>('error_traces')
             .put('e2', _makePlainJson(id: 'e2'));
-        await Hive.box('error_traces')
+        await Hive.box<dynamic>('error_traces')
             .put('e3', _makePlainJson(id: 'e3'));
 
         final raw = storage.exportAsJson();
@@ -336,7 +336,7 @@ void main() {
           'a THROWING supplier must never kill the export mid-attach — its '
           'failure is recorded in-line and the rest of the export survives',
           () async {
-        await Hive.box('error_traces').put('e1', _makePlainJson(id: 'e1'));
+        await Hive.box<dynamic>('error_traces').put('e1', _makePlainJson(id: 'e1'));
         TraceStorage.extraExportSections['sick'] =
             () => throw StateError('box corrupt');
         TraceStorage.extraExportSections['healthy'] = () => 'ok';
@@ -365,7 +365,7 @@ void main() {
       test(
           'count returns the raw box length while parsedCount filters out '
           'failures', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('valid', _makePlainJson(id: 'valid'));
         await box.put('broken-1', malformedEntry('broken-1'));
         await box.put('broken-2', malformedEntry('broken-2'));
@@ -378,7 +378,7 @@ void main() {
       test(
           'when every entry fails to parse, exportAsJson surfaces the raw '
           'payload under unparsedRaw and traces is empty', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('broken-1', malformedEntry('broken-1'));
         await box.put('broken-2', malformedEntry('broken-2'));
 
@@ -404,7 +404,7 @@ void main() {
       test(
           'with mixed valid/invalid entries both arrays populate and counts '
           'add up to the raw box length', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('valid-1', _makePlainJson(id: 'valid-1'));
         await box.put('valid-2', _makePlainJson(id: 'valid-2'));
         await box.put('broken', malformedEntry('broken'));
@@ -426,7 +426,7 @@ void main() {
 
       test('unparsedCount is 0 (never negative) when every entry parses',
           () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('a', _makePlainJson(id: 'a'));
         await box.put('b', _makePlainJson(id: 'b'));
 
@@ -496,7 +496,7 @@ void main() {
       }
 
       test('getAll parses Hive-shaped Map<dynamic, dynamic> trace', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
 
         final all = storage.getAll();
@@ -512,7 +512,7 @@ void main() {
       });
 
       test('getUnparsedRaw is empty when input is Hive-shaped', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
 
         expect(storage.getUnparsedRaw(), isEmpty);
@@ -522,7 +522,7 @@ void main() {
 
       test('getById parses Hive-shaped Map<dynamic, dynamic> trace',
           () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         await box.put('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca', hiveShapedTrace());
 
         final t = storage.getById('30be7070-8aa2-4f9e-bfc0-e61fa4e486ca');
@@ -533,7 +533,7 @@ void main() {
       test(
           'malformed entries still surface in unparsedRaw (regression: #1301 '
           'broad-catch path is preserved)', () async {
-        final box = Hive.box('error_traces');
+        final box = Hive.box<dynamic>('error_traces');
         // Hive-shaped map with the required `id` field removed — schema drift.
         final broken = hiveShapedTrace()..remove('id');
         await box.put('broken', broken);
@@ -568,7 +568,7 @@ void main() {
             'detail': 'lat=48.137154 lng=11.576124 type=PlatformException',
           },
         ];
-        await Hive.box('error_traces').put('coord-trace', json);
+        await Hive.box<dynamic>('error_traces').put('coord-trace', json);
 
         final raw = storage.exportAsJson();
         expect(raw, isNot(contains('48.137154')),
@@ -582,7 +582,7 @@ void main() {
         // Schema-drifted entry (no id → fails fromJson) carrying coords.
         final broken = _makePlainJson(id: 'drifted')..remove('id');
         broken['errorMessage'] = 'failed at lat=48.137154 lng=11.576124';
-        await Hive.box('error_traces').put('drifted', broken);
+        await Hive.box<dynamic>('error_traces').put('drifted', broken);
 
         final raw = storage.exportAsJson();
         final decoded = jsonDecode(raw) as Map<String, dynamic>;

--- a/test/core/widgets/help_banner_test.dart
+++ b/test/core/widgets/help_banner_test.dart
@@ -14,7 +14,7 @@ void main() {
     testWidgets('shows banner on first open', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.getSetting('test_banner')).thenReturn(null);
-      when(() => test.mockStorage.putSetting(any(), any()))
+      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
           .thenAnswer((_) async {});
 
       await pumpApp(
@@ -50,7 +50,7 @@ void main() {
     testWidgets('dismissing banner stores the flag', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.getSetting('test_banner')).thenReturn(null);
-      when(() => test.mockStorage.putSetting(any(), any()))
+      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
           .thenAnswer((_) async {});
 
       await pumpApp(

--- a/test/features/alerts/data/radius_alert_dedup_test.dart
+++ b/test/features/alerts/data/radius_alert_dedup_test.dart
@@ -21,10 +21,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/alerts/data/radius_alert_runner_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_test.dart
@@ -123,10 +123,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/alerts/data/radius_alert_runner_throttle_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_throttle_test.dart
@@ -108,10 +108,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/alerts/data/radius_alert_store_test.dart
+++ b/test/features/alerts/data/radius_alert_store_test.dart
@@ -45,10 +45,10 @@ void main() {
     // Reopen a clean alerts box for every test. Mirrors the pattern
     // used by the legacy alerts repository test.
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {
@@ -117,7 +117,7 @@ void main() {
       // Legacy per-station alerts live under the 'alerts' key (a
       // list of maps). list() must filter those out so we don't
       // crash on unrelated payloads.
-      final box = Hive.box(HiveBoxes.alerts);
+      final box = Hive.box<dynamic>(HiveBoxes.alerts);
       await box.put('alerts', [
         {'id': 'legacy', 'stationId': 's', 'targetPrice': 1.5},
       ]);
@@ -147,13 +147,13 @@ void main() {
     });
 
     test('list returns empty list when the alerts box is closed', () async {
-      final box = Hive.box(HiveBoxes.alerts);
+      final box = Hive.box<dynamic>(HiveBoxes.alerts);
       await box.close();
 
       final store = RadiusAlertStore();
       expect(await store.list(), isEmpty);
       // Restore for teardown
-      await Hive.openBox(HiveBoxes.alerts);
+      await Hive.openBox<dynamic>(HiveBoxes.alerts);
     });
   });
 
@@ -223,7 +223,7 @@ void main() {
         '(pre-#1012 hive payload backwards compat)', () async {
       // Simulate a Hive payload written before #1012 — no
       // frequencyPerDay key.
-      final box = Hive.box(HiveBoxes.alerts);
+      final box = Hive.box<dynamic>(HiveBoxes.alerts);
       await box.put('${RadiusAlertStore.keyPrefix}legacy', {
         'id': 'legacy',
         'fuelType': 'diesel',

--- a/test/features/alerts/data/repositories/alert_repository_test.dart
+++ b/test/features/alerts/data/repositories/alert_repository_test.dart
@@ -18,12 +18,12 @@ void main() {
     // Use a temporary directory for Hive in tests
     final dir = '${Directory.systemTemp.path}/hive_test_${DateTime.now().millisecondsSinceEpoch}';
     Hive.init(dir);
-    await Hive.openBox('alerts');
+    await Hive.openBox<dynamic>('alerts');
   });
 
   setUp(() async {
     // Clear alerts box before each test
-    final box = Hive.box('alerts');
+    final box = Hive.box<dynamic>('alerts');
     await box.clear();
     repo = AlertRepository(HiveStorage());
   });

--- a/test/features/alerts/data/velocity_alert_cooldown_test.dart
+++ b/test/features/alerts/data/velocity_alert_cooldown_test.dart
@@ -19,10 +19,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/alerts/data/velocity_alert_runner_test.dart
+++ b/test/features/alerts/data/velocity_alert_runner_test.dart
@@ -78,10 +78,10 @@ void main() {
       await Hive.box<String>(name).clear();
     }
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/alerts/providers/radius_alerts_provider_test.dart
+++ b/test/features/alerts/providers/radius_alerts_provider_test.dart
@@ -89,10 +89,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.alerts)) {
-      await Hive.box(HiveBoxes.alerts).close();
+      await Hive.box<dynamic>(HiveBoxes.alerts).close();
     }
-    await Hive.openBox(HiveBoxes.alerts);
-    await Hive.box(HiveBoxes.alerts).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.alerts);
+    await Hive.box<dynamic>(HiveBoxes.alerts).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/approach/providers/approach_state_provider_test.dart
+++ b/test/features/approach/providers/approach_state_provider_test.dart
@@ -63,7 +63,7 @@ class _FakeGeolocator extends GeolocatorWrapper {
       controller.stream;
 
   void close() {
-    if (!controller.isClosed) controller.close();
+    if (!controller.isClosed) unawaited(controller.close());
   }
 }
 

--- a/test/features/car/car_data_service_test.dart
+++ b/test/features/car/car_data_service_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
@@ -215,9 +217,9 @@ void main() {
 
     test('getUserLocation reports the persisted fix payload', () {
       final storage = FakeStorageRepository();
-      storage.inner.putSetting(StorageKeys.userPositionLat, 48.8566);
-      storage.inner.putSetting(StorageKeys.userPositionLng, 2.3522);
-      storage.inner.putSetting(StorageKeys.userPositionSource, 'gps');
+      unawaited(storage.inner.putSetting(StorageKeys.userPositionLat, 48.8566));
+      unawaited(storage.inner.putSetting(StorageKeys.userPositionLng, 2.3522));
+      unawaited(storage.inner.putSetting(StorageKeys.userPositionSource, 'gps'));
       final loc = CarDataService().readUserLocation(storage);
       expect(loc['lat'], 48.8566);
       expect(loc['lng'], 2.3522);

--- a/test/features/consent/presentation/widgets/consent_settings_section_test.dart
+++ b/test/features/consent/presentation/widgets/consent_settings_section_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -25,12 +27,12 @@ void main() {
     bool vinOnlineDecode = false,
     bool syncTrips = false,
   }) {
-    fakeStorage.putSetting(StorageKeys.consentLocation, location);
-    fakeStorage.putSetting(StorageKeys.consentErrorReporting, errorReporting);
-    fakeStorage.putSetting(StorageKeys.consentCloudSync, cloudSync);
-    fakeStorage.putSetting(
-        StorageKeys.consentVinOnlineDecode, vinOnlineDecode);
-    fakeStorage.putSetting(StorageKeys.consentSyncTrips, syncTrips);
+    unawaited(fakeStorage.putSetting(StorageKeys.consentLocation, location));
+    unawaited(fakeStorage.putSetting(StorageKeys.consentErrorReporting, errorReporting));
+    unawaited(fakeStorage.putSetting(StorageKeys.consentCloudSync, cloudSync));
+    unawaited(fakeStorage.putSetting(
+        StorageKeys.consentVinOnlineDecode, vinOnlineDecode));
+    unawaited(fakeStorage.putSetting(StorageKeys.consentSyncTrips, syncTrips));
 
     return ProviderScope(
       overrides: [

--- a/test/features/consumption/data/baseline_sync_test.dart
+++ b/test/features/consumption/data/baseline_sync_test.dart
@@ -106,7 +106,7 @@ void main() {
     });
 
     test('empty payload → 0', () {
-      expect(totalSampleCount({'version': 1, 'perSituation': {}}), 0);
+      expect(totalSampleCount({'version': 1, 'perSituation': <dynamic, dynamic>{}}), 0);
     });
   });
 

--- a/test/features/consumption/data/charging_log_store_test.dart
+++ b/test/features/consumption/data/charging_log_store_test.dart
@@ -44,10 +44,10 @@ void main() {
   setUp(() async {
     // Fresh settings box per test — mirrors the RadiusAlertStore test.
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {
@@ -133,7 +133,7 @@ void main() {
         () async {
       // The settings box carries lots of unrelated payloads — user
       // prefs, last filter, etc. list() must filter by key prefix.
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       await box.put('theme', 'dark');
       await box.put('user_locale', 'fr');
 
@@ -162,12 +162,12 @@ void main() {
     });
 
     test('list returns empty when the settings box is closed', () async {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
 
       final store = ChargingLogStore();
       expect(await store.list(), isEmpty);
       // Restore for teardown
-      await Hive.openBox(HiveBoxes.settings);
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
     });
   });
 }

--- a/test/features/consumption/data/maintenance_snooze_repository_test.dart
+++ b/test/features/consumption/data/maintenance_snooze_repository_test.dart
@@ -22,13 +22,13 @@ void main() {
     setUp(() async {
       tmpDir = Directory.systemTemp.createTempSync('snooze_repo_test_');
       Hive.init(tmpDir.path);
-      await Hive.openBox(HiveBoxes.settings);
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
     });
 
     tearDown(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).clear();
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).clear();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
       await Hive.close();
       tmpDir.deleteSync(recursive: true);
@@ -188,7 +188,7 @@ void main() {
       );
       // The underlying key is gone from the box.
       expect(
-        Hive.box(HiveBoxes.settings)
+        Hive.box<dynamic>(HiveBoxes.settings)
             .containsKey(repo.keyFor(MaintenanceSignal.idleRpmCreep)),
         isFalse,
       );
@@ -207,7 +207,7 @@ void main() {
       );
       // Drop an unrelated key into the same box; clearAll must NOT touch
       // it — the repo only owns the maintenance.snooze.* prefix.
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       await box.put('unrelated.key', 'keep me');
 
       await repo.clearAll();
@@ -247,7 +247,7 @@ void main() {
       // Manually poison the storage with a non-ISO-8601 string. The
       // repository must treat this as "not snoozed" rather than
       // permanently silencing the signal.
-      await Hive.box(HiveBoxes.settings).put(
+      await Hive.box<dynamic>(HiveBoxes.settings).put(
         repo.keyFor(MaintenanceSignal.idleRpmCreep),
         'not a date',
       );
@@ -282,8 +282,8 @@ void main() {
 
     tearDown(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).clear();
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).clear();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
       await Hive.close();
       tmpDir.deleteSync(recursive: true);
@@ -320,9 +320,9 @@ void main() {
       );
 
       // Now open the settings box and confirm nothing leaked through.
-      await Hive.openBox(HiveBoxes.settings);
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
       expect(
-        Hive.box(HiveBoxes.settings)
+        Hive.box<dynamic>(HiveBoxes.settings)
             .containsKey(repo.keyFor(MaintenanceSignal.idleRpmCreep)),
         isFalse,
       );

--- a/test/features/consumption/data/obd2/connect_resilience_test.dart
+++ b/test/features/consumption/data/obd2/connect_resilience_test.dart
@@ -94,7 +94,7 @@ void main() {
         );
 
         var done = false;
-        svc.stopScanBeforeConnect().then((_) => done = true);
+        unawaited(svc.stopScanBeforeConnect().then((_) => done = true));
         async.flushMicrotasks();
 
         // FlutterBluePlus.isScanningNow is false in tests, so the settle is

--- a/test/features/consumption/data/obd2/obd2_connect_trace_persistence_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connect_trace_persistence_test.dart
@@ -102,7 +102,7 @@ void main() {
   group('append / load / prune (#3184)', () {
     test('round-trips a trace through the box JSON-string encoding',
         () async {
-      await Hive.openBox(Obd2ConnectTracePersistence.boxName);
+      await Hive.openBox<dynamic>(Obd2ConnectTracePersistence.boxName);
       final persistence = Obd2ConnectTracePersistence();
       final trace = makeTrace(id: 't1', startedAtMs: _nowMs());
 
@@ -112,7 +112,7 @@ void main() {
     });
 
     test('caps the box at maxPersisted, dropping the OLDEST', () async {
-      await Hive.openBox(Obd2ConnectTracePersistence.boxName);
+      await Hive.openBox<dynamic>(Obd2ConnectTracePersistence.boxName);
       final persistence = Obd2ConnectTracePersistence();
       final base = _nowMs();
       const extra = 5;
@@ -132,7 +132,7 @@ void main() {
 
     test('drops traces older than maxAge on prune AND skips them on load',
         () async {
-      await Hive.openBox(Obd2ConnectTracePersistence.boxName);
+      await Hive.openBox<dynamic>(Obd2ConnectTracePersistence.boxName);
       final now = DateTime.now();
       final persistence = Obd2ConnectTracePersistence(clock: () => now);
       final aged = now
@@ -146,13 +146,13 @@ void main() {
           makeTrace(id: 'fresh', startedAtMs: now.millisecondsSinceEpoch));
 
       expect(persistence.load().single.attemptId, 'fresh');
-      final box = Hive.box(Obd2ConnectTracePersistence.boxName);
+      final box = Hive.box<dynamic>(Obd2ConnectTracePersistence.boxName);
       expect(box.get('old'), isNull,
           reason: 'the aged-out entry must be physically pruned');
     });
 
     test('a corrupt entry is skipped and never poisons the rest', () async {
-      final box = await Hive.openBox(Obd2ConnectTracePersistence.boxName);
+      final box = await Hive.openBox<dynamic>(Obd2ConnectTracePersistence.boxName);
       final persistence = Obd2ConnectTracePersistence();
       await box.put('corrupt', 'not json at all {');
       await box.put('wrong-type', 42);
@@ -190,7 +190,7 @@ void main() {
 
   group('serialised PII shape (#3184)', () {
     test('the persisted JSON carries only the REDACTED MAC', () async {
-      await Hive.openBox(Obd2ConnectTracePersistence.boxName);
+      await Hive.openBox<dynamic>(Obd2ConnectTracePersistence.boxName);
       final persistence = Obd2ConnectTracePersistence();
 
       final h = Obd2ConnectTraceLog.beginTrace(
@@ -203,7 +203,7 @@ void main() {
       await persistence.append(Obd2ConnectTraceLog.snapshot().single);
 
       final raw =
-          Hive.box(Obd2ConnectTracePersistence.boxName).values.single
+          Hive.box<dynamic>(Obd2ConnectTracePersistence.boxName).values.single
               as String;
       expect(raw, isNot(contains('AA:BB')),
           reason: 'the raw MAC must never reach disk');

--- a/test/features/consumption/data/obd2/obd2_session_context_block_test.dart
+++ b/test/features/consumption/data/obd2/obd2_session_context_block_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       final session = block['obd2Session'] as Map<String, Object?>;
       // Compact short keys carried from the model's toJson.
-      expect(session['pid'], isA<Map>());
+      expect(session['pid'], isA<Map<dynamic, dynamic>>());
       expect((session['pid'] as Map).keys, containsAll(['010C', '0105']));
       expect((session['conn'] as Map)['dr'], 1); // one drop
     });
@@ -75,7 +75,7 @@ void main() {
       // Must not throw — proves the block is JSON-safe inside the export.
       final encoded = jsonEncode(block);
       expect(encoded, contains('obd2Session'));
-      expect(jsonDecode(encoded), isA<Map>());
+      expect(jsonDecode(encoded), isA<Map<dynamic, dynamic>>());
     });
   });
 

--- a/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
+++ b/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:collection';
 
 import 'package:fake_async/fake_async.dart';
@@ -198,7 +200,7 @@ void main() {
       // Elapsing 4×shortPoll lands on the 4th periodic boundary
       // inclusively, so the 5th read completes before cancel.
       async.elapse(shortPoll * 4);
-      sub.cancel();
+      unawaited(sub.cancel());
       async.flushMicrotasks();
 
       expect(received, [20.0]);

--- a/test/features/consumption/data/obd2/paused_trip_repository_test.dart
+++ b/test/features/consumption/data/obd2/paused_trip_repository_test.dart
@@ -228,7 +228,7 @@ void main() {
       // Required keys present.
       expect(json['id'], entry.id);
       expect(json['pausedAt'], entry.pausedAt.toIso8601String());
-      expect(json['summary'], isA<Map>());
+      expect(json['summary'], isA<Map<dynamic, dynamic>>());
 
       // Summary-level optional keys absent.
       final summaryJson = (json['summary'] as Map).cast<String, dynamic>();

--- a/test/features/consumption/data/ocr/ocr_trace_serializer_test.dart
+++ b/test/features/consumption/data/ocr/ocr_trace_serializer_test.dart
@@ -80,7 +80,7 @@ void main() {
     expect((decoded['mlkit'] as Map)['blocks'], isList);
     expect(decoded['classification'], isList);
     expect(decoded['anchors'], isList);
-    expect(decoded['confidence'], isA<Map>());
+    expect(decoded['confidence'], isA<Map<dynamic, dynamic>>());
     expect((decoded['gate'] as Map)['reason'], 'consistent');
     expect((decoded['gate'] as Map)['checks'], isList);
     final result = decoded['result'] as Map;
@@ -126,7 +126,7 @@ void main() {
     final decoded =
         jsonDecode(formatOcrTracePackageJson(recorder.build())) as Map;
     expect(decoded['schema'], 1);
-    expect(decoded['crossCheck'], isA<Map>());
+    expect(decoded['crossCheck'], isA<Map<dynamic, dynamic>>());
   });
 
   group('includeImage (#2853 — clipboard TransactionTooLargeException)', () {

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -342,7 +342,7 @@ void main() {
       // Stored under the compact 'fe' key; the measured 'f' key is absent.
       final raw = box.get(start.toIso8601String())!;
       final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
-      final stored = (decoded['samples'] as List).cast<Map>().first;
+      final stored = (decoded['samples'] as List).cast<Map<dynamic, dynamic>>().first;
       expect(stored.containsKey('fe'), isTrue);
       expect(stored.containsKey('f'), isFalse);
     });
@@ -440,7 +440,7 @@ void main() {
       // Read the raw stored JSON and inspect the sample's keys.
       final raw = box.get(start.toIso8601String())!;
       final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
-      final samples = (decoded['samples'] as List).cast<Map>();
+      final samples = (decoded['samples'] as List).cast<Map<dynamic, dynamic>>();
       expect(samples.first.containsKey('th'), isFalse);
       expect(samples.first.containsKey('f'), isFalse);
     });
@@ -819,7 +819,7 @@ void main() {
 
       final raw = box.get(start.toIso8601String())!;
       final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
-      final samples = (decoded['samples'] as List).cast<Map>();
+      final samples = (decoded['samples'] as List).cast<Map<dynamic, dynamic>>();
       expect(samples.first.containsKey('el'), isFalse);
       expect(samples.first.containsKey('ct'), isFalse);
     });
@@ -940,7 +940,7 @@ void main() {
 
       final raw = box.get(start.toIso8601String())!;
       final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
-      final samples = (decoded['samples'] as List).cast<Map>();
+      final samples = (decoded['samples'] as List).cast<Map<dynamic, dynamic>>();
       expect(samples.first.containsKey('la'), isFalse,
           reason: 'flag-off ticks must not bloat the JSON');
       expect(samples.first.containsKey('lo'), isFalse,

--- a/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
+++ b/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
@@ -97,7 +97,7 @@ Future<void> _pumpRecordingScreen(
       wakelockFacadeProvider.overrideWithValue(facade),
       // #2785 — these tests exercise the MANUAL pin toggle from an unpinned
       // start, so pin the profile to auto-pin OFF (the global default is now ON).
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
     ],
   );
 }

--- a/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
@@ -52,8 +52,8 @@ class _RecordingExporter extends FullBackupExporter {
   Future<FullBackupExportResult> export({
     required List<VehicleProfile> vehicles,
     required List<FillUp> fillUps,
-    required List trips,
-    required List chargingLogs,
+    required List<dynamic> trips,
+    required List<dynamic> chargingLogs,
   }) async {
     callCount++;
     lastFillUps = fillUps;
@@ -74,8 +74,8 @@ class _ThrowingExporter extends FullBackupExporter {
   Future<FullBackupExportResult> export({
     required List<VehicleProfile> vehicles,
     required List<FillUp> fillUps,
-    required List trips,
-    required List chargingLogs,
+    required List<dynamic> trips,
+    required List<dynamic> chargingLogs,
   }) async {
     throw StateError('share-sheet refused');
   }
@@ -91,8 +91,8 @@ class _SavedExporter extends FullBackupExporter {
   Future<FullBackupExportResult> export({
     required List<VehicleProfile> vehicles,
     required List<FillUp> fillUps,
-    required List trips,
-    required List chargingLogs,
+    required List<dynamic> trips,
+    required List<dynamic> chargingLogs,
   }) async {
     return const FullBackupExportResult(
       filePath: '/tmp/tankstellen_backup_2026.zip',

--- a/test/features/consumption/presentation/screens/pick_station_for_fill_up_screen_test.dart
+++ b/test/features/consumption/presentation/screens/pick_station_for_fill_up_screen_test.dart
@@ -41,7 +41,7 @@ void main() {
       await tester.tap(find.byKey(const Key('pick_station_tile_super-u-1')));
       await tester.pumpAndSettle();
       expect(_lastRoute, '/consumption/add');
-      expect(_lastExtra, isA<Map>());
+      expect(_lastExtra, isA<Map<dynamic, dynamic>>());
       final extra = _lastExtra as Map;
       expect(extra['stationId'], 'super-u-1');
       expect(extra['stationName'], 'SUPER U');

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -702,7 +702,7 @@ void main() {
                 'r': 1200.0,
               },
             ],
-            'gpsd': const [],
+            'gpsd': const <dynamic>[],
           };
         };
 

--- a/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_degradation_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_degradation_test.dart
@@ -166,7 +166,7 @@ Future<void> _pumpRecordingScreen(
         () => _LiveFakeTripRecording(live),
       ),
       wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
       hapticEcoCoachLifecycleProvider
           .overrideWith(() => _FakeHapticEcoCoachLifecycle(coachEvents)),
       activeVehicleProfileProvider

--- a/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_test.dart
@@ -188,7 +188,7 @@ Future<void> _pumpRecordingScreen(
         () => _FakeTripRecording(_recordingState()),
       ),
       wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
       hapticEcoCoachLifecycleProvider
           .overrideWith(() => _FakeHapticEcoCoachLifecycle(
                 coachEventsController,

--- a/test/features/consumption/presentation/screens/trip_recording_screen_landscape_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_landscape_test.dart
@@ -64,7 +64,7 @@ void main() {
 
   List<Object> bodyOverrides() => [
         wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-        recordingProfileOverride(),
+        recordingProfileOverride() as Object,
         effectiveApproachStateProvider.overrideWithValue(
           const ApproachInRadius(station: station, distanceMeters: 250),
         ),

--- a/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
@@ -51,7 +51,7 @@ Future<void> _pumpRecordingScreen(WidgetTester tester) async {
         () => _FakeTripRecording(_recordingState()),
       ),
       wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
     ],
   );
 }

--- a/test/features/consumption/presentation/screens/trip_recording_screen_pip_auto_enter_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_pip_auto_enter_test.dart
@@ -94,7 +94,7 @@ void main() {
       overrides: [
         tripRecordingProvider.overrideWith(() => _ActiveTripRecording()),
         wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
         pipControllerProvider.overrideWithValue(pip),
       ],
     );

--- a/test/features/consumption/presentation/screens/trip_recording_screen_radar_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_radar_test.dart
@@ -68,7 +68,7 @@ void main() {
       overrides: [
         tripRecordingProvider.overrideWith(_LiveFakeTripRecording.new),
         wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
         // Fake provider override pushing an in-radius approach hit —
         // the radar card renders this station directly (no GPS / search
         // chain needed) at the top of the column.
@@ -112,7 +112,7 @@ void main() {
       overrides: [
         tripRecordingProvider.overrideWith(_LiveFakeTripRecording.new),
         wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
         effectiveApproachStateProvider.overrideWithValue(null),
         effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
         radarCandidateListProvider.overrideWith((ref) async => const []),

--- a/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
@@ -115,7 +115,7 @@ Future<void> _pumpAndStop(
     overrides: [
       tripRecordingProvider.overrideWith(() => notifier),
       wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
     ],
   );
 
@@ -178,7 +178,7 @@ void main() {
         overrides: [
           tripRecordingProvider.overrideWith(() => notifier),
           wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
         ],
       );
 
@@ -250,7 +250,7 @@ void main() {
         overrides: [
           tripRecordingProvider.overrideWith(() => notifier),
           wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
         ],
       );
 

--- a/test/features/consumption/presentation/screens/trip_recording_screen_saving_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_saving_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_save_progress.dart';
@@ -53,7 +54,7 @@ Future<void> _pumpSaving(WidgetTester tester, TripSaveStage stage) async {
           ),
         ),
         wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Override,
       ],
       child: const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
@@ -97,7 +97,7 @@ void main() {
           overrides: [
             tripRecordingProvider.overrideWith(() => notifier),
             wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
           ],
         );
         // The warning is deferred ~600 ms post-mount so it doesn't
@@ -137,7 +137,7 @@ void main() {
           overrides: [
             tripRecordingProvider.overrideWith(() => notifier),
             wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
           ],
         );
         // Pump past the deferred-fire timer so the post-mount path
@@ -179,7 +179,7 @@ void main() {
           overrides: [
             tripRecordingProvider.overrideWith(() => notifier),
             wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
           ],
         );
         await tester.pump();
@@ -215,7 +215,7 @@ void main() {
           overrides: [
             tripRecordingProvider.overrideWith(() => notifier),
             wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-            recordingProfileOverride(),
+            recordingProfileOverride() as Object,
           ],
         );
         await tester.pump();

--- a/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
@@ -121,7 +121,7 @@ Future<void> _pumpRecordingScreen(
         () => _FakeTripRecording(state ?? _recordingState()),
       ),
       wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
       hapticEcoCoachLifecycleProvider
           .overrideWith(() => _FakeHapticEcoCoachLifecycle(
                 coachEventsController,
@@ -187,7 +187,7 @@ void main() {
             key: const Key('openRecordingScreen'),
             onPressed: () {
               Navigator.of(context).push(
-                MaterialPageRoute(
+                MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
               );
@@ -200,7 +200,7 @@ void main() {
             () => _FakeTripRecording(_recordingState()),
           ),
           wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
           hapticEcoCoachLifecycleProvider
               .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
         ],
@@ -332,7 +332,7 @@ void main() {
             key: const Key('openRecordingScreen'),
             onPressed: () {
               Navigator.of(context).push(
-                MaterialPageRoute(
+                MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
               );
@@ -345,7 +345,7 @@ void main() {
             () => _FakeTripRecording(_recordingState()),
           ),
           wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
           hapticEcoCoachLifecycleProvider
               .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
           settingsStorageProvider.overrideWithValue(settings),
@@ -400,7 +400,7 @@ void main() {
             key: const Key('openRecordingScreen'),
             onPressed: () {
               Navigator.of(context).push(
-                MaterialPageRoute(
+                MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
               );
@@ -413,7 +413,7 @@ void main() {
             () => _FakeTripRecording(_recordingState()),
           ),
           wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
-      recordingProfileOverride(),
+      recordingProfileOverride() as Object,
           hapticEcoCoachLifecycleProvider
               .overrideWith(() => _FakeHapticEcoCoachLifecycle(events)),
           settingsStorageProvider.overrideWithValue(settings),

--- a/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
@@ -186,11 +186,11 @@ void main() {
           builder: (context) => ElevatedButton(
             key: const Key('openRecordingScreen'),
             onPressed: () {
-              Navigator.of(context).push(
+              unawaited(Navigator.of(context).push(
                 MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
-              );
+              ));
             },
             child: const Text('Open'),
           ),
@@ -331,11 +331,11 @@ void main() {
           builder: (context) => ElevatedButton(
             key: const Key('openRecordingScreen'),
             onPressed: () {
-              Navigator.of(context).push(
+              unawaited(Navigator.of(context).push(
                 MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
-              );
+              ));
             },
             child: const Text('Open'),
           ),
@@ -399,11 +399,11 @@ void main() {
           builder: (context) => ElevatedButton(
             key: const Key('openRecordingScreen'),
             onPressed: () {
-              Navigator.of(context).push(
+              unawaited(Navigator.of(context).push(
                 MaterialPageRoute<dynamic>(
                   builder: (_) => const TripRecordingScreen(),
                 ),
-              );
+              ));
             },
             child: const Text('Open'),
           ),

--- a/test/features/consumption/presentation/widgets/maintenance_suggestion_card_test.dart
+++ b/test/features/consumption/presentation/widgets/maintenance_suggestion_card_test.dart
@@ -38,10 +38,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {
@@ -171,7 +171,7 @@ void main() {
       );
 
       // Box must be empty before the tap.
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       expect(box.length, 0,
           reason: 'No snooze key should exist before user interaction');
 

--- a/test/features/consumption/providers/charging_logs_provider_test.dart
+++ b/test/features/consumption/providers/charging_logs_provider_test.dart
@@ -39,10 +39,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {

--- a/test/features/consumption/providers/gps_only_imu_fusion_test.dart
+++ b/test/features/consumption/providers/gps_only_imu_fusion_test.dart
@@ -369,7 +369,7 @@ class _Harness {
 
   void dispose() {
     container.dispose();
-    geo.dispose();
+    unawaited(geo.dispose());
   }
 }
 
@@ -473,7 +473,7 @@ class _RecordingGeolocator extends GeolocatorWrapper {
     positionStreamCallCount++;
     lastAccuracy = locationSettings?.accuracy;
     final prev = _controller;
-    if (prev != null && !prev.isClosed) prev.close();
+    if (prev != null && !prev.isClosed) unawaited(prev.close());
     _controller = StreamController<Position>(
       onListen: () => activeListeners++,
       onCancel: () => activeListeners--,

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -349,7 +349,7 @@ class _Harness {
 
   void dispose() {
     container.dispose();
-    geo.dispose();
+    unawaited(geo.dispose());
   }
 }
 
@@ -486,7 +486,7 @@ class _RecordingGeolocator extends GeolocatorWrapper {
     lastAccuracy = locationSettings?.accuracy;
     lastSettings = locationSettings;
     final prev = _controller;
-    if (prev != null && !prev.isClosed) prev.close();
+    if (prev != null && !prev.isClosed) unawaited(prev.close());
     _controller = StreamController<Position>(
       onListen: () => activeListeners++,
       onCancel: () => activeListeners--,

--- a/test/features/consumption/providers/maintenance_provider_test.dart
+++ b/test/features/consumption/providers/maintenance_provider_test.dart
@@ -43,10 +43,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {
@@ -124,7 +124,7 @@ void main() {
           .read(maintenanceSuggestionsControllerProvider.notifier);
       await controller.snoozeForDefault(MaintenanceSignal.idleRpmCreep);
 
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       final stored = box.get(
         '${MaintenanceSnoozeRepository.keyPrefix}'
         '${MaintenanceSignal.idleRpmCreep.name}',

--- a/test/features/consumption/providers/trip_history_save_integration_test.dart
+++ b/test/features/consumption/providers/trip_history_save_integration_test.dart
@@ -46,7 +46,7 @@ void main() {
     // Give the poll loop one real tick so the TripRecorder captures
     // at least one sample — without it, startedAt never gets set and
     // the history save path short-circuits.
-    await Future.delayed(const Duration(milliseconds: 50));
+    await Future<dynamic>.delayed(const Duration(milliseconds: 50));
     await notifier.stop();
 
     final repo = container.read(tripHistoryRepositoryProvider);

--- a/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
+++ b/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
@@ -117,7 +117,7 @@ class _FakeGeo extends GeolocatorWrapper {
   Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
     final prev = _controller;
     if (prev != null && !prev.isClosed) {
-      prev.close();
+      unawaited(prev.close());
     }
     _controller = StreamController<Position>(
       onListen: () => activeListeners++,

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -400,7 +400,7 @@ class _RecordingGeolocator extends GeolocatorWrapper {
     if (prev != null && !prev.isClosed) {
       // Fire-and-forget — tests only re-call getPositionStream when
       // the previous subscription is already gone.
-      prev.close();
+      unawaited(prev.close());
     }
     _controller = StreamController<Position>(
       onListen: () => activeListeners++,

--- a/test/features/favorites/cross_country_favorites_test.dart
+++ b/test/features/favorites/cross_country_favorites_test.dart
@@ -93,7 +93,7 @@ void main() {
     container.invalidate(favoritesProvider);
 
     final state = container.read(favoriteStationsProvider);
-    expect(state, isA<AsyncData>(),
+    expect(state, isA<AsyncData<dynamic>>(),
         reason: 'Provider builds synchronously from storage');
     final stations = state.value!.data;
     expect(stations, hasLength(3),

--- a/test/features/favorites/providers/favorites_provider_test.dart
+++ b/test/features/favorites/providers/favorites_provider_test.dart
@@ -258,7 +258,7 @@ void main() {
       container = createContainer();
       final state = container.read(favoriteStationsProvider);
 
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       expect(state.value!.data, isEmpty);
     });
 

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -86,7 +88,7 @@ void main() {
     });
 
     test('persisted profile is returned verbatim on subsequent boots', () {
-      profileBox.put('profile', AppProfile.medium.name);
+      unawaited(profileBox.put('profile', AppProfile.medium.name));
       final c = makeContainer();
       expect(c.read(activeAppProfileProvider), AppProfile.medium);
     });

--- a/test/features/glide_coach/data/osm_traffic_signal_client_test.dart
+++ b/test/features/glide_coach/data/osm_traffic_signal_client_test.dart
@@ -36,7 +36,7 @@ void main() {
             any(),
             data: any(named: 'data'),
             options: any(named: 'options'),
-          )).thenAnswer((_) async => okResponse({'elements': []}));
+          )).thenAnswer((_) async => okResponse({'elements': <dynamic>[]}));
 
       await client.fetchInBoundingBox(
         south: 43.4,

--- a/test/features/loyalty/data/loyalty_card_repository_test.dart
+++ b/test/features/loyalty/data/loyalty_card_repository_test.dart
@@ -37,10 +37,10 @@ void main() {
 
   setUp(() async {
     if (Hive.isBoxOpen(HiveBoxes.settings)) {
-      await Hive.box(HiveBoxes.settings).close();
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
     }
-    await Hive.openBox(HiveBoxes.settings);
-    await Hive.box(HiveBoxes.settings).clear();
+    await Hive.openBox<dynamic>(HiveBoxes.settings);
+    await Hive.box<dynamic>(HiveBoxes.settings).clear();
   });
 
   tearDownAll(() async {
@@ -130,7 +130,7 @@ void main() {
 
     test('loadAll ignores unrelated keys in the shared settings box',
         () async {
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       // Legacy settings entry — must not be deserialised as a card.
       await box.put('some_other_setting', {'foo': 'bar'});
 
@@ -143,7 +143,7 @@ void main() {
     });
 
     test('clear wipes only the loyalty-card keys', () async {
-      final box = Hive.box(HiveBoxes.settings);
+      final box = Hive.box<dynamic>(HiveBoxes.settings);
       await box.put('unrelated_setting', {'x': 1});
       final repo = LoyaltyCardRepository(box: box);
       await repo.upsert(makeCard(id: 'a1'));
@@ -165,8 +165,8 @@ void main() {
       );
 
       // Simulate "app restart": close and reopen the box.
-      await Hive.box(HiveBoxes.settings).close();
-      await Hive.openBox(HiveBoxes.settings);
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
 
       final repo2 = LoyaltyCardRepository(box: Hive.box(HiveBoxes.settings));
       final all = repo2.loadAll();

--- a/test/features/loyalty/providers/loyalty_provider_test.dart
+++ b/test/features/loyalty/providers/loyalty_provider_test.dart
@@ -74,7 +74,7 @@ void main() {
       // Make absolutely sure the box is closed before we read the
       // provider.
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
 
       final c = makeContainer();
@@ -93,11 +93,11 @@ void main() {
       'returns a non-null LoyaltyCardRepository when the box is open',
       () async {
         if (!Hive.isBoxOpen(HiveBoxes.settings)) {
-          await Hive.openBox(HiveBoxes.settings);
+          await Hive.openBox<dynamic>(HiveBoxes.settings);
         }
         addTearDown(() async {
           if (Hive.isBoxOpen(HiveBoxes.settings)) {
-            await Hive.box(HiveBoxes.settings).close();
+            await Hive.box<dynamic>(HiveBoxes.settings).close();
           }
         });
 
@@ -116,16 +116,16 @@ void main() {
   group('LoyaltyCards (Hive open)', () {
     setUp(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
-      await Hive.openBox(HiveBoxes.settings);
-      await Hive.box(HiveBoxes.settings).clear();
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
+      await Hive.box<dynamic>(HiveBoxes.settings).clear();
     });
 
     tearDown(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).clear();
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).clear();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
     });
 
@@ -321,7 +321,7 @@ void main() {
   group('LoyaltyCards (Hive closed → repo is null)', () {
     setUp(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
     });
 
@@ -386,16 +386,16 @@ void main() {
   group('activeDiscountByBrandProvider', () {
     setUp(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
-      await Hive.openBox(HiveBoxes.settings);
-      await Hive.box(HiveBoxes.settings).clear();
+      await Hive.openBox<dynamic>(HiveBoxes.settings);
+      await Hive.box<dynamic>(HiveBoxes.settings).clear();
     });
 
     tearDown(() async {
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).clear();
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).clear();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
     });
 
@@ -767,7 +767,7 @@ void main() {
       // returns null, so the cards list is const [] and the derived
       // map collapses to an empty map.
       if (Hive.isBoxOpen(HiveBoxes.settings)) {
-        await Hive.box(HiveBoxes.settings).close();
+        await Hive.box<dynamic>(HiveBoxes.settings).close();
       }
 
       final c = makeContainer();

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -99,7 +99,7 @@ void main() {
       ),
     ];
 
-    AsyncValue resultFor(List<Station> stations) => AsyncValue.data(
+    AsyncValue<dynamic> resultFor(List<Station> stations) => AsyncValue.data(
           ServiceResult(
             data: stations.map((s) => FuelStationResult(s)).toList(),
             source: ServiceSource.tankerkoenigApi,
@@ -108,7 +108,7 @@ void main() {
         );
 
     Widget viewFor(
-      AsyncValue searchState,
+      AsyncValue<dynamic> searchState,
       _CountingMapController controller,
     ) =>
         SizedBox(
@@ -307,8 +307,8 @@ class _CountingMapController extends MapControllerImpl {
 /// NearbyMapView, so a test can drive a genuine (or value-equal) rebuild.
 class _Rebuildable extends StatefulWidget {
   final _CountingMapController controller;
-  final Widget Function(AsyncValue, _CountingMapController) viewFor;
-  final AsyncValue initial;
+  final Widget Function(AsyncValue<dynamic>, _CountingMapController) viewFor;
+  final AsyncValue<dynamic> initial;
 
   const _Rebuildable({
     required this.controller,
@@ -321,9 +321,9 @@ class _Rebuildable extends StatefulWidget {
 }
 
 class _RebuildableState extends State<_Rebuildable> {
-  late AsyncValue _state = widget.initial;
+  late AsyncValue<dynamic> _state = widget.initial;
 
-  void show(AsyncValue next) => setState(() => _state = next);
+  void show(AsyncValue<dynamic> next) => setState(() => _state = next);
 
   @override
   Widget build(BuildContext context) =>

--- a/test/features/profile/presentation/widgets/config_verification_widget_test.dart
+++ b/test/features/profile/presentation/widgets/config_verification_widget_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/providers/app_state_provider.dart';
@@ -66,7 +68,7 @@ List<Object> _buildOverrides({
   // PLUS the actual key — `hasApiKey` here controls only the custom-key flag.
   final fake = FakeStorageRepository();
   if (hasApiKey) {
-    fake.setApiKey('custom-key');
+    unawaited(fake.setApiKey('custom-key'));
   }
   // The widget reads the bundled-default fingerprint when no custom key is
   // configured; mirror the legacy mock value so any UI that surfaces the

--- a/test/features/profile/presentation/widgets/profile_edit_sheet_test.dart
+++ b/test/features/profile/presentation/widgets/profile_edit_sheet_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -20,7 +22,7 @@ void main() {
           home: Builder(
             builder: (context) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                showDialog<bool>(
+                unawaited(showDialog<bool>(
                   context: context,
                   builder: (context) => AlertDialog(
                     icon: Icon(
@@ -51,7 +53,7 @@ void main() {
                       ),
                     ],
                   ),
-                );
+                ));
               });
               return const Scaffold(body: SizedBox.expand());
             },

--- a/test/features/profile/presentation/widgets/storage_section_test.dart
+++ b/test/features/profile/presentation/widgets/storage_section_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/storage_section.dart';
@@ -141,20 +143,20 @@ void _seedStorageStats(
   int alerts = 0,
 }) {
   for (var i = 0; i < profiles; i++) {
-    fake.saveProfile('p$i', {'name': 'p$i'});
+    unawaited(fake.saveProfile('p$i', {'name': 'p$i'}));
   }
-  fake.setFavoriteIds(List.generate(favorites, (i) => 'f$i'));
+  unawaited(fake.setFavoriteIds(List.generate(favorites, (i) => 'f$i')));
   for (var i = 0; i < cacheEntries; i++) {
-    fake.cacheData('k$i', {'v': i});
+    unawaited(fake.cacheData('k$i', {'v': i}));
   }
   if (priceHistory > 0) {
-    fake.savePriceRecords(
+    unawaited(fake.savePriceRecords(
       's-history',
       List.generate(priceHistory, (i) => {'ts': '$i'}),
-    );
+    ));
   }
   if (alerts > 0) {
-    fake.saveAlerts(List.generate(alerts, (i) => {'id': 'a$i'}));
+    unawaited(fake.saveAlerts(List.generate(alerts, (i) => {'id': 'a$i'})));
   }
 
   // Override the byte-stats so the widget gets stable totals matching

--- a/test/features/route_search/data/cross_border_near_border_corridor_test.dart
+++ b/test/features/route_search/data/cross_border_near_border_corridor_test.dart
@@ -123,7 +123,7 @@ class _PrixCarburantsFixtureAdapter implements HttpClientAdapter {
   int calls = 0;
 
   static final _emptyBody =
-      jsonEncode({'total_count': 0, 'results': const []});
+      jsonEncode({'total_count': 0, 'results': const <dynamic>[]});
 
   // The recorded A9 stations cluster around Perpignan (lat ~42.6–42.8); the
   // live feed has none south of ~42.4. Parse the query point out of the
@@ -175,7 +175,7 @@ class _MitecoFixtureAdapter implements HttpClientAdapter {
         : id == '08'
             ? barcelona08
             : jsonEncode(
-                {'ResultadoConsulta': 'OK', 'ListaEESSPrecio': const []});
+                {'ResultadoConsulta': 'OK', 'ListaEESSPrecio': const <dynamic>[]});
     return ResponseBody.fromBytes(utf8.encode(body), 200, headers: {
       Headers.contentTypeHeader: ['application/json'],
     });

--- a/test/features/route_search/data/helpers/batch_query_helper_test.dart
+++ b/test/features/route_search/data/helpers/batch_query_helper_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -387,7 +389,7 @@ void main() {
         // Capture the future so its completion can be awaited within the fake
         // zone — leaving it dangling lets a thrown sub-future surface as an
         // unhandled zone error under concurrent suite load (#2255 test flake).
-        helper
+        unawaited(helper
             .queryAll(
               samplePoints: [const LatLng(48, 2), const LatLng(49, 2)],
               fuelType: FuelType.e10,
@@ -403,7 +405,7 @@ void main() {
                 return const <SearchResultItem>[];
               },
             )
-            .whenComplete(() => done = true);
+            .whenComplete(() => done = true));
         // Advance the fake clock past any pause and flush all microtasks so
         // the sweep fully settles before we read the recorded gap.
         async.elapse(const Duration(seconds: 2));

--- a/test/features/route_search/data/strategies/eco_route_search_strategy_test.dart
+++ b/test/features/route_search/data/strategies/eco_route_search_strategy_test.dart
@@ -230,7 +230,7 @@ void main() {
     test('returns empty list when OSRM code != "Ok"', () {
       final candidates = EcoRouteSearchStrategy.parseOsrmAlternatives({
         'code': 'NoRoute',
-        'routes': [],
+        'routes': <dynamic>[],
       });
       expect(candidates, isEmpty);
     });

--- a/test/features/route_search/providers/route_search_cross_border_test.dart
+++ b/test/features/route_search/providers/route_search_cross_border_test.dart
@@ -182,7 +182,8 @@ class _MitecoFixtureAdapter implements HttpClientAdapter {
     final id = options.uri.path.split('/').last; // …/FiltroProvincia/<id>
     final body = id == '08'
         ? _province08Body
-        : jsonEncode({'ResultadoConsulta': 'OK', 'ListaEESSPrecio': const []});
+        : jsonEncode(
+            {'ResultadoConsulta': 'OK', 'ListaEESSPrecio': const <dynamic>[]});
     return ResponseBody.fromBytes(utf8.encode(body), 200, headers: {
       Headers.contentTypeHeader: ['application/json'],
     });

--- a/test/features/search/data/services/ev_charging_service_test.dart
+++ b/test/features/search/data/services/ev_charging_service_test.dart
@@ -287,7 +287,7 @@ void main() {
 
       Future<ChargingStation> parseSingle(Map<String, dynamic> item) async {
         final dio = MockDio();
-        when(() => dio.get(
+        when(() => dio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),

--- a/test/features/search/domain/entities/station_amenities_roundtrip_test.dart
+++ b/test/features/search/domain/entities/station_amenities_roundtrip_test.dart
@@ -84,7 +84,7 @@ void main() {
       );
 
       final json = station.toJson();
-      expect(json['amenities'], isA<List>());
+      expect(json['amenities'], isA<List<dynamic>>());
       expect(json['amenities'], contains('shop'));
     });
 

--- a/test/features/search/presentation/screens/search_criteria_screen_test.dart
+++ b/test/features/search/presentation/screens/search_criteria_screen_test.dart
@@ -181,7 +181,7 @@ void main() {
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       // #1792 — open-only, amenities and brands have no UserProfile
       // field; they persist device-locally via putSetting.
-      when(() => test.mockStorage.putSetting(any(), any()))
+      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
           .thenAnswer((_) async {});
 
       const initialProfile = UserProfile(
@@ -238,7 +238,7 @@ void main() {
         (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
-      when(() => test.mockStorage.putSetting(any(), any()))
+      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
           .thenAnswer((_) async {});
 
       const initialProfile = UserProfile(id: 'p1', name: 'Standard');

--- a/test/features/search/providers/ev_search_provider_test.dart
+++ b/test/features/search/providers/ev_search_provider_test.dart
@@ -64,7 +64,7 @@ void main() {
           .searchNearby(lat: 48.85, lng: 2.35, radiusKm: 10);
 
       final state = container.read(eVSearchStateProvider);
-      expect(state, isA<AsyncError>());
+      expect(state, isA<AsyncError<dynamic>>());
       expect(state.error, isA<NoEvApiKeyException>());
     });
 
@@ -78,7 +78,7 @@ void main() {
           .searchNearby(lat: 0, lng: 0, radiusKm: 5);
 
       final state = container.read(eVSearchStateProvider);
-      expect(state, isA<AsyncError>());
+      expect(state, isA<AsyncError<dynamic>>());
       expect(state.error, isA<NoEvApiKeyException>());
     });
 
@@ -104,7 +104,7 @@ void main() {
       await notifier.searchNearby(lat: 1, lng: 1, radiusKm: 5);
 
       final state = container.read(eVSearchStateProvider);
-      expect(state, isA<AsyncError>());
+      expect(state, isA<AsyncError<dynamic>>());
     });
   });
 }

--- a/test/features/search/providers/radar_pin_provider_test.dart
+++ b/test/features/search/providers/radar_pin_provider_test.dart
@@ -4,6 +4,8 @@
 // #2785 — the radar auto-pin preference defaults ON and persists across
 // controller builds; a stored explicit false (a deliberate opt-out) is
 // honoured.
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
@@ -31,7 +33,7 @@ void main() {
 
   test('a stored explicit false is honoured (deliberate opt-out)', () {
     final storage = FakeStorageRepository();
-    storage.putSetting(StorageKeys.radarAutoPin, false);
+    unawaited(storage.putSetting(StorageKeys.radarAutoPin, false));
     final c = _container(storage);
     expect(c.read(radarAutoPinProvider), isFalse);
   });

--- a/test/features/search/providers/search_provider_orchestration_test.dart
+++ b/test/features/search/providers/search_provider_orchestration_test.dart
@@ -143,7 +143,7 @@ void main() {
 
       final result = classifySearchError(err, stack);
 
-      expect(result, isA<AsyncError>());
+      expect(result, isA<AsyncError<dynamic>>());
       expect(result!.error, same(err));
       expect(result.stackTrace, same(stack));
     });
@@ -157,7 +157,7 @@ void main() {
 
       final result = classifySearchError(err, stack);
 
-      expect(result, isA<AsyncError>());
+      expect(result, isA<AsyncError<dynamic>>());
       expect(result!.error, same(err));
     });
 
@@ -168,7 +168,7 @@ void main() {
 
       final result = classifySearchError(err, stack);
 
-      expect(result, isA<AsyncError>());
+      expect(result, isA<AsyncError<dynamic>>());
       expect(result!.error, same(err));
       expect(result.stackTrace, same(stack));
     });
@@ -178,7 +178,7 @@ void main() {
 
       final result = classifySearchError(err, stack);
 
-      expect(result, isA<AsyncError>());
+      expect(result, isA<AsyncError<dynamic>>());
       expect(result!.error, same(err));
     });
 
@@ -189,7 +189,7 @@ void main() {
 
       final result = classifySearchError(err, stack);
 
-      expect(result, isA<AsyncError>());
+      expect(result, isA<AsyncError<dynamic>>());
       expect(result!.error, same(err));
       expect(result.stackTrace, same(stack));
     });

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -313,7 +313,7 @@ void main() {
       final container = createContainer();
       final state = container.read(searchStateProvider);
 
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       final data = state.value!;
       expect(data.data, isEmpty);
       expect(data.source, ServiceSource.cache);
@@ -346,7 +346,7 @@ void main() {
       await notifier.searchByZipCode(zipCode: '10115');
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       expect(state.value!.data.length, 1);
       expect(state.value!.data.first.id, 'test-1');
     });
@@ -361,7 +361,7 @@ void main() {
       await notifier.searchByZipCode(zipCode: '99999');
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncError>());
+      expect(state, isA<AsyncError<dynamic>>());
     });
 
     test('searchByCoordinates uses explicit lat/lng', () async {
@@ -383,7 +383,7 @@ void main() {
       );
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       expect(state.value!.data.length, 1);
     });
 
@@ -439,7 +439,7 @@ void main() {
           .searchByCoordinates(lat: 52.52, lng: 13.41);
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncError>());
+      expect(state, isA<AsyncError<dynamic>>());
     });
 
     test('searchByZipCode merges geocoding errors into result', () async {
@@ -586,7 +586,7 @@ void main() {
           .searchByZipCode(zipCode: '10115');
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       expect(state.value!.data.length, 1);
     });
 
@@ -696,7 +696,7 @@ void main() {
       await notifier.repeatLastSearch();
 
       final state = container.read(searchStateProvider);
-      expect(state, isA<AsyncData>());
+      expect(state, isA<AsyncData<dynamic>>());
       expect(state.value!.data, isEmpty);
       verifyNever(() => mockStationService.searchStations(any(),
           cancelToken: any(named: 'cancelToken')));
@@ -1161,7 +1161,7 @@ void main() {
 
       await t.container.read(searchStateProvider.notifier).searchByGps();
 
-      expect(t.container.read(searchStateProvider), isA<AsyncError>());
+      expect(t.container.read(searchStateProvider), isA<AsyncError<dynamic>>());
       expect(t.spy.persisted, isEmpty,
           reason: 'a null-island fix must never reach userPositionProvider');
       verifyNever(() => mockStationService.searchStations(any(),
@@ -1175,7 +1175,7 @@ void main() {
 
       await t.container.read(searchStateProvider.notifier).searchByGps();
 
-      expect(t.container.read(searchStateProvider), isA<AsyncError>());
+      expect(t.container.read(searchStateProvider), isA<AsyncError<dynamic>>());
       expect(t.spy.persisted, isEmpty);
       verifyNever(() => mockStationService.searchStations(any(),
           cancelToken: any(named: 'cancelToken')));
@@ -1195,7 +1195,7 @@ void main() {
 
       await t.container.read(searchStateProvider.notifier).searchByGps();
 
-      expect(t.container.read(searchStateProvider), isA<AsyncData>());
+      expect(t.container.read(searchStateProvider), isA<AsyncData<dynamic>>());
       expect(t.spy.persisted, hasLength(1));
       expect(t.spy.persisted.single.lat, closeTo(42.7667, 0.0001));
       expect(t.spy.persisted.single.lng, closeTo(2.8667, 0.0001));

--- a/test/features/setup/data/api_key_validator_test.dart
+++ b/test/features/setup/data/api_key_validator_test.dart
@@ -18,10 +18,10 @@ void main() {
   });
 
   test('returns valid when API responds with ok=true', () async {
-    when(() => mockDio.get(any(),
+    when(() => mockDio.get<dynamic>(any(),
             queryParameters: any(named: 'queryParameters')))
         .thenAnswer((_) async => Response(
-              data: {'ok': true, 'stations': []},
+              data: {'ok': true, 'stations': <dynamic>[]},
               statusCode: 200,
               requestOptions: RequestOptions(path: '/list.php'),
             ));
@@ -33,7 +33,7 @@ void main() {
 
   test('returns invalid with message when API responds with ok=false',
       () async {
-    when(() => mockDio.get(any(),
+    when(() => mockDio.get<dynamic>(any(),
             queryParameters: any(named: 'queryParameters')))
         .thenAnswer((_) async => Response(
               data: {'ok': false, 'message': 'apikey invalid'},
@@ -48,7 +48,7 @@ void main() {
   });
 
   test('returns invalid on DioException', () async {
-    when(() => mockDio.get(any(),
+    when(() => mockDio.get<dynamic>(any(),
             queryParameters: any(named: 'queryParameters')))
         .thenThrow(DioException(
       requestOptions: RequestOptions(path: '/list.php'),
@@ -61,7 +61,7 @@ void main() {
   });
 
   test('returns invalid on timeout', () async {
-    when(() => mockDio.get(any(),
+    when(() => mockDio.get<dynamic>(any(),
             queryParameters: any(named: 'queryParameters')))
         .thenThrow(DioException(
       type: DioExceptionType.connectionTimeout,
@@ -76,7 +76,7 @@ void main() {
   });
 
   test('includes error message from API response', () async {
-    when(() => mockDio.get(any(),
+    when(() => mockDio.get<dynamic>(any(),
             queryParameters: any(named: 'queryParameters')))
         .thenAnswer((_) async => Response(
               data: {

--- a/test/features/station_services/chile/chile_station_service_test.dart
+++ b/test/features/station_services/chile/chile_station_service_test.dart
@@ -167,7 +167,7 @@ void main() {
 
       test('sends the API key as an Authorization: Bearer header, not a '
           'query parameter (#3200)', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([])));
@@ -180,7 +180,7 @@ void main() {
 
         // And the call carries the documented v4 path with NO token
         // query parameter (the old ?token= form 404s live).
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               captureAny(),
               cancelToken: any(named: 'cancelToken'),
             )).captured.single as String;
@@ -204,7 +204,7 @@ void main() {
           File('test/fixtures/cl_cne_v4_auth_error.json')
               .readAsStringSync(),
         );
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(recorded));
@@ -219,7 +219,7 @@ void main() {
       });
 
       test('parses the CNE envelope into Stations with cl- prefix', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([_cneStation()])));
@@ -247,7 +247,7 @@ void main() {
       });
 
       test('empty data → empty list, not an error', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([])));
@@ -260,7 +260,7 @@ void main() {
 
       test('HTTP 401 is re-raised as ApiException with clear message',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -283,7 +283,7 @@ void main() {
       });
 
       test('HTTP 403 is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -304,7 +304,7 @@ void main() {
       });
 
       test('network timeout is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -320,7 +320,7 @@ void main() {
       });
 
       test('every parsed station id starts with `cl-`', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([
@@ -342,7 +342,7 @@ void main() {
       });
 
       test('codigo already prefixed `cl-` is not double-prefixed', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([

--- a/test/features/station_services/denmark/denmark_station_service_test.dart
+++ b/test/features/station_services/denmark/denmark_station_service_test.dart
@@ -114,7 +114,7 @@ void main() {
           'items': [
             {
               'facility_number': '1001',
-              'prices': [],
+              'prices': <dynamic>[],
             },
           ],
         };
@@ -165,7 +165,7 @@ void main() {
             {
               'facility_number': '1001',
               'coordinates': {'latitude': 55.5, 'longitude': 12.5},
-              'prices': [],
+              'prices': <dynamic>[],
               'street': 'TestStreet',
               'house_number': null,
               'city': 'TestCity',
@@ -216,7 +216,7 @@ void main() {
           {
             'stationId': 'S1',
             'coordinates': {'latitude': '55.5', 'longitude': '12.5'},
-            'prices': [],
+            'prices': <dynamic>[],
           },
         ];
 
@@ -245,7 +245,7 @@ void main() {
           {
             'stationId': 'S1',
             'coordinates': <String, dynamic>{},
-            'prices': [],
+            'prices': <dynamic>[],
           },
         ];
 
@@ -348,7 +348,7 @@ void main() {
             {
               'facility_number': '1001',
               'coordinates': {'latitude': 0, 'longitude': 0},
-              'prices': [],
+              'prices': <dynamic>[],
             },
           ],
         };
@@ -372,7 +372,7 @@ void main() {
           'items': [
             {
               'coordinates': {'latitude': 55.5, 'longitude': 12.5},
-              'prices': [],
+              'prices': <dynamic>[],
             },
           ],
         };
@@ -453,7 +453,7 @@ void main() {
           {
             'stationId': 'S1',
             'coordinates': {'latitude': '0', 'longitude': '0'},
-            'prices': [],
+            'prices': <dynamic>[],
           },
         ];
 
@@ -471,7 +471,7 @@ void main() {
           {
             'stationId': 'S1',
             'coordinates': {'latitude': '55.5', 'longitude': '12.5'},
-            'prices': [],
+            'prices': <dynamic>[],
           },
         ];
 
@@ -725,13 +725,13 @@ void main() {
           {
             'facility_number': '1001',
             'coordinates': {'latitude': 55.80, 'longitude': 12.50},
-            'prices': [],
+            'prices': <dynamic>[],
             'city': 'Far',
           },
           {
             'facility_number': '1002',
             'coordinates': {'latitude': 55.68, 'longitude': 12.57},
-            'prices': [],
+            'prices': <dynamic>[],
             'city': 'Near',
           },
         ],
@@ -774,7 +774,7 @@ void main() {
           {
             'facility_number': '1001',
             'coordinates': {'latitude': 55.5, 'longitude': 12.5},
-            'prices': [],
+            'prices': <dynamic>[],
             'last_updated_time': '2026-03-29T14:30:00Z',
           },
         ],

--- a/test/features/station_services/france/prix_carburants_geo_distance_order_test.dart
+++ b/test/features/station_services/france/prix_carburants_geo_distance_order_test.dart
@@ -183,7 +183,7 @@ class _GeoOrderAdapter implements HttpClientAdapter {
       final isOrdered = uri.contains('order_by');
       body.addAll(isOrdered ? ordered : unordered);
     } else {
-      body['results'] = const [];
+      body['results'] = const <dynamic>[];
     }
     return ResponseBody.fromString(
       jsonEncode(body),

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -111,7 +111,7 @@ void main() {
         );
         final result = await service.searchStations(params);
         expect(result.source, ServiceSource.prixCarburantsApi);
-        expect(result.data, isA<List>());
+        expect(result.data, isA<List<dynamic>>());
       });
 
       test('returns empty list for coordinates far from France', () async {
@@ -176,7 +176,7 @@ void main() {
         'services_service': ['Lavage automatique', 'DAB'],
         'horaires_automate_24_24': 'Oui',
         'carburants_disponibles': ['Gazole', 'SP95', 'E10'],
-        'carburants_indisponibles': [],
+        'carburants_indisponibles': <dynamic>[],
         'pop': 'R',
         'departement': 'Hérault',
         'region': 'Occitanie',
@@ -833,7 +833,7 @@ void main() {
       // First request (CP query) returns results
       adapter.addResponse(makeApiResponse('75012', 3));
       // Second request (geo follow-up for neighboring postal codes — #315)
-      adapter.addResponse({'results': const []});
+      adapter.addResponse({'results': const <dynamic>[]});
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -857,7 +857,7 @@ void main() {
     test('falls back to geo query when postal code returns empty', () async {
       final adapter = _TrackingMockAdapter();
       // First request (CP query) returns empty
-      adapter.addResponse({'results': []});
+      adapter.addResponse({'results': <dynamic>[]});
       // Second request (geo query) returns results
       adapter.addResponse(makeApiResponse('75012', 2));
 
@@ -902,7 +902,7 @@ void main() {
       // to the cp query when valid coordinates are present.
       final adapter = _TrackingMockAdapter();
       adapter.addResponse(makeApiResponse('34120', 5));
-      adapter.addResponse({'results': const []}); // geo follow-up
+      adapter.addResponse({'results': const <dynamic>[]}); // geo follow-up
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -989,7 +989,7 @@ void main() {
     test('postal-code path filters stations by radius (regression #298)', () async {
       final adapter = _TrackingMockAdapter()
         ..addResponse(scatteredStations('34120'))
-        ..addResponse({'results': const []}); // geo follow-up returns nothing extra
+        ..addResponse({'results': const <dynamic>[]}); // geo follow-up returns nothing extra
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -1013,9 +1013,9 @@ void main() {
     test('postal-code path with different radii returns different result counts (#298)', () async {
       final adapter = _TrackingMockAdapter()
         ..addResponse(scatteredStations('34120'))
-        ..addResponse({'results': const []}) // geo follow-up for narrow
+        ..addResponse({'results': const <dynamic>[]}) // geo follow-up for narrow
         ..addResponse(scatteredStations('34120'))
-        ..addResponse({'results': const []}); // geo follow-up for wide
+        ..addResponse({'results': const <dynamic>[]}); // geo follow-up for wide
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -1036,7 +1036,7 @@ void main() {
 
     test('geo path preserves decimal radius (no integer rounding) (#298)', () async {
       final adapter = _TrackingMockAdapter()
-        ..addResponse({'results': []});
+        ..addResponse({'results': <dynamic>[]});
 
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
@@ -1380,7 +1380,7 @@ void main() {
 
     test('caps the batch at 10 ids', () async {
       final adapter = _TrackingMockAdapter()
-        ..addResponse({'results': const []});
+        ..addResponse({'results': const <dynamic>[]});
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
 
@@ -1411,7 +1411,7 @@ void main() {
     });
 
     test('injected baseUrl is used as the request URL', () async {
-      final adapter = _TrackingMockAdapter()..addResponse({'results': const []});
+      final adapter = _TrackingMockAdapter()..addResponse({'results': const <dynamic>[]});
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(
         dio: dio,
@@ -1432,7 +1432,7 @@ void main() {
     });
 
     test('defaults to defaultBaseUrl when baseUrl is omitted', () async {
-      final adapter = _TrackingMockAdapter()..addResponse({'results': const []});
+      final adapter = _TrackingMockAdapter()..addResponse({'results': const <dynamic>[]});
       final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
       final svc = PrixCarburantsStationService(dio: dio);
 

--- a/test/features/station_services/germany/germany_opening_hours_adapter_test.dart
+++ b/test/features/station_services/germany/germany_opening_hours_adapter_test.dart
@@ -219,7 +219,7 @@ void main() {
       expect(
         () => adapter.parse({
           'openingTimes': [
-            {'text': null, 'start': 123, 'end': const []},
+            {'text': null, 'start': 123, 'end': const <dynamic>[]},
             'not even a map',
           ],
           'wholeDay': 'maybe',

--- a/test/features/station_services/germany/tankerkoenig_station_service_test.dart
+++ b/test/features/station_services/germany/tankerkoenig_station_service_test.dart
@@ -22,7 +22,7 @@ void main() {
 
   group('searchStations', () {
     test('parses valid response with stations', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 statusCode: 200,
@@ -58,10 +58,10 @@ void main() {
     });
 
     test('returns empty list for empty stations array', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
-                data: {'ok': true, 'stations': []},
+                data: {'ok': true, 'stations': <dynamic>[]},
               ));
 
       const params = SearchParams(lat: 52.52, lng: 13.405, radiusKm: 10.0);
@@ -71,7 +71,7 @@ void main() {
     });
 
     test('throws ApiException when ok is false', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 data: {'ok': false, 'message': 'Invalid API key'},
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('throws on DioException', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters'), cancelToken: any(named: 'cancelToken')))
           .thenThrow(DioException(
             type: DioExceptionType.connectionTimeout,
             requestOptions: RequestOptions(),
@@ -101,7 +101,7 @@ void main() {
 
   group('getStationDetail', () {
     test('parses valid detail response', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 data: {
@@ -139,7 +139,7 @@ void main() {
     });
 
     test('handles missing openingTimes gracefully', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 data: {
@@ -173,7 +173,7 @@ void main() {
     });
 
     test('parses valid prices response', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 data: {
@@ -193,7 +193,7 @@ void main() {
     });
 
     test('handles empty prices map', () async {
-      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+      when(() => mockDio.get<dynamic>(any(), queryParameters: any(named: 'queryParameters')))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(),
                 data: <String, dynamic>{'ok': true, 'prices': <String, dynamic>{}},

--- a/test/features/station_services/greece/greece_station_service_test.dart
+++ b/test/features/station_services/greece/greece_station_service_test.dart
@@ -88,12 +88,12 @@ void main() {
         expect(result.errors, hasLength(1));
         expect(result.errors.single.kind, FailureKind.unsupported);
         expect(result.errors.single.message, contains('#3194'));
-        verifyNever(() => mockDio.get(
+        verifyNever(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
             ));
-        verifyNever(() => mockDio.get(
+        verifyNever(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             ));
@@ -101,7 +101,7 @@ void main() {
 
       test('a self-hosted baseUrl bypasses the short-circuit and fetches',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([])));
@@ -112,7 +112,7 @@ void main() {
         final result = await service.searchStations(params);
 
         expect(result.source, ServiceSource.greeceApi);
-        verify(() => mockDio.get(
+        verify(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).called(greaterThan(0));
@@ -194,7 +194,7 @@ void main() {
     group('searchStations', () {
       test('builds stations for the nearest prefectures from Athens',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
@@ -224,7 +224,7 @@ void main() {
       });
 
       test('fetches exactly 4 closest prefectures (not all 8)', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
@@ -232,14 +232,14 @@ void main() {
         const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
         await service.searchStations(params);
 
-        verify(() => mockDio.get(
+        verify(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).called(4);
       });
 
       test('targets the /data/daily/prefecture/{name} path', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(_envelope([_priceResponse()])));
@@ -247,7 +247,7 @@ void main() {
         const params = SearchParams(lat: 37.98, lng: 23.73, radiusKm: 500);
         await service.searchStations(params);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               captureAny(),
               cancelToken: any(named: 'cancelToken'),
             )).captured;
@@ -261,7 +261,7 @@ void main() {
       });
 
       test('HTTP 401 is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -282,7 +282,7 @@ void main() {
       });
 
       test('HTTP 403 is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -305,7 +305,7 @@ void main() {
       test(
           'network timeout on every prefecture surfaces ApiException to '
           'the fallback chain', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenThrow(DioException(
@@ -324,7 +324,7 @@ void main() {
           'partial failures (some prefectures up, some down) still return '
           'data with accumulated errors', () async {
         var callCount = 0;
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async {
@@ -347,7 +347,7 @@ void main() {
       });
 
       test('empty list for a prefecture drops that entry silently', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response(<Map<String, dynamic>>[]));

--- a/test/features/station_services/luxembourg/luxembourg_station_service_test.dart
+++ b/test/features/station_services/luxembourg/luxembourg_station_service_test.dart
@@ -45,7 +45,7 @@ void main() {
 
   /// Stub the two LUSTAT dataflow calls with the recorded fixtures.
   void stubLiveLustat() {
-    when(() => mockDio.get(
+    when(() => mockDio.get<dynamic>(
           any(),
           cancelToken: any(named: 'cancelToken'),
         )).thenAnswer((invocation) async {
@@ -61,7 +61,7 @@ void main() {
   }
 
   void stubLustatDown() {
-    when(() => mockDio.get(
+    when(() => mockDio.get<dynamic>(
           any(),
           cancelToken: any(named: 'cancelToken'),
         )).thenThrow(DioException(
@@ -238,7 +238,7 @@ void main() {
 
       test('unparseable LUSTAT body also degrades to the stale fallback',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               cancelToken: any(named: 'cancelToken'),
             )).thenAnswer((_) async => response('<html>maintenance</html>'));

--- a/test/features/station_services/romania/romania_station_service_test.dart
+++ b/test/features/station_services/romania/romania_station_service_test.dart
@@ -82,7 +82,7 @@ void main() {
     group('searchStations', () {
       test('fans out one call per catalog product and merges by station id',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -110,7 +110,7 @@ void main() {
 
         expect(result.source, ServiceSource.romaniaApi);
         // Five calls, one per catalog product id.
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -146,7 +146,7 @@ void main() {
 
       test('every station id carries the ro- prefix for currency routing',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -159,7 +159,7 @@ void main() {
       });
 
       test('clamps an absurd radius to the 30 km buffer ceiling', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -171,7 +171,7 @@ void main() {
         const huge = SearchParams(lat: 44.43, lng: 26.10, radiusKm: 10000);
         await service.searchStations(huge);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -181,7 +181,7 @@ void main() {
 
       test('bare empty-list body (live-verified backend quirk) → empty '
           'result, not an error', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -194,7 +194,7 @@ void main() {
 
       test('backend exception envelope raises ApiException', () async {
         // Live-recorded WebAPI error shape (Npgsql error, 2026-06-10).
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -216,7 +216,7 @@ void main() {
       });
 
       test('network failure is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -233,7 +233,7 @@ void main() {
 
       test('HTTP 404 surfaces the status code (the failure mode that '
           'killed the old endpoint)', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),

--- a/test/features/station_services/slovenia/slovenia_station_service_test.dart
+++ b/test/features/station_services/slovenia/slovenia_station_service_test.dart
@@ -103,7 +103,7 @@ void main() {
 
     group('searchStations', () {
       test('parses a canonical goriva.si response', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -142,7 +142,7 @@ void main() {
       });
 
       test('builds the correct query parameters (radius in meters)', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -155,7 +155,7 @@ void main() {
         );
         await service.searchStations(params);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -167,7 +167,7 @@ void main() {
       });
 
       test('clamps unrealistic radius values', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -180,7 +180,7 @@ void main() {
         );
         await service.searchStations(params);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -189,7 +189,7 @@ void main() {
       });
 
       test('returns empty list for empty results array', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -202,7 +202,7 @@ void main() {
       });
 
       test('returns empty list for non-map response', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -214,7 +214,7 @@ void main() {
       });
 
       test('wraps DioException as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -231,7 +231,7 @@ void main() {
       });
 
       test('sort by price sorts cheapest e5 first', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -268,7 +268,7 @@ void main() {
         // goriva.si search would still have returned them (the upstream
         // query is server-side). filterByRadius should then fall back
         // to the top-N nearest so the user never sees an empty list.
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -419,7 +419,7 @@ void main() {
 
       test('returns empty list when results is not a list', () {
         expect(service.parseResponse({'results': 'nope'}), isEmpty);
-        expect(service.parseResponse({}), isEmpty);
+        expect(service.parseResponse(<dynamic, dynamic>{}), isEmpty);
       });
     });
 

--- a/test/features/station_services/south_korea/south_korea_station_service_test.dart
+++ b/test/features/station_services/south_korea/south_korea_station_service_test.dart
@@ -127,7 +127,7 @@ void main() {
           () async {
         // OPINET returns one product per call; the service fires four
         // requests (e5, e98, diesel, lpg) and merges results by station.
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -184,7 +184,7 @@ void main() {
         var inFlight = 0;
         var maxInFlight = 0;
 
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -224,7 +224,7 @@ void main() {
 
       test('sends API key and KATEC-projected coordinates in query '
           'parameters (#3192)', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -235,7 +235,7 @@ void main() {
         // this test only asserts on the outgoing parameters.
         await service.searchStations(params);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -256,7 +256,7 @@ void main() {
 
       test('clamps radius to the documented 5 km OPINET ceiling (#3192)',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -267,7 +267,7 @@ void main() {
         // this test only asserts on the outgoing parameters.
         await service.searchStations(params);
 
-        final captured = verify(() => mockDio.get(
+        final captured = verify(() => mockDio.get<dynamic>(
               any(),
               queryParameters: captureAny(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -283,7 +283,7 @@ void main() {
         // usually a station-free radius. OPINET still answers an INVALID
         // key with the same silent empty envelope, so the service leaves
         // an errorLogger trace, but it must NOT fail the search.
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -296,7 +296,7 @@ void main() {
 
       test('HTTP 401 is re-raised as ApiException with clear message',
           () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -320,7 +320,7 @@ void main() {
       });
 
       test('HTTP 403 is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -342,7 +342,7 @@ void main() {
       });
 
       test('network timeout is re-raised as ApiException', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),
@@ -359,7 +359,7 @@ void main() {
       });
 
       test('every parsed station id starts with `kr-`', () async {
-        when(() => mockDio.get(
+        when(() => mockDio.get<dynamic>(
               any(),
               queryParameters: any(named: 'queryParameters'),
               cancelToken: any(named: 'cancelToken'),

--- a/test/features/sync/presentation/widgets/data_transparency_cards_test.dart
+++ b/test/features/sync/presentation/widgets/data_transparency_cards_test.dart
@@ -86,7 +86,7 @@ void main() {
         const SyncedDataCard(data: {
           'favorites': [1, 2, 3],
           'alerts': [1],
-          'push_tokens': [],
+          'push_tokens': <dynamic>[],
           'reports': [1, 2],
           'trip_summaries': [1, 2, 2, 4, 5, 6, 7], // 7 trips
         }),
@@ -108,9 +108,9 @@ void main() {
         tester,
         const SyncedDataCard(data: {
           'favorites': [1],
-          'alerts': [],
-          'push_tokens': [],
-          'reports': [],
+          'alerts': <dynamic>[],
+          'push_tokens': <dynamic>[],
+          'reports': <dynamic>[],
           // intentionally no trip_summaries key
         }),
       );

--- a/test/features/vehicle/data/vin_decoder_test.dart
+++ b/test/features/vehicle/data/vin_decoder_test.dart
@@ -147,7 +147,7 @@ void main() {
           )).thenAnswer((_) async => Response<Map<String, dynamic>>(
             requestOptions: RequestOptions(path: ''),
             statusCode: 200,
-            data: const {'Results': []},
+            data: const {'Results': <dynamic>[]},
           ));
 
       final dec = VinDecoder(dio: dio);

--- a/test/features/widget/data/car_station_data_test.dart
+++ b/test/features/widget/data/car_station_data_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:convert';
+import 'dart:ui' show Color;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/price_band_colors.dart';
@@ -41,7 +42,7 @@ void main() {
         isOpen: true,
       );
 
-  int argb(c) {
+  int argb(Color c) {
     int ch(double v) => (v * 255.0).round() & 0xff;
     return (ch(c.a) << 24) | (ch(c.r) << 16) | (ch(c.g) << 8) | ch(c.b);
   }

--- a/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
+++ b/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
@@ -17,6 +17,8 @@
 // the `home_widget` plugin via platform channels; we mock the channel so
 // the call path completes instead of throwing.
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -142,15 +144,15 @@ void main() {
         // searchStations when online (otherwise the no-GPS path
         // short-circuits and the test proves nothing).
         final fake = FakeHiveStorage();
-        fake.putSetting(StorageKeys.userPositionLat, 43.44);
-        fake.putSetting(StorageKeys.userPositionLng, 3.44);
-        fake.saveProfile('p1', const {
+        unawaited(fake.putSetting(StorageKeys.userPositionLat, 43.44));
+        unawaited(fake.putSetting(StorageKeys.userPositionLng, 3.44));
+        unawaited(fake.saveProfile('p1', const {
           'id': 'p1',
           'name': 'Std',
           'preferredFuelType': 'e10',
           'defaultSearchRadius': 10.0,
-        });
-        fake.setActiveProfileId('p1');
+        }));
+        unawaited(fake.setActiveProfileId('p1'));
         final repo = FakeStorageRepository(inner: fake);
 
         return ProviderContainer(
@@ -198,15 +200,15 @@ void main() {
         countingService = _CountingStationService();
         final fake = FakeHiveStorage();
         fakeHive = fake;
-        fake.putSetting(StorageKeys.userPositionLat, 43.44);
-        fake.putSetting(StorageKeys.userPositionLng, 3.44);
-        fake.saveProfile('p1', const {
+        unawaited(fake.putSetting(StorageKeys.userPositionLat, 43.44));
+        unawaited(fake.putSetting(StorageKeys.userPositionLng, 3.44));
+        unawaited(fake.saveProfile('p1', const {
           'id': 'p1',
           'name': 'Std',
           'preferredFuelType': 'e10',
           'defaultSearchRadius': 10.0,
-        });
-        fake.setActiveProfileId('p1');
+        }));
+        unawaited(fake.setActiveProfileId('p1'));
         final repo = FakeStorageRepository(inner: fake);
 
         return ProviderContainer(

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -652,8 +652,10 @@ void main() {
     // connection read, so the connect opens its OWN trace (beginTrace
     // supersedes a live pickerScan trace) instead of the scan's absorbing
     // it. Decomposition stays tracked under #2187/#2188.
+    // #3164 — re-grandfathered 552 → 555: errorLogger routing adds 3 lines
+    // (the connect-failure catch now logs e/st before the mounted check).
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':
-        552,
+        555,
     // #2624 — shrank 463 → 450: dropped the post-frame `fitCamera` block
     // (+ its dart:async / error_logger imports) in favour of
     // `MapOptions.initialCameraFit`, fixing the grey-tile cold-start race.

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -779,7 +779,10 @@ void main() {
     // `station_marker.dart` (the `_drivingMarker` content variant), not here, so
     // nothing further can move off this widget. Decomposition of this god-class
     // is still tracked by #2187/#2188.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 699,
+    // +1 (#3161): the `discarded_futures` burn-down added the lint-mandated
+    // `import 'dart:async';` line for the `unawaited(...)` wrap of the
+    // marker-tap HapticFeedback call. No new logic.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 700,
     // #2681 — feature_management_section.dart graduated: the #2681 ordered-
     // category reorg decomposed the 718-line god-class into the
     // widgets/feature_management/ folder (conso_feature_card.dart,

--- a/test/lint/no_inline_platform_check_test.dart
+++ b/test/lint/no_inline_platform_check_test.dart
@@ -56,6 +56,12 @@ void main() {
     'lib/features/consumption/data/pip_controller.dart',
     'lib/features/consumption/providers/auto_record_orchestrator_factories.dart',
     'lib/features/setup/providers/onboarding_platform_steps_provider.dart',
+    // #3169 — the SLC-wake factory seam (no-op off-iOS by design) and the
+    // iOS-only best-effort disclosure render gate.
+    'lib/core/background/slc_wake_monitor.dart',
+    'lib/features/alerts/presentation/widgets/alerts_best_effort_note.dart',
+    // #3170 — the Live Activity capability gate (ActivityKit is iOS-only).
+    'lib/features/consumption/data/live_activity_controller.dart',
   };
 
   // Files already violating the rule when the guard landed (#2350).

--- a/test/lint/no_inline_platform_check_test.dart
+++ b/test/lint/no_inline_platform_check_test.dart
@@ -5,9 +5,10 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Static-scan guard (#2350): no handwritten Dart file in shared `lib/`
-/// code may branch on `Platform.isIOS`, `Platform.isAndroid`,
-/// `Platform.isMacOS`, `Platform.isLinux`, or `Platform.isWindows`
+/// Static-scan guard (#2350, extended in #3163): no handwritten Dart
+/// file in shared `lib/` code may branch on `Platform.isIOS`,
+/// `Platform.isAndroid`, `Platform.isMacOS`, `Platform.isLinux`,
+/// `Platform.isWindows` — or on `defaultTargetPlatform` (#3163) —
 /// outside the designated allowed locations.
 ///
 /// **Why:** The plugin-pattern rule requires platform branching to be
@@ -38,6 +39,25 @@ void main() {
     'lib/features/consumption/data/obd2/obd2_permissions.dart',
   };
 
+  // Sanctioned `defaultTargetPlatform` dispatch seams (#3163). These
+  // files exist to resolve platform-specific behavior by design (BLE
+  // transport selection, recording/PiP/auto-record orchestration,
+  // platform-resolved onboarding steps) but live outside impl/ and
+  // don't carry the ios_/android_ filename convention. Adding an entry
+  // requires the same justification as `allowedPlatformWrappers`: the
+  // file's *purpose* must be platform dispatch — never add one to
+  // silence the guard for an inline branch in shared presentation or
+  // business logic (that's exactly the hole #3163 closed).
+  const sanctionedDefaultTargetPlatformSeams = <String>{
+    'lib/core/location/recording_location_settings.dart',
+    'lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart',
+    'lib/features/consumption/data/obd2/obd2_connect_by_mac.dart',
+    'lib/features/consumption/data/obd2/obd2_connection_service.dart',
+    'lib/features/consumption/data/pip_controller.dart',
+    'lib/features/consumption/providers/auto_record_orchestrator_factories.dart',
+    'lib/features/setup/providers/onboarding_platform_steps_provider.dart',
+  };
+
   // Files already violating the rule when the guard landed (#2350).
   // Debt — remove each once the inline Platform check is refactored.
   // This set may only SHRINK; target is 0. NEVER add an entry here.
@@ -56,6 +76,12 @@ void main() {
   // We strip single-line comments before matching to avoid false
   // positives from doc comments that mention the API.
   final platformCheckPattern = RegExp(r'\bPlatform\.is[A-Z][a-zA-Z]+');
+
+  // Foundation's `defaultTargetPlatform` is the same inline-branching
+  // hole through a different API (#3163) — it used to be invisible to
+  // this guard. `debugDefaultTargetPlatformOverride` (the test seam) is
+  // not matched: it is a distinct identifier, so `\b…\b` excludes it.
+  final defaultTargetPlatformPattern = RegExp(r'\bdefaultTargetPlatform\b');
 
   bool isAllowed(String path) {
     // Normalise separators so the checks work on Windows too.
@@ -140,5 +166,101 @@ void main() {
           'them from the `grandfathered` set in this test:\n'
           '${staleBaseline.join('\n')}',
     );
+  });
+
+  test('no inline defaultTargetPlatform check outside impl/, platform '
+      'wrappers, or sanctioned dispatch seams (#3163)', () {
+    final violations = <String>[];
+    final stillUsing = <String>{};
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (!isScanned(path)) continue;
+
+      final lines = entity.readAsLinesSync();
+      var fileUses = false;
+      for (var i = 0; i < lines.length; i++) {
+        final code = stripLineComment(lines[i]);
+        if (defaultTargetPlatformPattern.hasMatch(code)) {
+          fileUses = true;
+          if (!sanctionedDefaultTargetPlatformSeams.contains(path)) {
+            violations.add('$path:${i + 1}: ${lines[i].trim()}');
+          }
+        }
+      }
+      if (fileUses && sanctionedDefaultTargetPlatformSeams.contains(path)) {
+        stillUsing.add(path);
+      }
+    }
+
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'Inline defaultTargetPlatform branching found in shared code '
+          '(#3163). Resolve the platform behind a provider or an impl/ '
+          'dispatch seam instead (see '
+          'onboarding_platform_steps_provider.dart for the pattern).\n\n'
+          'New violations:\n${violations.join('\n')}',
+    );
+
+    // Ratchet: a seam that no longer uses defaultTargetPlatform must be
+    // removed from the set so the allow-list stays honest.
+    final staleSeams =
+        sanctionedDefaultTargetPlatformSeams.difference(stillUsing);
+    expect(
+      staleSeams,
+      isEmpty,
+      reason:
+          'These files no longer use defaultTargetPlatform — remove them '
+          'from `sanctionedDefaultTargetPlatformSeams`:\n'
+          '${staleSeams.join('\n')}',
+    );
+  });
+
+  // Regression cases for the #3163 hole: pin the patterns so they keep
+  // matching real branches and keep ignoring comments / the test seam.
+  group('pattern regression (#3163)', () {
+    test('defaultTargetPlatform branch is matched', () {
+      expect(
+        defaultTargetPlatformPattern.hasMatch(
+          'final isIos = defaultTargetPlatform == TargetPlatform.iOS;',
+        ),
+        isTrue,
+      );
+    });
+
+    test('debugDefaultTargetPlatformOverride (test seam) is not matched',
+        () {
+      expect(
+        defaultTargetPlatformPattern.hasMatch(
+          'debugDefaultTargetPlatformOverride = TargetPlatform.iOS;',
+        ),
+        isFalse,
+      );
+    });
+
+    test('comment mentions are not matched after stripping', () {
+      expect(
+        defaultTargetPlatformPattern.hasMatch(
+          stripLineComment('// uses defaultTargetPlatform internally'),
+        ),
+        isFalse,
+      );
+      expect(
+        platformCheckPattern.hasMatch(
+          stripLineComment('// Platform.isIOS would be wrong here'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('Platform.isXxx branch is still matched', () {
+      expect(
+        platformCheckPattern.hasMatch('if (Platform.isAndroid) {'),
+        isTrue,
+      );
+    });
   });
 }

--- a/test/lint/no_silent_catch_test.dart
+++ b/test/lint/no_silent_catch_test.dart
@@ -5,47 +5,267 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Static-scan regression test (#565): no `catch (_) {}` (silent) or
-/// `catch (e) {}` (stored-but-unused) blocks in `lib/`. Silent catches
-/// hide root causes — replace with at least `debugPrint('context: $e')`
-/// or route through `TraceRecorder.recordError(e)`.
+/// Static-scan regression test (#565, evasion hole closed in #3163): no
+/// silent catch blocks in `lib/`. A catch is *silent* when its body
+/// contains no executable statement — that covers the literally-empty
+/// `catch (_) {}` **and** the comment-only `catch (_) { /* meh */ }`
+/// form that used to evade this gate (#3163). Silent catches hide root
+/// causes — replace with at least `debugPrint('context: $e')` or route
+/// through `errorLogger.log(...)`.
 ///
-/// The scan uses a simple regex that tolerates optional whitespace and
-/// the Dart `on T catch` form. False positives should add a minimal log
-/// line rather than relaxing this scan.
+/// Two-parameter catches (`catch (e, st) { }`) with an empty or
+/// comment-only body are silent too and are scanned the same way
+/// (#3163 — they previously evaded both this gate and the
+/// stacktrace-coverage gate, which excludes them by design).
+///
+/// **Opt-out** (mirrors the `catch_no_st` convention of
+/// `catch_block_stacktrace_coverage_test.dart`): a *deliberate*
+/// best-effort swallow — e.g. teardown where every failure mode is
+/// benign — may opt out with a comment containing
+/// `// ignore: silent_catch — <reason>` on the catch line, the line
+/// directly above it, or inside the catch body. The reason is
+/// mandatory by convention; use sparingly.
 void main() {
-  test('no silent catch blocks in lib/ (#565)', () {
-    final offenders = <String>[];
+  group('no silent catch blocks in lib/ (#565, #3163)', () {
+    test('filesystem scan', () {
+      final offenders = <String>[];
 
-    // Matches `catch (_) {}` and `catch (e) {}` (with optional whitespace).
-    // Does NOT match catches that contain a statement — the body has to be
-    // literally empty (whitespace/newlines only) to qualify as "silent".
-    final silent = RegExp(
-      r'catch\s*\(\s*\w+\s*\)\s*\{\s*\}',
-    );
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        // Skip generated files — they don't follow handwritten conventions.
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
 
-    for (final entity in Directory('lib').listSync(recursive: true)) {
-      if (entity is! File || !entity.path.endsWith('.dart')) continue;
-      // Skip generated files — they don't follow handwritten conventions.
-      if (entity.path.endsWith('.g.dart') ||
-          entity.path.endsWith('.freezed.dart')) {
-        continue;
+        final src = entity.readAsStringSync();
+        for (final hit in findSilentCatches(src)) {
+          offenders.add('${entity.path}:${hit.line}  ${hit.snippet}');
+        }
       }
 
-      final src = entity.readAsStringSync();
-      for (final m in silent.allMatches(src)) {
-        final line = src.substring(0, m.start).split('\n').length;
-        offenders.add('${entity.path}:$line  ${m.group(0)}');
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'Silent catch (empty or comment-only body) hides the root '
+            'cause. Replace with at least `debugPrint("context: \$e")` or '
+            '`errorLogger.log(...)` so the reason ends up in logs. For a '
+            'deliberate best-effort swallow, opt out with '
+            '`// ignore: silent_catch — <reason>`. '
+            'Offending sites:\n${offenders.join("\n")}',
+      );
+    });
+
+    // Regression cases for the evasion holes closed in #3163. These pin
+    // the matcher itself so a future "simplification" cannot quietly
+    // reopen a hole.
+    group('matcher regression (#3163)', () {
+      test('literally empty body is silent (original #565 behavior)', () {
+        expect(findSilentCatches('try {} catch (_) {}'), hasLength(1));
+        expect(findSilentCatches('try {} catch (e) {  }'), hasLength(1));
+        expect(
+          findSilentCatches('try {} on FormatException catch (e) {\n}'),
+          hasLength(1),
+        );
+      });
+
+      test('comment-only body is silent (evasion hole a)', () {
+        expect(
+          findSilentCatches('try {} catch (_) { /* best effort */ }'),
+          hasLength(1),
+        );
+        expect(
+          findSilentCatches(
+            'try {} catch (_) {\n  // nothing we can do\n}',
+          ),
+          hasLength(1),
+        );
+        expect(
+          findSilentCatches(
+            'try {} catch (e) {\n  // line one\n  /* line\n  two */\n}',
+          ),
+          hasLength(1),
+        );
+        // Braces inside the comment must not hide the catch.
+        expect(
+          findSilentCatches(
+            'try {} catch (_) {\n  // cleanup of {nested} things\n}',
+          ),
+          hasLength(1),
+        );
+      });
+
+      test('two-parameter catch with empty/comment-only body is silent', () {
+        expect(findSilentCatches('try {} catch (e, st) {}'), hasLength(1));
+        expect(
+          findSilentCatches('try {} catch (e, st) { /* shrug */ }'),
+          hasLength(1),
+        );
+      });
+
+      test('a body with any executable statement is not silent', () {
+        expect(
+          findSilentCatches(
+            "try {} catch (e) { debugPrint('context: \$e'); }",
+          ),
+          isEmpty,
+        );
+        expect(
+          findSilentCatches(
+            'try {} catch (e, st) {\n  // log it\n  log(e, st);\n}',
+          ),
+          isEmpty,
+        );
+      });
+
+      test('opt-out comment suppresses the finding', () {
+        // Inside the body.
+        expect(
+          findSilentCatches(
+            'try {} catch (_) {\n'
+            '  // ignore: silent_catch — best-effort teardown\n'
+            '}',
+          ),
+          isEmpty,
+        );
+        // On the catch line.
+        expect(
+          findSilentCatches(
+            'try {} catch (_) { // ignore: silent_catch — benign\n}',
+          ),
+          isEmpty,
+        );
+        // On the line directly above.
+        expect(
+          findSilentCatches(
+            'try {\n} \n// ignore: silent_catch — benign\ncatch (_) {\n}',
+          ),
+          isEmpty,
+        );
+        // An unrelated comment is NOT an opt-out.
+        expect(
+          findSilentCatches('try {} catch (_) { // ignore: lines_long\n}'),
+          hasLength(1),
+        );
+      });
+    });
+  });
+}
+
+/// One silent-catch finding: 1-based [line] plus the matched [snippet].
+class SilentCatch {
+  const SilentCatch(this.line, this.snippet);
+  final int line;
+  final String snippet;
+}
+
+/// Scans [src] for silent catch blocks: a `catch (x)` / `catch (e, st)`
+/// whose body contains nothing but whitespace and comments, and which
+/// does not carry the `// ignore: silent_catch` opt-out (on the catch
+/// line, the line above, or inside the body).
+///
+/// Comments are blanked out (newlines preserved, so line numbers stay
+/// stable) *before* the empty-body regex runs — this is what closes the
+/// comment-only evasion hole (#3163): after blanking, a comment-only
+/// body is indistinguishable from an empty one.
+List<SilentCatch> findSilentCatches(String src) {
+  final blanked = _blankComments(src);
+  final lines = src.split('\n');
+
+  // Matches `catch (_) { }` and `catch (e, st) { }` — body empty after
+  // comment-blanking (whitespace/newlines only).
+  final silent = RegExp(
+    r'catch\s*\(\s*\w+(?:\s*,\s*\w+)?\s*\)\s*\{\s*\}',
+  );
+
+  final findings = <SilentCatch>[];
+  for (final m in silent.allMatches(blanked)) {
+    final startLine = blanked.substring(0, m.start).split('\n').length - 1;
+    final endLine = blanked.substring(0, m.end).split('\n').length - 1;
+    // Opt-out window: line above the catch through the closing brace.
+    final from = startLine > 0 ? startLine - 1 : 0;
+    var optedOut = false;
+    for (var i = from; i <= endLine && i < lines.length; i++) {
+      if (lines[i].contains('ignore: silent_catch')) {
+        optedOut = true;
+        break;
       }
     }
-
-    expect(
-      offenders,
-      isEmpty,
-      reason:
-          'Silent catch hides the root cause. Replace with at least '
-          '`debugPrint("context: \$e")` so the reason ends up in logs. '
-          'Offending sites:\n${offenders.join("\n")}',
+    if (optedOut) continue;
+    findings.add(
+      SilentCatch(startLine + 1, src.split('\n')[startLine].trim()),
     );
-  });
+  }
+  return findings;
+}
+
+/// Blanks `// …` and `/* … */` comments, preserving newlines so the
+/// blanked text keeps the original line numbering. Quote-aware enough
+/// for this scan: a `//` inside a string literal never blanks code that
+/// precedes it on the line, so a body with real statements can never be
+/// blanked down to "empty" (false positives are impossible; a comment
+/// containing string-quote characters merely stays conservative).
+String _blankComments(String src) {
+  final out = StringBuffer();
+  var i = 0;
+  String? quote; // active string-literal delimiter, if any
+  var inLineComment = false;
+  var inBlockComment = false;
+  while (i < src.length) {
+    final c = src[i];
+    final next = i + 1 < src.length ? src[i + 1] : '';
+    if (inLineComment) {
+      if (c == '\n') {
+        inLineComment = false;
+        out.write('\n');
+      }
+      i++;
+      continue;
+    }
+    if (inBlockComment) {
+      if (c == '*' && next == '/') {
+        inBlockComment = false;
+        i += 2;
+        continue;
+      }
+      if (c == '\n') out.write('\n');
+      i++;
+      continue;
+    }
+    if (quote != null) {
+      out.write(c);
+      if (c == r'\') {
+        // Skip the escaped character.
+        if (next.isNotEmpty) {
+          out.write(next);
+          i += 2;
+          continue;
+        }
+      } else if (c == quote) {
+        quote = null;
+      }
+      i++;
+      continue;
+    }
+    if (c == "'" || c == '"') {
+      quote = c;
+      out.write(c);
+      i++;
+      continue;
+    }
+    if (c == '/' && next == '/') {
+      inLineComment = true;
+      i += 2;
+      continue;
+    }
+    if (c == '/' && next == '*') {
+      inBlockComment = true;
+      i += 2;
+      continue;
+    }
+    out.write(c);
+    i++;
+  }
+  return out.toString();
 }

--- a/tool/promote_ocr_fixture.dart
+++ b/tool/promote_ocr_fixture.dart
@@ -261,9 +261,9 @@ String _renderTest({
   required String slug,
   required String packagePath,
   required String? country,
-  required Map? profileJson,
+  required Map<dynamic, dynamic>? profileJson,
   required List<_Block> blocks,
-  required Map expected,
+  required Map<dynamic, dynamic> expected,
   required String? imageRef,
   required String? capturedAt,
 }) {
@@ -377,7 +377,7 @@ String _renderTest({
 /// Maps the package's `expected.derived` field-name list (which uses the
 /// result keys `totalCost`/`liters`/`pricePerLiter`) onto [PumpField]
 /// enum-value names, ignoring any unknown entry. Empty when absent.
-List<String> _derivedPumpFields(Map expected) {
+List<String> _derivedPumpFields(Map<dynamic, dynamic> expected) {
   final raw = expected['derived'];
   if (raw is! List) return const [];
   const mapping = {


### PR DESCRIPTION
## Lint strictness wave — strict modes, unused_catch_stack, evasion holes, fatal infos

All four children of epic #3158:

- **#3160 — analyzer strict modes**: strict-casts / strict-raw-types / strict-inference on, ~157 files of semantically-identical type fixes.
- **#3164 — unused_catch_stack**: enabled; the ~40 suppressed stack traces now reach errorLogger.
- **#3163 — lint evasion holes closed**: the silent-catch scanner comment-blanks before matching (comment-only bodies no longer pass), covers two-parameter catches, and has an explicit `// ignore: silent_catch — <reason>` opt-out; the platform-check scanner now also matches `defaultTargetPlatform` with a sanctioned-seam allow-list + stale-seam ratchet. 20 deliberate best-effort swallows annotated with reasons; the onboarding wizard's inline iOS branch moved behind a provider.
- **#3161 — the phase-in is real**: correctness lints promoted to error severity, `discarded_futures` on (208 sites wrapped in `unawaited`), and CI + the pre-push hook now run bare `flutter analyze` — **fatal on infos**, so findings can't accumulate again. The 38 `avoid_public_notifier_properties` infos were audited (7 documented lib seams, 31 test fakes); riverpod_lint 3.1.3's native plugin doesn't honor ignore comments (verified empirically), so that one rule is disabled in the plugin's diagnostics map with the rationale inline.

Post-rebase, the now-fatal gate caught and fixed findings in freshly-merged code (FR parser null-aware elements, the Spain mixin's discarded future, Hive box typing in the counters/journal, one silent catch, three new platform seams sanctioned with rationale) — proving the gate does exactly what #3161 wanted.

The tree is now `flutter analyze`-clean with zero flags.

Closes #3160, closes #3161, closes #3163, closes #3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
