### PR TITLE
refactor(nav): typed routes — RoutePaths + AppRoute payloads, no string-literal navigation (#3135)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -19,6 +19,7 @@ import '../features/alerts/background/background_service.dart';
 import '../core/constants/app_constants.dart';
 import '../core/cache/cache_manager.dart';
 import '../core/feedback/auto_record_badge_provider.dart';
+import '../core/navigation/app_routes.dart';
 import '../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../core/telemetry/health_counters.dart';
 import '../core/telemetry/storage/isolate_error_spool.dart';
@@ -815,7 +816,7 @@ class AppInitializer {
           SchedulerBinding.instance.addPostFrameCallback((_) {
             try {
               final goRouter = container.read(routerProvider);
-              goRouter.go('/trip-recording');
+              goRouter.go(RoutePaths.tripRecording);
             } catch (e, st) {
               unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
                 'where': 'activeTripRecovery go(/trip-recording)'

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../core/data/storage_repository.dart';
+import '../core/navigation/app_routes.dart';
 import '../core/navigation/root_navigator_key.dart';
 import '../l10n/app_localizations.dart';
 import '../core/telemetry/integrations/navigation_trace_observer.dart';
@@ -60,9 +61,9 @@ String? _consumePendingWidgetPath(Ref ref) {
 /// by the screen, so without the guard the redirect would route to
 /// `/consumption/add` again on the very next evaluation).
 String? _resolvePendingSharedReceiptPath(Ref ref, GoRouterState state) {
-  if (state.matchedLocation == '/consumption/add') return null;
+  if (state.matchedLocation == RoutePaths.addFillUp) return null;
   final pending = ref.read(pendingSharedReceiptProvider);
-  return pending != null ? '/consumption/add' : null;
+  return pending != null ? RoutePaths.addFillUp : null;
 }
 
 /// Resolves the route to land on based on the active profile's
@@ -71,21 +72,21 @@ String? _resolvePendingSharedReceiptPath(Ref ref, GoRouterState state) {
 /// Exposed for unit tests.
 String resolveLandingLocation(StorageRepository storage) {
   final profileId = storage.getActiveProfileId();
-  if (profileId == null) return '/';
+  if (profileId == null) return RoutePaths.search;
   final landing = storage.getProfile(profileId)?['landingScreen']?.toString();
   switch (landing) {
     case 'favorites':
     case 'LandingScreen.favorites':
-      return '/favorites';
+      return RoutePaths.favorites;
     case 'map':
     case 'LandingScreen.map':
-      return '/map';
+      return RoutePaths.map;
     case 'cheapest':
     case 'LandingScreen.cheapest':
     case 'nearest':
     case 'LandingScreen.nearest':
     default:
-      return '/';
+      return RoutePaths.search;
   }
 }
 
@@ -98,7 +99,7 @@ GoRouter router(Ref ref) {
     // navigator (e.g. `CountrySwitchListener` in the MaterialApp
     // builder) can reach a navigator-bearing context for `showDialog`.
     navigatorKey: rootNavigatorKey,
-    initialLocation: '/consent',
+    initialLocation: RoutePaths.consent,
     observers: [NavigationTraceObserver()],
     errorBuilder: (context, state) {
       // #1690 — the 404 / page-not-found screen is localized so it
@@ -121,7 +122,7 @@ GoRouter router(Ref ref) {
               ),
               const SizedBox(height: 16),
               FilledButton(
-                onPressed: () => context.go('/'),
+                onPressed: () => context.go(RoutePaths.search),
                 child: Text(l?.notFoundHomeButton ?? 'Home'),
               ),
             ],
@@ -132,15 +133,15 @@ GoRouter router(Ref ref) {
     redirect: (context, state) {
       // Read live from storage each redirect — not cached at provider creation
       final hasConsent = storage.getSetting(StorageKeys.gdprConsentGiven) == true;
-      final isConsent = state.matchedLocation == '/consent';
+      final isConsent = state.matchedLocation == RoutePaths.consent;
       final isReady = storage.isSetupComplete;
-      final isSetup = state.matchedLocation == '/setup';
+      final isSetup = state.matchedLocation == RoutePaths.setup;
       // Routes the user can visit FROM inside /setup without the redirect
       // kicking them back to the wizard (#695). Without this whitelist,
       // pushing /vehicles/edit during the wizard's Vehicles step rounded
       // straight back to /setup, making "Add vehicle" appear broken.
-      final isSetupAllowedChild = state.matchedLocation == '/vehicles' ||
-          state.matchedLocation == '/vehicles/edit';
+      final isSetupAllowedChild = state.matchedLocation == RoutePaths.vehicles ||
+          state.matchedLocation == RoutePaths.editVehicle;
 
       // Cold-start widget tap on an existing fully-setup user lands the
       // router at the configured `landingScreen` (typically '/'). The
@@ -166,9 +167,9 @@ GoRouter router(Ref ref) {
       }
 
       // Step 1: GDPR consent must be given before anything else
-      if (!hasConsent && !isConsent) return '/consent';
+      if (!hasConsent && !isConsent) return RoutePaths.consent;
       if (hasConsent && isConsent) {
-        if (!isReady) return '/setup';
+        if (!isReady) return RoutePaths.setup;
         // Past consent + past setup: prefer a pending widget cold-launch
         // URI over the user's configured landing screen so a home-widget
         // tap lands directly on the station detail. `consumeDeferred`
@@ -185,7 +186,7 @@ GoRouter router(Ref ref) {
 
       // Step 2: Setup (onboarding) must be complete before main app
       if (!isReady && !isSetup && !isConsent && !isSetupAllowedChild) {
-        return '/setup';
+        return RoutePaths.setup;
       }
       // Landing preference is only applied when leaving the setup flow — not
       // on every subsequent navigation back to '/', which would trap the

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'144746d6ae41a220c99cb108e53453c51c93b9f1';
+String _$routerHash() => r'32b9ea9e7a081f1696aa58dc4c78d3479f75e08c';

--- a/lib/app/routes/consumption_routes.dart
+++ b/lib/app/routes/consumption_routes.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
 import '../../features/consumption/presentation/screens/add_fill_up_screen.dart';
 import '../../features/consumption/presentation/screens/consumption_statistics_screen.dart';
@@ -14,7 +15,6 @@ import '../../features/consumption/presentation/screens/trip_detail_screen.dart'
 import '../../features/consumption/presentation/screens/trip_recording_screen.dart';
 import '../../features/feature_management/application/feature_flags_provider.dart';
 import '../../features/feature_management/domain/feature.dart';
-import '../../core/domain/fuel_type.dart';
 import 'invalid_id_screen.dart';
 
 /// Routes that drive the "behind-the-wheel" savings lens: consumption logging,
@@ -23,11 +23,11 @@ import 'invalid_id_screen.dart';
 /// file owns every consumption route that pushes on top of the shell.
 List<RouteBase> get consumptionRoutes => [
   GoRoute(
-    path: '/consumption',
+    path: RoutePaths.consumption,
     builder: (context, state) => const ConsumptionScreen(),
   ),
   GoRoute(
-    path: '/carbon',
+    path: RoutePaths.carbon,
     // #1613 — the Carbon dashboard is gated on Feature.carbonDashboard.
     // Guarding the route (not just the entry-point button) means a
     // deep link or restored navigation stack cannot reach the
@@ -39,7 +39,7 @@ List<RouteBase> get consumptionRoutes => [
             .contains(Feature.carbonDashboard);
         if (!enabled) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (context.mounted) context.go('/consumption-tab');
+            if (context.mounted) context.go(RoutePaths.consumptionTab);
           });
           return const SizedBox.shrink();
         }
@@ -51,11 +51,11 @@ List<RouteBase> get consumptionRoutes => [
   // comparison + evolution charts). No feature gate: it re-presents
   // fill-up data the user already sees on the summary card.
   GoRoute(
-    path: '/consumption-stats',
+    path: RoutePaths.consumptionStats,
     builder: (_, _) => const ConsumptionStatisticsPage(),
   ),
   GoRoute(
-    path: '/consumption/pick-station',
+    path: RoutePaths.pickStationForFillUp,
     builder: (_, _) => const PickStationForFillUpScreen(),
   ),
   // #726 — global trip recording view. The recording session
@@ -65,14 +65,14 @@ List<RouteBase> get consumptionRoutes => [
   // re-entered by tapping the banner shown on every screen
   // while a trip is active.
   GoRoute(
-    path: '/trip-recording',
+    path: RoutePaths.tripRecording,
     builder: (_, _) => const TripRecordingScreen(),
   ),
   // #889 — placeholder trip-detail route wired up alongside the
   // new Trajets tab on the Consumption screen. Full detail UI
   // (timeline / per-minute consumption / map) lands in #890.
   GoRoute(
-    path: '/trip/:id',
+    path: RoutePaths.tripPattern,
     builder: (context, state) {
       final id = state.pathParameters['id'];
       if (id == null || id.isEmpty) {
@@ -82,26 +82,18 @@ List<RouteBase> get consumptionRoutes => [
     },
   ),
   GoRoute(
-    path: '/consumption/add',
+    path: RoutePaths.addFillUp,
     builder: (context, state) {
+      // #3135 — the pre-fill payload crosses as the typed [AddFillUpRoute]
+      // itself (it used to be a stringly-keyed Map). A redirect-driven
+      // entry (shared receipt, #2735) carries no extra → bare form.
       final extra = state.extra;
-      String? stationId;
-      String? stationName;
-      FuelType? fuelType;
-      double? pricePerLiter;
-      if (extra is Map) {
-        stationId = extra['stationId']?.toString();
-        stationName = extra['stationName']?.toString();
-        final ft = extra['fuelType'];
-        if (ft is FuelType) fuelType = ft;
-        final price = extra['pricePerLiter'];
-        if (price is num) pricePerLiter = price.toDouble();
-      }
+      final args = extra is AddFillUpRoute ? extra : null;
       return AddFillUpScreen(
-        stationId: stationId,
-        stationName: stationName,
-        preFilledFuelType: fuelType,
-        preFilledPricePerLiter: pricePerLiter,
+        stationId: args?.stationId,
+        stationName: args?.stationName,
+        preFilledFuelType: args?.fuelType,
+        preFilledPricePerLiter: args?.pricePerLiter,
       );
     },
   ),

--- a/lib/app/routes/invalid_id_screen.dart
+++ b/lib/app/routes/invalid_id_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../l10n/app_localizations.dart';
 
 /// Fallback widget shown when a deep link supplies an id that fails
@@ -25,7 +26,7 @@ Widget invalidIdScreen(BuildContext context, String path) {
           ),
           const SizedBox(height: 16),
           FilledButton(
-            onPressed: () => context.go('/'),
+            onPressed: () => context.go(RoutePaths.search),
             child: Text(l?.home ?? 'Home'),
           ),
         ],

--- a/lib/app/routes/onboarding_routes.dart
+++ b/lib/app/routes/onboarding_routes.dart
@@ -3,6 +3,7 @@
 
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/consent/presentation/screens/gdpr_consent_screen.dart';
 import '../../features/setup/presentation/screens/onboarding_wizard_screen.dart';
 
@@ -11,11 +12,11 @@ import '../../features/setup/presentation/screens/onboarding_wizard_screen.dart'
 /// [routerProvider] can deep-link straight to either of them.
 List<RouteBase> get onboardingRoutes => [
       GoRoute(
-        path: '/consent',
+        path: RoutePaths.consent,
         builder: (context, state) => const GdprConsentScreen(),
       ),
       GoRoute(
-        path: '/setup',
+        path: RoutePaths.setup,
         builder: (context, state) => const OnboardingWizardScreen(),
       ),
     ];

--- a/lib/app/routes/profile_routes.dart
+++ b/lib/app/routes/profile_routes.dart
@@ -3,6 +3,7 @@
 
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/itinerary/presentation/screens/itineraries_screen.dart';
 import '../../features/loyalty/presentation/loyalty_settings_screen.dart';
 import '../../features/profile/presentation/screens/developer_tools/developer_tools_screen.dart';
@@ -22,11 +23,11 @@ import '../../features/vehicle/presentation/screens/vehicle_list_screen.dart';
 /// on `Feature.debugMode` so a stale deep-link cannot expose them.
 List<RouteBase> get profileRoutes => [
       GoRoute(
-        path: '/vehicles',
+        path: RoutePaths.vehicles,
         builder: (context, state) => const VehicleListScreen(),
       ),
       GoRoute(
-        path: '/vehicles/edit',
+        path: RoutePaths.editVehicle,
         builder: (context, state) {
           final extra = state.extra;
           final vehicleId = extra is String ? extra : null;
@@ -34,11 +35,11 @@ List<RouteBase> get profileRoutes => [
         },
       ),
       GoRoute(
-        path: '/itineraries',
+        path: RoutePaths.itineraries,
         builder: (context, state) => const ItinerariesScreen(),
       ),
       GoRoute(
-        path: '/privacy-dashboard',
+        path: RoutePaths.privacyDashboard,
         builder: (context, state) => const PrivacyDashboardScreen(),
       ),
       // #897 — dedicated Theme settings screen, pushed from the
@@ -46,42 +47,42 @@ List<RouteBase> get profileRoutes => [
       // the inline bottom sheet so the Theme entry matches the
       // Privacy + Storage card pattern.
       GoRoute(
-        path: '/theme-settings',
+        path: RoutePaths.themeSettings,
         builder: (context, state) => const ThemeSettingsScreen(),
       ),
       // #1120 — fuel-club / loyalty discount settings. Pilot ships
       // with one brand (Total Energies); the screen lists, adds,
       // toggles, and deletes user-entered cards.
       GoRoute(
-        path: '/loyalty-settings',
+        path: RoutePaths.loyaltySettings,
         builder: (context, state) => const LoyaltySettingsScreen(),
       ),
       // #2248 — Developer / Debug tools. Reached from the Settings tile
       // that only renders when `Feature.debugMode` is on; the screens
       // also self-guard on the flag so a stale deep-link is inert.
       GoRoute(
-        path: '/developer-tools',
+        path: RoutePaths.developerTools,
         builder: (context, state) => const DeveloperToolsScreen(),
       ),
       GoRoute(
-        path: '/developer-tools/error-log',
+        path: RoutePaths.developerToolsErrorLog,
         builder: (context, state) => const ErrorLogViewerScreen(),
       ),
       GoRoute(
-        path: '/developer-tools/flags',
+        path: RoutePaths.developerToolsFlags,
         builder: (context, state) => const FeatureFlagDumpScreen(),
       ),
       // #2471 — OBD2 communication-health diagnostics (Epic #2463 TAIL).
       // Self-guards on `Feature.debugMode` like the rest of the dev tools.
       GoRoute(
-        path: '/developer-tools/obd2-health',
+        path: RoutePaths.developerToolsObd2Health,
         builder: (context, state) => const Obd2HealthScreen(),
       ),
       // #2518 — in-app OCR tester (Epic #2516 Child 2): runs the pump /
       // receipt pipeline on a chosen image and shows the block overlay +
       // step trace. Self-guards on `Feature.debugMode` like its siblings.
       GoRoute(
-        path: '/developer-tools/ocr-tester',
+        path: RoutePaths.developerToolsOcrTester,
         builder: (context, state) => const PumpOcrTesterScreen(),
       ),
     ];

--- a/lib/app/routes/search_routes.dart
+++ b/lib/app/routes/search_routes.dart
@@ -3,6 +3,7 @@
 
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/alerts/presentation/screens/alerts_screen.dart';
 import '../../features/calculator/presentation/screens/calculator_screen.dart';
 import '../../features/driving/presentation/screens/driving_mode_screen.dart';
@@ -13,15 +14,15 @@ import '../../features/driving/presentation/screens/driving_mode_screen.dart';
 /// any shell branch.
 List<RouteBase> get searchRoutes => [
       GoRoute(
-        path: '/driving',
+        path: RoutePaths.driving,
         builder: (context, state) => const DrivingModeScreen(),
       ),
       GoRoute(
-        path: '/alerts',
+        path: RoutePaths.alerts,
         builder: (context, state) => const AlertsScreen(),
       ),
       GoRoute(
-        path: '/calculator',
+        path: RoutePaths.calculator,
         builder: (context, state) {
           // #2543 — the search-results launch passes the price the
           // user was looking at as `extra` so the calculator opens

--- a/lib/app/routes/shell_branches.dart
+++ b/lib/app/routes/shell_branches.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/consumption/presentation/screens/consumption_screen.dart';
 import '../../features/favorites/presentation/screens/favorites_screen.dart';
 import '../../features/map/presentation/screens/map_screen.dart';
@@ -32,7 +33,7 @@ List<StatefulShellBranch> get shellBranches => [
         navigatorKey: searchBranchNavigatorKey,
         routes: [
           GoRoute(
-            path: '/',
+            path: RoutePaths.search,
             builder: (context, state) => const SearchScreen(),
           ),
         ],
@@ -40,7 +41,7 @@ List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: '/map',
+            path: RoutePaths.map,
             builder: (context, state) => const MapScreen(),
           ),
         ],
@@ -48,7 +49,7 @@ List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: '/favorites',
+            path: RoutePaths.favorites,
             builder: (context, state) => const FavoritesScreen(),
           ),
         ],
@@ -59,7 +60,7 @@ List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: '/consumption-tab',
+            path: RoutePaths.consumptionTab,
             builder: (_, _) => const ConsumptionScreen(
               section: ConsumptionSection.fuel,
             ),
@@ -69,7 +70,7 @@ List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: '/profile',
+            path: RoutePaths.profile,
             builder: (context, state) => const ProfileScreen(),
           ),
         ],
@@ -80,7 +81,7 @@ List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: '/trajets-tab',
+            path: RoutePaths.trajetsTab,
             builder: (_, _) => const ConsumptionScreen(
               section: ConsumptionSection.trajets,
             ),

--- a/lib/app/routes/station_routes.dart
+++ b/lib/app/routes/station_routes.dart
@@ -8,10 +8,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/data/storage_repository.dart';
+import '../../core/domain/ev/charging_station.dart';
 import '../../core/logging/error_logger.dart';
+import '../../core/navigation/app_routes.dart';
 import '../../core/storage/storage_providers.dart';
 import '../../features/ev/data/repositories/ev_station_repository.dart';
-import '../../core/domain/ev/charging_station.dart';
 import '../../features/ev/providers/ev_providers.dart';
 import '../../features/price_history/presentation/screens/price_history_screen.dart';
 import '../../features/report/presentation/screens/report_screen.dart';
@@ -27,7 +28,7 @@ import 'invalid_id_screen.dart';
 /// list is parameterised with the router's [Ref].
 List<RouteBase> stationRoutes(Ref ref) => [
       GoRoute(
-        path: '/station/:id/history',
+        path: RoutePaths.stationHistoryPattern,
         builder: (context, state) {
           final id = state.pathParameters['id'];
           if (!isValidStationId(id)) {
@@ -37,7 +38,7 @@ List<RouteBase> stationRoutes(Ref ref) => [
         },
       ),
       GoRoute(
-        path: '/station/:id',
+        path: RoutePaths.stationPattern,
         builder: (context, state) {
           final id = state.pathParameters['id'];
           if (!isValidStationId(id)) {
@@ -47,7 +48,7 @@ List<RouteBase> stationRoutes(Ref ref) => [
         },
       ),
       GoRoute(
-        path: '/ev-station',
+        path: RoutePaths.evStation,
         builder: (context, state) {
           final station = state.extra as ChargingStation;
           return EVStationDetailScreen(station: station);
@@ -59,7 +60,7 @@ List<RouteBase> stationRoutes(Ref ref) => [
       // a home-screen widget tap or an external URL. Falls back to the
       // invalid-id screen only when the id is genuinely unknown.
       GoRoute(
-        path: '/ev-station/:id',
+        path: RoutePaths.evStationPattern,
         builder: (context, state) {
           final id = state.pathParameters['id'];
           if (!isValidStationId(id)) {
@@ -77,7 +78,7 @@ List<RouteBase> stationRoutes(Ref ref) => [
         },
       ),
       GoRoute(
-        path: '/report/:id',
+        path: RoutePaths.reportPattern,
         builder: (context, state) {
           final id = state.pathParameters['id'];
           if (!isValidStationId(id)) {

--- a/lib/app/routes/sync_routes.dart
+++ b/lib/app/routes/sync_routes.dart
@@ -3,6 +3,7 @@
 
 import 'package:go_router/go_router.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../../features/sync/presentation/screens/auth_screen.dart';
 import '../../features/sync/presentation/screens/data_transparency_screen.dart';
 import '../../features/sync/presentation/screens/link_device_screen.dart';
@@ -13,19 +14,19 @@ import '../../features/sync/presentation/screens/sync_setup_screen.dart';
 /// users who never opt into sync never see them.
 List<RouteBase> get syncRoutes => [
       GoRoute(
-        path: '/sync-setup',
+        path: RoutePaths.syncSetup,
         builder: (context, state) => const SyncSetupScreen(),
       ),
       GoRoute(
-        path: '/link-device',
+        path: RoutePaths.linkDevice,
         builder: (context, state) => const LinkDeviceScreen(),
       ),
       GoRoute(
-        path: '/data-transparency',
+        path: RoutePaths.dataTransparency,
         builder: (context, state) => const DataTransparencyScreen(),
       ),
       GoRoute(
-        path: '/auth',
+        path: RoutePaths.auth,
         builder: (context, state) => const AuthScreen(),
       ),
     ];

--- a/lib/app/shell/settings_app_bar_action.dart
+++ b/lib/app/shell/settings_app_bar_action.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../core/navigation/app_routes.dart';
 import '../current_shell_branch_provider.dart';
 import '../../l10n/app_localizations.dart';
 
@@ -61,7 +62,7 @@ class SettingsAppBarAction extends ConsumerWidget {
         // branch switch below has no back-stack of its own.
         final from = routeForShellBranch(ref.read(currentShellBranchProvider));
         ref.read(settingsReturnLocationProvider.notifier).update(from);
-        context.go('/profile');
+        context.go(RoutePaths.profile);
       },
     );
   }

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+import '../domain/ev/charging_station.dart';
+import '../domain/fuel_type.dart';
+
+/// Single source of truth for every router path (#3135).
+///
+/// The route TABLE (`lib/app/routes/*.dart`) declares its `path:` from the
+/// constants below, and every navigation call site goes through either a
+/// constant (payload-free routes) or a typed [AppRoute] object (routes that
+/// carry a path parameter or an `extra` payload). String literals in
+/// `go`/`push` call sites are banned by
+/// `test/lint/no_string_literal_routes_test.dart`.
+///
+/// ### Deep-link stability
+/// The path VALUES are part of the app's external contract — home-screen
+/// widgets (`widgetUriToPath` resolves to [station]/[evStationById]),
+/// notification payloads (`NotificationPayload.toRouterPath` resolves to
+/// [station]), and the OBD2 auto-record flow (`/trip-recording`, #3167)
+/// all depend on them. Renaming a constant is fine; changing its VALUE is
+/// a breaking deep-link change.
+abstract final class RoutePaths {
+  // Shell branches (bottom-nav tabs).
+  static const search = '/';
+  static const map = '/map';
+  static const favorites = '/favorites';
+  static const consumptionTab = '/consumption-tab';
+  static const profile = '/profile';
+  static const trajetsTab = '/trajets-tab';
+
+  // Onboarding gates.
+  static const consent = '/consent';
+  static const setup = '/setup';
+
+  // Search-adjacent pushes.
+  static const driving = '/driving';
+  static const alerts = '/alerts';
+  static const calculator = '/calculator';
+
+  // Profile / settings sub-screens.
+  static const vehicles = '/vehicles';
+  static const editVehicle = '/vehicles/edit';
+  static const itineraries = '/itineraries';
+  static const privacyDashboard = '/privacy-dashboard';
+  static const themeSettings = '/theme-settings';
+  static const loyaltySettings = '/loyalty-settings';
+  static const developerTools = '/developer-tools';
+  static const developerToolsErrorLog = '/developer-tools/error-log';
+  static const developerToolsFlags = '/developer-tools/flags';
+  static const developerToolsObd2Health = '/developer-tools/obd2-health';
+  static const developerToolsOcrTester = '/developer-tools/ocr-tester';
+
+  // Consumption / trips.
+  static const consumption = '/consumption';
+  static const carbon = '/carbon';
+  static const consumptionStats = '/consumption-stats';
+  static const pickStationForFillUp = '/consumption/pick-station';
+  static const tripRecording = '/trip-recording';
+  static const addFillUp = '/consumption/add';
+  static const tripPattern = '/trip/:id';
+  static String trip(String id) => '/trip/$id';
+
+  // Station detail family.
+  static const stationPattern = '/station/:id';
+  static String station(String id) => '/station/$id';
+  static const stationHistoryPattern = '/station/:id/history';
+  static String stationHistory(String id) => '/station/$id/history';
+  static const evStation = '/ev-station';
+  static const evStationPattern = '/ev-station/:id';
+  static String evStationById(String id) => '/ev-station/$id';
+  static const reportPattern = '/report/:id';
+  static String report(String id) => '/report/$id';
+
+  // TankSync.
+  static const syncSetup = '/sync-setup';
+  static const linkDevice = '/link-device';
+  static const dataTransparency = '/data-transparency';
+  static const auth = '/auth';
+}
+
+/// A typed navigation target: a route that carries data — a path
+/// parameter, an `extra` payload, or both (#3135).
+///
+/// Hand-rolled rather than `go_router_builder` `TypedGoRoute`s: the
+/// builder package would be a new dependency and would force the whole
+/// route table (including the `StatefulShellRoute`) into its codegen
+/// shape; this sealed hierarchy types exactly what was untyped — the
+/// `extra` payloads and id interpolation — while the table keeps its
+/// existing `GoRoute` declarations and path strings byte-for-byte.
+///
+/// Payload-free routes don't get a subclass; call sites navigate with a
+/// [RoutePaths] constant directly (`context.push(RoutePaths.alerts)`).
+sealed class AppRoute {
+  const AppRoute();
+
+  /// The concrete location to navigate to (path parameters resolved).
+  String get location;
+
+  /// The typed payload passed through go_router's `extra`. The matching
+  /// route builder in `lib/app/routes/` downcasts it back; both ends
+  /// reference the same subclass so the shape can't silently drift.
+  Object? get extra => null;
+
+  void go(BuildContext context) => context.go(location, extra: extra);
+
+  Future<T?> push<T extends Object?>(BuildContext context) =>
+      context.push<T>(location, extra: extra);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location, extra: extra);
+}
+
+/// Fuel-station detail (`/station/:id`). Externally referenced: home-widget
+/// taps and radius-alert notifications deep-link here by id.
+final class StationDetailRoute extends AppRoute {
+  const StationDetailRoute(this.stationId);
+  final String stationId;
+  @override
+  String get location => RoutePaths.station(stationId);
+}
+
+/// Price-history chart for one station (`/station/:id/history`).
+final class PriceHistoryRoute extends AppRoute {
+  const PriceHistoryRoute(this.stationId);
+  final String stationId;
+  @override
+  String get location => RoutePaths.stationHistory(stationId);
+}
+
+/// User price-report flow (`/report/:id`).
+final class ReportRoute extends AppRoute {
+  const ReportRoute(this.stationId);
+  final String stationId;
+  @override
+  String get location => RoutePaths.report(stationId);
+}
+
+/// Trip detail (`/trip/:id`).
+final class TripDetailRoute extends AppRoute {
+  const TripDetailRoute(this.tripId);
+  final String tripId;
+  @override
+  String get location => RoutePaths.trip(tripId);
+}
+
+/// EV station detail (`/ev-station`) with the in-memory [ChargingStation]
+/// as the typed payload — the route the map overlay / search results /
+/// favorites use when they already hold the full station (#3174 unified
+/// detail screen). The id-only deep-link variant (`/ev-station/:id`)
+/// hydrates by id instead and is reached via
+/// [RoutePaths.evStationById] from the widget-URI parser.
+final class EvStationDetailRoute extends AppRoute {
+  const EvStationDetailRoute(this.station);
+  final ChargingStation station;
+  @override
+  String get location => RoutePaths.evStation;
+  @override
+  Object? get extra => station;
+}
+
+/// Add-fill-up form (`/consumption/add`). Replaces the stringly-keyed
+/// `Map<String, Object?>` extra (#3135): the route object itself crosses
+/// as the payload, so the station pre-fill fields are compile-checked on
+/// both sides. All fields optional — the redirect-driven shared-receipt
+/// entry (#2735) and the "skip station" path open the bare form.
+final class AddFillUpRoute extends AppRoute {
+  const AddFillUpRoute({
+    this.stationId,
+    this.stationName,
+    this.fuelType,
+    this.pricePerLiter,
+  });
+
+  final String? stationId;
+  final String? stationName;
+  final FuelType? fuelType;
+  final double? pricePerLiter;
+
+  @override
+  String get location => RoutePaths.addFillUp;
+  @override
+  Object? get extra => this;
+}
+
+/// Vehicle editor (`/vehicles/edit`). A null [vehicleId] opens the
+/// "add vehicle" form; non-null edits the existing vehicle.
+final class EditVehicleRoute extends AppRoute {
+  const EditVehicleRoute({this.vehicleId});
+  final String? vehicleId;
+  @override
+  String get location => RoutePaths.editVehicle;
+  @override
+  Object? get extra => vehicleId;
+}
+
+/// Fuel-cost calculator (`/calculator`), optionally pre-filled with the
+/// cheapest visible price from the search results (#2543).
+final class CalculatorRoute extends AppRoute {
+  const CalculatorRoute({this.initialPrice});
+  final double? initialPrice;
+  @override
+  String get location => RoutePaths.calculator;
+  @override
+  Object? get extra => initialPrice;
+}

--- a/lib/core/notifications/notification_payload.dart
+++ b/lib/core/notifications/notification_payload.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import '../../core/logging/error_logger.dart';
+import '../navigation/app_routes.dart';
 
 /// Payload format embedded in price-alert notifications (#1012 phase 3).
 ///
@@ -96,7 +97,7 @@ class NotificationPayload {
   String? toRouterPath() {
     switch (kind) {
       case kindRadius:
-        return '/station/$stationId';
+        return RoutePaths.station(stationId);
     }
     return null;
   }

--- a/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -141,7 +142,7 @@ class AlertStationPickerSheet extends ConsumerWidget {
               searchLabel: l10n?.search ?? 'Search',
               onSearch: () {
                 Navigator.of(context).pop();
-                context.go('/');
+                context.go(RoutePaths.search);
               },
             )
           else

--- a/lib/features/calculator/presentation/screens/calculator_screen.dart
+++ b/lib/features/calculator/presentation/screens/calculator_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/spacing.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -88,7 +89,7 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         tooltip: l10n?.tooltipBack ?? 'Back',
-        onPressed: () => context.go('/'),
+        onPressed: () => context.go(RoutePaths.search),
       ),
       bodyPadding: EdgeInsets.zero,
       body: ListView(

--- a/lib/features/consent/presentation/screens/gdpr_consent_screen.dart
+++ b/lib/features/consent/presentation/screens/gdpr_consent_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/gdpr_consent_form_provider.dart';
@@ -31,7 +32,7 @@ class GdprConsentScreen extends ConsumerWidget {
           cloudSync: form.cloudSyncConsent,
           vinOnlineDecode: form.vinOnlineDecodeConsent,
         );
-    if (context.mounted) context.go('/setup');
+    if (context.mounted) context.go(RoutePaths.setup);
   }
 
   Future<void> _acceptAll(BuildContext context, WidgetRef ref) async {
@@ -41,7 +42,7 @@ class GdprConsentScreen extends ConsumerWidget {
           cloudSync: true,
           vinOnlineDecode: true,
         );
-    if (context.mounted) context.go('/setup');
+    if (context.mounted) context.go(RoutePaths.setup);
   }
 
   @override

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -9,8 +9,8 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../../../core/country/country_provider.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/discard_changes_dialog.dart';
-
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -633,7 +633,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
               fuelType: _fuelType,
               onFuelChanged: (next) => setState(() => _fuelType = next),
               onOpenVehicle: () =>
-                  context.push('/vehicles/edit', extra: _vehicleId!),
+                  EditVehicleRoute(vehicleId: _vehicleId!).push<void>(context),
               isFullTank: _isFullTank,
               onIsFullTankChanged: (v) => setState(() => _isFullTank = v),
               litersCtrl: _litersCtrl,

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/tab_switcher.dart';
@@ -118,7 +119,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
         key: const Key('open_vehicles'),
         tooltip: l?.vehiclesMenuTitle ?? 'My vehicles',
         icon: const Icon(Icons.directions_car_outlined),
-        onPressed: () => context.push('/vehicles'),
+        onPressed: () => context.push(RoutePaths.vehicles),
       );
 
   @override
@@ -249,7 +250,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   Widget _addFillUpFab(BuildContext context, AppLocalizations? l) =>
       FloatingActionButton.extended(
         key: const Key('fab_add_fillup'),
-        onPressed: () => unawaited(context.push('/consumption/pick-station')),
+        onPressed: () => unawaited(context.push(RoutePaths.pickStationForFillUp)),
         icon: const Icon(Icons.add),
         label: Text(l?.addFillUp ?? 'Add fill-up'),
       );

--- a/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
@@ -7,12 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/domain/fuel_type.dart';
+import '../../../../core/domain/station.dart';
+import '../../../../core/logging/error_logger.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
-import '../../../../core/domain/station.dart';
-import '../../../../core/logging/error_logger.dart';
 
 /// Station-first entry point for the fill-up form (#715).
 ///
@@ -97,7 +99,7 @@ class PickStationForFillUpScreen extends ConsumerWidget {
               child: TextButton.icon(
                 key: const Key('pick_station_skip'),
                 onPressed: () =>
-                    context.pushReplacement('/consumption/add'),
+                    const AddFillUpRoute().pushReplacement(context),
                 icon: const Icon(Icons.skip_next_outlined),
                 label: Text(
                   l?.pickStationSkip ?? 'Skip — add without a station',
@@ -113,18 +115,17 @@ class PickStationForFillUpScreen extends ConsumerWidget {
   void _openFillUp(
     BuildContext context,
     Station station,
-    Object? profileFuel,
+    FuelType? profileFuel,
   ) {
     final price = _priceForFuel(station, profileFuel);
-    context.pushReplacement(
-      '/consumption/add',
-      extra: <String, Object?>{
-        'stationId': station.id,
-        'stationName': station.brand.isNotEmpty ? station.brand : station.name,
-        'fuelType': profileFuel,
-        'pricePerLiter': ?price,
-      },
-    );
+    // #3135 — the pre-fill crosses as a typed AddFillUpRoute instead of
+    // a stringly-keyed Map.
+    AddFillUpRoute(
+      stationId: station.id,
+      stationName: station.brand.isNotEmpty ? station.brand : station.name,
+      fuelType: profileFuel,
+      pricePerLiter: price,
+    ).pushReplacement(context);
   }
 
   double? _priceForFuel(Station s, Object? fuel) {

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -583,7 +584,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     if (Navigator.canPop(context)) {
       Navigator.pop(context);
     } else {
-      GoRouter.of(context).go('/');
+      GoRouter.of(context).go(RoutePaths.search);
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
@@ -117,7 +118,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
   void _onSelected(BuildContext context, _OverflowAction action) {
     switch (action) {
       case _OverflowAction.settings:
-        context.go('/profile');
+        context.go(RoutePaths.profile);
     }
   }
 
@@ -180,7 +181,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
             if (carbonEnabled)
               PopupMenuItem<_OverflowAction>(
                 key: const Key('open_carbon_dashboard'),
-                onTap: () => context.push('/carbon'),
+                onTap: () => context.push(RoutePaths.carbon),
                 child: _MenuRow(
                   icon: Icons.eco_outlined,
                   label: l?.carbonDashboardMenuLabel ?? 'Carbon dashboard',

--- a/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 
@@ -56,7 +57,7 @@ class FillUpNoVehicleCta extends StatelessWidget {
             ),
             const SizedBox(height: 24),
             FilledButton.icon(
-              onPressed: () => context.push('/vehicles/edit'),
+              onPressed: () => const EditVehicleRoute().push<void>(context),
               icon: const Icon(Icons.add),
               label: Text(l?.vehicleAdd ?? 'Add vehicle'),
             ),

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../app/responsive_search_layout.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/empty_state.dart';
@@ -80,7 +81,7 @@ class FuelTab extends ConsumerWidget {
         // #2698 — tapping the summary card opens the full
         // consumption-statistics detail page (month-over-month
         // comparison + evolution charts).
-        onTap: () => context.push('/consumption-stats'),
+        onTap: () => context.push(RoutePaths.consumptionStats),
       ),
     ];
 

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
@@ -8,6 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../app/router.dart';
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/navigation/root_navigator_key.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -127,7 +128,7 @@ class ShareReceiptHandler {
   void _stashAndRoute(String path) {
     _ref.read(pendingSharedReceiptProvider.notifier).set(path);
     debugPrint('ShareReceiptHandler.handle stashed image $path');
-    _push('/consumption/add');
+    _push(RoutePaths.addFillUp);
   }
 
   /// Rasterises the shared PDF at [path] to a JPEG and, on success, takes the
@@ -163,7 +164,7 @@ class ShareReceiptHandler {
     }
     _ref.read(pendingSharedReceiptTextProvider.notifier).set(result);
     debugPrint('ShareReceiptHandler.handle stashed parsed text result');
-    _push('/consumption/add');
+    _push(RoutePaths.addFillUp);
   }
 
   bool _featureEnabled() {

--- a/lib/features/consumption/presentation/widgets/shared_trips_section.dart
+++ b/lib/features/consumption/presentation/widgets/shared_trips_section.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/shared_trips_provider.dart';
 import 'trajet_row.dart';
@@ -57,7 +57,7 @@ class SharedTripsSection extends ConsumerWidget {
             l: l,
             theme: theme,
             shared: true,
-            onTap: () => context.push('/trip/${entry.id}'),
+            onTap: () => TripDetailRoute(entry.id).push<void>(context),
           ),
         ),
       ],

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -3,9 +3,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../app/responsive_search_layout.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -128,7 +128,7 @@ class TrajetsTab extends ConsumerWidget {
                     isScrollControlled: true,
                     builder: (_) => EditVirtualTrajetSheet(entry: entry),
                   )
-              : () => context.push('/trip/${entry.id}'),
+              : () => TripDetailRoute(entry.id).push<void>(context),
         );
       },
     );

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../app/router.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/approach_detector.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../approach/providers/effective_approach_state_provider.dart';
@@ -195,7 +196,7 @@ class TripRecordingBanner extends ConsumerWidget {
                   // active recording (the old context-lookup fell back
                   // to a snackbar naming the long-removed "Conso" tab).
                   onTap: () =>
-                      ref.read(routerProvider).push('/trip-recording'),
+                      ref.read(routerProvider).push(RoutePaths.tripRecording),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 6),

--- a/lib/features/driving/presentation/screens/driving_mode_screen.dart
+++ b/lib/features/driving/presentation/screens/driving_mode_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
@@ -111,7 +112,7 @@ class _DrivingModeScreenState extends ConsumerState<DrivingModeScreen> {
                 onRecenter: () => _recenter(stations),
                 onNearestStation: () =>
                     _navigateToNearest(context, stations, selectedFuel),
-                onExit: () => context.go('/map'),
+                onExit: () => context.go(RoutePaths.map),
               ),
             ),
             if (_isLocked) DrivingLockOverlay(onUnlock: _unlock),

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/spacing.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/labeled_value_slider.dart';
@@ -94,7 +95,7 @@ class DrivingSettingsSection extends ConsumerWidget {
           subtitle: l?.vehiclesMenuSubtitle ??
               'Your cars — fuel type, engine and tank size for accurate '
                   'consumption estimates',
-          onTap: () => context.push('/vehicles'),
+          onTap: () => context.push(RoutePaths.vehicles),
         ),
 
         // 2. Coaching while driving — the two haptic driving assists
@@ -155,7 +156,7 @@ class DrivingSettingsSection extends ConsumerWidget {
             title: l?.loyaltyMenuTitle ?? 'Fuel club cards',
             subtitle: l?.loyaltyMenuSubtitle ??
                 'Apply per-litre discounts from Total, Aral, Shell, …',
-            onTap: () => context.push('/loyalty-settings'),
+            onTap: () => context.push(RoutePaths.loyaltySettings),
           ),
         const GamificationSettingsTile(),
 

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/ev/charging_station.dart';
@@ -44,7 +44,7 @@ class _EvMapLayerState extends ConsumerState<EvMapLayer> {
             // #3174 — route to the SAME rich detail screen every other EV
             // entry point uses (search list, favorites, route results),
             // instead of pushing the now-deleted legacy in-feature copy.
-            onTap: () => context.push('/ev-station', extra: s),
+            onTap: () => EvStationDetailRoute(s).push<void>(context),
           ),
         )
         .toList();

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -122,7 +123,7 @@ class AlertsTab extends StatelessWidget {
                     ref.read(alertProvider.notifier).toggleAlert(alert.id),
               ),
               // Tap to open station detail (shows price history)
-              onTap: () => context.push('/station/${alert.stationId}'),
+              onTap: () => StationDetailRoute(alert.stationId).push<void>(context),
             ),
           );
         },
@@ -152,7 +153,7 @@ class _RadiusAlertsEntry extends StatelessWidget {
       margin: const EdgeInsets.fromLTRB(12, 12, 12, 4),
       child: InkWell(
         key: const Key('radiusAlertsEntry'),
-        onTap: () => context.push('/alerts'),
+        onTap: () => context.push(RoutePaths.alerts),
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.all(16),

--- a/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -103,7 +103,7 @@ class EvFavoriteDismissible extends ConsumerWidget {
       child: EvFavoriteCard(
         key: ValueKey(station.id),
         station: station,
-        onTap: () => context.push('/ev-station', extra: station),
+        onTap: () => EvStationDetailRoute(station).push<void>(context),
         onFavoriteTap: () =>
             ref.read(evFavoritesProvider.notifier).remove(station.id),
       ),

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -5,8 +5,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
@@ -114,7 +114,7 @@ class FavoriteStationDismissible extends ConsumerWidget {
         selectedFuelType: FuelType.all,
         isFavorite: true,
         profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
-        onTap: () => context.push('/station/${station.id}'),
+        onTap: () => StationDetailRoute(station.id).push<void>(context),
         onFavoriteTap: () {
           unawaited(ref.read(favoritesProvider.notifier).remove(station.id));
         },

--- a/lib/features/favorites/presentation/widgets/favorites_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -44,7 +45,7 @@ class FavoritesTab extends ConsumerWidget {
           subtitle: l10n?.noFavoritesHint ??
               'Tap the star on a station to save it here',
           actionLabel: l10n?.search ?? 'Search Stations',
-          onAction: () => context.go('/'),
+          onAction: () => context.go(RoutePaths.search),
           topBiased: true,
         ),
       );

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/swipe_to_delete.dart';
@@ -114,7 +115,7 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     ));
 
     // Navigate to search screen
-    context.go('/');
+    context.go(RoutePaths.search);
 
     SnackBarHelper.show(context, AppLocalizations.of(context)?.loadingRoute(it.name as String) ?? 'Loading route: ${it.name}');
   }

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/empty_state.dart';
@@ -83,7 +84,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
             title: l10n?.startSearch ??
                 'Search for stations to see them on the map',
             actionLabel: l10n?.search ?? 'Search now',
-            onAction: () => context.go('/'),
+            onAction: () => context.go(RoutePaths.search),
             iconSize: 80,
           );
         }
@@ -183,7 +184,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) => ServiceChainErrorWidget(
         error: error,
-        onRetry: () => context.go('/'),
+        onRetry: () => context.go(RoutePaths.search),
       ),
     );
   }

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -114,7 +115,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         icon: Icons.route,
         title: l10n?.noStationsAlongRoute ?? 'No stations found along route',
         actionLabel: l10n?.search ?? 'Back to search',
-        onAction: () => context.go('/'),
+        onAction: () => context.go(RoutePaths.search),
       );
     }
 

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/price_band_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/price_gradient.dart';
@@ -186,7 +186,7 @@ class StationMarkerBuilder {
           child: GestureDetector(
             // #2939 — [onTap] lets the radar split map select the row instead
             // of navigating; null keeps the default push-to-detail.
-            onTap: onTap ?? () => GoRouter.of(context).push('/station/${station.id}'),
+            onTap: onTap ?? () => StationDetailRoute(station.id).push<void>(context),
             child: Tooltip(
               message: brand,
               waitDuration: const Duration(milliseconds: 300),

--- a/lib/features/profile/presentation/screens/developer_tools/developer_tools_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/developer_tools_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/navigation/app_routes.dart';
 import '../../../../../core/notifications/notification_providers.dart';
 import '../../../../../core/services/diagnostics/data_access_recorder_provider.dart';
 import '../../../../../core/services/diagnostics/data_access_trace_export.dart';
@@ -90,7 +91,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           ErrorLogExportRow(
-            onView: () => context.push('/developer-tools/error-log'),
+            onView: () => context.push(RoutePaths.developerToolsErrorLog),
           ),
           const SizedBox(height: 16),
 
@@ -131,7 +132,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           const SizedBox(height: 8),
           OutlinedButton.icon(
             key: const ValueKey('debug-feature-flag-dump'),
-            onPressed: () => context.push('/developer-tools/flags'),
+            onPressed: () => context.push(RoutePaths.developerToolsFlags),
             icon: const Icon(Icons.flag_outlined),
             label: Text(
               l?.developerToolsFeatureFlagDump ?? 'Feature flag inspector',
@@ -141,7 +142,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // #2471 — OBD2 communication-health diagnostics (Epic #2463).
           OutlinedButton.icon(
             key: const ValueKey('debug-obd2-health'),
-            onPressed: () => context.push('/developer-tools/obd2-health'),
+            onPressed: () => context.push(RoutePaths.developerToolsObd2Health),
             icon: const Icon(Icons.bluetooth_searching_outlined),
             label: Text(
               l?.obd2HealthNavLabel ?? 'OBD2 communication health',
@@ -151,7 +152,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // #2518 — in-app OCR tester (Epic #2516 Child 2).
           OutlinedButton.icon(
             key: const ValueKey('debug-ocr-tester'),
-            onPressed: () => context.push('/developer-tools/ocr-tester'),
+            onPressed: () => context.push(RoutePaths.developerToolsOcrTester),
             icon: const Icon(Icons.document_scanner_outlined),
             label: Text(l?.ocrTesterNavLabel ?? 'OCR tester'),
           ),

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -14,6 +14,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/sharing/public_file_exporter.dart';
 import '../../../../core/telemetry/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
@@ -335,7 +336,7 @@ class _PrivacyDashboardScreenState
       await box.clear();
     }
     if (mounted) {
-      context.go('/setup');
+      context.go(RoutePaths.setup);
     }
   }
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../app/shell/settings_app_bar_action.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/theme/theme_mode_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -218,7 +219,7 @@ class ProfileScreen extends ConsumerWidget {
             icon: Icons.palette_outlined,
             title: l?.themeCardTitle ?? 'Theme',
             subtitle: _themeSubtitle(ref, l),
-            onTap: () => context.push('/theme-settings'),
+            onTap: () => context.push(RoutePaths.themeSettings),
           ),
           const SizedBox(height: 8),
           // #1806 — home-screen widget help. The Android widget's
@@ -253,7 +254,7 @@ class ProfileScreen extends ConsumerWidget {
             title: l?.privacyDashboardTitle ?? 'Privacy Dashboard',
             subtitle: l?.privacyDashboardSubtitle ??
                 'View, export, or delete your data',
-            onTap: () => context.push('/privacy-dashboard'),
+            onTap: () => context.push(RoutePaths.privacyDashboard),
           ),
           const SizedBox(height: 8),
           // Storage & Cache
@@ -295,7 +296,7 @@ class ProfileScreen extends ConsumerWidget {
                 title: l?.developerToolsSectionTitle ?? 'Developer tools',
                 subtitle: l?.developerToolsMenuSubtitle ??
                     'Error log, test alerts, diagnostics',
-                onTap: () => context.push('/developer-tools'),
+                onTap: () => context.push(RoutePaths.developerTools),
               ),
               const SizedBox(height: 8),
             ],

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../../core/navigation/app_routes.dart';
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../../providers/privacy_data_provider.dart';
@@ -140,7 +141,7 @@ class _SyncEnabledBody extends ConsumerWidget {
           contentPadding: EdgeInsets.zero,
         ),
         OutlinedButton.icon(
-          onPressed: () => context.push('/data-transparency'),
+          onPressed: () => context.push(RoutePaths.dataTransparency),
           icon: const Icon(Icons.visibility, size: 18),
           label: Text(l?.privacyViewServerData ?? 'View server data'),
         ),

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../../../../core/cache/cache_manager.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -305,7 +306,7 @@ class StorageSection extends ConsumerWidget {
       }
       if (!ctx.mounted) return; // #3159 — see _clearCache.
       ref.invalidate(storageManagementProvider);
-      ctx.go('/setup');
+      ctx.go(RoutePaths.setup);
     }
   }
 }

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../sync/presentation/widgets/qr_share_widget.dart';
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/providers/app_state_provider.dart';
@@ -63,7 +64,7 @@ class TankSyncSection extends ConsumerWidget {
           leading: const Icon(Icons.email_outlined),
           title: Text(l?.switchToEmail ?? 'Switch to email'),
           subtitle: Text(l?.switchToEmailSubtitle ?? 'Keep data, add sign-in from other devices'),
-          onTap: () => context.push('/auth'),
+          onTap: () => context.push(RoutePaths.auth),
         )
       else
         ListTile(
@@ -108,12 +109,12 @@ class TankSyncSection extends ConsumerWidget {
       ListTile(
         leading: const Icon(Icons.visibility_outlined),
         title: Text(l?.viewMyData ?? 'View my data'),
-        onTap: () => context.push('/data-transparency'),
+        onTap: () => context.push(RoutePaths.dataTransparency),
       ),
       ListTile(
         leading: const Icon(Icons.link),
         title: Text(l?.linkDevice ?? 'Link device'),
-        onTap: () => context.push('/link-device'),
+        onTap: () => context.push(RoutePaths.linkDevice),
       ),
       if (syncConfig.mode != SyncMode.community)
         ListTile(
@@ -150,7 +151,7 @@ class TankSyncSection extends ConsumerWidget {
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: FilledButton.icon(
-          onPressed: () => context.push('/sync-setup'),
+          onPressed: () => context.push(RoutePaths.syncSetup),
           icon: const Icon(Icons.cloud_upload),
           label: Text(l?.setupCloudSync ?? 'Set up cloud sync'),
         ),

--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/country/country_config.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/country_service_registry.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -63,7 +64,7 @@ class DemoModeBanner extends ConsumerWidget {
         leading: const Icon(Icons.science_outlined),
         actions: [
           TextButton(
-            onPressed: () => context.go('/profile'),
+            onPressed: () => context.go(RoutePaths.profile),
             child: Text(l10n?.demoModeBannerAction ?? 'Get live prices'),
           ),
         ],

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/geo_utils.dart';
@@ -103,7 +103,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
                 return EVStationCard(
                   key: ValueKey('route-ev-${item.station.id}'),
                   result: item,
-                  onTap: () => context.push('/ev-station', extra: item.station),
+                  onTap: () => EvStationDetailRoute(item.station).push<void>(context),
                 );
               }
               return const SizedBox.shrink();
@@ -264,7 +264,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
         ),
         isFavorite: ref.watch(isFavoriteProvider(item.id)),
         profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
-        onTap: () => context.push('/station/${item.id}'),
+        onTap: () => StationDetailRoute(item.id).push<void>(context),
         onFavoriteTap: () => ref.read(favoritesProvider.notifier)
             .toggle(item.id, stationData: item.station),
         isCheapest: item.id == result.cheapestId,

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../app/responsive_search_layout.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
@@ -131,7 +132,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                 label: l10n?.showOnMapSemanticLabel ?? 'Show stations on map',
                 button: true,
                 child: InkWell(
-                  onTap: () => context.go('/map'),
+                  onTap: () => context.go(RoutePaths.map),
                   borderRadius: BorderRadius.circular(12),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
@@ -167,10 +168,9 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                         fuel,
                         requirePositive: true,
                       );
-                      context.go(
-                        '/calculator',
-                        extra: minP > 0 ? minP : null,
-                      );
+                      CalculatorRoute(
+                        initialPrice: minP > 0 ? minP : null,
+                      ).go(context);
                     },
                     borderRadius: BorderRadius.circular(12),
                     child: Padding(
@@ -276,8 +276,9 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                                     .read(favoritesProvider.notifier)
                                     .toggle(item.id,
                                         rawJson: item.station.toJson()),
-                                onTap: () => context.push('/ev-station',
-                                    extra: item.station),
+                                onTap: () => EvStationDetailRoute(
+                                        item.station)
+                                    .push<void>(context),
                               ),
                           };
                         },
@@ -320,7 +321,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
           if (isWideScreen(context)) {
             ref.read(selectedStationProvider.notifier).select(station.id);
           } else {
-            unawaited(context.push('/station/${station.id}'));
+            unawaited(StationDetailRoute(station.id).push<void>(context));
           }
         },
         onFavoriteTap: () => ref
@@ -388,7 +389,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
         if (isWideScreen(context)) {
           ref.read(selectedStationProvider.notifier).select(station.id);
         } else {
-          unawaited(context.push('/station/${station.id}'));
+          unawaited(StationDetailRoute(station.id).push<void>(context));
         }
       },
       onFavoriteTap: () => ref

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -222,7 +223,7 @@ class _OnboardingWizardScreenState
       await profileRepo.updateProfile(updated);
       profileNotifier.refresh();
 
-      if (mounted) context.go('/');
+      if (mounted) context.go(RoutePaths.search);
     } finally {
       if (mounted) ctrl.setLoading(false);
     }

--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -131,7 +132,7 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
     await profileRepo.updateProfile(updated);
     profileNotifier.refresh();
 
-    if (mounted) context.go('/');
+    if (mounted) context.go(RoutePaths.search);
   }
 
   @override

--- a/lib/features/setup/presentation/widgets/vehicles_step.dart
+++ b/lib/features/setup/presentation/widgets/vehicles_step.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 
@@ -106,7 +106,7 @@ class VehiclesStep extends ConsumerWidget {
                     ),
                     trailing: const Icon(Icons.edit_outlined),
                     onTap: () =>
-                        context.push<void>('/vehicles/edit', extra: v.id),
+                        EditVehicleRoute(vehicleId: v.id).push<void>(context),
                   );
                 }),
               ],
@@ -123,7 +123,7 @@ class VehiclesStep extends ConsumerWidget {
                 // saves/cancels the vehicle edit screen — without the
                 // await, the returned Future is dropped and the step
                 // never re-reads `vehicleProfileListProvider`.
-                await context.push<void>('/vehicles/edit');
+                await const EditVehicleRoute().push<void>(context);
               },
               icon: const Icon(Icons.add),
               label: Text(l10n?.vehicleAdd ?? 'Add vehicle'),

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -5,8 +5,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/sync/price_history_sync.dart';
@@ -132,7 +132,7 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
         Align(
           alignment: Alignment.centerRight,
           child: TextButton(
-            onPressed: () => GoRouter.of(context).push('/station/${widget.stationId}/history'),
+            onPressed: () => PriceHistoryRoute(widget.stationId).push<void>(context),
             child: Text(AppLocalizations.of(context)?.showAllFuelTypes ?? 'Show all fuel types'),
           ),
         ),

--- a/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
@@ -5,9 +5,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/animated_favorite_star.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -85,7 +85,7 @@ class StationDetailAppBarActions extends ConsumerWidget {
           IconButton(
             key: const Key('report_price'),
             icon: const Icon(Icons.flag_outlined),
-            onPressed: () => context.push('/report/$stationId'),
+            onPressed: () => ReportRoute(stationId).push<void>(context),
             tooltip: l10n?.reportPrice ?? 'Report price',
           ),
         IconButton(

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -5,9 +5,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../core/country/country_config.dart';
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -109,13 +109,14 @@ class LogFillUpButton extends ConsumerWidget {
 
     return OutlinedButton.icon(
       onPressed: () {
-        final extra = <String, Object>{
-          'stationId': station.id,
-          'stationName': stationName,
-        };
-        if (pricedFuel != null) extra['fuelType'] = pricedFuel;
-        if (pricePerLiter != null) extra['pricePerLiter'] = pricePerLiter;
-        unawaited(context.push('/consumption/add', extra: extra));
+        // #3135 — the pre-fill crosses as a typed AddFillUpRoute instead
+        // of a stringly-keyed Map.
+        unawaited(AddFillUpRoute(
+          stationId: station.id,
+          stationName: stationName,
+          fuelType: pricedFuel,
+          pricePerLiter: pricePerLiter,
+        ).push<void>(context));
       },
       icon: const Icon(Icons.local_gas_station_outlined),
       label: Text(

--- a/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
+++ b/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -69,8 +69,8 @@ class VehicleListScreen extends ConsumerWidget {
                 return VehicleCard(
                   vehicle: v,
                   isActive: v.id == active?.id,
-                  onTap: () => context.push('/vehicles/edit', extra: v.id),
-                  onEdit: () => context.push('/vehicles/edit', extra: v.id),
+                  onTap: () => EditVehicleRoute(vehicleId: v.id).push<void>(context),
+                  onEdit: () => EditVehicleRoute(vehicleId: v.id).push<void>(context),
                   onSetActive: () => ref
                       .read(activeVehicleProfileProvider.notifier)
                       .setActive(v.id),
@@ -79,7 +79,7 @@ class VehicleListScreen extends ConsumerWidget {
               },
             ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.push('/vehicles/edit'),
+        onPressed: () => const EditVehicleRoute().push<void>(context),
         icon: const Icon(Icons.add),
         label: Text(l?.vehicleAdd ?? 'Add vehicle'),
       ),

--- a/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/catalog_reresolve_detector.dart';
@@ -98,8 +98,8 @@ class _CatalogReresolveSnackbarHostState
             // through to the global router. The vehicle-edit route
             // expects the vehicle id as `extra` (see profile_routes.dart).
             try {
-              unawaited(GoRouter.of(context)
-                  .push('/vehicles/edit', extra: candidate.vehicleId));
+              unawaited(EditVehicleRoute(vehicleId: candidate.vehicleId)
+                  .push<void>(context));
             } catch (_) {
               // ignore: silent_catch — Best-effort — if the router isn't available (widget
               // tests without a router) we still want the flag write

--- a/lib/features/widget/presentation/widget_uri_parser.dart
+++ b/lib/features/widget/presentation/widget_uri_parser.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../../../core/navigation/app_routes.dart';
+
 /// Parses a home-widget launch URI into the router path it should push.
 ///
 /// URI contract (set natively by `StationWidgetRenderer.buildActivity`):
@@ -29,5 +31,7 @@ String? widgetUriToPath(Uri? uri) {
   if (uri.host != 'station') return null;
   final id = uri.queryParameters['id'];
   if (id == null || id.isEmpty) return null;
-  return id.startsWith('ocm-') ? '/ev-station/$id' : '/station/$id';
+  return id.startsWith('ocm-')
+      ? RoutePaths.evStationById(id)
+      : RoutePaths.station(id);
 }

--- a/test/features/consumption/presentation/screens/pick_station_for_fill_up_screen_test.dart
+++ b/test/features/consumption/presentation/screens/pick_station_for_fill_up_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/navigation/app_routes.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/'
     'pick_station_for_fill_up_screen.dart';
@@ -41,10 +42,11 @@ void main() {
       await tester.tap(find.byKey(const Key('pick_station_tile_super-u-1')));
       await tester.pumpAndSettle();
       expect(_lastRoute, '/consumption/add');
-      expect(_lastExtra, isA<Map<dynamic, dynamic>>());
-      final extra = _lastExtra as Map;
-      expect(extra['stationId'], 'super-u-1');
-      expect(extra['stationName'], 'SUPER U');
+      // #3135 — the pre-fill crosses as the typed AddFillUpRoute payload.
+      expect(_lastExtra, isA<AddFillUpRoute>());
+      final extra = _lastExtra as AddFillUpRoute;
+      expect(extra.stationId, 'super-u-1');
+      expect(extra.stationName, 'SUPER U');
     });
 
     testWidgets('Skip button navigates to /consumption/add with no context',
@@ -53,7 +55,12 @@ void main() {
       await tester.tap(find.byKey(const Key('pick_station_skip')));
       await tester.pumpAndSettle();
       expect(_lastRoute, '/consumption/add');
-      expect(_lastExtra, isNull);
+      // #3135 — Skip pushes an empty typed payload (no station context).
+      final extra = _lastExtra as AddFillUpRoute;
+      expect(extra.stationId, isNull);
+      expect(extra.stationName, isNull);
+      expect(extra.fuelType, isNull);
+      expect(extra.pricePerLiter, isNull);
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -129,11 +129,15 @@ void main() {
     // (the cold-launch opportunistic alert scan, + rationale comment). The
     // gating/scheduling logic lives in the under-cap background_service.dart;
     // this is launch glue only.
-    // 13 bumps — decomposition forced (#3141), tracked by the OPEN #3139
+    // #3135 — re-grandfathered 1113 → 1114: the typed-route layer import
+    // (core/navigation/app_routes.dart) so the #3167 active-trip recovery
+    // navigates via RoutePaths.tripRecording instead of a banned string
+    // literal. Pure import line; no logic added.
+    // 14 bumps — decomposition forced (#3141), tracked by the OPEN #3139
     // (AppInitializer phase decomposition).
     'lib/app/app_initializer.dart': (
-      lines: 1113,
-      bumps: 13,
+      lines: 1114,
+      bumps: 14,
       decompositionIssue: 3139,
     ),
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
@@ -733,10 +737,14 @@ void main() {
     // trip_recording_landscape_body.dart (262 lines); only the
     // MediaQuery.orientation branch + its import remain here. Full
     // decomposition of this screen still tracked under #2187/#2188.
-    // 7 bumps — decomposition forced (#3141), tracked by the OPEN #3138
+    // #3135 — re-grandfathered 1106 → 1107: the typed-route layer import
+    // (core/navigation/app_routes.dart) so the exit navigation uses
+    // RoutePaths.search instead of a banned string literal. Pure import
+    // line; no logic added.
+    // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3138
     // (trips/fillups feature split; this screen is trips).
     'lib/features/consumption/presentation/screens/trip_recording_screen.dart':
-        (lines: 1106, bumps: 7, decompositionIssue: 3138),
+        (lines: 1107, bumps: 8, decompositionIssue: 3138),
     'lib/features/consumption/presentation/widgets/broken_map_widgets.dart': (
       lines: 439,
       bumps: 0,

--- a/test/lint/no_string_literal_routes_test.dart
+++ b/test/lint/no_string_literal_routes_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan guard (#3135): no navigation call site in `lib/` may pass a
+/// string LITERAL to `go` / `push` / `pushReplacement` / `replace` /
+/// `goNamed` / `pushNamed`.
+///
+/// Every router path lives once in `lib/core/navigation/app_routes.dart` —
+/// payload-free routes navigate with a `RoutePaths` constant, data-carrying
+/// routes (path parameter or `extra`) through their typed `AppRoute`
+/// subclass. A string literal in a call site re-introduces the stringly
+/// duplication this rule killed (63 raw literals + untyped `extra` Maps
+/// before #3135) and silently de-types the payload contract between the
+/// caller and the route builder.
+///
+/// Route TABLE declarations (`GoRoute(path: ...)`) are not matched — they
+/// also use the `RoutePaths` constants, but the deep-link contract tests
+/// in `test/app/routes/` pin the literal VALUES (widgets / notifications
+/// depend on `/station/:id`, `/ev-station/:id`, `/trip-recording`).
+///
+/// Dynamic locations (e.g. `context.go(ref.read(...))`) are fine — the rule
+/// only bans literals at the call site. The target is and must stay **0**:
+/// never add a baseline.
+void main() {
+  test('no string-literal route paths in go/push call sites (#3135)', () {
+    // Matches `.go('`, `.push("`, `.push<void>('`, `.pushReplacement('`,
+    // `.goNamed('`, `.pushNamed('` — including a line break between the
+    // opening parenthesis and the literal.
+    final call = RegExp(
+      r'''\.(go|push|pushReplacement|replace|goNamed|pushNamed)(<[^>(]*>)?\(\s*['"]''',
+    );
+
+    final violations = <String>[];
+    final files = Directory('lib')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) =>
+            f.path.endsWith('.dart') &&
+            !f.path.endsWith('.g.dart') &&
+            !f.path.endsWith('.freezed.dart') &&
+            !f.path.contains('lib/l10n/'));
+
+    for (final file in files) {
+      // Strip line comments so a commented-out example can't trip the scan.
+      // Naive per-line stripping is safe here: a route literal never
+      // legitimately contains `//`.
+      final source = file
+          .readAsLinesSync()
+          .map((l) => l.replaceFirst(RegExp(r'//.*'), ''))
+          .join('\n');
+      for (final m in call.allMatches(source)) {
+        final line = '\n'.allMatches(source.substring(0, m.start)).length + 1;
+        violations.add('${file.path}:$line  .${m.group(1)}(<string literal>)');
+      }
+    }
+
+    expect(
+      violations,
+      isEmpty,
+      reason: 'String-literal route paths are banned (#3135). Navigate with '
+          'a RoutePaths constant or a typed AppRoute subclass from '
+          'lib/core/navigation/app_routes.dart instead:\n'
+          '${violations.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
## Typed routes — RoutePaths + AppRoute payload objects, zero string-literal navigation

Fifth child of epic #3129:

- **`RoutePaths`** centralizes all 38 path constants, `:id` patterns and location builders — the route table, the router redirects, and the deep-link producers (widget URIs, notification payloads) all read from it, killing the path-string duplication.
- **Sealed `AppRoute` hierarchy** for every data-carrying route (station detail, EV detail with its `ChargingStation` extra, price history, trip detail, edit vehicle, add-fill-up — whose stringly-keyed `Map` extra becomes a typed payload object the builder downcasts). Hand-rolled, no new dependency: `go_router_builder` isn't in the tree and would force the shell route into codegen shape.
- **All 66 `go`/`push` call sites migrated**; a new lint test bans string-literal paths in navigation calls forever (target 0, no baseline).
- Externally-referenced routes verified byte-stable: `/station/:id` + `/ev-station/:id` (Android/iOS widget renderers emit only the URI scheme; the parsers now produce the identical strings via RoutePaths) and `/trip-recording` (#3167's auto-navigate).

Analyze-clean under the zero-flag gate; full features suite 10,573 green + app/lint/l10n green post-rebase.

Closes #3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
