### PR TITLE
test(arch): feature api.dart barrels + import-direction gate with two-way ratchet (#3132)

### DIFF
--- a/lib/features/achievements/api.dart
+++ b/lib/features/achievements/api.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `achievements` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/widgets/badge_shelf.dart';

--- a/lib/features/alerts/api.dart
+++ b/lib/features/alerts/api.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `alerts` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/price_snapshot_store.dart';
+export 'data/radius_alert_dedup.dart';
+export 'data/radius_alert_runner.dart';
+export 'data/radius_alert_store.dart';
+export 'data/repositories/alert_repository.dart';
+export 'data/test_alert_runner.dart';
+export 'data/velocity_alert_cooldown.dart';
+export 'data/velocity_alert_runner.dart';
+export 'domain/entities/price_alert.dart';
+export 'domain/entities/radius_alert.dart';
+export 'domain/radius_alert_evaluator.dart';
+export 'domain/velocity_alert_detector.dart';
+export 'presentation/screens/alerts_screen.dart';
+export 'presentation/widgets/create_alert_dialog.dart';
+export 'providers/alert_provider.dart';

--- a/lib/features/approach/api.dart
+++ b/lib/features/approach/api.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `approach` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/widgets/approach_test_panel.dart';
+export 'providers/approach_state_provider.dart';
+export 'providers/effective_approach_state_provider.dart';
+export 'providers/fuel_station_radar_provider.dart';
+export 'providers/nearest_station_radar_provider.dart';
+export 'providers/radar_candidate_list_provider.dart';
+export 'providers/radar_swipe_provider.dart';

--- a/lib/features/calculator/api.dart
+++ b/lib/features/calculator/api.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `calculator` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/calculator_screen.dart';

--- a/lib/features/car/api.dart
+++ b/lib/features/car/api.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `car` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// This feature currently has no cross-feature consumers, so it
+/// exports nothing. Add an `export` here (and nothing else) when
+/// another feature legitimately needs one of its types.
+library;

--- a/lib/features/carbon/api.dart
+++ b/lib/features/carbon/api.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `carbon` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/monthly_summary.dart';
+export 'presentation/screens/carbon_dashboard_screen.dart';
+export 'presentation/widgets/monthly_bar_chart.dart';

--- a/lib/features/consent/api.dart
+++ b/lib/features/consent/api.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `consent` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/gdpr_consent_screen.dart';
+export 'presentation/widgets/consent_settings_section.dart';

--- a/lib/features/consumption/api.dart
+++ b/lib/features/consumption/api.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `consumption` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/baseline_sync.dart';
+export 'data/driving_score_calculator.dart';
+export 'data/obd2/active_trip_recovery_service.dart';
+export 'data/obd2/active_trip_repository.dart';
+export 'data/obd2/adapter_capability.dart';
+export 'data/obd2/adapter_registry.dart';
+export 'data/obd2/broken_map_belief.dart';
+export 'data/obd2/broken_map_detector.dart';
+export 'data/obd2/elm327_protocol.dart';
+export 'data/obd2/event_channel_cancel.dart';
+export 'data/obd2/ios_state_restoration_provider.dart';
+export 'data/obd2/obd2_comm_diagnostics.dart';
+export 'data/obd2/obd2_connect_trace.dart';
+export 'data/obd2/obd2_connect_trace_log.dart';
+export 'data/obd2/obd2_connect_trace_persistence.dart';
+export 'data/obd2/obd2_connection_service.dart';
+export 'data/obd2/obd2_read_telemetry.dart';
+export 'data/obd2/obd2_self_test_driver.dart';
+export 'data/obd2/obd2_service.dart';
+export 'data/obd2/obd2_session_diagnostic.dart';
+export 'data/obd2/obd_adapter_blocklist.dart';
+export 'data/obd2/paused_trip_recovery_service.dart';
+export 'data/obd2/paused_trip_repository.dart';
+export 'data/obd2/trip_live_reading.dart';
+export 'data/ocr/ocr_geometry.dart';
+export 'data/ocr/ocr_trace_package.dart';
+export 'data/ocr/ocr_trace_recorder.dart';
+export 'data/ocr/ocr_trace_serializer.dart';
+export 'data/ocr/pump_ocr_config.dart';
+export 'data/pip_controller.dart';
+export 'data/receipt_scan_service.dart';
+export 'data/trip_history_repository.dart';
+export 'domain/direct_fuel_rate_detector.dart';
+export 'domain/driving_coaching.dart';
+export 'domain/entities/fill_up.dart';
+export 'domain/harsh_event.dart';
+export 'domain/services/speed_consumption_histogram.dart';
+export 'domain/services/trip_length_aggregator.dart';
+export 'domain/trip_recorder.dart';
+export 'presentation/screens/add_charging_log_screen.dart';
+export 'presentation/screens/add_fill_up_screen.dart';
+export 'presentation/screens/consumption_screen.dart';
+export 'presentation/screens/consumption_statistics_screen.dart';
+export 'presentation/screens/pick_station_for_fill_up_screen.dart';
+export 'presentation/screens/pump_display_camera_screen.dart';
+export 'presentation/screens/trip_detail_screen.dart';
+export 'presentation/screens/trip_recording_screen.dart';
+export 'presentation/widgets/broken_map_widgets.dart';
+export 'presentation/widgets/obd2_adapter_picker.dart';
+export 'presentation/widgets/obd2_connect_trace_card.dart';
+export 'presentation/widgets/obd2_diagnostics_card.dart';
+export 'presentation/widgets/ocr_block_overlay_painter.dart';
+export 'presentation/widgets/ocr_trace_steps_panel.dart';
+export 'presentation/widgets/proximity_fill_bar.dart';
+export 'presentation/widgets/share_receipt_listener.dart';
+export 'presentation/widgets/trip_recording_banner.dart';
+export 'presentation/widgets/vehicle_adapter_section.dart';
+export 'presentation/widgets/vehicle_baseline_section.dart';
+export 'providers/auto_record_orchestrator.dart';
+export 'providers/consumption_providers.dart';
+export 'providers/obd2_capability_provider.dart';
+export 'providers/obd2_comm_diagnostics_gate_provider.dart';
+export 'providers/obd2_connect_trace_revision_provider.dart';
+export 'providers/obd2_debug_logging_provider.dart';
+export 'providers/obd2_self_test_controller.dart';
+export 'providers/pending_shared_receipt_provider.dart';
+export 'providers/pip_mode_provider.dart';
+export 'providers/trip_history_provider.dart';
+export 'providers/trip_recording_provider.dart';
+export 'providers/trip_ve_recompute_provider.dart';
+export 'providers/wakelock_facade.dart';

--- a/lib/features/driving/api.dart
+++ b/lib/features/driving/api.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `driving` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'haptic_eco_coach.dart';
+export 'presentation/screens/driving_mode_screen.dart';
+export 'presentation/widgets/driving_settings_section.dart';
+export 'providers/driving_coach_voice_listener_provider.dart';
+export 'providers/haptic_eco_coach_provider.dart';
+export 'providers/live_harsh_event_bus_provider.dart';
+export 'providers/voice_announcement_listener_provider.dart';

--- a/lib/features/ev/api.dart
+++ b/lib/features/ev/api.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `ev` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/repositories/ev_station_repository.dart';
+export 'data/services/ev_price_enricher.dart';
+export 'data/services/fr_irve_price_service.dart';
+export 'data/services/ocm_poi_parser.dart';
+export 'domain/charging_cost_calculator.dart';
+export 'domain/entities/charging_log.dart';
+export 'presentation/widgets/connector_status_style.dart';
+export 'presentation/widgets/ev_filter_chips.dart';
+export 'presentation/widgets/ev_map_overlay.dart';
+export 'providers/ev_providers.dart';

--- a/lib/features/favorites/api.dart
+++ b/lib/features/favorites/api.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `favorites` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/favorites_screen.dart';
+export 'presentation/widgets/swipe_tutorial_banner.dart';
+export 'providers/favorite_stations_provider.dart';
+export 'providers/favorites_provider.dart';

--- a/lib/features/feature_management/api.dart
+++ b/lib/features/feature_management/api.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `feature_management` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'application/app_profile_provider.dart';
+export 'application/feature_flags_provider.dart';
+export 'application/feature_toggle_notifier.dart';
+export 'application/legacy_toggle_migration_provider.dart';
+export 'domain/app_profile.dart';
+export 'domain/build_channel.dart';
+export 'domain/conso_mode.dart';
+export 'domain/consumption_tab_visibility.dart';
+export 'domain/feature.dart';
+export 'domain/feature_category.dart';
+export 'domain/feature_dependency_graph.dart';
+export 'domain/feature_manifest.dart';

--- a/lib/features/glide_coach/api.dart
+++ b/lib/features/glide_coach/api.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `glide_coach` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/entities/glide_coach_advice.dart';
+export 'providers/glide_coach_enabled_provider.dart';
+export 'providers/glide_coach_evaluator_provider.dart';
+export 'providers/glide_coach_settings_provider.dart';

--- a/lib/features/itinerary/api.dart
+++ b/lib/features/itinerary/api.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `itinerary` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/entities/saved_itinerary.dart';
+export 'presentation/screens/itineraries_screen.dart';
+export 'providers/itinerary_provider.dart';

--- a/lib/features/loyalty/api.dart
+++ b/lib/features/loyalty/api.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `loyalty` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/loyalty_settings_screen.dart';
+export 'providers/loyalty_provider.dart';

--- a/lib/features/map/api.dart
+++ b/lib/features/map/api.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `map` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/sparkilo_tile_layer.dart';
+export 'presentation/screens/map_screen.dart';
+export 'presentation/widgets/inline_map.dart';
+export 'presentation/widgets/station_map_layers.dart';
+export 'presentation/widgets/station_marker.dart';

--- a/lib/features/payment/api.dart
+++ b/lib/features/payment/api.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `payment` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/qr_payment_decoder.dart';
+export 'presentation/scan_payment_dispatcher.dart';
+export 'presentation/widgets/unknown_qr_dialog.dart';

--- a/lib/features/price_history/api.dart
+++ b/lib/features/price_history/api.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `price_history` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/repositories/price_history_repository.dart';
+export 'domain/entities/price_prediction.dart';
+export 'domain/entities/price_record.dart';
+export 'presentation/screens/price_history_screen.dart';
+export 'presentation/widgets/price_chart.dart';
+export 'presentation/widgets/price_stats_card.dart';
+export 'providers/price_history_provider.dart';
+export 'providers/price_prediction_provider.dart';

--- a/lib/features/profile/api.dart
+++ b/lib/features/profile/api.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `profile` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/repositories/profile_repository.dart';
+export 'domain/entities/user_profile.dart';
+export 'presentation/screens/developer_tools/developer_tools_screen.dart';
+export 'presentation/screens/developer_tools/error_log_viewer_screen.dart';
+export 'presentation/screens/developer_tools/feature_flag_dump_screen.dart';
+export 'presentation/screens/developer_tools/obd2_health_screen.dart';
+export 'presentation/screens/developer_tools/pump_ocr_tester_screen.dart';
+export 'presentation/screens/privacy_dashboard_screen.dart';
+export 'presentation/screens/profile_screen.dart';
+export 'presentation/screens/theme_settings_screen.dart';
+export 'presentation/widgets/gamification_settings_tile.dart';
+export 'providers/approach_overlay_enabled_provider.dart';
+export 'providers/effective_fuel_type_provider.dart';
+export 'providers/gamification_enabled_provider.dart';
+export 'providers/profile_provider.dart';
+export 'providers/show_electric_enabled_provider.dart';
+export 'providers/show_fuel_enabled_provider.dart';
+export 'providers/voice_announcements_enabled_provider.dart';

--- a/lib/features/report/api.dart
+++ b/lib/features/report/api.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `report` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/report_screen.dart';

--- a/lib/features/route_search/api.dart
+++ b/lib/features/route_search/api.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `route_search` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/cross_border_corridor.dart';
+export 'domain/entities/route_info.dart';
+export 'domain/route_search_strategy.dart';
+export 'presentation/widgets/route_input.dart';
+export 'providers/route_input_provider.dart';
+export 'providers/route_search_params_provider.dart';
+export 'providers/route_search_provider.dart';

--- a/lib/features/search/api.dart
+++ b/lib/features/search/api.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `search` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/entities/brand_registry.dart';
+export 'presentation/screens/ev_station_detail_screen.dart';
+export 'presentation/screens/search_criteria_screen.dart';
+export 'presentation/screens/search_screen.dart';
+export 'presentation/widgets/amenity_chips.dart';
+export 'presentation/widgets/pay_with_app_button.dart';
+export 'presentation/widgets/payment_method_chips.dart';
+export 'presentation/widgets/sort_selector.dart';
+export 'presentation/widgets/station_card.dart';
+export 'providers/ev_charging_service_provider.dart';
+export 'providers/ev_search_provider.dart';
+export 'providers/radar_search_provider.dart';
+export 'providers/search_filters_provider.dart';
+export 'providers/search_mode_provider.dart';
+export 'providers/search_provider.dart';
+export 'providers/search_screen_ui_provider.dart';
+export 'providers/selected_station_provider.dart';
+export 'providers/station_rating_provider.dart';

--- a/lib/features/setup/api.dart
+++ b/lib/features/setup/api.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `setup` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/onboarding_wizard_screen.dart';

--- a/lib/features/station_detail/api.dart
+++ b/lib/features/station_detail/api.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `station_detail` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'domain/open_now.dart';
+export 'presentation/screens/station_detail_screen.dart';
+export 'presentation/widgets/station_brand_helpers.dart';
+export 'presentation/widgets/station_detail_inline.dart';

--- a/lib/features/station_services/api.dart
+++ b/lib/features/station_services/api.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `station_services` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'argentina/argentina_station_service.dart';
+export 'australia/australia_station_service.dart';
+export 'austria/econtrol_station_service.dart';
+export 'chile/chile_station_service.dart';
+export 'denmark/denmark_station_service.dart';
+export 'france/prix_carburants_flux_station_service.dart';
+export 'france/prix_carburants_station_service.dart';
+export 'germany/tankerkoenig_station_service.dart';
+export 'greece/greece_station_service.dart';
+export 'italy/mise_station_service.dart';
+export 'luxembourg/luxembourg_station_service.dart';
+export 'mexico/mexico_station_service.dart';
+export 'portugal/portugal_station_service.dart';
+export 'romania/romania_station_service.dart';
+export 'slovenia/slovenia_station_service.dart';
+export 'south_korea/south_korea_station_service.dart';
+export 'spain/miteco_station_service.dart';
+export 'uk/uk_cma_bulk_station_service.dart';
+export 'uk/uk_station_service.dart';

--- a/lib/features/sync/api.dart
+++ b/lib/features/sync/api.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `sync` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'presentation/screens/auth_screen.dart';
+export 'presentation/screens/data_transparency_screen.dart';
+export 'presentation/screens/link_device_screen.dart';
+export 'presentation/screens/sync_setup_screen.dart';
+export 'presentation/widgets/qr_scanner_screen.dart';
+export 'presentation/widgets/qr_share_widget.dart';
+export 'providers/baseline_sync_enabled_provider.dart';

--- a/lib/features/vehicle/api.dart
+++ b/lib/features/vehicle/api.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `vehicle` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/reference_vehicle_catalog_provider.dart';
+export 'data/repositories/vehicle_profile_repository.dart';
+export 'data/ve_learner.dart';
+export 'data/vehicle_profile_catalog_matcher.dart';
+export 'data/vehicle_profile_migrator.dart';
+export 'domain/calibration_confidence_tier.dart';
+export 'domain/entities/reference_vehicle.dart';
+export 'domain/entities/vin_data.dart';
+export 'domain/fuzzy_classifier.dart';
+export 'presentation/screens/edit_vehicle_screen.dart';
+export 'presentation/screens/vehicle_list_screen.dart';
+export 'presentation/widgets/catalog_reresolve_snackbar_host.dart';
+export 'presentation/widgets/vin_confirm_dialog.dart';
+export 'providers/calibration_mode_providers.dart';
+export 'providers/service_reminder_providers.dart';
+export 'providers/vehicle_aggregate_updater_provider.dart';
+export 'providers/vehicle_providers.dart';
+export 'providers/vin_decoder_provider.dart';

--- a/lib/features/widget/api.dart
+++ b/lib/features/widget/api.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Public API barrel of the `widget` feature (#3132).
+///
+/// Cross-feature consumers must import THIS file — never a path
+/// under `providers/`, `data/`, `domain/` or `presentation/` of
+/// another feature. Enforced by `test/lint/feature_boundary_test.dart`
+/// with an only-decreasing baseline (epic #3129).
+///
+/// The export list below is the de-facto contract measured when the
+/// barrel was introduced — every file of this feature that other
+/// features imported at the time. It should only ever SHRINK as
+/// cross-feature reach-ins are inverted or moved to `lib/core/`.
+library;
+
+export 'data/car_station_data.dart';
+export 'data/car_station_writer.dart';
+export 'data/home_widget_service.dart';
+export 'presentation/widget_click_listener.dart';
+export 'presentation/widget_help_section.dart';
+export 'presentation/widget_uri_parser.dart';
+export 'providers/nearest_widget_refresh_provider.dart';
+export 'providers/pending_widget_uri_provider.dart';

--- a/test/lint/feature_boundary_test.dart
+++ b/test/lint/feature_boundary_test.dart
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Feature-boundary gate (#3132, epic #3129) — the import-direction lint.
+///
+/// The feature-first layout describes folders, not the dependency graph:
+/// the 2026-06-10 audit found 787 cross-feature imports across 110
+/// directed pairs with 24 bidirectional cycles, plus 101 core→feature
+/// inversions (the #3130 domain kernel removed ~310 of them; the
+/// baselines below are the post-kernel measurement). This test freezes
+/// the remaining graph and lets it move in ONE direction only.
+///
+/// ## What counts as a violation
+///
+///   * **feature → feature** — a file under `lib/features/<a>/` importing
+///     (or exporting) a file under `lib/features/<b>/` (`a != b`) that is
+///     NOT `lib/features/<b>/api.dart`. Every feature's public contract is
+///     its `api.dart` barrel; reaching into `providers/`, `data/`,
+///     `domain/` or `presentation/` of another feature is the violation.
+///   * **core → feature** — a file under `lib/core/` importing anything
+///     under `lib/features/` (the barrel does NOT excuse this direction:
+///     core must never depend on features at all — epic #3129's goal).
+///
+/// The app shell (`lib/` outside `core/` and `features/`) is out of scope
+/// here — #3133/#3135 own that surface.
+///
+/// ## Relative-import resolution (the audit's key finding)
+///
+/// The codebase uses *relative* imports exclusively — a
+/// `package:tankstellen/` grep finds **zero** cross-feature imports while
+/// the real count is in the hundreds. Every `import`/`export` URI is
+/// therefore resolved against the importing file's directory (and
+/// `package:tankstellen/` URIs against `lib/`) before classification.
+///
+/// ## The only-decreasing ratchet
+///
+/// The baselines are **exact-match** snapshots (same mechanism as the
+/// `file_length_test` shrink signal):
+///
+///   1. a count above its baseline entry — or a brand-new pair — fails CI;
+///   2. a count below its baseline entry ALSO fails ("stale baseline") so
+///      every single decrement is locked in by updating the map in the
+///      same PR and can never silently creep back.
+///
+/// NEVER raise an entry or add a new pair. The targets are: zero
+/// core→feature imports, zero bidirectional cycles, and every surviving
+/// feature→feature edge routed through `api.dart`.
+void main() {
+  // importing feature -> imported feature -> count (api.dart exempt).
+  final featurePairs = <String, int>{};
+  // imported feature -> count of lib/core/ files importing it.
+  final coreImports = <String, int>{};
+  final violationLines = <String>[];
+
+  // ---------------------------------------------------------------------
+  // Scan: resolve every import/export directive in lib/ to a lib/ path.
+  // ---------------------------------------------------------------------
+  setUpAll(() {
+    final directive = RegExp(
+      r'''^\s*(?:import|export)\s+['"]([^'"]+)['"]''',
+      multiLine: true,
+    );
+
+    String normalize(String path) {
+      final parts = <String>[];
+      for (final seg in path.split('/')) {
+        if (seg == '.' || seg.isEmpty) continue;
+        if (seg == '..') {
+          if (parts.isNotEmpty) parts.removeLast();
+          continue;
+        }
+        parts.add(seg);
+      }
+      return parts.join('/');
+    }
+
+    /// `lib/features/<name>/...` → `<name>`, else null.
+    String? featureOf(String libPath) =>
+        RegExp(r'^lib/features/([^/]+)/').firstMatch('$libPath/')?.group(1);
+
+    final libDir = Directory('lib');
+    expect(
+      libDir.existsSync(),
+      isTrue,
+      reason: 'lib/ must exist at project root',
+    );
+
+    for (final entity in libDir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (!path.endsWith('.dart')) continue;
+      if (path.endsWith('.g.dart') || path.endsWith('.freezed.dart')) {
+        continue;
+      }
+      if (path.contains('/l10n/app_localizations')) continue;
+
+      final fromFeature = featureOf(path);
+      final isCore = path.startsWith('lib/core/');
+      if (fromFeature == null && !isCore) continue; // shell: out of scope
+
+      final source = entity.readAsStringSync();
+      final dir = path.substring(0, path.lastIndexOf('/'));
+      for (final match in directive.allMatches(source)) {
+        final uri = match.group(1)!;
+        String target;
+        if (uri.startsWith('package:tankstellen/')) {
+          target = 'lib/${uri.substring('package:tankstellen/'.length)}';
+        } else if (uri.startsWith('dart:') || uri.startsWith('package:')) {
+          continue; // SDK / third-party
+        } else {
+          target = normalize('$dir/$uri');
+        }
+        final toFeature = featureOf(target);
+        if (toFeature == null) continue; // target outside lib/features
+        if (fromFeature == toFeature) continue; // intra-feature: fine
+
+        if (isCore) {
+          // core -> feature: ALWAYS a violation, even via api.dart.
+          coreImports.update(toFeature, (v) => v + 1, ifAbsent: () => 1);
+          violationLines.add('$path -> $target');
+        } else {
+          // feature -> feature: api.dart barrel is the public contract.
+          if (target == 'lib/features/$toFeature/api.dart') continue;
+          featurePairs.update(
+            '$fromFeature -> $toFeature',
+            (v) => v + 1,
+            ifAbsent: () => 1,
+          );
+          violationLines.add('$path -> $target');
+        }
+      }
+    }
+  });
+
+  /// Renders [actual] as the Dart map literal to paste over a baseline.
+  String literalOf(Map<String, int> actual) {
+    final keys = actual.keys.toList()..sort();
+    return keys.map((k) => "    '$k': ${actual[k]},").join('\n');
+  }
+
+  /// All keys whose actual count differs from its baseline entry, with
+  /// the direction of the drift spelled out.
+  List<String> driftOf(Map<String, int> actual, Map<String, int> baseline) {
+    final drift = <String>[];
+    for (final key in {...actual.keys, ...baseline.keys}) {
+      final a = actual[key] ?? 0;
+      final b = baseline[key] ?? 0;
+      if (a > b) drift.add('$key: $a (baseline $b) — REGRESSION, revert it');
+      if (a < b) drift.add('$key: $a (baseline $b) — stale, lower the entry');
+    }
+    return drift..sort();
+  }
+
+  test('every feature exposes an api.dart public barrel', () {
+    final missing = <String>[];
+    for (final dir in Directory('lib/features').listSync()) {
+      if (dir is! Directory) continue;
+      final path = dir.path.replaceAll(r'\', '/');
+      if (!File('$path/api.dart').existsSync()) missing.add(path);
+    }
+    expect(
+      missing..sort(),
+      isEmpty,
+      reason:
+          'Every feature directory must expose a public api.dart barrel '
+          '(#3132) — the only file other features may import.\n'
+          'Missing:\n${missing.join('\n')}',
+    );
+  });
+
+  test('feature → feature imports never exceed the per-pair baseline', () {
+    final drift = driftOf(featurePairs, _featurePairBaseline);
+    expect(
+      drift,
+      isEmpty,
+      reason:
+          'Cross-feature import graph drifted from the only-decreasing '
+          'baseline (#3132).\n'
+          'A new/raised pair means a feature reached into another feature\'s '
+          'internals — import its api.dart barrel (or move the shared type '
+          'to lib/core/domain) instead. A lowered pair must be locked in by '
+          'updating _featurePairBaseline in the same PR.\n\n'
+          'Drift:\n${drift.join('\n')}\n\n'
+          'Up-to-date baseline literal:\n${literalOf(featurePairs)}\n\n'
+          'All current cross-feature imports:\n'
+          '${(violationLines..sort()).join('\n')}',
+    );
+  });
+
+  test('core → feature imports never exceed the (target-zero) baseline', () {
+    final drift = driftOf(coreImports, _coreImportBaseline);
+    expect(
+      drift,
+      isEmpty,
+      reason:
+          'core → feature is the WORST inversion direction: lib/core/ '
+          'must never depend on lib/features/ at all (epic #3129; the '
+          'api.dart barrel does not excuse it). Invert the dependency '
+          '(callback / interface in core, implementation in the feature) or '
+          'move the shared type to lib/core/. A lowered count must be locked '
+          'in by updating _coreImportBaseline in the same PR.\n\n'
+          'Drift:\n${drift.join('\n')}\n\n'
+          'Up-to-date baseline literal:\n${literalOf(coreImports)}',
+    );
+  });
+
+  test('bidirectional feature cycles never exceed the baseline', () {
+    final cycles = <String>{};
+    for (final key in featurePairs.keys) {
+      final parts = key.split(' -> ');
+      final reverse = '${parts[1]} -> ${parts[0]}';
+      if (featurePairs.containsKey(reverse)) {
+        final pair = [parts[0], parts[1]]..sort();
+        cycles.add('${pair[0]} <-> ${pair[1]}');
+      }
+    }
+    final sorted = cycles.toList()..sort();
+    expect(
+      sorted.length,
+      _cycleBaseline,
+      reason:
+          'Bidirectional feature cycles changed (baseline '
+          '$_cycleBaseline, target 0). A new cycle is a hard architectural '
+          'regression — break it before merging. A broken cycle must be '
+          'locked in by lowering _cycleBaseline in the same PR.\n\n'
+          'Current cycles:\n${sorted.join('\n')}',
+    );
+  });
+}
+
+/// Post-#3130 measurement (2026-06-11): cross-feature imports that do NOT
+/// go through the target feature's `api.dart` barrel, grouped
+/// `importing-feature -> imported-feature`. ONLY EVER DECREASES — never
+/// raise an entry, never add a pair; remove an entry when it hits 0.
+const _featurePairBaseline = <String, int>{
+  'achievements -> consumption': 8,
+  'achievements -> price_history': 2,
+  'alerts -> map': 1,
+  'approach -> consumption': 2,
+  'approach -> favorites': 1,
+  'approach -> profile': 8,
+  'calculator -> consumption': 2,
+  'calculator -> profile': 1,
+  'calculator -> search': 3,
+  'calculator -> vehicle': 1,
+  'car -> widget': 1,
+  'carbon -> consumption': 8,
+  'carbon -> vehicle': 1,
+  'consumption -> achievements': 1,
+  'consumption -> approach': 8,
+  'consumption -> carbon': 2,
+  'consumption -> driving': 6,
+  'consumption -> ev': 12,
+  'consumption -> feature_management': 25,
+  'consumption -> glide_coach': 4,
+  'consumption -> map': 2,
+  'consumption -> profile': 10,
+  'consumption -> search': 2,
+  'consumption -> sync': 1,
+  'consumption -> vehicle': 47,
+  'driving -> approach': 1,
+  'driving -> consumption': 8,
+  'driving -> feature_management': 6,
+  'driving -> glide_coach': 2,
+  'driving -> map': 3,
+  'driving -> profile': 5,
+  'driving -> search': 1,
+  'ev -> search': 1,
+  'ev -> vehicle': 1,
+  'favorites -> alerts': 1,
+  'favorites -> price_history': 1,
+  'favorites -> profile': 1,
+  'favorites -> search': 2,
+  'favorites -> widget': 1,
+  'feature_management -> profile': 2,
+  'glide_coach -> feature_management': 2,
+  'itinerary -> profile': 1,
+  'itinerary -> route_search': 3,
+  'itinerary -> search': 1,
+  'map -> ev': 5,
+  'map -> itinerary': 1,
+  'map -> profile': 1,
+  'map -> route_search': 6,
+  'map -> search': 10,
+  'price_history -> feature_management': 6,
+  'profile -> alerts': 2,
+  'profile -> approach': 1,
+  'profile -> consent': 1,
+  'profile -> consumption': 23,
+  'profile -> driving': 1,
+  'profile -> feature_management': 52,
+  'profile -> search': 2,
+  'profile -> sync': 2,
+  'profile -> vehicle': 3,
+  'profile -> widget': 1,
+  'route_search -> profile': 11,
+  'route_search -> search': 1,
+  'search -> approach': 1,
+  'search -> consumption': 5,
+  'search -> ev': 4,
+  'search -> favorites': 4,
+  'search -> feature_management': 8,
+  'search -> loyalty': 1,
+  'search -> map': 1,
+  'search -> profile': 15,
+  'search -> route_search': 14,
+  'search -> station_detail': 3,
+  'search -> widget': 2,
+  'setup -> consumption': 5,
+  'setup -> feature_management': 4,
+  'setup -> profile': 4,
+  'setup -> vehicle': 7,
+  'station_detail -> alerts': 3,
+  'station_detail -> favorites': 1,
+  'station_detail -> feature_management': 2,
+  'station_detail -> payment': 3,
+  'station_detail -> price_history': 4,
+  'station_detail -> profile': 1,
+  'station_detail -> route_search': 1,
+  'station_detail -> search': 8,
+  'station_detail -> sync': 1,
+  'station_services -> station_detail': 1,
+  'sync -> alerts': 3,
+  'sync -> consumption': 3,
+  'sync -> favorites': 2,
+  'sync -> feature_management': 2,
+  'sync -> vehicle': 2,
+  'vehicle -> consumption': 24,
+  'vehicle -> profile': 1,
+  'widget -> consumption': 1,
+  'widget -> price_history': 2,
+  'widget -> profile': 3,
+};
+
+/// Post-#3130 measurement (2026-06-11): `lib/core/` files importing
+/// `lib/features/` files, grouped by imported feature. Target **0** —
+/// this direction is never legitimate. ONLY EVER DECREASES.
+const _coreImportBaseline = <String, int>{
+  'alerts': 17,
+  'consumption': 8,
+  'feature_management': 3,
+  'itinerary': 3,
+  'map': 1,
+  'price_history': 1,
+  'profile': 5,
+  'search': 2,
+  'station_services': 19,
+  'widget': 1,
+};
+
+/// Post-#3130 measurement (2026-06-11): bidirectional feature↔feature
+/// cycles implied by [_featurePairBaseline]. Target **0**. ONLY EVER
+/// DECREASES.
+const _cycleBaseline = 19;


### PR DESCRIPTION
## Feature-boundary gate — api.dart barrels + import-direction lint

Second child of epic #3129, on top of the #3130 kernel:

- **`api.dart` barrels for all 28 features**, each exporting exactly the de-facto contract (what other code imported at measurement time), documented shrink-only; 3 redundant model duplicates deduped.
- **`test/lint/feature_boundary_test.dart`** — the scanner RESOLVES relative imports to lib/ paths (a package:-grep finds zero in this codebase) and enforces: per-pair feature→feature exact-match baseline (477 imports / 97 pairs post-kernel, down from 787/110), core→feature target-zero baseline (60 remaining; a barrel does NOT excuse this direction), and the cycle count (19, down from 24). Exact-match in both directions — a decrement locks in automatically, a raise fails with a copy-paste-ready new literal. Fault-injection verified RED both ways.
- Worst offenders now visible and pinned: `profile→feature_management` 52, `consumption↔vehicle` 47/24, `search↔profile` 15. App-shell imports deliberately out of scope (#3133/#3135 own them).

Closes #3132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
