### PR TITLE
fix(cache): cross-build freshness gate — cached parse output can't mask an app update (#3219 follow-up)

### DIFF
--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../constants/app_constants.dart';
 import '../data/storage_repository.dart';
 import '../logging/error_logger.dart';
 import '../services/service_result.dart';
@@ -31,11 +32,21 @@ class CacheEntry {
   final ServiceSource originalSource;
   final Duration ttl;
 
+  /// The app build that wrote this entry (`AppConstants.appVersion` at
+  /// `put()` time), or `null` for an entry persisted by a build that
+  /// predates the stamp (#3219 follow-up). Cached payloads are PARSED
+  /// output, so an entry written by a different build may embed the very
+  /// parser bug an update just fixed — [CacheManager.getFresh] therefore
+  /// refuses to serve a cross-build entry as fresh (it stays available to
+  /// the stale/offline fallback via [CacheManager.get]).
+  final String? appBuild;
+
   CacheEntry({
     required this.payload,
     required this.storedAt,
     required this.originalSource,
     required this.ttl,
+    this.appBuild,
   });
 
   bool get isExpired => DateTime.now().difference(storedAt) > ttl;
@@ -109,6 +120,9 @@ class CacheManager implements CacheStrategy {
         // #3150 — the enum NAME, not the reorder-fragile index.
         'source': source.name,
         'ttlMs': ttl.inMilliseconds,
+        // #3219 follow-up — stamp the writing build so [getFresh] can
+        // refuse to serve another build's PARSED payload as fresh.
+        'appBuild': AppConstants.appVersion,
       });
     } on FileSystemException catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
@@ -143,6 +157,7 @@ class CacheManager implements CacheStrategy {
       ),
       originalSource: _sourceFrom(raw['source']),
       ttl: Duration(milliseconds: raw['ttlMs'] as int? ?? 300000),
+      appBuild: raw['appBuild'] as String?,
     );
   }
 
@@ -158,11 +173,25 @@ class CacheManager implements CacheStrategy {
     return ServiceSource.cache;
   }
 
-  /// Get data only if the cache entry is still valid (not expired).
+  /// Get data only if the cache entry is still valid (not expired) AND was
+  /// written by THIS app build.
+  ///
+  /// #3219 follow-up — cached payloads are PARSED output (e.g. the
+  /// `serializeStationList` Station JSON), so an entry persisted by an older
+  /// build embeds that build's parser bugs. With FR's 6-hour
+  /// `searchResultTtl`, the #3224 hours fix was invisible after updating:
+  /// the freshly installed build kept serving the PRE-fix build's hour-less
+  /// stations for the same search key until the TTL lapsed — "the fix
+  /// shipped but the phone still shows the bug". A cross-build (or
+  /// unstamped pre-stamp) entry is therefore treated as a fresh-miss —
+  /// forcing one re-fetch + re-parse with the current code — while [get]
+  /// still serves it to the chain's stale/offline fallback, so an update
+  /// never costs the offline backbone.
   @override
   CacheEntry? getFresh(String key) {
     final entry = get(key);
     if (entry == null || entry.isExpired) return null;
+    if (entry.appBuild != AppConstants.appVersion) return null;
     return entry;
   }
 

--- a/test/core/cache/cache_build_stamp_test.dart
+++ b/test/core/cache/cache_build_stamp_test.dart
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/constants/app_constants.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+
+/// #3219 follow-up — the cross-build cache-freshness gate.
+///
+/// Cached payloads are PARSED output, so an entry written by an older app
+/// build embeds that build's parser bugs. The field shape: the #3224 FR
+/// per-day-hours fix shipped, the maintainer updated, and the phone STILL
+/// showed only 24/7 hours — because the pre-fix build's hour-less parse
+/// output sat fresh (FR `searchResultTtl` = 6 h) under the same search key
+/// and `getFresh` happily served it. The gate: `getFresh` refuses an entry
+/// stamped by a different build (or carrying no stamp at all — every
+/// pre-stamp build), forcing one re-fetch + re-parse with the current code,
+/// while `get` keeps serving it to the stale/offline fallback.
+class _FakeCacheStorage implements CacheStorage {
+  final Map<String, dynamic> store = {};
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async {
+    if (data == null) {
+      store.remove(key);
+    } else {
+      store[key] = data;
+    }
+  }
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
+    final raw = store[key];
+    if (raw is! Map) return null;
+    return Map<String, dynamic>.from(raw);
+  }
+
+  @override
+  Future<void> clearCache() async => store.clear();
+
+  @override
+  int get cacheEntryCount => store.length;
+
+  @override
+  Iterable<dynamic> get cacheKeys => store.keys;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => store.remove(key);
+}
+
+void main() {
+  late _FakeCacheStorage storage;
+  late CacheManager cache;
+
+  setUp(() {
+    storage = _FakeCacheStorage();
+    cache = CacheManager(storage);
+  });
+
+  group('CacheManager cross-build freshness gate (#3219 follow-up)', () {
+    test('an entry written by THIS build is served fresh (no regression)',
+        () async {
+      AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_A');
+      await cache.put('k', {'v': 1},
+          ttl: const Duration(hours: 6),
+          source: ServiceSource.prixCarburantsApi);
+
+      final entry = cache.getFresh('k');
+      expect(entry, isNotNull);
+      expect(entry!.payload['v'], 1);
+      expect(entry.appBuild, '6.0.0+TEST_BUILD_A');
+    });
+
+    test(
+        'an unexpired entry written by a DIFFERENT build is a fresh-miss '
+        'but still serves the stale/offline fallback', () async {
+      AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_A');
+      await cache.put('k', {'v': 1},
+          ttl: const Duration(hours: 6),
+          source: ServiceSource.prixCarburantsApi);
+
+      // The app updates: same cache file, new build.
+      AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_B');
+
+      expect(cache.getFresh('k'), isNull,
+          reason: 'a cross-build entry may embed the parser bug the update '
+              'just fixed — it must force a re-fetch');
+      final stale = cache.get('k');
+      expect(stale, isNotNull,
+          reason: 'the stale/offline fallback must keep working across '
+              'an update');
+      expect(stale!.payload['v'], 1);
+    });
+
+    test(
+        'a legacy UNSTAMPED envelope (written by a pre-stamp build) is a '
+        'fresh-miss but keeps its stale fallback', () async {
+      AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_B');
+      // Byte-shape of what every pre-#3219-follow-up build persisted: no
+      // `appBuild` key at all — exactly the envelopes on a field device the
+      // moment it updates onto this code.
+      storage.store['legacy'] = {
+        'payload': {'v': 42},
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': ServiceSource.prixCarburantsApi.name,
+        'ttlMs': const Duration(hours: 6).inMilliseconds,
+      };
+
+      expect(cache.getFresh('legacy'), isNull);
+      final stale = cache.get('legacy');
+      expect(stale, isNotNull);
+      expect(stale!.payload['v'], 42);
+      expect(stale.appBuild, isNull);
+    });
+
+    test('the stamp round-trips through the persisted envelope', () async {
+      AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_C');
+      await cache.put('k', {'v': 1},
+          ttl: const Duration(minutes: 5), source: ServiceSource.cache);
+      expect(
+        (storage.store['k'] as Map)['appBuild'],
+        '6.0.0+TEST_BUILD_C',
+      );
+    });
+  });
+}

--- a/test/features/station_services/france/prix_carburants_cross_build_cache_test.dart
+++ b/test/features/station_services/france/prix_carburants_cross_build_cache_test.dart
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/constants/app_constants.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/domain/opening_hours.dart';
+import 'package:tankstellen/core/domain/search_params.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/station_services/france/prix_carburants_parsers.dart'
+    as parser;
+import 'package:tankstellen/features/station_services/france/prix_carburants_station_service.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3219 follow-up — the field re-report: the #3224 per-day-hours fix was IN
+/// the installed build (versionCode tag → merge commit verified) yet the
+/// phone STILL showed only 24/7 hours for France.
+///
+/// Mechanism: the chain caches PARSED stations under the search key with
+/// FR's 6-hour `searchResultTtl`. The pre-fix build — running while the
+/// upstream had dropped the derived `horaires_jour` column — persisted
+/// hour-less stations. After the update, `getFresh` kept serving that
+/// pre-fix parse output for the same search key until the TTL lapsed, so
+/// the fix was invisible for up to 6 hours ("fix shipped, phone still
+/// broken"). This test drives the REAL chain with the REAL recorded Paris
+/// corpus: the cache is seeded with exactly what the pre-fix build wrote
+/// (hour-less parse of the degraded record, in an envelope with no build
+/// stamp — pre-stamp builds wrote none), and the API fixture carries the
+/// recorded row whose structured `horaires` column has the schedule. The
+/// chain must NOT serve the stale pre-fix payload as fresh: the returned
+/// stations must carry the per-day schedule parsed by the CURRENT code.
+class _FixtureAdapter implements HttpClientAdapter {
+  _FixtureAdapter(this.body);
+  final Object body;
+  int fetchCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? rs,
+      Future<void>? cf) async {
+    fetchCount++;
+    return ResponseBody.fromString(jsonEncode(body), 200, headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeCacheStorage implements CacheStorage {
+  final Map<String, dynamic> store = {};
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async {
+    if (data == null) {
+      store.remove(key);
+    } else {
+      store[key] = data;
+    }
+  }
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
+    final raw = store[key];
+    if (raw is! Map) return null;
+    return Map<String, dynamic>.from(raw);
+  }
+
+  @override
+  Future<void> clearCache() async => store.clear();
+
+  @override
+  int get cacheEntryCount => store.length;
+
+  @override
+  Iterable<dynamic> get cacheKeys => store.keys;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => store.remove(key);
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late Map<String, dynamic> recorded;
+
+  setUpAll(() {
+    recorded = jsonDecode(
+      File('test/fixtures/prix_carburants_paris_geo_ordered.json')
+          .readAsStringSync(),
+    ) as Map<String, dynamic>;
+  });
+
+  Map<String, dynamic> recordedRow(int id) => (recorded['results'] as List)
+      .cast<Map<String, dynamic>>()
+      .firstWhere((r) => r['id'] == id);
+
+  test(
+      'an update is not masked by the pre-fix build\'s cached hour-less '
+      'parse output — the chain re-fetches and the per-day schedule renders '
+      '(#3219 field re-report)', () async {
+    AppConstants.setRuntimeVersion('6.0.0+CURRENT_BUILD');
+    const params = SearchParams(lat: 48.8566, lng: 2.3522, radiusKm: 10.0);
+
+    // The recorded Total Energies 75008010 row — a real split-shift week in
+    // the structured `horaires` column; the derived column nulled, the very
+    // degradation that triggered #3219.
+    final degraded = Map<String, dynamic>.of(recordedRow(75008010))
+      ..['horaires_jour'] = null;
+
+    // What the PRE-#3224 build persisted for this search: the same record
+    // parsed with BOTH hours columns absent (the old code never read the
+    // structured column, so its output is byte-identical to parsing a
+    // hours-less record with the current code).
+    final hourless = Map<String, dynamic>.of(degraded)..['horaires'] = null;
+    final preFixStation =
+        parser.parsePrixCarburantsStation(hourless, params.lat, params.lng)!;
+    expect(
+      preFixStation.openingHours?.availability,
+      OpeningHoursAvailability.notProvided,
+      reason: 'seed sanity: the pre-fix parse output carries no schedule',
+    );
+
+    final storage = _FakeCacheStorage();
+    // Seed the EXACT envelope a pre-stamp build wrote: fresh (stored now,
+    // 6 h TTL like FR's searchResultTtl), parsed payload, NO appBuild key.
+    storage.store[CacheKey.stationSearch(
+      params.lat, params.lng, params.radiusKm, FuelType.all.apiValue,
+      countryCode: 'FR',
+    )] = {
+      'payload': serializeStationList([preFixStation]),
+      'storedAt': DateTime.now().millisecondsSinceEpoch,
+      'source': ServiceSource.prixCarburantsApi.name,
+      'ttlMs': const Duration(hours: 6).inMilliseconds,
+    };
+
+    final adapter = _FixtureAdapter({
+      'total_count': 1,
+      'results': [degraded],
+    });
+    final dio = Dio(BaseOptions(baseUrl: 'https://data.economie.gouv.fr'))
+      ..httpClientAdapter = adapter;
+    final chain = StationServiceChain(
+      PrixCarburantsStationService(dio: dio, enricher: null),
+      CacheManager(storage),
+      errorSource: ServiceSource.prixCarburantsApi,
+      countryCode: 'FR',
+    );
+
+    final result = await chain.searchStations(params);
+
+    expect(adapter.fetchCount, greaterThan(0),
+        reason: 'the cross-build cache entry must be a fresh-miss that '
+            'forces a re-fetch — serving it fresh is exactly how the #3224 '
+            'fix stayed invisible on the updated device');
+    expect(result.data, hasLength(1));
+    final hours = result.data.single.openingHours;
+    expect(hours, isNotNull);
+    final monday = hours!.dayFor(OpeningDay.mon);
+    expect(monday?.state, DayState.openRanges,
+        reason: 'the re-fetched record must carry the per-day schedule '
+            'parsed from the structured horaires column by the CURRENT code');
+    expect(monday!.ranges, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Cross-build cache freshness gate — an app update can no longer be masked by the old build's cached parse output

Follow-up to #3219/#3224 (field-verified): the maintainer's build contained the FR hours fix, yet the bug persisted — because the service chain caches **parsed** stations under the search key (FR `searchResultTtl` = 6 h), and `CacheManager.getFresh` had no build stamp. The pre-update build's hour-less parse output (written during an upstream `horaires_jour` outage) was served as *fresh* to the updated app for the same search keys, masking the fix for up to 6 hours per area.

- `put()` now stamps `appBuild`; `getFresh()` treats a cross-build or unstamped entry as a miss (forced re-fetch/re-parse). `get()` is untouched, so the stale/offline fallback still works across updates.
- Chain-level regression test seeds the exact pre-fix envelope from the recorded Paris corpus: RED on master (stale hour-less list served, zero refetches), GREEN with the fix.
- Live-data verification along the way: the #3224 parser handles every real shape — dept 34: 29 per-day / 39 pure-24/7 / 32 genuinely hours-less upstream (empty skeleton columns; nothing to render, correctly).

Refs #3219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
