### PR TITLE
refactor(l10n): nullable-getter:false + eliminate the hardcoded English fallbacks (#3162)

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -4,3 +4,8 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+# HARD RULE #1 enforcement (#3162): AppLocalizations.of(context) is
+# non-nullable, so the `l10n?.key ?? 'English fallback'` blind spot is
+# impossible. Contexts without delegates (background isolates, TTS,
+# notifications) use `lookupAppLocalizations(locale)` instead.
+nullable-getter: false

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -39,9 +39,7 @@ String? _consumePendingWidgetPath(Ref ref) {
   // returns — Riverpod asserts against state writes during the build
   // phase. The URI itself is returned synchronously so the redirect
   // can act on it in the same tick.
-  final pending = ref
-      .read(pendingWidgetUriProvider.notifier)
-      .consumeDeferred();
+  final pending = ref.read(pendingWidgetUriProvider.notifier).consumeDeferred();
   if (pending == null) return null;
   return widgetUriToPath(pending);
 }
@@ -106,9 +104,7 @@ GoRouter router(Ref ref) {
       // doesn't render in English for non-English users.
       final l = AppLocalizations.of(context);
       return Scaffold(
-        appBar: AppBar(
-          title: Text(l?.notFoundTitle ?? 'Page not found'),
-        ),
+        appBar: AppBar(title: Text(l.notFoundTitle)),
         body: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -116,14 +112,13 @@ GoRouter router(Ref ref) {
               const Icon(Icons.error_outline, size: 64, color: Colors.grey),
               const SizedBox(height: 16),
               Text(
-                l?.notFoundBody(state.matchedLocation) ??
-                    '"${state.matchedLocation}" not found.',
+                l.notFoundBody(state.matchedLocation),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
               FilledButton(
                 onPressed: () => context.go(RoutePaths.search),
-                child: Text(l?.notFoundHomeButton ?? 'Home'),
+                child: Text(l.notFoundHomeButton),
               ),
             ],
           ),

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'32b9ea9e7a081f1696aa58dc4c78d3479f75e08c';
+String _$routerHash() => r'67d4ced7d8275fb484f21e50671e4c82d74248e5';

--- a/lib/app/routes/invalid_id_screen.dart
+++ b/lib/app/routes/invalid_id_screen.dart
@@ -13,21 +13,18 @@ import '../../l10n/app_localizations.dart';
 Widget invalidIdScreen(BuildContext context, String path) {
   final l = AppLocalizations.of(context);
   return Scaffold(
-    appBar: AppBar(title: Text(l?.invalidLinkTitle ?? 'Invalid link')),
+    appBar: AppBar(title: Text(l.invalidLinkTitle)),
     body: Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           const Icon(Icons.link_off, size: 64, color: Colors.grey),
           const SizedBox(height: 16),
-          Text(
-            l?.invalidLinkBody(path) ?? 'The link "$path" is not valid.',
-            textAlign: TextAlign.center,
-          ),
+          Text(l.invalidLinkBody(path), textAlign: TextAlign.center),
           const SizedBox(height: 16),
           FilledButton(
             onPressed: () => context.go(RoutePaths.search),
-            child: Text(l?.home ?? 'Home'),
+            child: Text(l.home),
           ),
         ],
       ),

--- a/lib/app/shell/shell_destinations.dart
+++ b/lib/app/shell/shell_destinations.dart
@@ -27,10 +27,7 @@ class ShellDestinations {
   final List<ShellNavItem> items;
   final List<int> branchForSlot;
 
-  const ShellDestinations({
-    required this.items,
-    required this.branchForSlot,
-  });
+  const ShellDestinations({required this.items, required this.branchForSlot});
 }
 
 /// Build the visible nav destinations.
@@ -60,7 +57,7 @@ class ShellDestinations {
 /// shell can re-resolve on every build without paying provider-read
 /// overhead.
 ShellDestinations resolveShellDestinations({
-  required AppLocalizations? l10n,
+  required AppLocalizations l10n,
   required bool showConsumption,
   required bool showTrajets,
 }) {
@@ -70,24 +67,24 @@ ShellDestinations resolveShellDestinations({
   final search = ShellNavItem(
     Icons.search_outlined,
     Icons.search,
-    l10n?.search ?? 'Search',
+    l10n.search,
     isPrimary: true,
   );
-  final map = ShellNavItem(Icons.map_outlined, Icons.map, l10n?.map ?? 'Map');
+  final map = ShellNavItem(Icons.map_outlined, Icons.map, l10n.map);
   final favorites = ShellNavItem(
     Icons.star_outline,
     Icons.star,
-    l10n?.favorites ?? 'Favorites',
+    l10n.favorites,
   );
   final carburant = ShellNavItem(
     Icons.local_gas_station_outlined,
     Icons.local_gas_station,
-    l10n?.consumptionTabFuel ?? 'Fuel',
+    l10n.consumptionTabFuel,
   );
   final trajets = ShellNavItem(
     Icons.route_outlined,
     Icons.route,
-    l10n?.trajetsTabLabel ?? 'Trips',
+    l10n.trajetsTabLabel,
   );
 
   if (!showConsumption) {

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -104,11 +104,16 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
 
   void _setupAnimations({required bool goingRight}) {
     final direction = goingRight ? 1.0 : -1.0;
-    _slideInAnim = Tween<Offset>(
-      begin: Offset(0.3 * direction, 0),
-      end: Offset.zero,
-    ).animate(CurvedAnimation(
-        parent: _transitionController, curve: Curves.easeOutCubic));
+    _slideInAnim =
+        Tween<Offset>(
+          begin: Offset(0.3 * direction, 0),
+          end: Offset.zero,
+        ).animate(
+          CurvedAnimation(
+            parent: _transitionController,
+            curve: Curves.easeOutCubic,
+          ),
+        );
     _fadeAnim = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _transitionController, curve: Curves.easeOut),
     );
@@ -136,9 +141,11 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     _iconControllers[index].reset();
     unawaited(_iconControllers[index].forward());
 
-    unawaited(_transitionController.forward().then((_) {
-      _isTransitioning = false;
-    }));
+    unawaited(
+      _transitionController.forward().then((_) {
+        _isTransitioning = false;
+      }),
+    );
 
     setState(() => _currentIndex = index);
     // Publish the new branch index so observers (e.g. MapScreen for its
@@ -162,16 +169,18 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
         initialLocation: index == widget.navigationShell.currentIndex,
       );
     } catch (e, st) {
-      unawaited(errorLogger.log(
-        ErrorLayer.ui,
-        e,
-        st,
-        context: {
-          'source': 'ShellScreen.goBranch',
-          'index': index,
-          'currentIndex': widget.navigationShell.currentIndex,
-        },
-      ));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {
+            'source': 'ShellScreen.goBranch',
+            'index': index,
+            'currentIndex': widget.navigationShell.currentIndex,
+          },
+        ),
+      );
     }
   }
 
@@ -209,14 +218,19 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
       // (#1692) isn't bypassed; plain info, no visual change.
       SnackBarHelper.show(
         context,
-        l10n?.swipeBetweenTabsHint ??
-            'Tip: swipe left or right to switch between tabs.',
+        l10n.swipeBetweenTabsHint,
         duration: const Duration(seconds: 5),
       );
     } catch (e, st) {
       // #3143 — release-visible: debugPrint is no-opped in release.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: {'where': 'ShellScreen swipe hint'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {'where': 'ShellScreen swipe hint'},
+        ),
+      );
     }
   }
 
@@ -269,13 +283,13 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     // snap the selection to Search (branch 0) — the Carburant/Trajets
     // slots are gone and leaving `_currentIndex` on one would leave no
     // item highlighted.
-    final onConsumptionBranch = _currentIndex == kConsumptionBranchIndex ||
+    final onConsumptionBranch =
+        _currentIndex == kConsumptionBranchIndex ||
         _currentIndex == kTrajetsBranchIndex;
     if (!showConsumption && onConsumptionBranch) {
       // #1690 — the tab vanishing + the selection jumping is silent
       // and confusing; tell the user a profile change hid the tab.
-      final tabHiddenNotice = l10n?.consumptionTabHiddenNotice ??
-          'The Consumption tab was hidden by your profile settings.';
+      final tabHiddenNotice = l10n.consumptionTabHiddenNotice;
       safePostFrame(() {
         if (!mounted) return;
         if (_currentIndex != kConsumptionBranchIndex &&
@@ -311,8 +325,9 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     final body = CatalogReresolveSnackbarHost(
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onHorizontalDragEnd:
-            screenSize == ScreenSize.compact ? _onHorizontalDragEnd : null,
+        onHorizontalDragEnd: screenSize == ScreenSize.compact
+            ? _onHorizontalDragEnd
+            : null,
         child: AnimatedBuilder(
           animation: _transitionController,
           builder: (context, _) {

--- a/lib/app/widgets/animated_splash.dart
+++ b/lib/app/widgets/animated_splash.dart
@@ -76,9 +76,10 @@ class _AnimatedSplashState extends State<AnimatedSplash>
     // Scale: start slightly under-sized so the logo settles in rather than
     // pops. 0.88 → 1.00 over the full duration with a cubic-out curve gives
     // the classic "arrival with inertia" feel.
-    _scale = Tween<double>(begin: 0.88, end: 1.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
-    );
+    _scale = Tween<double>(
+      begin: 0.88,
+      end: 1.0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
     // Fade: lead out the first ~28% of the duration (native splash is still
     // visible, no need to cross-fade) and then ramp to full opacity.
     _fade = CurvedAnimation(
@@ -118,7 +119,7 @@ class _AnimatedSplashState extends State<AnimatedSplash>
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final loadingLabel = l10n?.splashLoadingLabel ?? 'Loading Sparkilo';
+    final loadingLabel = l10n.splashLoadingLabel;
     return Semantics(
       label: loadingLabel,
       liveRegion: true,
@@ -140,9 +141,7 @@ class _AnimatedSplashState extends State<AnimatedSplash>
                         child: SizedBox(
                           width: 144,
                           height: 144,
-                          child: CustomPaint(
-                            painter: _BrandGlyphPainter(),
-                          ),
+                          child: CustomPaint(painter: _BrandGlyphPainter()),
                         ),
                       ),
                     ),
@@ -157,7 +156,7 @@ class _AnimatedSplashState extends State<AnimatedSplash>
                     FadeTransition(
                       opacity: _fade,
                       child: Text(
-                        l10n?.appTitle ?? 'Sparkilo',
+                        l10n.appTitle,
                         style: const TextStyle(
                           color: AnimatedSplash.logoColor,
                           fontSize: 22,
@@ -293,4 +292,3 @@ class SplashHost extends StatelessWidget {
     );
   }
 }
-

--- a/lib/app/widgets/storage_recovery_screen.dart
+++ b/lib/app/widgets/storage_recovery_screen.dart
@@ -50,14 +50,9 @@ class _StorageRecoveryBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final title = l10n?.storageRecoveryTitle ?? 'Storage problem';
-    final message = l10n?.storageRecoveryMessage ??
-        "Sparkilo couldn't open its local data store. The storage file "
-            'appears to be damaged.';
-    final guidance = l10n?.storageRecoveryGuidance ??
-        "To recover, clear the app's storage in your device settings, or "
-            'reinstall the app. Your favourites and history are stored on '
-            'this device only, so they cannot be restored automatically.';
+    final title = l10n.storageRecoveryTitle;
+    final message = l10n.storageRecoveryMessage;
+    final guidance = l10n.storageRecoveryGuidance;
 
     return Semantics(
       container: true,

--- a/lib/core/country/country_switch_listener.dart
+++ b/lib/core/country/country_switch_listener.dart
@@ -44,8 +44,10 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<CountrySwitchEvent?>(countrySwitchEventProvider,
-        (previous, next) {
+    ref.listen<CountrySwitchEvent?>(countrySwitchEventProvider, (
+      previous,
+      next,
+    ) {
       if (next == null) return;
       if (_isOnCooldown(next.detectedCountryCode)) return;
 
@@ -64,14 +66,15 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
 
   void _handleAutoSwitch(CountrySwitchEvent event) {
     final profile = event.matchingProfile!;
-    unawaited(ref.read(activeProfileProvider.notifier).switchProfile(profile.id));
+    unawaited(
+      ref.read(activeProfileProvider.notifier).switchProfile(profile.id),
+    );
 
     final l = AppLocalizations.of(context);
     final countryName =
         Countries.byCode(event.detectedCountryCode)?.name ??
-            event.detectedCountryCode;
-    final message = l?.switchedToProfile(profile.name, countryName) ??
-        'Switched to profile "${profile.name}" ($countryName)';
+        event.detectedCountryCode;
+    final message = l.switchedToProfile(profile.name, countryName);
 
     SnackBarHelper.showSuccess(context, message);
     _markDismissed(event.detectedCountryCode);
@@ -101,19 +104,16 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
       barrierDismissible: true,
       builder: (ctx) => AlertDialog(
         icon: Text(countryFlag, style: const TextStyle(fontSize: 48)),
-        title: Text(l?.switchProfileTitle ?? 'Country changed'),
-        content: Text(
-          l?.switchProfilePrompt(countryName, profile.name) ??
-              'You are now in $countryName. Switch to profile "${profile.name}"?',
-        ),
+        title: Text(l.switchProfileTitle),
+        content: Text(l.switchProfilePrompt(countryName, profile.name)),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text(l?.dismiss ?? 'Dismiss'),
+            child: Text(l.dismiss),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l?.switchProfile ?? 'Switch'),
+            child: Text(l.switchProfile),
           ),
         ],
       ),
@@ -143,15 +143,12 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
       barrierDismissible: true,
       builder: (ctx) => AlertDialog(
         icon: Text(countryFlag, style: const TextStyle(fontSize: 48)),
-        title: Text(l?.noProfileForCountryTitle ?? 'No profile for this country'),
-        content: Text(
-          l?.noProfileForCountry(countryName) ??
-              'You are in $countryName, but no profile is configured for it. Create one in Settings.',
-        ),
+        title: Text(l.noProfileForCountryTitle),
+        content: Text(l.noProfileForCountry(countryName)),
         actions: [
           FilledButton(
             onPressed: () => Navigator.pop(ctx),
-            child: Text(l?.dialogOk ?? 'OK'),
+            child: Text(l.dialogOk),
           ),
         ],
       ),

--- a/lib/core/error/error_localizer.dart
+++ b/lib/core/error/error_localizer.dart
@@ -14,45 +14,41 @@ class ErrorLocalizer {
 
   /// Convert any error to a user-friendly message using localized strings.
   /// Falls back to English when l10n is unavailable.
-  static String localize(Object error, AppLocalizations? l10n) {
+  static String localize(Object error, AppLocalizations l10n) {
     if (error is ApiException) {
       if (error.statusCode != null && error.statusCode! >= 500) {
-        return l10n?.errorServer ?? 'Server error. Please try again later.';
+        return l10n.errorServer;
       }
       if (error.statusCode == 403 || error.statusCode == 401) {
-        return l10n?.errorApiKey ?? 'Invalid API key. Check your settings.';
+        return l10n.errorApiKey;
       }
-      return l10n?.errorNetwork ?? 'Network error. Check your connection.';
+      return l10n.errorNetwork;
     }
 
     if (error is LocationException) {
-      return l10n?.errorLocation ?? 'Could not determine your location.';
+      return l10n.errorLocation;
     }
 
     if (error is NoApiKeyException) {
-      return l10n?.errorNoApiKey ?? 'No API key configured. Go to Settings to add one.';
+      return l10n.errorNoApiKey;
     }
 
     if (error is NoEvApiKeyException) {
-      return l10n?.errorNoEvApiKey ??
-          'OpenChargeMap API key not configured. Add one in Settings to search EV charging stations.';
+      return l10n.errorNoEvApiKey;
     }
 
     if (error is UpstreamCertificateException) {
       // ARB message carries a `{host}` placeholder so the user knows who to
       // contact. Fallback mirrors the ARB wording in English (#837).
-      return l10n?.errorUpstreamCertExpired(error.host) ??
-          'Upstream data provider (${error.host}) is serving an expired or '
-              'invalid TLS certificate — the app cannot load data from this '
-              'provider until they fix it. Please contact ${error.host}.';
+      return l10n.errorUpstreamCertExpired(error.host);
     }
 
     if (error is ServiceChainExhaustedException) {
-      return l10n?.errorAllServicesFailed ?? 'Could not load data. Check your connection and try again.';
+      return l10n.errorAllServicesFailed;
     }
 
     if (error is CacheException) {
-      return l10n?.errorCache ?? 'Local data error. Try clearing the cache.';
+      return l10n.errorCache;
     }
 
     if (error is DioException) {
@@ -60,28 +56,28 @@ class ErrorLocalizer {
     }
 
     // Fallback for unknown errors
-    return l10n?.errorUnknown ?? 'An unexpected error occurred.';
+    return l10n.errorUnknown;
   }
 
-  static String _localizeDioError(DioException error, AppLocalizations? l10n) {
+  static String _localizeDioError(DioException error, AppLocalizations l10n) {
     switch (error.type) {
       case DioExceptionType.connectionTimeout:
       case DioExceptionType.sendTimeout:
       case DioExceptionType.receiveTimeout:
-        return l10n?.errorTimeout ?? 'Connection timed out. Please try again.';
+        return l10n.errorTimeout;
       case DioExceptionType.connectionError:
-        return l10n?.errorNoConnection ?? 'No internet connection.';
+        return l10n.errorNoConnection;
       case DioExceptionType.badResponse:
         final code = error.response?.statusCode ?? 0;
         if (code >= 500) {
-          return l10n?.errorServer ?? 'Server error. Please try again later.';
+          return l10n.errorServer;
         }
-        return l10n?.errorNetwork ?? 'Network error. Check your connection.';
+        return l10n.errorNetwork;
       case DioExceptionType.cancel:
-        return l10n?.errorCancelled ?? 'Request was cancelled.';
+        return l10n.errorCancelled;
       case DioExceptionType.badCertificate:
       case DioExceptionType.unknown:
-        return l10n?.errorNetwork ?? 'Network error. Check your connection.';
+        return l10n.errorNetwork;
     }
   }
 }

--- a/lib/core/feedback/feedback_consent.dart
+++ b/lib/core/feedback/feedback_consent.dart
@@ -19,11 +19,7 @@ import '../../core/logging/error_logger.dart';
 ///
 /// `denied` — user explicitly opted out. Subsequent reports fall
 /// back to the SharePlus path without re-prompting.
-enum FeedbackConsentState {
-  unset,
-  granted,
-  denied,
-}
+enum FeedbackConsentState { unset, granted, denied }
 
 /// Persistent storage for [FeedbackConsentState], backed by
 /// `shared_preferences` so the choice survives app restarts but is
@@ -57,7 +53,14 @@ class FeedbackConsent {
           return FeedbackConsentState.unset;
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FeedbackConsent.read failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.other,
+          e,
+          st,
+          context: const {'where': 'FeedbackConsent.read failed'},
+        ),
+      );
       return FeedbackConsentState.unset;
     }
   }
@@ -79,7 +82,14 @@ class FeedbackConsent {
           return;
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FeedbackConsent.write failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.other,
+          e,
+          st,
+          context: const {'where': 'FeedbackConsent.write failed'},
+        ),
+      );
     }
   }
 }
@@ -87,11 +97,7 @@ class FeedbackConsent {
 /// Result of [FeedbackConsentDialog]. Distinct from [FeedbackConsentState]
 /// because "later" must NOT mutate persisted state — the dialog will be
 /// shown again on the next attempt.
-enum FeedbackConsentChoice {
-  granted,
-  denied,
-  later,
-}
+enum FeedbackConsentChoice { granted, denied, later }
 
 /// One-time consent dialog asking the user to allow the bad-scan
 /// reporter to file a public GitHub issue with the receipt photo and
@@ -122,30 +128,23 @@ class FeedbackConsentDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      title: Text(
-        l?.feedbackConsentTitle ?? 'Send report to GitHub?',
-      ),
-      content: Text(
-        l?.feedbackConsentBody ??
-            'This creates a public ticket on our GitHub repository with '
-                'your photo and the OCR text. No personal data (location, '
-                'account id) is sent. Continue?',
-      ),
+      title: Text(l.feedbackConsentTitle),
+      content: Text(l.feedbackConsentBody),
       actions: [
         TextButton(
           onPressed: () =>
               Navigator.of(context).pop(FeedbackConsentChoice.later),
-          child: Text(l?.feedbackConsentLater ?? 'Later'),
+          child: Text(l.feedbackConsentLater),
         ),
         TextButton(
           onPressed: () =>
               Navigator.of(context).pop(FeedbackConsentChoice.denied),
-          child: Text(l?.feedbackConsentCancel ?? 'Cancel'),
+          child: Text(l.feedbackConsentCancel),
         ),
         FilledButton(
           onPressed: () =>
               Navigator.of(context).pop(FeedbackConsentChoice.granted),
-          child: Text(l?.feedbackConsentContinue ?? 'Continue'),
+          child: Text(l.feedbackConsentContinue),
         ),
       ],
     );

--- a/lib/core/feedback/github_issue_reporter/error_reporter.dart
+++ b/lib/core/feedback/github_issue_reporter/error_reporter.dart
@@ -39,7 +39,7 @@ class ErrorReporter {
   final UrlLauncher _launcher;
 
   const ErrorReporter({UrlLauncher launcher = _defaultLauncher})
-      : _launcher = launcher;
+    : _launcher = launcher;
 
   /// Recently-reported error fingerprints — a process-lifetime ring
   /// buffer so the same failure reported twice in a session does not
@@ -79,10 +79,7 @@ class ErrorReporter {
     if (_recentFingerprints.contains(payload.fingerprint)) {
       if (context.mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.show(
-          context,
-          l10n?.reportAlreadySent ?? 'You already reported this issue.',
-        );
+        SnackBarHelper.show(context, l10n.reportAlreadySent);
       }
       return false;
     }
@@ -98,7 +95,14 @@ class ErrorReporter {
       if (launched) _rememberFingerprint(payload.fingerprint);
       return launched;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ErrorReporter launch failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.other,
+          e,
+          st,
+          context: const {'where': 'ErrorReporter launch failed'},
+        ),
+      );
       return false;
     }
   }
@@ -112,18 +116,13 @@ class ErrorReporter {
       context: context,
       builder: (ctx) {
         return AlertDialog(
-          title: Text(l10n?.reportConsentTitle ?? 'Report to GitHub?'),
+          title: Text(l10n.reportConsentTitle),
           content: SingleChildScrollView(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  l10n?.reportConsentBody ??
-                      'This will open a public GitHub issue with the '
-                          'error details shown below. No GPS coordinates, '
-                          'API keys, or personal data are included.',
-                ),
+                Text(l10n.reportConsentBody),
                 const SizedBox(height: 12),
                 Container(
                   padding: const EdgeInsets.all(8),
@@ -142,12 +141,12 @@ class ErrorReporter {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(false),
-              child: Text(l10n?.reportConsentCancel ?? 'Cancel'),
+              child: Text(l10n.reportConsentCancel),
             ),
             FilledButton.icon(
               onPressed: () => Navigator.of(ctx).pop(true),
               icon: const Icon(Icons.open_in_new, size: 18),
-              label: Text(l10n?.reportConsentConfirm ?? 'Open GitHub'),
+              label: Text(l10n.reportConsentConfirm),
             ),
           ],
         );

--- a/lib/core/location/location_consent.dart
+++ b/lib/core/location/location_consent.dart
@@ -26,7 +26,7 @@ class LocationConsentDialog {
   /// locales and silently fell back to English for the rest, which is
   /// unacceptable on a consent surface.
   static Future<bool> show(BuildContext context) async {
-    final l = AppLocalizations.of(context)!;
+    final l = AppLocalizations.of(context);
     final bullets = <String>[
       l.locationConsentBulletApi,
       l.locationConsentBulletNoServer,
@@ -43,32 +43,40 @@ class LocationConsentDialog {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(l.locationConsentSubtitle,
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              Text(
+                l.locationConsentSubtitle,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
               const SizedBox(height: 16),
               Text(l.locationConsentWhatHappens),
               const SizedBox(height: 8),
-              ...bullets.map((b) => Padding(
-                    padding: const EdgeInsets.only(bottom: 6),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text('  •  ', style: TextStyle(fontSize: 14)),
-                        Expanded(
-                          child:
-                              Text(b, style: const TextStyle(fontSize: 13)),
-                        ),
-                      ],
-                    ),
-                  )),
+              ...bullets.map(
+                (b) => Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('  •  ', style: TextStyle(fontSize: 14)),
+                      Expanded(
+                        child: Text(b, style: const TextStyle(fontSize: 13)),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
               const SizedBox(height: 16),
-              Text(l.locationConsentRevoke,
-                  style: const TextStyle(fontSize: 13)),
+              Text(
+                l.locationConsentRevoke,
+                style: const TextStyle(fontSize: 13),
+              ),
               const SizedBox(height: 12),
-              Text(l.locationConsentLegalBasis,
-                  style: TextStyle(
-                      fontSize: 11,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant)),
+              Text(
+                l.locationConsentLegalBasis,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/core/services/widgets/freshness_badge.dart
+++ b/lib/core/services/widgets/freshness_badge.dart
@@ -30,16 +30,15 @@ class FreshnessBadge extends StatelessWidget {
 
     final String label;
     if (result.isStale) {
-      final stalePrefix = l10n?.freshnessStale ?? 'Stale';
+      final stalePrefix = l10n.freshnessStale;
       label = '$stalePrefix — ${result.freshnessLabel}';
     } else {
-      final agoSuffix = l10n?.freshnessAgo ?? 'ago';
+      final agoSuffix = l10n.freshnessAgo;
       label = '${result.freshnessLabel} $agoSuffix';
     }
 
     return Semantics(
-      label: l10n?.freshnessBadgeSemantics(result.freshnessLabel) ??
-          'Data freshness: ${result.freshnessLabel}',
+      label: l10n.freshnessBadgeSemantics(result.freshnessLabel),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
         decoration: BoxDecoration(
@@ -69,7 +68,10 @@ class FreshnessBadge extends StatelessWidget {
   }
 
   static _BadgeStyle _styleForAge(
-      BuildContext context, Duration age, bool isStale) {
+    BuildContext context,
+    Duration age,
+    bool isStale,
+  ) {
     if (isStale || age.inMinutes > 15) {
       // #2492 — very-stale stays amber (warning family), NOT error red.
       // Staleness is an attention state matching the warning_amber_rounded

--- a/lib/core/services/widgets/service_status_banner.dart
+++ b/lib/core/services/widgets/service_status_banner.dart
@@ -33,8 +33,7 @@ class ServiceStatusBanner extends StatelessWidget {
     if (result.isStale) {
       backgroundColor = theme.colorScheme.errorContainer;
       icon = Icons.cloud_off;
-      message =
-          '${l10n?.offlineLabel ?? 'Offline'} — ${result.freshnessLabel}';
+      message = '${l10n.offlineLabel} — ${result.freshnessLabel}';
     } else if (result.hadFallbacks) {
       backgroundColor = theme.colorScheme.tertiaryContainer;
       icon = Icons.info_outline;
@@ -61,12 +60,13 @@ class ServiceStatusBanner extends StatelessWidget {
 /// Builds the "X unavailable. Using Y." banner message using the active
 /// localization, falling back to the untranslated [ServiceResult.fallbackSummary].
 String _localizedFallbackSummary(
-    ServiceResult<dynamic> result, AppLocalizations? l10n) {
+  ServiceResult<dynamic> result,
+  AppLocalizations l10n,
+) {
   if (result.errors.isEmpty) return '';
   final failedNames = result.errors.map((e) => e.source.displayName).join(', ');
   final current = result.source.displayName;
-  return l10n?.fallbackSummary(failedNames, current) ??
-      result.fallbackSummary;
+  return l10n.fallbackSummary(failedNames, current);
 }
 
 /// Shows error when the entire service chain failed.
@@ -104,47 +104,42 @@ class ServiceChainErrorWidget extends StatelessWidget {
   });
 
   /// Extract a short, user-friendly title from the error.
-  String _title(AppLocalizations? l10n) {
+  String _title(AppLocalizations l10n) {
     if (error is NoApiKeyException || error is NoEvApiKeyException) {
-      return l10n?.errorTitleApiKey ?? 'API key required';
+      return l10n.errorTitleApiKey;
     }
     if (error is LocationException) {
-      return l10n?.errorTitleLocation ?? 'Location unavailable';
+      return l10n.errorTitleLocation;
     }
-    return l10n?.noResults ?? 'No stations found.';
+    return l10n.noResults;
   }
 
   /// Extract actionable hint text from the error chain.
-  String _hint(AppLocalizations? l10n) {
+  String _hint(AppLocalizations l10n) {
     final msg = error.toString().toLowerCase();
     if (msg.contains('no stations found') ||
         msg.contains('keine tankstellen')) {
-      return l10n?.errorHintNoStations ??
-          'Try increasing the search radius or search a different location.';
+      return l10n.errorHintNoStations;
     }
     if (msg.contains('api key') ||
         error is NoApiKeyException ||
         error is NoEvApiKeyException) {
-      return l10n?.errorHintApiKey ?? 'Configure your API key in Settings.';
+      return l10n.errorHintApiKey;
     }
     if (msg.contains('location') ||
         msg.contains('gps') ||
         error is LocationException) {
-      return l10n?.locationDenied ??
-          'Location unavailable. Try searching by postal code or city name.';
+      return l10n.locationDenied;
     }
     if (msg.contains('timeout') || msg.contains('connection')) {
-      return l10n?.errorHintConnection ??
-          'Check your internet connection and try again.';
+      return l10n.errorHintConnection;
     }
     if (msg.contains('route') ||
         msg.contains('osrm') ||
         msg.contains('routing')) {
-      return l10n?.errorHintRouting ??
-          'Route calculation failed. Check your internet connection and try again.';
+      return l10n.errorHintRouting;
     }
-    return l10n?.errorHintFallback ??
-        'Try again or search by postal code / city name.';
+    return l10n.errorHintFallback;
   }
 
   /// Extract technical details for the expandable section.
@@ -152,7 +147,7 @@ class ServiceChainErrorWidget extends StatelessWidget {
   /// Domain exceptions go through [ErrorLocalizer] so the user sees the
   /// translated message; unknown errors stay as their raw [toString] so the
   /// expandable section still carries useful debug info.
-  List<String> _technicalDetails(AppLocalizations? l10n) {
+  List<String> _technicalDetails(AppLocalizations l10n) {
     String render(Object e) =>
         e is AppException ? ErrorLocalizer.localize(e, l10n) : e.toString();
 
@@ -186,7 +181,9 @@ class ServiceChainErrorWidget extends StatelessWidget {
       searchContext: searchContext,
       stackTrace: stackTrace,
     );
-    unawaited((reporter ?? const ErrorReporter()).reportError(context, payload));
+    unawaited(
+      (reporter ?? const ErrorReporter()).reportError(context, payload),
+    );
   }
 
   @override
@@ -220,7 +217,7 @@ class ServiceChainErrorWidget extends StatelessWidget {
               FilledButton.icon(
                 onPressed: onRetry,
                 icon: const Icon(Icons.refresh),
-                label: Text(l10n?.retry ?? 'Try again'),
+                label: Text(l10n.retry),
               ),
             // #1606 — suppress the report CTA for errors that should
             // never become a GitHub issue: designed-in stop-gap
@@ -232,7 +229,7 @@ class ServiceChainErrorWidget extends StatelessWidget {
               TextButton.icon(
                 onPressed: () => _onReportPressed(context),
                 icon: const Icon(Icons.bug_report_outlined, size: 18),
-                label: Text(l10n?.reportThisIssue ?? 'Report this issue'),
+                label: Text(l10n.reportThisIssue),
               ),
             ],
             const SizedBox(height: 12),
@@ -241,23 +238,27 @@ class ServiceChainErrorWidget extends StatelessWidget {
               data: theme.copyWith(dividerColor: Colors.transparent),
               child: ExpansionTile(
                 title: Text(
-                  l10n?.detailsLabel ?? 'Details',
+                  l10n.detailsLabel,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
                 children: _technicalDetails(l10n)
-                    .map((d) => Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 16, vertical: 2),
-                          child: Text(
-                            d,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                              fontSize: 11,
-                            ),
+                    .map(
+                      (d) => Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 2,
+                        ),
+                        child: Text(
+                          d,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                            fontSize: 11,
                           ),
-                        ))
+                        ),
+                      ),
+                    )
                     .toList(),
               ),
             ),

--- a/lib/core/widgets/brand_logo.dart
+++ b/lib/core/widgets/brand_logo.dart
@@ -22,11 +22,7 @@ class BrandLogo extends StatelessWidget {
   /// The size of the logo (width and height). Defaults to 48.
   final double size;
 
-  const BrandLogo({
-    super.key,
-    required this.brand,
-    this.size = 48,
-  });
+  const BrandLogo({super.key, required this.brand, this.size = 48});
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +34,7 @@ class BrandLogo extends StatelessWidget {
     // logo on every station card. `image: true` marks it as a
     // graphic; the label names the brand it depicts.
     return Semantics(
-      label: l10n?.brandLogoLabel(brand) ?? '$brand logo',
+      label: l10n.brandLogoLabel(brand),
       image: true,
       child: url == null
           ? _fallbackIcon(theme)

--- a/lib/core/widgets/discard_changes_dialog.dart
+++ b/lib/core/widgets/discard_changes_dialog.dart
@@ -17,19 +17,16 @@ Future<bool> showDiscardChangesDialog(BuildContext context) async {
   final result = await showDialog<bool>(
     context: context,
     builder: (dialogContext) => AlertDialog(
-      title: Text(l?.discardChangesTitle ?? 'Discard changes?'),
-      content: Text(
-        l?.discardChangesBody ??
-            'You have unsaved changes. Leaving now will discard them.',
-      ),
+      title: Text(l.discardChangesTitle),
+      content: Text(l.discardChangesBody),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(dialogContext).pop(false),
-          child: Text(l?.discardChangesKeepEditing ?? 'Keep editing'),
+          child: Text(l.discardChangesKeepEditing),
         ),
         FilledButton(
           onPressed: () => Navigator.of(dialogContext).pop(true),
-          child: Text(l?.discardChangesConfirm ?? 'Discard'),
+          child: Text(l.discardChangesConfirm),
         ),
       ],
     ),

--- a/lib/core/widgets/fuel_type_dropdown.dart
+++ b/lib/core/widgets/fuel_type_dropdown.dart
@@ -50,15 +50,12 @@ class FuelTypeDropdown extends ConsumerWidget {
     return DropdownButtonFormField<FuelType>(
       initialValue: value,
       decoration: InputDecoration(
-        labelText: labelText ?? l10n?.preferredFuel ?? 'Preferred fuel',
+        labelText: labelText ?? l10n.preferredFuel,
         border: const OutlineInputBorder(),
         prefixIcon: prefixIcon,
       ),
       items: items
-          .map((t) => DropdownMenuItem(
-                value: t,
-                child: Text(t.displayName),
-              ))
+          .map((t) => DropdownMenuItem(value: t, child: Text(t.displayName)))
           .toList(),
       onChanged: (v) {
         if (v != null) onChanged(v);
@@ -103,7 +100,7 @@ class NullableFuelTypeDropdown extends ConsumerWidget {
     return DropdownButtonFormField<FuelType?>(
       initialValue: value,
       decoration: InputDecoration(
-        labelText: labelText ?? l10n?.preferredFuel ?? 'Preferred fuel',
+        labelText: labelText ?? l10n.preferredFuel,
         border: const OutlineInputBorder(),
         prefixIcon: prefixIcon,
       ),
@@ -111,14 +108,14 @@ class NullableFuelTypeDropdown extends ConsumerWidget {
         DropdownMenuItem<FuelType?>(
           value: null,
           child: Text(
-            notSetLabel ?? l10n?.vehicleFuelNotSet ?? 'Not set',
+            notSetLabel ?? l10n.vehicleFuelNotSet,
             style: const TextStyle(fontStyle: FontStyle.italic),
           ),
         ),
-        ...items.map((t) => DropdownMenuItem<FuelType?>(
-              value: t,
-              child: Text(t.displayName),
-            )),
+        ...items.map(
+          (t) =>
+              DropdownMenuItem<FuelType?>(value: t, child: Text(t.displayName)),
+        ),
       ],
       onChanged: onChanged,
     );

--- a/lib/core/widgets/help_banner.dart
+++ b/lib/core/widgets/help_banner.dart
@@ -55,7 +55,14 @@ class _HelpBannerState extends ConsumerState<HelpBanner> {
     } catch (e, st) {
       // Widget tests without an initialized settings box — keep the
       // banner hidden rather than crashing.
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'HelpBanner: cannot read shown flag'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.other,
+          e,
+          st,
+          context: const {'where': 'HelpBanner: cannot read shown flag'},
+        ),
+      );
     }
   }
 
@@ -64,7 +71,14 @@ class _HelpBannerState extends ConsumerState<HelpBanner> {
       final settings = ref.read(settingsStorageProvider);
       await settings.putSetting(widget.storageKey, true);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'HelpBanner: cannot persist dismiss'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.other,
+          e,
+          st,
+          context: const {'where': 'HelpBanner: cannot persist dismiss'},
+        ),
+      );
     }
     if (mounted) {
       setState(() => _visible = false);
@@ -87,7 +101,11 @@ class _HelpBannerState extends ConsumerState<HelpBanner> {
       ),
       child: Row(
         children: [
-          Icon(widget.icon, color: theme.colorScheme.onPrimaryContainer, size: 28),
+          Icon(
+            widget.icon,
+            color: theme.colorScheme.onPrimaryContainer,
+            size: 28,
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Text(
@@ -98,10 +116,7 @@ class _HelpBannerState extends ConsumerState<HelpBanner> {
             ),
           ),
           const SizedBox(width: 8),
-          TextButton(
-            onPressed: _dismiss,
-            child: Text(l?.swipeTutorialDismiss ?? 'Got it'),
-          ),
+          TextButton(onPressed: _dismiss, child: Text(l.swipeTutorialDismiss)),
         ],
       ),
     );

--- a/lib/core/widgets/osm_attribution.dart
+++ b/lib/core/widgets/osm_attribution.dart
@@ -23,7 +23,7 @@ const String _osmBrand = 'OpenStreetMap'; // i18n-ignore: brand / proper noun
 /// localizations are not yet available.
 String osmAttributionText(BuildContext context) {
   final l = AppLocalizations.of(context);
-  return l?.mapAttributionOsm(_osmBrand) ?? '© $_osmBrand contributors';
+  return l.mapAttributionOsm(_osmBrand);
 }
 
 /// The standard flutter_map [RichAttributionWidget] credit for the
@@ -37,9 +37,7 @@ class OsmAttribution extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return RichAttributionWidget(
-      attributions: [
-        TextSourceAttribution(osmAttributionText(context)),
-      ],
+      attributions: [TextSourceAttribution(osmAttributionText(context))],
     );
   }
 }

--- a/lib/core/widgets/password_strength_indicator.dart
+++ b/lib/core/widgets/password_strength_indicator.dart
@@ -36,9 +36,9 @@ class PasswordStrengthIndicator extends StatelessWidget {
     };
 
     final label = switch (strength) {
-      PasswordStrength.weak => l10n?.passwordStrengthWeak ?? 'Weak',
-      PasswordStrength.fair => l10n?.passwordStrengthFair ?? 'Fair',
-      PasswordStrength.strong => l10n?.passwordStrengthStrong ?? 'Strong',
+      PasswordStrength.weak => l10n.passwordStrengthWeak,
+      PasswordStrength.fair => l10n.passwordStrengthFair,
+      PasswordStrength.strong => l10n.passwordStrengthStrong,
     };
 
     return Column(
@@ -71,44 +71,55 @@ class PasswordStrengthIndicator extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         // Requirements checklist
-        ...requirements.map((req) => Padding(
-          padding: const EdgeInsets.only(bottom: 2),
-          child: Row(
-            children: [
-              Icon(
-                req.met ? Icons.check_circle : Icons.circle_outlined,
-                size: 14,
-                color: req.met ? DarkModeColors.success(context) : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-              ),
-              const SizedBox(width: 6),
-              Text(
-                _requirementLabel(l10n, req.type),
-                style: theme.textTheme.bodySmall?.copyWith(
+        ...requirements.map(
+          (req) => Padding(
+            padding: const EdgeInsets.only(bottom: 2),
+            child: Row(
+              children: [
+                Icon(
+                  req.met ? Icons.check_circle : Icons.circle_outlined,
+                  size: 14,
                   color: req.met
-                      ? theme.colorScheme.onSurface
-                      : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-                  fontSize: 11,
+                      ? DarkModeColors.success(context)
+                      : theme.colorScheme.onSurfaceVariant.withValues(
+                          alpha: 0.5,
+                        ),
                 ),
-              ),
-            ],
+                const SizedBox(width: 6),
+                Text(
+                  _requirementLabel(l10n, req.type),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: req.met
+                        ? theme.colorScheme.onSurface
+                        : theme.colorScheme.onSurfaceVariant.withValues(
+                            alpha: 0.7,
+                          ),
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
           ),
-        )),
+        ),
       ],
     );
   }
 
-  String _requirementLabel(AppLocalizations? l10n, PasswordRequirementType type) {
+  String _requirementLabel(
+    AppLocalizations l10n,
+    PasswordRequirementType type,
+  ) {
     switch (type) {
       case PasswordRequirementType.minLength:
-        return l10n?.passwordReqMinLength ?? 'At least ${PasswordValidator.minLength} characters';
+        return l10n.passwordReqMinLength;
       case PasswordRequirementType.uppercase:
-        return l10n?.passwordReqUppercase ?? 'At least 1 uppercase letter';
+        return l10n.passwordReqUppercase;
       case PasswordRequirementType.lowercase:
-        return l10n?.passwordReqLowercase ?? 'At least 1 lowercase letter';
+        return l10n.passwordReqLowercase;
       case PasswordRequirementType.digit:
-        return l10n?.passwordReqDigit ?? 'At least 1 number';
+        return l10n.passwordReqDigit;
       case PasswordRequirementType.special:
-        return l10n?.passwordReqSpecial ?? 'At least 1 special character';
+        return l10n.passwordReqSpecial;
     }
   }
 }

--- a/lib/core/widgets/settings_app_bar_action.dart
+++ b/lib/core/widgets/settings_app_bar_action.dart
@@ -17,12 +17,12 @@ part 'settings_app_bar_action.g.dart';
 /// branch the user came from. Branch 4 is Settings itself, so it is never an
 /// origin; anything unmapped falls back to home (`/`).
 String routeForShellBranch(int branch) => switch (branch) {
-      1 => '/map',
-      2 => '/favorites',
-      3 => '/consumption-tab',
-      5 => '/trajets-tab',
-      _ => '/', // 0 = Search / home
-    };
+  1 => '/map',
+  2 => '/favorites',
+  3 => '/consumption-tab',
+  5 => '/trajets-tab',
+  _ => '/', // 0 = Search / home
+};
 
 /// Where the Settings (Profile) branch returns to when its top-left back arrow
 /// is tapped (#3061). [SettingsAppBarAction] records it from the app's reliable
@@ -54,7 +54,7 @@ class SettingsAppBarAction extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     return IconButton(
       icon: const Icon(Icons.settings_outlined),
-      tooltip: l10n?.settings ?? 'Settings',
+      tooltip: l10n.settings,
       onPressed: () {
         // #3061 — record the branch the user is on (the shell keeps this
         // current) BEFORE switching to Settings, so the Settings back arrow

--- a/lib/core/widgets/snackbar_helper.dart
+++ b/lib/core/widgets/snackbar_helper.dart
@@ -57,13 +57,12 @@ class SnackBarHelper {
     Duration duration = _infoDuration,
     SnackBarAction? action,
     Key? key,
-  }) =>
-      SnackBar(
-        key: key,
-        content: _Announced(child: Text(message)),
-        duration: duration,
-        action: action,
-      );
+  }) => SnackBar(
+    key: key,
+    content: _Announced(child: Text(message)),
+    duration: duration,
+    action: action,
+  );
 
   /// A success [SnackBar] — themed via [scheme] (`tertiaryContainer`,
   /// never hard-coded green) with a check icon so success is signalled
@@ -72,16 +71,15 @@ class SnackBarHelper {
     ColorScheme scheme,
     String message, {
     Duration duration = _infoDuration,
-  }) =>
-      SnackBar(
-        content: _IconatedContent(
-          icon: Icons.check_circle_outline,
-          message: message,
-          foreground: scheme.onTertiaryContainer,
-        ),
-        backgroundColor: scheme.tertiaryContainer,
-        duration: duration,
-      );
+  }) => SnackBar(
+    content: _IconatedContent(
+      icon: Icons.check_circle_outline,
+      message: message,
+      foreground: scheme.onTertiaryContainer,
+    ),
+    backgroundColor: scheme.tertiaryContainer,
+    duration: duration,
+  );
 
   /// An informational [SnackBar] with a leading icon but the DEFAULT
   /// SnackBar theme (no coloured background) — for coaching/info rows
@@ -94,55 +92,66 @@ class SnackBarHelper {
     String message, {
     Duration duration = _infoDuration,
     Key? key,
-  }) =>
-      SnackBar(
-        key: key,
-        content: _IconatedContent(icon: icon, message: message),
-        duration: duration,
-      );
+  }) => SnackBar(
+    key: key,
+    content: _IconatedContent(icon: icon, message: message),
+    duration: duration,
+  );
 
   /// An error [SnackBar] — themed via [scheme] (`errorContainer`) with
   /// an error icon so the failure is signalled by more than colour.
-  static SnackBar errorSnackBar(ColorScheme scheme, String message) =>
-      SnackBar(
-        content: _IconatedContent(
-          icon: Icons.error_outline,
-          message: message,
-          foreground: scheme.onErrorContainer,
-        ),
-        backgroundColor: scheme.errorContainer,
-        duration: _errorDuration,
-      );
+  static SnackBar errorSnackBar(ColorScheme scheme, String message) => SnackBar(
+    content: _IconatedContent(
+      icon: Icons.error_outline,
+      message: message,
+      foreground: scheme.onErrorContainer,
+    ),
+    backgroundColor: scheme.errorContainer,
+    duration: _errorDuration,
+  );
 
   // ---- Context wrappers ----------------------------------------------
 
   /// Show a simple informational snackbar. [action] adds a trailing
   /// button (e.g. a navigation shortcut).
-  static void show(BuildContext context, String message,
-      {Duration duration = _infoDuration, SnackBarAction? action}) {
+  static void show(
+    BuildContext context,
+    String message, {
+    Duration duration = _infoDuration,
+    SnackBarAction? action,
+  }) {
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      infoSnackBar(message, duration: duration, action: action),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(infoSnackBar(message, duration: duration, action: action));
   }
 
   /// Show a success snackbar — themed with a check icon.
-  static void showSuccess(BuildContext context, String message,
-      {Duration duration = _infoDuration}) {
+  static void showSuccess(
+    BuildContext context,
+    String message, {
+    Duration duration = _infoDuration,
+  }) {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      successSnackBar(Theme.of(context).colorScheme, message,
-          duration: duration),
+      successSnackBar(
+        Theme.of(context).colorScheme,
+        message,
+        duration: duration,
+      ),
     );
   }
 
   /// Show a snackbar with an undo action. [undoLabel] defaults to the
   /// localized "Undo" string — never a hard-coded literal.
-  static void showWithUndo(BuildContext context, String message,
-      {required VoidCallback onUndo, String? undoLabel}) {
+  static void showWithUndo(
+    BuildContext context,
+    String message, {
+    required VoidCallback onUndo,
+    String? undoLabel,
+  }) {
     if (!context.mounted) return;
-    final label =
-        undoLabel ?? AppLocalizations.of(context)?.undo ?? 'Undo';
+    final label = undoLabel ?? AppLocalizations.of(context).undo;
     ScaffoldMessenger.of(context).showSnackBar(
       infoSnackBar(
         message,
@@ -155,9 +164,9 @@ class SnackBarHelper {
   /// Show an error snackbar — themed with an error icon.
   static void showError(BuildContext context, String message) {
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      errorSnackBar(Theme.of(context).colorScheme, message),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(errorSnackBar(Theme.of(context).colorScheme, message));
   }
 }
 

--- a/lib/core/widgets/star_rating.dart
+++ b/lib/core/widgets/star_rating.dart
@@ -37,7 +37,7 @@ class StarRating extends StatelessWidget {
         final isFilled = rating != null && starNumber <= rating!;
         return Semantics(
           button: true,
-          label: l10n?.ratingStarLabel(starNumber) ?? 'Rate $starNumber stars',
+          label: l10n.ratingStarLabel(starNumber),
           child: GestureDetector(
             onTap: () => onRatingChanged(starNumber),
             behavior: HitTestBehavior.opaque,

--- a/lib/features/achievements/presentation/widgets/badge_shelf.dart
+++ b/lib/features/achievements/presentation/widgets/badge_shelf.dart
@@ -31,8 +31,9 @@ class BadgeShelf extends ConsumerWidget {
     final cardMargin = compact
         ? const EdgeInsets.symmetric(horizontal: 12, vertical: 4)
         : const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
-    final cardPadding =
-        compact ? const EdgeInsets.all(8) : const EdgeInsets.all(12);
+    final cardPadding = compact
+        ? const EdgeInsets.all(8)
+        : const EdgeInsets.all(12);
 
     return Card(
       margin: cardMargin,
@@ -45,10 +46,7 @@ class BadgeShelf extends ConsumerWidget {
               children: [
                 const Icon(Icons.emoji_events_outlined, size: 20),
                 const SizedBox(width: 8),
-                Text(
-                  l?.achievementsTitle ?? 'Achievements',
-                  style: theme.textTheme.titleSmall,
-                ),
+                Text(l.achievementsTitle, style: theme.textTheme.titleSmall),
                 const Spacer(),
                 Text(
                   '${earnedIds.length}/${AchievementId.values.length}',
@@ -135,76 +133,49 @@ class _BadgeTile extends StatelessWidget {
     );
   }
 
-  (IconData, String) _iconAndLabel(AchievementId id, AppLocalizations? l) {
+  (IconData, String) _iconAndLabel(AchievementId id, AppLocalizations l) {
     switch (id) {
       case AchievementId.firstTrip:
-        return (Icons.route, l?.achievementFirstTrip ?? 'First trip');
+        return (Icons.route, l.achievementFirstTrip);
       case AchievementId.firstFillUp:
-        return (
-          Icons.local_gas_station,
-          l?.achievementFirstFillUp ?? 'First fill-up',
-        );
+        return (Icons.local_gas_station, l.achievementFirstFillUp);
       case AchievementId.tenTrips:
-        return (Icons.military_tech, l?.achievementTenTrips ?? '10 trips');
+        return (Icons.military_tech, l.achievementTenTrips);
       case AchievementId.zeroHarshTrip:
-        return (Icons.spa, l?.achievementZeroHarsh ?? 'Smooth driver');
+        return (Icons.spa, l.achievementZeroHarsh);
       case AchievementId.ecoWeek:
-        return (
-          Icons.event_available,
-          l?.achievementEcoWeek ?? 'Eco week',
-        );
+        return (Icons.event_available, l.achievementEcoWeek);
       case AchievementId.priceWin:
-        return (
-          Icons.savings,
-          l?.achievementPriceWin ?? 'Price win',
-        );
+        return (Icons.savings, l.achievementPriceWin);
       case AchievementId.smoothDriver:
-        return (
-          Icons.timeline,
-          l?.achievementSmoothDriver ?? 'Smooth streak',
-        );
+        return (Icons.timeline, l.achievementSmoothDriver);
       case AchievementId.coldStartAware:
-        return (
-          Icons.ac_unit,
-          l?.achievementColdStartAware ?? 'Cold-start aware',
-        );
+        return (Icons.ac_unit, l.achievementColdStartAware);
       case AchievementId.highwayMaster:
-        return (
-          Icons.straight,
-          l?.achievementHighwayMaster ?? 'Highway master',
-        );
+        return (Icons.straight, l.achievementHighwayMaster);
     }
   }
 
-  String _description(AchievementId id, AppLocalizations? l) {
+  String _description(AchievementId id, AppLocalizations l) {
     switch (id) {
       case AchievementId.firstTrip:
-        return l?.achievementFirstTripDesc ??
-            'Record your first OBD2 trip.';
+        return l.achievementFirstTripDesc;
       case AchievementId.firstFillUp:
-        return l?.achievementFirstFillUpDesc ??
-            'Log your first fill-up.';
+        return l.achievementFirstFillUpDesc;
       case AchievementId.tenTrips:
-        return l?.achievementTenTripsDesc ??
-            'Record 10 OBD2 trips.';
+        return l.achievementTenTripsDesc;
       case AchievementId.zeroHarshTrip:
-        return l?.achievementZeroHarshDesc ??
-            'Complete a trip of 10 km or more with no harsh braking or acceleration.';
+        return l.achievementZeroHarshDesc;
       case AchievementId.ecoWeek:
-        return l?.achievementEcoWeekDesc ??
-            'Drive 7 consecutive days with at least one smooth trip each day.';
+        return l.achievementEcoWeekDesc;
       case AchievementId.priceWin:
-        return l?.achievementPriceWinDesc ??
-            'Log a fill-up that beats the station\'s 30-day average by 5 % or more.';
+        return l.achievementPriceWinDesc;
       case AchievementId.smoothDriver:
-        return l?.achievementSmoothDriverDesc ??
-            'Drive 5 trips in a row with a smooth-driving score of 80 or higher.';
+        return l.achievementSmoothDriverDesc;
       case AchievementId.coldStartAware:
-        return l?.achievementColdStartAwareDesc ??
-            'Keep a whole month\'s cold-start fuel cost under 2 % of total fuel — combine short trips.';
+        return l.achievementColdStartAwareDesc;
       case AchievementId.highwayMaster:
-        return l?.achievementHighwayMasterDesc ??
-            'Complete a 30 km+ trip at consistent speed with a smooth-driving score of 90 or higher.';
+        return l.achievementHighwayMasterDesc;
     }
   }
 }

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -34,11 +34,11 @@ class AlertsScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
 
     return PageScaffold(
-      title: l10n?.priceAlerts ?? 'Price Alerts',
+      title: l10n.priceAlerts,
       bodyPadding: EdgeInsets.zero,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
         onPressed: () => context.pop(),
       ),
       body: alertsAsync.when(
@@ -47,8 +47,7 @@ class AlertsScreen extends ConsumerWidget {
         error: (error, stackTrace) => ServiceChainErrorWidget(
           error: error,
           stackTrace: stackTrace,
-          searchContext:
-              l10n?.alertsLoadErrorTitle ?? "Couldn't load your alerts",
+          searchContext: l10n.alertsLoadErrorTitle,
           onRetry: () {
             // Invalidate both the underlying notifier and the async
             // wrapper so the read is retried from scratch.
@@ -87,9 +86,9 @@ class _AlertsBody extends ConsumerWidget {
         const SizedBox(height: 4),
         // ── Station alerts ──────────────────────────────────────────
         _SectionHeader(
-          title: l10n?.alertsStationSectionTitle ?? 'Station alerts',
+          title: l10n.alertsStationSectionTitle,
           count: alerts.length,
-          addTooltip: l10n?.alertsStationAdd ?? 'Add a station alert',
+          addTooltip: l10n.alertsStationAdd,
           // #2857 — the "+" used to be a dead-end that only re-showed the
           // "create from a station's detail page" hint. It now opens the
           // favorite-station picker and, on selection, the same
@@ -99,8 +98,7 @@ class _AlertsBody extends ConsumerWidget {
         if (alerts.isEmpty)
           _SectionEmpty(
             icon: Icons.notifications_off_outlined,
-            text: l10n?.noPriceAlertsHint ??
-                'Create an alert from a station\'s detail page.',
+            text: l10n.noPriceAlertsHint,
           )
         else
           _GroupedAlertsCard(
@@ -112,9 +110,9 @@ class _AlertsBody extends ConsumerWidget {
         const SizedBox(height: 12),
         // ── Zone / radius alerts (#578 phase 2) ─────────────────────
         _SectionHeader(
-          title: l10n?.alertsRadiusSectionTitle ?? 'Radius alerts',
+          title: l10n.alertsRadiusSectionTitle,
           count: radiusAsync.asData?.value.length ?? 0,
-          addTooltip: l10n?.alertsRadiusAdd ?? 'Add radius alert',
+          addTooltip: l10n.alertsRadiusAdd,
           onAdd: () => RadiusAlertCreateSheet.show(context),
         ),
         radiusAsync.when(
@@ -126,7 +124,9 @@ class _AlertsBody extends ConsumerWidget {
               children: [
                 for (final a in radiusAlerts)
                   _RadiusAlertListTile(
-                      key: ValueKey('radius-${a.id}'), alert: a),
+                    key: ValueKey('radius-${a.id}'),
+                    alert: a,
+                  ),
               ],
             );
           },
@@ -137,8 +137,7 @@ class _AlertsBody extends ConsumerWidget {
           error: (error, stackTrace) => ServiceChainErrorWidget(
             error: error,
             stackTrace: stackTrace,
-            searchContext:
-                l10n?.alertsLoadErrorTitle ?? "Couldn't load your alerts",
+            searchContext: l10n.alertsLoadErrorTitle,
             onRetry: () => ref.invalidate(radiusAlertsProvider),
           ),
         ),
@@ -237,7 +236,7 @@ class _AlertListTile extends ConsumerWidget {
       ),
       onDismissed: (_) {
         unawaited(ref.read(alertProvider.notifier).removeAlert(alert.id));
-        SnackBarHelper.show(context, l10n?.alertDeleted(alert.stationName) ?? 'Alert "${alert.stationName}" deleted');
+        SnackBarHelper.show(context, l10n.alertDeleted(alert.stationName));
       },
       child: ListTile(
         dense: true,
@@ -289,10 +288,7 @@ class _SectionHeader extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: Text(
-              '$title ($count)',
-              style: theme.textTheme.titleMedium,
-            ),
+            child: Text('$title ($count)', style: theme.textTheme.titleMedium),
           ),
           IconButton(
             icon: const Icon(Icons.add),
@@ -313,8 +309,8 @@ class _RadiusEmptyState extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: EmptyState(
         icon: Icons.location_searching,
-        title: l10n?.alertsRadiusEmptyTitle ?? 'No radius alerts yet',
-        actionLabel: l10n?.alertsRadiusEmptyCta ?? 'Create a radius alert',
+        title: l10n.alertsRadiusEmptyTitle,
+        actionLabel: l10n.alertsRadiusEmptyCta,
         onAction: () => RadiusAlertCreateSheet.show(context),
       ),
     );
@@ -354,8 +350,7 @@ class _RadiusAlertListTile extends ConsumerWidget {
         unawaited(notifier.remove(alert.id));
         SnackBarHelper.showWithUndo(
           context,
-          l10n?.radiusAlertDeleted(alert.label) ??
-              'Radius alert "${alert.label}" deleted',
+          l10n.radiusAlertDeleted(alert.label),
           onUndo: () => notifier.add(alert),
         );
       },
@@ -365,11 +360,7 @@ class _RadiusAlertListTile extends ConsumerWidget {
           Icons.location_searching,
           color: alert.enabled ? theme.colorScheme.primary : Colors.grey,
         ),
-        title: Text(
-          alert.label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
+        title: Text(alert.label, maxLines: 1, overflow: TextOverflow.ellipsis),
         subtitle: Text(
           '${FuelType.fromString(alert.fuelType).displayName} ≤ '
           '${PriceFormatter.formatPrice(alert.threshold)} '

--- a/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
@@ -74,10 +74,7 @@ class AlertStationPickerSheet extends ConsumerWidget {
     await ref.read(alertProvider.notifier).addAlert(alert);
     if (!context.mounted) return;
     final l10n = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l10n?.alertCreated ?? 'Price alert created',
-    );
+    SnackBarHelper.showSuccess(context, l10n.alertCreated);
   }
 
   /// Brand → name → street fallback for the dialog title (#2161): French
@@ -102,12 +99,16 @@ class AlertStationPickerSheet extends ConsumerWidget {
       try {
         stations.add(Station.fromJson(raw));
       } catch (e, st) {
-        unawaited(errorLogger.log(
-          ErrorLayer.ui,
-          e,
-          st,
-          context: {'where': 'AlertStationPicker: skipping malformed fav $id'},
-        ));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: {
+              'where': 'AlertStationPicker: skipping malformed fav $id',
+            },
+          ),
+        );
       }
     }
 
@@ -119,16 +120,14 @@ class AlertStationPickerSheet extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: Text(
-              l10n?.pickStationTitle ?? 'Pick a station',
+              l10n.pickStationTitle,
               style: theme.textTheme.titleLarge,
             ),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
             child: Text(
-              l10n?.pickStationHelper ??
-                  'Start the fill-up from a known station so prices, brand '
-                      'and fuel type fill themselves in.',
+              l10n.pickStationHelper,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -136,10 +135,8 @@ class AlertStationPickerSheet extends ConsumerWidget {
           ),
           if (stations.isEmpty)
             _PickerEmptyState(
-              message: l10n?.pickStationEmpty ??
-                  'No favorite stations yet — add some from Search or '
-                      'Favorites, or skip and fill in manually.',
-              searchLabel: l10n?.search ?? 'Search',
+              message: l10n.pickStationEmpty,
+              searchLabel: l10n.search,
               onSearch: () {
                 Navigator.of(context).pop();
                 context.go(RoutePaths.search);

--- a/lib/features/alerts/presentation/widgets/alert_statistics_card.dart
+++ b/lib/features/alerts/presentation/widgets/alert_statistics_card.dart
@@ -28,7 +28,7 @@ class AlertStatisticsCard extends ConsumerWidget {
               icon: Icons.notifications_active,
               iconColor: theme.colorScheme.primary,
               value: stats.activeAlerts.toString(),
-              label: l10n?.alertStatsActive ?? 'Active',
+              label: l10n.alertStatsActive,
             ),
             _StatColumn(
               icon: Icons.today,
@@ -36,13 +36,13 @@ class AlertStatisticsCard extends ConsumerWidget {
                   ? DarkModeColors.success(context)
                   : theme.colorScheme.onSurfaceVariant,
               value: stats.triggeredToday.toString(),
-              label: l10n?.alertStatsToday ?? 'Today',
+              label: l10n.alertStatsToday,
             ),
             _StatColumn(
               icon: Icons.date_range,
               iconColor: theme.colorScheme.onSurfaceVariant,
               value: stats.triggeredThisWeek.toString(),
-              label: l10n?.alertStatsThisWeek ?? 'This week',
+              label: l10n.alertStatsThisWeek,
             ),
           ],
         ),

--- a/lib/features/alerts/presentation/widgets/alerts_best_effort_note.dart
+++ b/lib/features/alerts/presentation/widgets/alerts_best_effort_note.dart
@@ -41,11 +41,7 @@ class AlertsBestEffortNote extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              l10n?.alertsIosBestEffortNote ??
-                  'On iPhone, alert checks are best effort: iOS decides '
-                      'when the app may check prices in the background, so '
-                      'an alert can arrive late or occasionally not at all. '
-                      'Opening the app always runs a fresh check.',
+              l10n.alertsIosBestEffortNote,
               key: const ValueKey('alerts-best-effort-note'),
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,

--- a/lib/features/alerts/presentation/widgets/alerts_last_checked_footer.dart
+++ b/lib/features/alerts/presentation/widgets/alerts_last_checked_footer.dart
@@ -30,12 +30,11 @@ class AlertsLastCheckedFooter extends StatelessWidget {
         final at = snapshot.data;
         final String label;
         if (at == null) {
-          label = l10n?.alertsLastCheckedNever ??
-              "Prices haven't been checked in the background yet";
+          label = l10n.alertsLastCheckedNever;
         } else {
           final locale = Localizations.localeOf(context).toString();
           final when = DateFormat.yMd(locale).add_Hm().format(at.toLocal());
-          label = l10n?.alertsLastChecked(when) ?? 'Last checked: $when';
+          label = l10n.alertsLastChecked(when);
         }
         return Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),

--- a/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
+++ b/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
@@ -41,20 +41,21 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
   /// no recognised prefix (legacy / demo ids).
   late final String _stationCountry =
       Countries.countryCodeForStationId(widget.stationId) ??
-          Countries.germany.code;
+      Countries.germany.code;
 
   /// The fuels the background evaluator can actually resolve for this
   /// station's country (#2865) — drops the search wildcard and any fuel
   /// the country's provider doesn't price, so a saved alert can always
   /// fire. DE keeps its historical e5/e10/diesel set.
-  late final List<FuelType> _alertFuelTypes =
-      alertEvaluableFuelsFor(_stationCountry);
+  late final List<FuelType> _alertFuelTypes = alertEvaluableFuelsFor(
+    _stationCountry,
+  );
 
   /// Currency symbol of the station's country (#2865), used in the
   /// target-price label + suffix instead of a hardcoded euro.
   late final String _currencySymbol =
       Countries.byCode(_stationCountry)?.currencySymbol ??
-          Countries.germany.currencySymbol;
+      Countries.germany.currencySymbol;
 
   @override
   void initState() {
@@ -65,8 +66,8 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
     _selectedFuelType = _alertFuelTypes.contains(FuelType.diesel)
         ? FuelType.diesel
         : (_alertFuelTypes.isNotEmpty
-            ? _alertFuelTypes.first
-            : FuelType.diesel);
+              ? _alertFuelTypes.first
+              : FuelType.diesel);
     final prefilled = widget.currentPrice != null
         ? (widget.currentPrice! - 0.05).toStringAsFixed(3)
         : '';
@@ -84,7 +85,7 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
     final l10n = AppLocalizations.of(context);
 
     return AlertDialog(
-      title: Text(l10n?.createAlert ?? 'Create Price Alert'),
+      title: Text(l10n.createAlert),
       content: Form(
         key: _formKey,
         child: Column(
@@ -93,41 +94,46 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
           children: [
             Text(
               widget.stationName,
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
             if (widget.currentPrice != null) ...[
               const SizedBox(height: 4),
               Text(
-                l10n?.currentPrice(PriceFormatter.formatPrice(widget.currentPrice)) ?? 'Current price: ${PriceFormatter.formatPrice(widget.currentPrice)}',
+                l10n.currentPrice(
+                  PriceFormatter.formatPrice(widget.currentPrice),
+                ),
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
             const SizedBox(height: 16),
             DropdownButtonFormField<FuelType>(
               initialValue: _selectedFuelType,
               decoration: InputDecoration(
-                labelText: l10n?.fuelType ?? 'Fuel type',
+                labelText: l10n.fuelType,
                 border: const OutlineInputBorder(),
                 isDense: true,
               ),
-              items: <FuelType>{
-                ..._alertFuelTypes,
-                // Keep the selected value present even in the unlikely
-                // case it's not in the evaluable set, so the dropdown
-                // never asserts on a missing initial value (#2865).
-                _selectedFuelType,
-              }
-                  .map((ft) => DropdownMenuItem(
-                        value: ft,
-                        child: Text(ft.displayName),
-                      ))
-                  .toList(),
+              items:
+                  <FuelType>{
+                        ..._alertFuelTypes,
+                        // Keep the selected value present even in the unlikely
+                        // case it's not in the evaluable set, so the dropdown
+                        // never asserts on a missing initial value (#2865).
+                        _selectedFuelType,
+                      }
+                      .map(
+                        (ft) => DropdownMenuItem(
+                          value: ft,
+                          child: Text(ft.displayName),
+                        ),
+                      )
+                      .toList(),
               onChanged: (value) {
                 if (value != null) {
                   setState(() => _selectedFuelType = value);
@@ -138,25 +144,24 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
             TextFormField(
               controller: _priceController,
               decoration: InputDecoration(
-                labelText:
-                    l10n?.alertTargetPriceWithCurrency(_currencySymbol) ??
-                        'Target price ($_currencySymbol)',
+                labelText: l10n.alertTargetPriceWithCurrency(_currencySymbol),
                 border: const OutlineInputBorder(),
                 hintText: '1.500',
                 suffixText: '$_currencySymbol/L',
               ),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
               validator: (value) {
                 if (value == null || value.isEmpty) {
-                  return l10n?.enterPrice ?? 'Please enter a price';
+                  return l10n.enterPrice;
                 }
                 final parsed = double.tryParse(value.replaceAll(',', '.'));
                 if (parsed == null || parsed <= 0) {
-                  return l10n?.invalidPrice ?? 'Invalid price';
+                  return l10n.invalidPrice;
                 }
                 if (parsed > 10) {
-                  return l10n?.priceTooHigh ?? 'Price too high';
+                  return l10n.priceTooHigh;
                 }
                 return null;
               },
@@ -167,12 +172,9 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n?.cancel ?? 'Cancel'),
+          child: Text(l10n.cancel),
         ),
-        FilledButton(
-          onPressed: _onSubmit,
-          child: Text(l10n?.create ?? 'Create'),
-        ),
+        FilledButton(onPressed: _onSubmit, child: Text(l10n.create)),
       ],
     );
   }
@@ -180,8 +182,7 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
   void _onSubmit() {
     if (!_formKey.currentState!.validate()) return;
 
-    final price =
-        double.parse(_priceController.text.replaceAll(',', '.'));
+    final price = double.parse(_priceController.text.replaceAll(',', '.'));
 
     final alert = PriceAlert(
       id: '${widget.stationId}_${_selectedFuelType.apiValue}_${DateTime.now().millisecondsSinceEpoch}',

--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -23,9 +23,8 @@ import 'radius_alert_map_picker.dart';
 /// [RadiusAlertMapPicker.push]; tests inject a stub that returns a
 /// pre-baked [LatLng] so the picker's own widget tree doesn't need to
 /// be built under `pumpApp` (#578 phase 3).
-typedef RadiusAlertMapPickerOpener = Future<LatLng?> Function(
-  BuildContext context,
-);
+typedef RadiusAlertMapPickerOpener =
+    Future<LatLng?> Function(BuildContext context);
 
 /// Bottom sheet that creates a new [RadiusAlert] (#578 phase 2 + 3,
 /// refactored in #563 phase: radius_alert_create_sheet).
@@ -68,9 +67,7 @@ class RadiusAlertCreateSheet extends ConsumerStatefulWidget {
       isScrollControlled: true,
       useSafeArea: true,
       builder: (ctx) => Padding(
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(ctx).viewInsets.bottom,
-        ),
+        padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
         child: RadiusAlertCreateSheet(
           idGenerator: idGenerator,
           mapPickerOpener: mapPickerOpener,
@@ -111,8 +108,7 @@ class _RadiusAlertCreateSheetState
     if (pos == null) {
       SnackBarHelper.showError(
         context,
-        AppLocalizations.of(context)?.errorTitleLocation ??
-            'Location unavailable',
+        AppLocalizations.of(context).errorTitleLocation,
       );
       return;
     }
@@ -124,30 +120,31 @@ class _RadiusAlertCreateSheetState
   }
 
   Future<void> _pickOnMap() async {
-    final opener = widget.mapPickerOpener ??
+    final opener =
+        widget.mapPickerOpener ??
         (ctx) => RadiusAlertMapPicker.push(
-              ctx,
-              initialCenter: _centerLat != null && _centerLng != null
-                  ? LatLng(_centerLat!, _centerLng!)
-                  : null,
-            );
+          ctx,
+          initialCenter: _centerLat != null && _centerLng != null
+              ? LatLng(_centerLat!, _centerLng!)
+              : null,
+        );
     final picked = await opener(context);
     if (!mounted || picked == null) return;
     final l10n = AppLocalizations.of(context);
     setState(() {
       _centerLat = picked.latitude;
       _centerLng = picked.longitude;
-      _centerSource = l10n?.radiusAlertCenterFromMap ?? 'Map location';
+      _centerSource = l10n.radiusAlertCenterFromMap;
     });
   }
 
   bool get _canSave => RadiusAlertValidators.canSave(
-        label: _labelController.text,
-        thresholdRaw: _thresholdController.text,
-        centerLat: _centerLat,
-        centerLng: _centerLng,
-        postalCode: _postalCodeController.text,
-      );
+    label: _labelController.text,
+    thresholdRaw: _thresholdController.text,
+    centerLat: _centerLat,
+    centerLng: _centerLng,
+    postalCode: _postalCodeController.text,
+  );
 
   /// The country the alert's centre falls in (#2865) — resolved from the
   /// picked coordinates via the registry's bounding boxes, exactly like
@@ -175,8 +172,9 @@ class _RadiusAlertCreateSheetState
   List<FuelType> get _evaluableFuels => alertEvaluableFuelsFor(_centerCountry);
 
   Future<void> _save() async {
-    final threshold =
-        RadiusAlertValidators.parseThreshold(_thresholdController.text);
+    final threshold = RadiusAlertValidators.parseThreshold(
+      _thresholdController.text,
+    );
     if (threshold == null) return;
 
     // #2211 — a real center is required (canSave enforces it). Guard
@@ -220,10 +218,7 @@ class _RadiusAlertCreateSheetState
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
-            l10n?.alertsRadiusCreateTitle ?? 'Create radius alert',
-            style: theme.textTheme.titleLarge,
-          ),
+          Text(l10n.alertsRadiusCreateTitle, style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
           RadiusAlertLabelField(
             controller: _labelController,
@@ -258,10 +253,7 @@ class _RadiusAlertCreateSheetState
           ),
           if (_centerSource != null) ...[
             const SizedBox(height: 8),
-            Text(
-              _centerSource!,
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(_centerSource!, style: theme.textTheme.bodySmall),
           ],
           const SizedBox(height: 16),
           RadiusAlertPostalCodeField(

--- a/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
@@ -31,7 +31,7 @@ class RadiusAlertLabelField extends StatelessWidget {
     return TextField(
       controller: controller,
       decoration: InputDecoration(
-        hintText: l10n?.alertsRadiusLabelHint ?? 'Label',
+        hintText: l10n.alertsRadiusLabelHint,
         border: const OutlineInputBorder(),
       ),
       onChanged: (_) => onChanged(),
@@ -77,14 +77,11 @@ class RadiusAlertFuelTypeField extends StatelessWidget {
     return DropdownButtonFormField<FuelType>(
       initialValue: value,
       decoration: InputDecoration(
-        labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
+        labelText: l10n.alertsRadiusFuelType,
         border: const OutlineInputBorder(),
       ),
       items: fuels
-          .map((t) => DropdownMenuItem(
-                value: t,
-                child: Text(t.displayName),
-              ))
+          .map((t) => DropdownMenuItem(value: t, child: Text(t.displayName)))
           .toList(),
       onChanged: (v) {
         if (v != null) onChanged(v);
@@ -121,8 +118,7 @@ class RadiusAlertThresholdField extends StatelessWidget {
       controller: controller,
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
       decoration: InputDecoration(
-        labelText: l10n?.alertThresholdWithCurrency(currencySymbol) ??
-            'Threshold ($currencySymbol/L)',
+        labelText: l10n.alertThresholdWithCurrency(currencySymbol),
         border: const OutlineInputBorder(),
       ),
       onChanged: (_) => onChanged(),
@@ -151,10 +147,7 @@ class RadiusAlertRadiusSlider extends StatelessWidget {
       children: [
         Row(
           children: [
-            Text(
-              l10n?.alertsRadiusKm ?? 'Radius (km)',
-              style: theme.textTheme.titleSmall,
-            ),
+            Text(l10n.alertsRadiusKm, style: theme.textTheme.titleSmall),
             const Spacer(),
             Text('${value.round()} km', style: theme.textTheme.titleSmall),
           ],
@@ -192,28 +185,25 @@ class RadiusAlertFrequencyField extends StatelessWidget {
     return DropdownButtonFormField<int>(
       initialValue: value,
       decoration: InputDecoration(
-        labelText: l10n?.alertsRadiusFrequencyLabel ?? 'Check frequency',
+        labelText: l10n.alertsRadiusFrequencyLabel,
         border: const OutlineInputBorder(),
       ),
       items: <DropdownMenuItem<int>>[
         DropdownMenuItem(
           value: 1,
-          child: Text(l10n?.alertsRadiusFrequencyDaily ?? 'Once a day'),
+          child: Text(l10n.alertsRadiusFrequencyDaily),
         ),
         DropdownMenuItem(
           value: 2,
-          child:
-              Text(l10n?.alertsRadiusFrequencyTwiceDaily ?? 'Twice a day'),
+          child: Text(l10n.alertsRadiusFrequencyTwiceDaily),
         ),
         DropdownMenuItem(
           value: 3,
-          child: Text(l10n?.alertsRadiusFrequencyThriceDaily ??
-              'Three times a day'),
+          child: Text(l10n.alertsRadiusFrequencyThriceDaily),
         ),
         DropdownMenuItem(
           value: 4,
-          child: Text(l10n?.alertsRadiusFrequencyFourTimesDaily ??
-              'Four times a day'),
+          child: Text(l10n.alertsRadiusFrequencyFourTimesDaily),
         ),
       ],
       onChanged: (v) {
@@ -243,7 +233,7 @@ class RadiusAlertCenterButtons extends StatelessWidget {
           child: OutlinedButton.icon(
             icon: const Icon(Icons.my_location),
             onPressed: onUseMyLocation,
-            label: Text(l10n?.alertsRadiusCenterGps ?? 'Use my location'),
+            label: Text(l10n.alertsRadiusCenterGps),
           ),
         ),
         const SizedBox(width: 12),
@@ -251,7 +241,7 @@ class RadiusAlertCenterButtons extends StatelessWidget {
           child: OutlinedButton.icon(
             icon: const Icon(Icons.map_outlined),
             onPressed: onPickOnMap,
-            label: Text(l10n?.radiusAlertPickOnMap ?? 'Pick on map'),
+            label: Text(l10n.radiusAlertPickOnMap),
           ),
         ),
       ],
@@ -277,7 +267,7 @@ class RadiusAlertPostalCodeField extends StatelessWidget {
     return TextField(
       controller: controller,
       decoration: InputDecoration(
-        labelText: l10n?.alertsRadiusCenterPostalCode ?? 'Postal code',
+        labelText: l10n.alertsRadiusCenterPostalCode,
         border: const OutlineInputBorder(),
       ),
       onChanged: (_) => onChanged(),
@@ -304,14 +294,14 @@ class RadiusAlertActionButtons extends StatelessWidget {
         Expanded(
           child: OutlinedButton(
             onPressed: onCancel,
-            child: Text(l10n?.alertsRadiusCancel ?? 'Cancel'),
+            child: Text(l10n.alertsRadiusCancel),
           ),
         ),
         const SizedBox(width: 12),
         Expanded(
           child: FilledButton(
             onPressed: onSave,
-            child: Text(l10n?.alertsRadiusSave ?? 'Save'),
+            child: Text(l10n.alertsRadiusSave),
           ),
         ),
       ],

--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -43,10 +43,7 @@ class RadiusAlertMapPicker extends ConsumerStatefulWidget {
 
   /// Convenience opener used by the create-sheet button. Returns the
   /// picked [LatLng], or `null` when the user cancels.
-  static Future<LatLng?> push(
-    BuildContext context, {
-    LatLng? initialCenter,
-  }) {
+  static Future<LatLng?> push(BuildContext context, {LatLng? initialCenter}) {
     return Navigator.of(context).push<LatLng>(
       MaterialPageRoute(
         fullscreenDialog: true,
@@ -151,18 +148,18 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
     final theme = Theme.of(context);
 
     return PageScaffold(
-      title: l10n?.radiusAlertMapPickerTitle ?? 'Pick alert center',
+      title: l10n.radiusAlertMapPickerTitle,
       bodyPadding: EdgeInsets.zero,
       leading: IconButton(
         icon: const Icon(Icons.close),
-        tooltip: l10n?.radiusAlertMapPickerCancel ?? 'Cancel',
+        tooltip: l10n.radiusAlertMapPickerCancel,
         onPressed: _cancel,
       ),
       actions: [
         TextButton(
           onPressed: _confirm,
           child: Text(
-            l10n?.radiusAlertMapPickerConfirm ?? 'Confirm',
+            l10n.radiusAlertMapPickerConfirm,
             style: TextStyle(color: theme.colorScheme.onPrimary),
           ),
         ),
@@ -197,9 +194,7 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
               Icons.add_location_alt,
               size: 48,
               color: theme.colorScheme.primary,
-              shadows: const [
-                Shadow(blurRadius: 4, color: Colors.black54),
-              ],
+              shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
             ),
           ),
           Positioned(
@@ -209,13 +204,13 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
             child: Card(
               // #2117 — hint card should lift subtly off the map backdrop;
               // surfaceContainerLow is the M3 tier for cards on `surface`.
-              color: theme.colorScheme.surfaceContainerLow
-                  .withValues(alpha: 0.9),
+              color: theme.colorScheme.surfaceContainerLow.withValues(
+                alpha: 0.9,
+              ),
               child: Padding(
                 padding: const EdgeInsets.all(12),
                 child: Text(
-                  l10n?.radiusAlertMapPickerHint ??
-                      'Drag the map to position the alert center',
+                  l10n.radiusAlertMapPickerHint,
                   textAlign: TextAlign.center,
                   style: theme.textTheme.bodyMedium,
                 ),

--- a/lib/features/approach/presentation/widgets/approach_test_panel.dart
+++ b/lib/features/approach/presentation/widgets/approach_test_panel.dart
@@ -59,25 +59,24 @@ class ApproachTestPanel extends ConsumerWidget {
               children: [
                 Expanded(
                   child: Text(
-                    l?.approachOverlaySection ?? 'Approach-station overlay',
+                    l.approachOverlaySection,
                     style: Theme.of(context).textTheme.titleSmall,
                   ),
                 ),
                 if (isSimulating)
                   TextButton.icon(
                     icon: const Icon(Icons.stop_circle_outlined),
-                    label: Text(l?.approachTestStopButton ?? 'Stop test'),
+                    label: Text(l.approachTestStopButton),
                     onPressed: () =>
                         ref.read(approachSimulatorProvider.notifier).clear(),
                   )
                 else
                   FilledButton.tonalIcon(
                     icon: const Icon(Icons.local_gas_station_outlined),
-                    label: Text(
-                      l?.approachTestSimulateButton ?? 'Test approach overlay',
-                    ),
-                    onPressed:
-                        target == null ? null : () => _simulate(ref, target!),
+                    label: Text(l.approachTestSimulateButton),
+                    onPressed: target == null
+                        ? null
+                        : () => _simulate(ref, target!),
                   ),
               ],
             ),
@@ -104,23 +103,18 @@ class _Caption extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final style = Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
-        );
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
     if (isSimulating && target != null) {
       return Text(
-        l?.approachTestActiveCaption(
-              target!.name.isNotEmpty ? target!.name : target!.street,
-            ) ??
-            'Test active — overlay shows the price for ${target!.name}',
+        l.approachTestActiveCaption(
+          target!.name.isNotEmpty ? target!.name : target!.street,
+        ),
         style: style,
       );
     }
     if (target == null) {
-      return Text(
-        l?.approachTestUnavailable ??
-            'Add a favorite station to test the approach overlay',
-        style: style,
-      );
+      return Text(l.approachTestUnavailable, style: style);
     }
     return Text(
       target!.name.isNotEmpty ? target!.name : target!.street,

--- a/lib/features/calculator/presentation/screens/calculator_screen.dart
+++ b/lib/features/calculator/presentation/screens/calculator_screen.dart
@@ -63,9 +63,11 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
 
     if (hasRoutePrice) {
       _priceApplied = true;
-      unawaited(Future.microtask(() {
-        ref.read(calculatorProvider.notifier).setPrice(routePrice);
-      }));
+      unawaited(
+        Future.microtask(() {
+          ref.read(calculatorProvider.notifier).setPrice(routePrice);
+        }),
+      );
     }
   }
 
@@ -85,10 +87,10 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
     final l10n = AppLocalizations.of(context);
 
     return PageScaffold(
-      title: l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator',
+      title: l10n.fuelCostCalculator,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
         onPressed: () => context.go(RoutePaths.search),
       ),
       bodyPadding: EdgeInsets.zero,
@@ -111,12 +113,14 @@ class _CalculatorScreenState extends ConsumerState<CalculatorScreen> {
             alignment: Alignment.centerRight,
             child: TextButton.icon(
               icon: const Icon(Icons.refresh),
-              label: Text(l10n?.calculatorReset ?? 'Reset'),
+              label: Text(l10n.calculatorReset),
               onPressed: () {
                 notifier.reset();
                 _distanceController.clear();
-                _consumptionController.text =
-                    ref.read(calculatorProvider).consumptionPer100Km.toString();
+                _consumptionController.text = ref
+                    .read(calculatorProvider)
+                    .consumptionPer100Km
+                    .toString();
                 _priceController.clear();
                 _tripsPerMonthController.clear();
                 setState(() => _priceApplied = false);

--- a/lib/features/calculator/presentation/widgets/calculator_inputs_card.dart
+++ b/lib/features/calculator/presentation/widgets/calculator_inputs_card.dart
@@ -53,25 +53,24 @@ class CalculatorInputsCard extends ConsumerWidget {
     final consumptionUnit = prefill.isEv ? 'kWh/100 km' : 'L/100 km';
 
     return SectionCard(
-      title: l10n?.tripDetails ?? 'Trip details',
+      title: l10n.tripDetails,
       leadingIcon: Icons.tune,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           CalculatorInputField(
             controller: distanceController,
-            labelText:
-                l10n?.calculatorDistanceLabel(distanceUnit) ??
-                    'Distance ($distanceUnit)',
-            hintText: l10n?.calculatorDistanceHint ?? 'e.g. 150',
+            labelText: l10n.calculatorDistanceLabel(distanceUnit),
+            hintText: l10n.calculatorDistanceHint,
             icon: Icons.straighten,
             onParsed: notifier.setDistance,
             action: prefill.distanceKm == null
                 ? null
                 : UseMineChip(
-                    prefix: l10n?.calculatorUseMine ?? 'Use',
-                    valueLabel:
-                        UnitFormatter.formatDistance(prefill.distanceKm),
+                    prefix: l10n.calculatorUseMine,
+                    valueLabel: UnitFormatter.formatDistance(
+                      prefill.distanceKm,
+                    ),
                     onApply: () => _apply(
                       notifier.setDistance,
                       distanceController,
@@ -83,19 +82,18 @@ class CalculatorInputsCard extends ConsumerWidget {
           const SizedBox(height: Spacing.xl),
           CalculatorInputField(
             controller: consumptionController,
-            labelText:
-                l10n?.calculatorConsumptionLabel(consumptionUnit) ??
-                    'Consumption ($consumptionUnit)',
-            hintText: l10n?.calculatorConsumptionHint ?? 'e.g. 7.0',
+            labelText: l10n.calculatorConsumptionLabel(consumptionUnit),
+            hintText: l10n.calculatorConsumptionHint,
             icon: Icons.local_gas_station,
             onParsed: notifier.setConsumption,
             action: prefill.consumptionPer100Km == null
                 ? null
                 : UseMineChip(
-                    prefix: l10n?.calculatorUseMine ?? 'Use',
+                    prefix: l10n.calculatorUseMine,
                     valueLabel: UnitFormatter.formatConsumption(
-                        prefill.consumptionPer100Km!,
-                        isEv: prefill.isEv),
+                      prefill.consumptionPer100Km!,
+                      isEv: prefill.isEv,
+                    ),
                     onApply: () => _apply(
                       notifier.setConsumption,
                       consumptionController,
@@ -107,10 +105,8 @@ class CalculatorInputsCard extends ConsumerWidget {
           const SizedBox(height: Spacing.xl),
           CalculatorInputField(
             controller: priceController,
-            labelText:
-                l10n?.calculatorPriceLabel(priceSuffix) ??
-                    'Fuel price ($priceSuffix)',
-            hintText: l10n?.calculatorPriceHint ?? 'e.g. 1.899',
+            labelText: l10n.calculatorPriceLabel(priceSuffix),
+            hintText: l10n.calculatorPriceHint,
             icon: Icons.local_offer,
             onParsed: notifier.setPrice,
             action: prefill.pricePerLiter == null && !priceApplied
@@ -118,8 +114,8 @@ class CalculatorInputsCard extends ConsumerWidget {
                 : UseMineChip(
                     applied: priceApplied,
                     prefix: priceApplied
-                        ? (l10n?.calculatorApplied ?? 'Applied')
-                        : (l10n?.calculatorUseMine ?? 'Use'),
+                        ? (l10n.calculatorApplied)
+                        : (l10n.calculatorUseMine),
                     valueLabel: PriceFormatter.formatPrice(
                       priceApplied
                           ? state.pricePerLiter
@@ -136,7 +132,7 @@ class CalculatorInputsCard extends ConsumerWidget {
           const SizedBox(height: Spacing.sm),
           SwitchListTile(
             contentPadding: EdgeInsets.zero,
-            title: Text(l10n?.calculatorRoundTrip ?? 'Round trip'),
+            title: Text(l10n.calculatorRoundTrip),
             value: state.roundTrip,
             onChanged: notifier.setRoundTrip,
           ),
@@ -178,13 +174,13 @@ class _MonthlyEstimate extends StatelessWidget {
     return ExpansionTile(
       tilePadding: EdgeInsets.zero,
       childrenPadding: const EdgeInsets.only(bottom: Spacing.md),
-      title: Text(l10n?.calculatorEstimateMonthly ?? 'Estimate monthly cost'),
+      title: Text(l10n.calculatorEstimateMonthly),
       children: [
         TextField(
           controller: controller,
           decoration: InputDecoration(
-            labelText: l10n?.calculatorTripsPerMonth ?? 'Trips per month',
-            hintText: l10n?.calculatorTripsPerMonthHint ?? 'e.g. 20',
+            labelText: l10n.calculatorTripsPerMonth,
+            hintText: l10n.calculatorTripsPerMonthHint,
             prefixIcon: const Icon(Icons.event_repeat),
             border: const OutlineInputBorder(),
           ),

--- a/lib/features/calculator/presentation/widgets/calculator_result_card.dart
+++ b/lib/features/calculator/presentation/widgets/calculator_result_card.dart
@@ -37,14 +37,15 @@ class CalculatorResultCard extends StatelessWidget {
 
     final tiles = <Widget>[
       _BreakdownTile(
-        label: l10n?.fuelNeeded ?? 'Fuel needed',
+        label: l10n.fuelNeeded,
         value: filled
             ? UnitFormatter.formatVolume(
-                calc.effectiveLiters(roundTrip: roundTrip))
+                calc.effectiveLiters(roundTrip: roundTrip),
+              )
             : _placeholder,
       ),
       _BreakdownTile(
-        label: l10n?.costPerDistance ?? 'Cost per km',
+        label: l10n.costPerDistance,
         value: filled
             ? '${PriceFormatter.formatPerKm(calc.costPerKm)} $_perKmSuffix'
             : _placeholder,
@@ -52,12 +53,14 @@ class CalculatorResultCard extends StatelessWidget {
     ];
 
     if (roundTrip) {
-      tiles.add(_BreakdownTile(
-        label: l10n?.roundTripTotal ?? 'Round trip',
-        value: filled
-            ? PriceFormatter.formatTotal(calc.roundTripCost)
-            : _placeholder,
-      ));
+      tiles.add(
+        _BreakdownTile(
+          label: l10n.roundTripTotal,
+          value: filled
+              ? PriceFormatter.formatTotal(calc.roundTripCost)
+              : _placeholder,
+        ),
+      );
     }
 
     final monthly = calc.monthlyCost(
@@ -65,14 +68,16 @@ class CalculatorResultCard extends StatelessWidget {
       tripsPerMonth: state.tripsPerMonth,
     );
     if (state.tripsPerMonth != null && state.tripsPerMonth! > 0) {
-      tiles.add(_BreakdownTile(
-        label: l10n?.costPerMonth ?? 'Cost per month',
-        value: filled ? PriceFormatter.formatTotal(monthly) : _placeholder,
-      ));
+      tiles.add(
+        _BreakdownTile(
+          label: l10n.costPerMonth,
+          value: filled ? PriceFormatter.formatTotal(monthly) : _placeholder,
+        ),
+      );
     }
 
     return SectionCard(
-      title: l10n?.tripCost ?? 'Trip Cost',
+      title: l10n.tripCost,
       leadingIcon: Icons.calculate_outlined,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -87,9 +92,7 @@ class CalculatorResultCard extends StatelessWidget {
           if (!filled) ...[
             const SizedBox(height: Spacing.sm),
             Text(
-              l10n?.calculatorResultPlaceholder ??
-                  'Fill in distance, consumption and price to see your '
-                      'trip cost',
+              l10n.calculatorResultPlaceholder,
               textAlign: TextAlign.center,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,

--- a/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
+++ b/lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart
@@ -49,24 +49,19 @@ class CarbonDashboardScreen extends ConsumerWidget {
     final hasData = fillUps.isNotEmpty;
 
     final Widget body = hasData
-        ? ChartsTab(
-            summaries: last12,
-            totalCost: totalCost,
-            totalCo2: totalCo2,
-          )
+        ? ChartsTab(summaries: last12, totalCost: totalCost, totalCo2: totalCo2)
         : EmptyState(
             icon: Icons.eco_outlined,
-            title: l?.carbonEmptyTitle ?? 'No data yet',
-            subtitle: l?.carbonEmptySubtitle ??
-                'Log fill-ups to see your carbon dashboard.',
+            title: l.carbonEmptyTitle,
+            subtitle: l.carbonEmptySubtitle,
           );
 
     return PageScaffold(
-      title: l?.carbonDashboardTitle ?? 'Carbon dashboard',
+      title: l.carbonDashboardTitle,
       bannerIcon: Icons.eco_outlined,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => context.pop(),
       ),
       // #2005 — share-summary button. Hidden when the user has no
@@ -80,7 +75,7 @@ class CarbonDashboardScreen extends ConsumerWidget {
               IconButton(
                 key: const Key('carbon-dashboard-share'),
                 icon: const Icon(Icons.share_outlined),
-                tooltip: l?.tooltipShare ?? 'Share',
+                tooltip: l.tooltipShare,
                 onPressed: () => _shareSummary(
                   l: l,
                   totalCost: totalCost,
@@ -100,17 +95,18 @@ class CarbonDashboardScreen extends ConsumerWidget {
   /// `carbonSummaryTotalCost`, `carbonSummaryTotalCo2`) — no new
   /// 24-locale fill is needed.
   Future<void> _shareSummary({
-    required AppLocalizations? l,
+    required AppLocalizations l,
     required double totalCost,
     required double totalCo2,
   }) async {
-    final title = l?.carbonDashboardTitle ?? 'Carbon dashboard';
-    final costLabel = l?.carbonSummaryTotalCost ?? 'Total cost';
-    final co2Label = l?.carbonSummaryTotalCo2 ?? 'Total CO2';
+    final title = l.carbonDashboardTitle;
+    final costLabel = l.carbonSummaryTotalCost;
+    final co2Label = l.carbonSummaryTotalCo2;
     // Same formatting as the on-screen `_SummaryRow` (charts_tab.dart):
     // integer cost with the currency suffix, integer kg for CO2.
     // i18n-ignore: language-neutral number/unit format mask.
-    final body = '$title\n\n'
+    final body =
+        '$title\n\n'
         '$costLabel: ${totalCost.toStringAsFixed(0)} ${PriceFormatter.currency}\n'
         '$co2Label: ${totalCo2.toStringAsFixed(0)} kg';
     final sink = debugCarbonShareSinkOverride ?? _defaultCarbonShareSink;
@@ -119,7 +115,14 @@ class CarbonDashboardScreen extends ConsumerWidget {
     } on Object catch (e, st) {
       // Share-sheet wiring failures should never crash the screen.
       // The user can re-tap; the failure ends in the debug console.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'CarbonDashboardScreen: share failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'CarbonDashboardScreen: share failed'},
+        ),
+      );
     }
   }
 }

--- a/lib/features/carbon/presentation/widgets/charts_tab.dart
+++ b/lib/features/carbon/presentation/widgets/charts_tab.dart
@@ -71,24 +71,23 @@ class ChartsTab extends ConsumerWidget {
       children: [
         _SummaryRow(totalCost: totalCost, totalCo2: totalCo2),
         const SizedBox(height: 8),
-        if (l != null && !breakdown.isEmpty)
+        if (!breakdown.isEmpty)
           TripLengthBreakdownCard(
             breakdown: breakdown,
             overallAvgLPer100Km: overallAvg,
             l: l,
             theme: theme,
           ),
-        if (l != null)
-          SpeedConsumptionCard(
-            bins: speedBins,
-            overallAvgLPer100Km: overallAvg,
-            l: l,
-            theme: theme,
-          ),
+        SpeedConsumptionCard(
+          bins: speedBins,
+          overallAvgLPer100Km: overallAvg,
+          l: l,
+          theme: theme,
+        ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: SectionCard(
-            title: l?.monthlyCostsTitle ?? 'Monthly costs',
+            title: l.monthlyCostsTitle,
             child: MonthlyBarChart(
               key: const Key('monthly_cost_chart'),
               summaries: summaries,
@@ -101,7 +100,7 @@ class ChartsTab extends ConsumerWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: SectionCard(
-            title: l?.monthlyEmissionsTitle ?? 'Monthly CO2 emissions',
+            title: l.monthlyEmissionsTitle,
             child: MonthlyBarChart(
               key: const Key('monthly_emissions_chart'),
               summaries: summaries,
@@ -156,8 +155,7 @@ List<TripHistoryEntry> _filterTrips(
 ) {
   if (vehicleId == null) return trips.toList(growable: false);
   return trips
-      .where((entry) =>
-          entry.vehicleId == null || entry.vehicleId == vehicleId)
+      .where((entry) => entry.vehicleId == null || entry.vehicleId == vehicleId)
       .toList(growable: false);
 }
 
@@ -181,7 +179,7 @@ class _SummaryRow extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    l?.carbonSummaryTotalCost ?? 'Total cost',
+                    l.carbonSummaryTotalCost,
                     style: theme.textTheme.bodySmall,
                   ),
                   const SizedBox(height: 4),
@@ -202,7 +200,7 @@ class _SummaryRow extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    l?.carbonSummaryTotalCo2 ?? 'Total CO2',
+                    l.carbonSummaryTotalCo2,
                     style: theme.textTheme.bodySmall,
                   ),
                   const SizedBox(height: 4),

--- a/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
+++ b/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
@@ -44,7 +44,7 @@ class MonthlyBarChart extends StatelessWidget {
       final l = AppLocalizations.of(context);
       return SizedBox(
         height: 180,
-        child: Center(child: Text(l?.noDataAvailable ?? 'No data')),
+        child: Center(child: Text(l.noDataAvailable)),
       );
     }
     // Month-axis labels are locale DATA, not a translatable string: resolve

--- a/lib/features/consent/presentation/screens/gdpr_consent_screen.dart
+++ b/lib/features/consent/presentation/screens/gdpr_consent_screen.dart
@@ -26,7 +26,9 @@ class GdprConsentScreen extends ConsumerWidget {
 
   Future<void> _acceptSelected(BuildContext context, WidgetRef ref) async {
     final form = ref.read(gdprConsentFormControllerProvider);
-    await ref.read(gdprConsentProvider.notifier).save(
+    await ref
+        .read(gdprConsentProvider.notifier)
+        .save(
           location: form.locationConsent,
           errorReporting: form.errorReportingConsent,
           cloudSync: form.cloudSyncConsent,
@@ -36,7 +38,9 @@ class GdprConsentScreen extends ConsumerWidget {
   }
 
   Future<void> _acceptAll(BuildContext context, WidgetRef ref) async {
-    await ref.read(gdprConsentProvider.notifier).save(
+    await ref
+        .read(gdprConsentProvider.notifier)
+        .save(
           location: true,
           errorReporting: true,
           cloudSync: true,
@@ -71,15 +75,14 @@ class GdprConsentScreen extends ConsumerWidget {
                     ),
                     const SizedBox(height: 16),
                     Text(
-                      l10n?.gdprTitle ?? 'Your Privacy',
+                      l10n.gdprTitle,
                       style: theme.textTheme.headlineMedium?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      l10n?.gdprSubtitle ??
-                          'This app respects your privacy. Choose which data you want to share. You can change these settings anytime.',
+                      l10n.gdprSubtitle,
                       style: theme.textTheme.bodyLarge?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
@@ -89,9 +92,8 @@ class GdprConsentScreen extends ConsumerWidget {
                     // Location consent
                     _ConsentToggle(
                       icon: Icons.my_location,
-                      title: l10n?.gdprLocationTitle ?? 'Location Access',
-                      description: l10n?.gdprLocationDescription ??
-                          'Your coordinates are sent to the fuel price API to find nearby stations. Location data is never stored on a server and is not used for tracking.',
+                      title: l10n.gdprLocationTitle,
+                      description: l10n.gdprLocationDescription,
                       value: form.locationConsent,
                       onChanged: notifier.setLocation,
                     ),
@@ -100,10 +102,8 @@ class GdprConsentScreen extends ConsumerWidget {
                     // Error reporting consent
                     _ConsentToggle(
                       icon: Icons.bug_report_outlined,
-                      title: l10n?.gdprErrorReportingTitle ??
-                          'Error Reporting',
-                      description: l10n?.gdprErrorReportingDescription ??
-                          'Anonymous crash reports help improve the app. No personal data is included. Reports are sent via Sentry only when configured.',
+                      title: l10n.gdprErrorReportingTitle,
+                      description: l10n.gdprErrorReportingDescription,
                       value: form.errorReportingConsent,
                       onChanged: notifier.setErrorReporting,
                     ),
@@ -112,9 +112,8 @@ class GdprConsentScreen extends ConsumerWidget {
                     // Cloud sync consent
                     _ConsentToggle(
                       icon: Icons.cloud_outlined,
-                      title: l10n?.gdprCloudSyncTitle ?? 'Cloud Sync',
-                      description: l10n?.gdprCloudSyncDescription ??
-                          'Sync favorites and alerts across devices via TankSync. Uses anonymous authentication. Your data is encrypted in transit.',
+                      title: l10n.gdprCloudSyncTitle,
+                      description: l10n.gdprCloudSyncDescription,
                       value: form.cloudSyncConsent,
                       onChanged: notifier.setCloudSync,
                     ),
@@ -123,10 +122,8 @@ class GdprConsentScreen extends ConsumerWidget {
                     // VIN online decode consent (#1399)
                     _ConsentToggle(
                       icon: Icons.directions_car_outlined,
-                      title: l10n?.gdprVinOnlineDecodeTitle ??
-                          'VIN online decode',
-                      description: l10n?.gdprVinOnlineDecodeDescription ??
-                          "When you pair an adapter, your vehicle's VIN is read locally to identify the car. Enabling this sends the 17-char VIN to NHTSA's free vPIC service to look up additional details (model, engine displacement, fuel type). The VIN is the only data sent — no other information leaves your device.",
+                      title: l10n.gdprVinOnlineDecodeTitle,
+                      description: l10n.gdprVinOnlineDecodeDescription,
                       value: form.vinOnlineDecodeConsent,
                       onChanged: notifier.setVinOnlineDecode,
                     ),
@@ -134,8 +131,7 @@ class GdprConsentScreen extends ConsumerWidget {
 
                     // Legal basis
                     Text(
-                      l10n?.gdprLegalBasis ??
-                          'Legal basis: Art. 6(1)(a) GDPR (Consent). You can withdraw consent anytime in Settings.',
+                      l10n.gdprLegalBasis,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
@@ -161,13 +157,12 @@ class GdprConsentScreen extends ConsumerWidget {
                   // does not nudge toward blanket consent.
                   FilledButton(
                     onPressed: () => _acceptSelected(context, ref),
-                    child: Text(
-                        l10n?.gdprAcceptSelected ?? 'Accept Selected'),
+                    child: Text(l10n.gdprAcceptSelected),
                   ),
                   const SizedBox(height: 8),
                   OutlinedButton(
                     onPressed: () => _acceptAll(context, ref),
-                    child: Text(l10n?.gdprAcceptAll ?? 'Accept All'),
+                    child: Text(l10n.gdprAcceptAll),
                   ),
                 ],
               ),
@@ -214,8 +209,9 @@ class _ConsentToggle extends StatelessWidget {
                 children: [
                   Text(
                     title,
-                    style: theme.textTheme.titleSmall
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 4),
                   Text(
@@ -228,10 +224,7 @@ class _ConsentToggle extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
-            Switch(
-              value: value,
-              onChanged: onChanged,
-            ),
+            Switch(value: value, onChanged: onChanged),
           ],
         ),
       ),

--- a/lib/features/consent/presentation/widgets/consent_settings_section.dart
+++ b/lib/features/consent/presentation/widgets/consent_settings_section.dart
@@ -54,8 +54,7 @@ class _ConsentSettingsSectionState
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Text(
-            l10n?.gdprSettingsHint ??
-                'You can change your privacy choices at any time.',
+            l10n.gdprSettingsHint,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -64,14 +63,15 @@ class _ConsentSettingsSectionState
         const SizedBox(height: 8),
         SwitchListTile(
           secondary: const Icon(Icons.my_location, size: 20),
-          title: Text(l10n?.gdprLocationTitle ?? 'Location Access'),
+          title: Text(l10n.gdprLocationTitle),
           subtitle: Text(
-            l10n?.gdprLocationShort ??
-                'Find nearby fuel stations using your location',
+            l10n.gdprLocationShort,
             style: theme.textTheme.bodySmall,
           ),
           value: consent.location,
-          onChanged: (v) => ref.read(gdprConsentProvider.notifier).save(
+          onChanged: (v) => ref
+              .read(gdprConsentProvider.notifier)
+              .save(
                 location: v,
                 errorReporting: consent.errorReporting,
                 cloudSync: consent.cloudSync,
@@ -81,14 +81,15 @@ class _ConsentSettingsSectionState
         ),
         SwitchListTile(
           secondary: const Icon(Icons.bug_report_outlined, size: 20),
-          title: Text(l10n?.gdprErrorReportingTitle ?? 'Error Reporting'),
+          title: Text(l10n.gdprErrorReportingTitle),
           subtitle: Text(
-            l10n?.gdprErrorReportingShort ??
-                'Send anonymous crash reports to improve the app',
+            l10n.gdprErrorReportingShort,
             style: theme.textTheme.bodySmall,
           ),
           value: consent.errorReporting,
-          onChanged: (v) => ref.read(gdprConsentProvider.notifier).save(
+          onChanged: (v) => ref
+              .read(gdprConsentProvider.notifier)
+              .save(
                 location: consent.location,
                 errorReporting: v,
                 cloudSync: consent.cloudSync,
@@ -98,16 +99,17 @@ class _ConsentSettingsSectionState
         ),
         SwitchListTile(
           secondary: const Icon(Icons.cloud_outlined, size: 20),
-          title: Text(l10n?.gdprCloudSyncTitle ?? 'Cloud Sync'),
+          title: Text(l10n.gdprCloudSyncTitle),
           subtitle: Text(
-            l10n?.gdprCloudSyncShort ??
-                'Sync favorites and alerts across devices',
+            l10n.gdprCloudSyncShort,
             style: theme.textTheme.bodySmall,
             maxLines: collapsedMaxLines(),
             overflow: collapsedOverflow(),
           ),
           value: consent.cloudSync,
-          onChanged: (v) => ref.read(gdprConsentProvider.notifier).save(
+          onChanged: (v) => ref
+              .read(gdprConsentProvider.notifier)
+              .save(
                 location: consent.location,
                 errorReporting: consent.errorReporting,
                 cloudSync: v,
@@ -117,16 +119,17 @@ class _ConsentSettingsSectionState
         ),
         SwitchListTile(
           secondary: const Icon(Icons.directions_car_outlined, size: 20),
-          title: Text(l10n?.gdprVinOnlineDecodeTitle ?? 'VIN online decode'),
+          title: Text(l10n.gdprVinOnlineDecodeTitle),
           subtitle: Text(
-            l10n?.gdprVinOnlineDecodeShort ??
-                "Decode the VIN via NHTSA's free public service",
+            l10n.gdprVinOnlineDecodeShort,
             style: theme.textTheme.bodySmall,
             maxLines: collapsedMaxLines(),
             overflow: collapsedOverflow(),
           ),
           value: consent.vinOnlineDecode,
-          onChanged: (v) => ref.read(gdprConsentProvider.notifier).save(
+          onChanged: (v) => ref
+              .read(gdprConsentProvider.notifier)
+              .save(
                 location: consent.location,
                 errorReporting: consent.errorReporting,
                 cloudSync: consent.cloudSync,
@@ -154,9 +157,7 @@ class _ConsentSettingsSectionState
               size: 18,
             ),
             label: Text(
-              _expanded
-                  ? (l10n?.consentHideDetails ?? 'Hide details')
-                  : (l10n?.consentShowDetails ?? 'Show details'),
+              _expanded ? (l10n.consentHideDetails) : (l10n.consentShowDetails),
             ),
             style: TextButton.styleFrom(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),

--- a/lib/features/consumption/domain/add_fill_up_validators.dart
+++ b/lib/features/consumption/domain/add_fill_up_validators.dart
@@ -9,10 +9,8 @@ import '../../../l10n/app_localizations.dart';
 /// the `charging_log_validators.dart` split landed for the Add-Charging
 /// form in PR #1156.
 ///
-/// All validators accept `null` localizations for tests / golden
-/// fallbacks and degrade to English defaults — the same pattern used
-/// elsewhere in the codebase (see `AppLocalizations.of(context)?.x ??
-/// 'Fallback'`).
+/// Validators take a non-nullable [AppLocalizations] (#3162) — unit
+/// tests drive them with the pure `lookupAppLocalizations` constructor.
 class AddFillUpValidators {
   AddFillUpValidators._();
 
@@ -20,13 +18,13 @@ class AddFillUpValidators {
   /// for liters, total cost, and odometer fields — all three must be
   /// > 0 for a fill-up to make sense (you can't fill nothing, pay
   /// nothing, or have a zero-km odometer reading).
-  static String? positiveNumber(String? value, AppLocalizations? l) {
+  static String? positiveNumber(String? value, AppLocalizations l) {
     if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
+      return l.fieldRequired;
     }
     final parsed = double.tryParse(value.replaceAll(',', '.'));
     if (parsed == null || parsed <= 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
+      return l.fieldInvalidNumber;
     }
     return null;
   }

--- a/lib/features/consumption/domain/charging_log_validators.dart
+++ b/lib/features/consumption/domain/charging_log_validators.dart
@@ -7,10 +7,8 @@ import '../../../l10n/app_localizations.dart';
 /// (#582 phase 2). Pulled out of `add_charging_log_screen.dart` so the
 /// rules can be unit-tested without pumping a full widget tree.
 ///
-/// All validators accept `null` localizations for tests / golden
-/// fallbacks and degrade to English defaults — the same pattern used
-/// elsewhere in the codebase (see `AppLocalizations.of(context)?.x ??
-/// 'Fallback'`).
+/// Validators take a non-nullable [AppLocalizations] (#3162) — unit
+/// tests drive them with the pure `lookupAppLocalizations` constructor.
 class ChargingLogValidators {
   ChargingLogValidators._();
 
@@ -18,13 +16,13 @@ class ChargingLogValidators {
   /// for kWh, cost, and odometer fields — all three must be > 0 for a
   /// charging log to make sense (you can't charge nothing, pay
   /// nothing, or have a zero-km odometer).
-  static String? positiveNumber(String? value, AppLocalizations? l) {
+  static String? positiveNumber(String? value, AppLocalizations l) {
     if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
+      return l.fieldRequired;
     }
     final parsed = double.tryParse(value.replaceAll(',', '.'));
     if (parsed == null || parsed <= 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
+      return l.fieldInvalidNumber;
     }
     return null;
   }
@@ -32,13 +30,13 @@ class ChargingLogValidators {
   /// Validates that [value] parses to a non-negative integer. Used for
   /// the charge-time-minutes field — 0 is allowed (slow chargers can
   /// log a zero-minute session if the user hasn't measured it).
-  static String? nonNegativeInt(String? value, AppLocalizations? l) {
+  static String? nonNegativeInt(String? value, AppLocalizations l) {
     if (value == null || value.trim().isEmpty) {
-      return l?.fieldRequired ?? 'Required';
+      return l.fieldRequired;
     }
     final parsed = int.tryParse(value.replaceAll(',', '.').split('.').first);
     if (parsed == null || parsed < 0) {
-      return l?.fieldInvalidNumber ?? 'Invalid number';
+      return l.fieldInvalidNumber;
     }
     return null;
   }

--- a/lib/features/consumption/domain/live_activity_content.dart
+++ b/lib/features/consumption/domain/live_activity_content.dart
@@ -84,20 +84,20 @@ class LiveActivityContent {
   /// `ios/TankstellenWidget/TripActivityAttributes.swift` — keep the two
   /// in lock-step.
   Map<String, Object?> toChannelMap() => <String, Object?>{
-        'mode': mode.name,
-        'paused': paused,
-        'startedAtEpochMs': startedAtEpochMs,
-        'bigFigure': bigFigure,
-        'bigCaption': bigCaption,
-        'isEstimate': isEstimate,
-        'distanceText': distanceText,
-        'pausedLabel': pausedLabel,
-        'stationName': stationName,
-        'priceText': priceText,
-        'fuelLabel': fuelLabel,
-        'stationDistanceText': stationDistanceText,
-        'progress': progress,
-      };
+    'mode': mode.name,
+    'paused': paused,
+    'startedAtEpochMs': startedAtEpochMs,
+    'bigFigure': bigFigure,
+    'bigCaption': bigCaption,
+    'isEstimate': isEstimate,
+    'distanceText': distanceText,
+    'pausedLabel': pausedLabel,
+    'stationName': stationName,
+    'priceText': priceText,
+    'fuelLabel': fuelLabel,
+    'stationDistanceText': stationDistanceText,
+    'progress': progress,
+  };
 
   @override
   bool operator ==(Object other) =>
@@ -118,20 +118,20 @@ class LiveActivityContent {
 
   @override
   int get hashCode => Object.hash(
-        mode,
-        paused,
-        startedAtEpochMs,
-        bigFigure,
-        bigCaption,
-        isEstimate,
-        distanceText,
-        pausedLabel,
-        stationName,
-        priceText,
-        fuelLabel,
-        stationDistanceText,
-        progress,
-      );
+    mode,
+    paused,
+    startedAtEpochMs,
+    bigFigure,
+    bigCaption,
+    isEstimate,
+    distanceText,
+    pausedLabel,
+    stationName,
+    priceText,
+    fuelLabel,
+    stationDistanceText,
+    progress,
+  );
 }
 
 /// Build the Live Activity content for one trip/approach snapshot, or
@@ -146,15 +146,15 @@ class LiveActivityContent {
 /// 3. **Otherwise** → the consumption hero (OBD2 L/100 km → GPS `~`
 ///    estimate → warm-up `~`), same branch order as the PiP (#2601).
 ///
-/// [l] is nullable with the project-wide `l?.key ?? 'English'` fallback
-/// convention so a harness without the l10n graph still renders.
+/// [l] is non-nullable (#3162) — context-free callers resolve it via
+/// `lookupAppLocalizations` (the #2766 pattern), never a literal fallback.
 LiveActivityContent? buildLiveActivityContent({
   required TripRecordingState state,
   required ApproachState? approach,
   required Station? radarStation,
   required FuelType fuel,
   required double? radiusMeters,
-  required AppLocalizations? l,
+  required AppLocalizations l,
   required DateTime now,
 }) {
   if (!state.isActive) return null;
@@ -164,9 +164,9 @@ LiveActivityContent? buildLiveActivityContent({
   // Round to the second so per-emit recomputation doesn't jitter equality.
   final startedAtEpochMs =
       ((now.millisecondsSinceEpoch - (live?.elapsed.inMilliseconds ?? 0)) ~/
-              1000) *
-          1000;
-  final pausedLabel = l?.tripBannerPaused ?? 'Paused';
+          1000) *
+      1000;
+  final pausedLabel = l.tripBannerPaused;
   final distance = live?.distanceKmSoFar;
   final distanceText = (distance != null && distance >= 0.1)
       ? '${distance.toStringAsFixed(1)} km'
@@ -175,8 +175,9 @@ LiveActivityContent? buildLiveActivityContent({
   // Resolve the consumption hero (shared by both modes — the approach
   // layouts keep it so the island's expanded view can show it secondary).
   final raw = (live != null && !paused) ? formatInstantConsumption(live) : null;
-  final gpsEstimate =
-      (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
+  final gpsEstimate = (live != null && !paused)
+      ? live.gpsEstimatedLPer100Km
+      : null;
   final String bigFigure;
   final String bigCaption;
   var isEstimate = false;
@@ -186,12 +187,12 @@ LiveActivityContent? buildLiveActivityContent({
     bigCaption = raw.contains('L/100') ? 'L/100 km' : 'L/h';
   } else if (gpsEstimate != null) {
     bigFigure = '~${gpsEstimate.toStringAsFixed(1)}';
-    bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+    bigCaption = l.tripRecordingPipEstConsumptionCaption;
     isEstimate = true;
   } else {
     // Warm-up / paused — keep the hero consumption-framed (#2601).
     bigFigure = '~';
-    bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+    bigCaption = l.tripRecordingPipEstConsumptionCaption;
     isEstimate = true;
   }
 
@@ -204,11 +205,10 @@ LiveActivityContent? buildLiveActivityContent({
     final String? stationDistanceText = distMeters == null
         ? null
         : kmCaption
-            ? (l?.fuelStationRadarDistanceKm(
-                    (distMeters / 1000.0).toStringAsFixed(1)) ??
-                '${(distMeters / 1000.0).toStringAsFixed(1)} km')
-            : (l?.approachStationDistance(distMeters.toStringAsFixed(0)) ??
-                '${distMeters.toStringAsFixed(0)} m');
+        ? (l.fuelStationRadarDistanceKm(
+            (distMeters / 1000.0).toStringAsFixed(1),
+          ))
+        : (l.approachStationDistance(distMeters.toStringAsFixed(0)));
     return LiveActivityContent(
       mode: LiveActivityMode.approach,
       paused: paused,

--- a/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
@@ -107,12 +107,19 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     try {
       activeId = ref.read(activeVehicleProfileProvider)?.id;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog: active vehicle unavailable'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'AddChargingLog: active vehicle unavailable',
+          },
+        ),
+      );
     }
-    final evVehicles =
-        vehicles.where((v) => v.isEv).toList(growable: false);
-    if (activeId != null &&
-        evVehicles.any((v) => v.id == activeId)) {
+    final evVehicles = vehicles.where((v) => v.isEv).toList(growable: false);
+    if (activeId != null && evVehicles.any((v) => v.id == activeId)) {
       _vehicleId = activeId;
     } else if (evVehicles.isNotEmpty) {
       _vehicleId = evVehicles.first.id;
@@ -157,15 +164,23 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
         costEur: ChargingLogValidators.parseDouble(_costCtrl.text),
         chargeTimeMin: ChargingLogValidators.parseInt(_timeMinCtrl.text),
         odometerKm: ChargingLogValidators.parseInt(_odoCtrl.text),
-        stationName:
-            _stationCtrl.text.trim().isEmpty ? null : _stationCtrl.text.trim(),
+        stationName: _stationCtrl.text.trim().isEmpty
+            ? null
+            : _stationCtrl.text.trim(),
         chargingStationId: widget.chargingStationId,
       );
       await ref.read(chargingLogsProvider.notifier).add(log);
       if (!mounted) return;
       Navigator.of(context).pop(true);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog._save'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'AddChargingLog._save'},
+        ),
+      );
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -178,14 +193,23 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     try {
       vehicles = ref.watch(vehicleProfileListProvider);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog build: vehicle list unavailable'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'AddChargingLog build: vehicle list unavailable',
+          },
+        ),
+      );
       vehicles = const [];
     }
     _initVehicleIfNeeded(vehicles);
 
     if (vehicles.isEmpty) {
       return PageScaffold(
-        title: l?.addChargingLogTitle ?? 'Log charging session',
+        title: l.addChargingLogTitle,
         bodyPadding: const EdgeInsets.all(32),
         body: Center(
           child: Column(
@@ -198,15 +222,13 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
               ),
               const SizedBox(height: 24),
               Text(
-                l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
+                l.consumptionNoVehicleTitle,
                 style: Theme.of(context).textTheme.headlineSmall,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 12),
               Text(
-                l?.consumptionNoVehicleBody ??
-                    'Charging sessions are attributed to a vehicle. '
-                        'Add your car to start logging.',
+                l.consumptionNoVehicleBody,
                 style: Theme.of(context).textTheme.bodyMedium,
                 textAlign: TextAlign.center,
               ),
@@ -216,8 +238,7 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
       );
     }
 
-    final dateStr =
-        '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
+    final dateStr = '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
     final derived = computeChargingLogReadout(
       vehicleId: _vehicleId,
       kWhText: _kwhCtrl.text,
@@ -228,7 +249,7 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     );
 
     return PageScaffold(
-      title: l?.addChargingLogTitle ?? 'Log charging session',
+      title: l.addChargingLogTitle,
       bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -441,8 +441,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     // success confirmation appears on the surface we return to (#1692).
     final messenger = ScaffoldMessenger.of(context);
     final scheme = Theme.of(context).colorScheme;
-    final savedMessage = AppLocalizations.of(context)?.fillUpSavedSnackbar ??
-        'Fill-up saved';
+    final savedMessage = AppLocalizations.of(context).fillUpSavedSnackbar;
 
     await ref.read(fillUpListProvider.notifier).add(fillUp);
     if (!mounted) return;
@@ -565,10 +564,10 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       canPop: !_isDirty,
       onPopInvokedWithResult: _onPopInvoked,
       child: PageScaffold(
-      title: l?.addFillUp ?? 'Add fill-up',
+      title: l.addFillUp,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => Navigator.maybePop(context),
       ),
       // #3073 — app-bar save stays above the iOS keyboard, which covers the
@@ -576,7 +575,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       actions: [
         IconButton(
           icon: const Icon(Icons.check),
-          tooltip: l?.save ?? 'Save',
+          tooltip: l.save,
           onPressed: _save,
         ),
       ],

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -47,10 +47,7 @@ class ConsumptionScreen extends ConsumerStatefulWidget {
   /// the bare `/consumption-tab` route keeps its historical behaviour.
   final ConsumptionSection section;
 
-  const ConsumptionScreen({
-    super.key,
-    this.section = ConsumptionSection.fuel,
-  });
+  const ConsumptionScreen({super.key, this.section = ConsumptionSection.fuel});
 
   /// Test-only override for the backup exporter wired into the AppBar
   /// download button (#1317). Lets widget tests assert the export
@@ -62,8 +59,7 @@ class ConsumptionScreen extends ConsumerStatefulWidget {
   static FullBackupExporter? debugExporterOverride;
 
   @override
-  ConsumerState<ConsumptionScreen> createState() =>
-      _ConsumptionScreenState();
+  ConsumerState<ConsumptionScreen> createState() => _ConsumptionScreenState();
 }
 
 class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
@@ -115,9 +111,9 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   /// of the title. Shared by every [ConsumptionSection] so the Trajets
   /// and Carburant tabs stay visually consistent. Keeps the original
   /// `open_vehicles` key, tooltip and `/vehicles` target (#1946).
-  Widget _vehiclesLeading(AppLocalizations? l) => IconButton(
+  Widget _vehiclesLeading(AppLocalizations l) => IconButton(
         key: const Key('open_vehicles'),
-        tooltip: l?.vehiclesMenuTitle ?? 'My vehicles',
+        tooltip: l.vehiclesMenuTitle,
         icon: const Icon(Icons.directions_car_outlined),
         onPressed: () => context.push(RoutePaths.vehicles),
       );
@@ -133,13 +129,10 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     ref.listen(lastVeLearnResultProvider, (previous, next) {
       if (next == null) return;
       final vehicles = ref.read(vehicleProfileListProvider);
-      final vehicle =
-          vehicles.where((v) => v.id == next.vehicleId).firstOrNull;
+      final vehicle = vehicles.where((v) => v.id == next.vehicleId).firstOrNull;
       final name = vehicle?.name ?? '';
       final percent = next.accuracyImprovementPct.round().toString();
-      final msg = l?.veCalibratedTitle(name, percent) ??
-          'Consumption calibration updated for $name — '
-              'accuracy improved by $percent%';
+      final msg = l.veCalibratedTitle(name, percent);
       SnackBarHelper.showSuccess(context, msg);
       // Clear so a rebuild doesn't re-fire the snackbar.
       ref.read(lastVeLearnResultProvider.notifier).set(null);
@@ -159,20 +152,22 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   /// #2374 — computes the same vehicle-filtered trip IDs that [TrajetsTab]
   /// renders, so the AppBar map action opens [TrajetsMapScreen] with exactly
   /// the visible set of trips.
-  Widget _buildTrajets(BuildContext context, AppLocalizations? l) {
+  Widget _buildTrajets(BuildContext context, AppLocalizations l) {
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final allTrips = ref.watch(tripHistoryListProvider);
     // Mirror TrajetsTab's filter: when a vehicle is active, show only that
     // vehicle's trips (plus untagged legacy trips); otherwise show all.
     final vehicleId = activeVehicle?.id;
-    final tripIds = (vehicleId == null
-            ? allTrips
-            : allTrips.where(
-                (t) => t.vehicleId == null || t.vehicleId == vehicleId))
-        .map((t) => t.id)
-        .toList(growable: false);
+    final tripIds =
+        (vehicleId == null
+                ? allTrips
+                : allTrips.where(
+                    (t) => t.vehicleId == null || t.vehicleId == vehicleId,
+                  ))
+            .map((t) => t.id)
+            .toList(growable: false);
     return PageScaffold(
-      title: l?.trajetsTabLabel ?? 'Trips',
+      title: l.trajetsTabLabel,
       leading: _vehiclesLeading(l),
       bodyPadding: EdgeInsets.zero,
       actions: [ConsumptionAppBarActions(tripIds: tripIds)],
@@ -183,7 +178,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
 
   /// #1901 — the Carburant destination: the fill-up list, plus a Fuel /
   /// Charging switcher for a vehicle that can charge.
-  Widget _buildFuel(BuildContext context, AppLocalizations? l) {
+  Widget _buildFuel(BuildContext context, AppLocalizations l) {
     final fillUps = ref.watch(fillUpListProvider);
     final chargingLogsAsync = ref.watch(chargingLogsProvider);
     final stats = ref.watch(consumptionStatsProvider);
@@ -197,7 +192,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     // no switcher, and the add-fill-up FAB.
     if (!showCharging) {
       return PageScaffold(
-        title: l?.consumptionTabFuel ?? 'Fuel',
+        title: l.consumptionTabFuel,
         leading: _vehiclesLeading(l),
         bodyPadding: EdgeInsets.zero,
         actions: const [ConsumptionAppBarActions()],
@@ -211,7 +206,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     final controller = _tabController!;
     final isCharging = controller.index == 1;
     return PageScaffold(
-      title: l?.consumptionTabFuel ?? 'Fuel',
+      title: l.consumptionTabFuel,
       leading: _vehiclesLeading(l),
       bodyPadding: EdgeInsets.zero,
       actions: const [ConsumptionAppBarActions()],
@@ -224,11 +219,11 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
             controller: controller,
             tabs: [
               TabSwitcherEntry(
-                label: l?.consumptionTabFuel ?? 'Fuel',
+                label: l.consumptionTabFuel,
                 icon: Icons.local_gas_station_outlined,
               ),
               TabSwitcherEntry(
-                label: l?.consumptionTabCharging ?? 'Charging',
+                label: l.consumptionTabCharging,
                 icon: Icons.ev_station_outlined,
               ),
             ],
@@ -247,25 +242,23 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     );
   }
 
-  Widget _addFillUpFab(BuildContext context, AppLocalizations? l) =>
+  Widget _addFillUpFab(BuildContext context, AppLocalizations l) =>
       FloatingActionButton.extended(
         key: const Key('fab_add_fillup'),
         onPressed: () => unawaited(context.push(RoutePaths.pickStationForFillUp)),
         icon: const Icon(Icons.add),
-        label: Text(l?.addFillUp ?? 'Add fill-up'),
+        label: Text(l.addFillUp),
       );
 
-  Widget _addChargingFab(BuildContext context, AppLocalizations? l) =>
+  Widget _addChargingFab(BuildContext context, AppLocalizations l) =>
       FloatingActionButton.extended(
         key: const Key('fab_add_charging'),
         onPressed: () async {
           await Navigator.of(context).push<bool?>(
-            MaterialPageRoute(
-              builder: (_) => const AddChargingLogScreen(),
-            ),
+            MaterialPageRoute(builder: (_) => const AddChargingLogScreen()),
           );
         },
         icon: const Icon(Icons.add),
-        label: Text(l?.addChargingLog ?? 'Log charging'),
+        label: Text(l.addChargingLog),
       );
 }

--- a/lib/features/consumption/presentation/screens/consumption_statistics_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_statistics_screen.dart
@@ -53,7 +53,7 @@ class ConsumptionStatisticsPage extends ConsumerWidget {
               const FuelTypeEfficiencyCard(),
               const SizedBox(height: 4),
               SectionHeader(
-                title: l?.consumptionStatsTrendsTitle ?? 'Evolution over time',
+                title: l.consumptionStatsTrendsTitle,
                 leadingIcon: Icons.show_chart,
               ),
               MonthlyFuelCharts(months: months),
@@ -61,18 +61,16 @@ class ConsumptionStatisticsPage extends ConsumerWidget {
           )
         : EmptyState(
             icon: Icons.show_chart_outlined,
-            title: l?.noFillUpsTitle ?? 'No fill-ups yet',
-            subtitle:
-                l?.noFillUpsSubtitle ??
-                'Log your first fill-up to start tracking consumption.',
+            title: l.noFillUpsTitle,
+            subtitle: l.noFillUpsSubtitle,
           );
 
     return PageScaffold(
-      title: l?.consumptionStatsPageTitle ?? 'Consumption statistics',
+      title: l.consumptionStatsPageTitle,
       bannerIcon: Icons.insights_outlined,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => context.pop(),
       ),
       bodyPadding: EdgeInsets.zero,
@@ -95,36 +93,36 @@ class _HeaderTiles extends StatelessWidget {
     final tiles = <_TileData>[
       _TileData(
         icon: Icons.local_gas_station,
-        label: l?.statTotalLiters ?? 'Total liters',
+        label: l.statTotalLiters,
         value: stats.totalLiters.toStringAsFixed(1),
       ),
       _TileData(
         icon: Icons.payments_outlined,
-        label: l?.statTotalSpent ?? 'Total spent',
+        label: l.statTotalSpent,
         value: PriceFormatter.formatTotal(stats.totalSpent),
       ),
       _TileData(
         icon: Icons.local_offer_outlined,
-        label: l?.consumptionStatsPricePerLiter ?? 'Avg price/L',
+        label: l.consumptionStatsPricePerLiter,
         value: PriceFormatter.formatPriceCompact(stats.avgPricePerLiter),
       ),
       _TileData(
         icon: Icons.speed,
-        label: l?.statAvgConsumption ?? 'Avg L/100km',
+        label: l.statAvgConsumption,
         value: stats.avgConsumptionL100km != null
             ? stats.avgConsumptionL100km!.toStringAsFixed(2)
             : '—',
       ),
       _TileData(
         icon: Icons.euro,
-        label: l?.statAvgCostPerKm ?? 'Avg cost/km',
+        label: l.statAvgCostPerKm,
         value: stats.avgCostPerKm != null
             ? PriceFormatter.formatPerKm(stats.avgCostPerKm)
             : '—',
       ),
       _TileData(
         icon: Icons.format_list_numbered,
-        label: l?.statFillUpCount ?? 'Fill-ups',
+        label: l.statFillUpCount,
         value: stats.fillUpCount.toString(),
       ),
     ];

--- a/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
@@ -43,17 +43,25 @@ class PickStationForFillUpScreen extends ConsumerWidget {
       try {
         stations.add(Station.fromJson(raw));
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {'where': 'PickStationForFillUp: skipping malformed favorite $id'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: {
+              'where': 'PickStationForFillUp: skipping malformed favorite $id',
+            },
+          ),
+        );
       }
     }
-    final profileFuel =
-        ref.watch(activeProfileProvider)?.preferredFuelType;
+    final profileFuel = ref.watch(activeProfileProvider)?.preferredFuelType;
 
     return PageScaffold(
-      title: l?.pickStationTitle ?? 'Pick a station',
+      title: l.pickStationTitle,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => context.pop(),
       ),
       bodyPadding: EdgeInsets.zero,
@@ -62,19 +70,13 @@ class PickStationForFillUpScreen extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.all(16),
             child: Text(
-              l?.pickStationHelper ??
-                  'Start the fill-up from a known station so prices, brand '
-                      'and fuel type fill themselves in.',
+              l.pickStationHelper,
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),
           Expanded(
             child: stations.isEmpty
-                ? _EmptyState(
-                    message: l?.pickStationEmpty ??
-                        'No favorite stations yet — add some from the Search '
-                            'or Favorites tab, or skip and fill in manually.',
-                  )
+                ? _EmptyState(message: l.pickStationEmpty)
                 : ListView.separated(
                     itemCount: stations.length,
                     separatorBuilder: (_, _) =>
@@ -92,18 +94,13 @@ class PickStationForFillUpScreen extends ConsumerWidget {
           SafeArea(
             top: false,
             child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 12,
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               child: TextButton.icon(
                 key: const Key('pick_station_skip'),
                 onPressed: () =>
                     const AddFillUpRoute().pushReplacement(context),
                 icon: const Icon(Icons.skip_next_outlined),
-                label: Text(
-                  l?.pickStationSkip ?? 'Skip — add without a station',
-                ),
+                label: Text(l.pickStationSkip),
               ),
             ),
           ),
@@ -169,8 +166,7 @@ class _StationTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final title =
-        station.brand.isNotEmpty ? station.brand : station.name;
+    final title = station.brand.isNotEmpty ? station.brand : station.name;
     final subtitleParts = <String>[];
     if (station.street.isNotEmpty) subtitleParts.add(station.street);
     if (station.place.isNotEmpty) subtitleParts.add(station.place);

--- a/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
+++ b/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
@@ -276,23 +276,19 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
     );
   }
 
-  Widget _body(BuildContext context, AppLocalizations? l10n) {
+  Widget _body(BuildContext context, AppLocalizations l10n) {
     if (_permissionDenied) {
       return PumpCameraMessage(
         icon: Icons.no_photography_outlined,
-        text: l10n?.pumpCameraPermissionDenied ??
-            'Camera access is needed to scan the pump display. '
-                'Enable it in your device settings.',
+        text: l10n.pumpCameraPermissionDenied,
       );
     }
     if (_failed) {
       return PumpCameraMessage(
         icon: Icons.error_outline,
-        text: l10n?.pumpCameraError ??
-            "The camera couldn't start. Try again or enter the values "
-                'by hand.',
+        text: l10n.pumpCameraError,
         onRetry: _setUpCamera,
-        retryLabel: l10n?.retry ?? 'Try again',
+        retryLabel: l10n.retry,
       );
     }
     final ctrl = _controller;
@@ -313,7 +309,7 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
 
   Widget _preview(
     BuildContext context,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     CameraController ctrl, {
     required bool isPortrait,
   }) {
@@ -332,7 +328,7 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
           top: 4,
           child: IconButton(
             icon: const Icon(Icons.close, color: Colors.white),
-            tooltip: l10n?.cancel ?? 'Cancel',
+            tooltip: l10n.cancel,
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),
@@ -348,9 +344,8 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
               color: Colors.white,
             ),
             tooltip: _orientation == OcrDisplayOrientation.horizontal
-                ? (l10n?.pumpCameraOrientationVertical ?? 'Switch to vertical')
-                : (l10n?.pumpCameraOrientationHorizontal ??
-                    'Switch to horizontal'),
+                ? (l10n.pumpCameraOrientationVertical)
+                : (l10n.pumpCameraOrientationHorizontal),
             onPressed: _toggleOrientation,
           ),
         ),

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -25,10 +25,8 @@ import '../../../../core/logging/error_logger.dart';
 /// captures the outgoing payload (#2030). Lets widget tests assert on
 /// the GPX bytes without launching `share_plus`.
 @visibleForTesting
-Future<void> Function({
-  required Uint8List bytes,
-  required String fileName,
-})? debugTrajetsMapGpxShareOverride;
+Future<void> Function({required Uint8List bytes, required String fileName})?
+debugTrajetsMapGpxShareOverride;
 
 /// Aggregates the GPS polylines of multiple trajets on a single
 /// flutter_map view (#2030).
@@ -53,8 +51,7 @@ class TrajetsMapScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final allTrips = ref.watch(tripHistoryListProvider);
     final selected = <TripHistoryEntry>[
-      for (final id in tripIds)
-        ...allTrips.where((t) => t.id == id),
+      for (final id in tripIds) ...allTrips.where((t) => t.id == id),
     ];
 
     final tracks = <_TripTrack>[];
@@ -72,28 +69,26 @@ class TrajetsMapScreen extends ConsumerWidget {
         }
       }
       if (points.length >= 2) {
-        tracks.add(_TripTrack(
-          entry: trip,
-          points: points,
-          colour: _colourForIndex(i),
-        ));
+        tracks.add(
+          _TripTrack(entry: trip, points: points, colour: _colourForIndex(i)),
+        );
       }
     }
 
     final canExport = tracks.isNotEmpty;
 
     return PageScaffold(
-      title: l?.trajetsMapTitle ?? 'Trajets on map',
+      title: l.trajetsMapTitle,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => Navigator.of(context).pop(),
       ),
       actions: [
         IconButton(
           key: const Key('trajets_map_share_gpx'),
           icon: const Icon(Icons.ios_share),
-          tooltip: l?.trajetsMapShareGpx ?? 'Share GPX',
+          tooltip: l.trajetsMapShareGpx,
           onPressed: canExport
               ? () => unawaited(_shareGpx(context, l, selected))
               : null,
@@ -104,11 +99,7 @@ class TrajetsMapScreen extends ConsumerWidget {
           ? Center(
               child: Padding(
                 padding: const EdgeInsets.all(24),
-                child: Text(
-                  l?.trajetsMapEmpty ??
-                      'None of the selected trajets carry GPS samples.',
-                  textAlign: TextAlign.center,
-                ),
+                child: Text(l.trajetsMapEmpty, textAlign: TextAlign.center),
               ),
             )
           : _Map(tracks: tracks, allPoints: allPoints),
@@ -117,7 +108,7 @@ class TrajetsMapScreen extends ConsumerWidget {
 
   Future<void> _shareGpx(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     List<TripHistoryEntry> trips,
   ) async {
     final messenger = ScaffoldMessenger.maybeOf(context);
@@ -143,16 +134,21 @@ class TrajetsMapScreen extends ConsumerWidget {
         mimeType: 'application/gpx+xml',
       );
       if (messenger == null) return;
-      final ok = l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
+      final ok = l.savedToDownloadsFolder;
       // #2173 — themed success toast (matches the sibling error path).
       messenger.showSnackBar(SnackBarHelper.successSnackBar(scheme, ok));
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TrajetsMapScreen save GPX'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'TrajetsMapScreen save GPX'},
+        ),
+      );
       if (messenger == null) return;
-      final errorMsg =
-          l?.trajetsMapShareError ?? "Couldn't save the GPX file";
-      messenger
-          .showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
+      final errorMsg = l.trajetsMapShareError;
+      messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }
   }
 
@@ -215,15 +211,9 @@ class _MapState extends State<_Map> {
       if (p.longitude < minLng) minLng = p.longitude;
       if (p.longitude > maxLng) maxLng = p.longitude;
     }
-    final bounds = LatLngBounds(
-      LatLng(minLat, minLng),
-      LatLng(maxLat, maxLng),
-    );
+    final bounds = LatLngBounds(LatLng(minLat, minLng), LatLng(maxLat, maxLng));
     _controller.fitCamera(
-      CameraFit.bounds(
-        bounds: bounds,
-        padding: const EdgeInsets.all(32),
-      ),
+      CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(32)),
     );
   }
 
@@ -246,11 +236,7 @@ class _MapState extends State<_Map> {
         PolylineLayer(
           polylines: [
             for (final t in widget.tracks)
-              Polyline(
-                points: t.points,
-                color: t.colour,
-                strokeWidth: 4,
-              ),
+              Polyline(points: t.points, color: t.colour, strokeWidth: 4),
           ],
         ),
         const OsmAttribution(),

--- a/lib/features/consumption/presentation/screens/trip_detail_downloads.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_downloads.dart
@@ -22,7 +22,8 @@ Future<void> Function({
   required String text,
   required String fileName,
   required String mimeType,
-})? debugTripDetailDownloadOverride;
+})?
+debugTripDetailDownloadOverride;
 
 /// Save the trip's full telemetry sample stream as a CSV file to the
 /// device's public Downloads folder (#2652). Mirrors [shareTripGpx]:
@@ -34,38 +35,36 @@ Future<void> Function({
 /// is never handed a header-only file.
 Future<void> downloadTripCsv(
   BuildContext context,
-  AppLocalizations? l,
+  AppLocalizations l,
   TripHistoryEntry entry,
-) =>
-    _downloadTripText(
-      context,
-      l,
-      entry,
-      text: () => buildTripDetailCsv(entry),
-      fileName: _fileNameFor(entry, 'csv'),
-      mimeType: 'text/csv',
-    );
+) => _downloadTripText(
+  context,
+  l,
+  entry,
+  text: () => buildTripDetailCsv(entry),
+  fileName: _fileNameFor(entry, 'csv'),
+  mimeType: 'text/csv',
+);
 
 /// Save the trip as its persisted, re-importable JSON wire form to the
 /// device's public Downloads folder (#2652). Same delivery + error +
 /// empty-trip semantics as [downloadTripCsv].
 Future<void> downloadTripJson(
   BuildContext context,
-  AppLocalizations? l,
+  AppLocalizations l,
   TripHistoryEntry entry,
-) =>
-    _downloadTripText(
-      context,
-      l,
-      entry,
-      text: () => buildTripDetailJson(entry),
-      fileName: _fileNameFor(entry, 'json'),
-      mimeType: 'application/json',
-    );
+) => _downloadTripText(
+  context,
+  l,
+  entry,
+  text: () => buildTripDetailJson(entry),
+  fileName: _fileNameFor(entry, 'json'),
+  mimeType: 'application/json',
+);
 
 Future<void> _downloadTripText(
   BuildContext context,
-  AppLocalizations? l,
+  AppLocalizations l,
   TripHistoryEntry entry, {
   required String Function() text,
   required String fileName,
@@ -74,7 +73,7 @@ Future<void> _downloadTripText(
   final messenger = ScaffoldMessenger.maybeOf(context);
   final scheme = Theme.of(context).colorScheme;
   if (entry.samples.isEmpty) {
-    final msg = l?.trajetDetailShareGpxEmpty ?? 'No GPS samples in this trip';
+    final msg = l.trajetDetailShareGpxEmpty;
     messenger?.showSnackBar(SnackBarHelper.errorSnackBar(scheme, msg));
     return;
   }
@@ -91,13 +90,19 @@ Future<void> _downloadTripText(
       mimeType: mimeType,
     );
     if (messenger == null) return;
-    final ok = l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
+    final ok = l.savedToDownloadsFolder;
     messenger.showSnackBar(SnackBarHelper.successSnackBar(scheme, ok));
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-        context: const {'where': 'TripDetailScreen download'}));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {'where': 'TripDetailScreen download'},
+      ),
+    );
     if (messenger == null) return;
-    final errorMsg = l?.trajetDetailDownloadError ?? "Couldn't save the file";
+    final errorMsg = l.trajetDetailDownloadError;
     messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
   }
 }
@@ -112,7 +117,7 @@ Future<void> _downloadTripText(
 /// sync is on). The GPX row doubles as the GPS-track download — it is
 /// disabled (with an explanatory subtitle) when the trip has no GPS fix.
 List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
-  AppLocalizations? l,
+  AppLocalizations l,
   TripHistoryEntry entry, {
   required bool showCrossAccount,
 }) {
@@ -123,7 +128,7 @@ List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
       value: 'image',
       child: ListTile(
         leading: const Icon(Icons.image_outlined),
-        title: Text(l?.trajetDetailShareImageOption ?? 'Share image'),
+        title: Text(l.trajetDetailShareImageOption),
       ),
     ),
     PopupMenuItem<String>(
@@ -132,14 +137,8 @@ List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
       enabled: hasGps,
       child: ListTile(
         leading: const Icon(Icons.route_outlined),
-        title: Text(
-          l?.trajetDetailShareGpxOption ?? 'Share GPS track (GPX)',
-        ),
-        subtitle: hasGps
-            ? null
-            : Text(
-                l?.trajetDetailShareGpxEmpty ?? 'No GPS samples in this trip',
-              ),
+        title: Text(l.trajetDetailShareGpxOption),
+        subtitle: hasGps ? null : Text(l.trajetDetailShareGpxEmpty),
       ),
     ),
     // #2652 — download the full telemetry sample stream (OBD2 + GPS)
@@ -150,9 +149,7 @@ List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
       value: 'download_csv',
       child: ListTile(
         leading: const Icon(Icons.table_chart_outlined),
-        title: Text(
-          l?.trajetDetailDownloadCsvOption ?? 'Download telemetry (CSV)',
-        ),
+        title: Text(l.trajetDetailDownloadCsvOption),
       ),
     ),
     PopupMenuItem<String>(
@@ -160,9 +157,7 @@ List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
       value: 'download_json',
       child: ListTile(
         leading: const Icon(Icons.data_object),
-        title: Text(
-          l?.trajetDetailDownloadJsonOption ?? 'Download telemetry (JSON)',
-        ),
+        title: Text(l.trajetDetailDownloadJsonOption),
       ),
     ),
     // #2240 — cross-account share, only when trip sync is on (you can't
@@ -173,9 +168,7 @@ List<PopupMenuEntry<String>> buildTripDetailShareMenuItems(
         value: 'cross_account',
         child: ListTile(
           leading: const Icon(Icons.group_add_outlined),
-          title: Text(
-            l?.tripShareAction ?? 'Share with another account',
-          ),
+          title: Text(l.tripShareAction),
         ),
       ),
   ];

--- a/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
@@ -21,10 +21,8 @@ import '../../../../core/logging/error_logger.dart';
 /// the 2026-05-24 follow-up (user request: "for files only download
 /// and do not suggest sharing").
 @visibleForTesting
-Future<void> Function({
-  required Uint8List bytes,
-  required String fileName,
-})? debugTripDetailGpxShareOverride;
+Future<void> Function({required Uint8List bytes, required String fileName})?
+debugTripDetailGpxShareOverride;
 
 /// Export the trip's persisted GPS samples as a GPX 1.1 file and save
 /// it to the device's public Downloads folder (#2032 + 2026-05-24
@@ -37,13 +35,13 @@ Future<void> Function({
 /// samples" message the share path used.
 Future<void> shareTripGpx(
   BuildContext context,
-  AppLocalizations? l,
+  AppLocalizations l,
   TripHistoryEntry entry,
 ) async {
   final messenger = ScaffoldMessenger.maybeOf(context);
   final scheme = Theme.of(context).colorScheme;
   if (countGpsFixes(entry) == 0) {
-    final msg = l?.trajetDetailShareGpxEmpty ?? 'No GPS samples in this trip';
+    final msg = l.trajetDetailShareGpxEmpty;
     messenger?.showSnackBar(SnackBarHelper.errorSnackBar(scheme, msg));
     return;
   }
@@ -62,14 +60,20 @@ Future<void> shareTripGpx(
       mimeType: 'application/gpx+xml',
     );
     if (messenger == null) return;
-    final ok =
-        l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
+    final ok = l.savedToDownloadsFolder;
     // #2173 — themed success toast (matches the sibling error path).
     messenger.showSnackBar(SnackBarHelper.successSnackBar(scheme, ok));
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen save GPX'}));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {'where': 'TripDetailScreen save GPX'},
+      ),
+    );
     if (messenger == null) return;
-    final errorMsg = l?.trajetDetailShareError ?? "Couldn't save the GPX file";
+    final errorMsg = l.trajetDetailShareError;
     messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
   }
 }

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -33,7 +33,7 @@ import '../../../../core/logging/error_logger.dart';
 /// up a Supabase client.
 @visibleForTesting
 Future<Map<String, dynamic>?> Function(String tripId)?
-    debugTripDetailFetchDetailsOverride;
+debugTripDetailFetchDetailsOverride;
 
 /// Test-only override for the trip-detail Share renderer (#1189).
 ///
@@ -46,7 +46,8 @@ Future<void> Function({
   required GlobalKey boundaryKey,
   required String subject,
   required String fileNameStem,
-})? debugTripDetailShareOverride;
+})?
+debugTripDetailShareOverride;
 
 /// Trip detail screen (#890).
 ///
@@ -128,7 +129,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     // only actions (cross-account share / delete) off for these.
     final sharedTrips = ref.watch(sharedTripsProvider).value ?? const [];
     final isShared = ownedEntry == null;
-    final entry = ownedEntry ??
+    final entry =
+        ownedEntry ??
         sharedTrips.where((t) => t.id == widget.tripId).firstOrNull;
     _maybeDecrementBadge(entry);
     if (!isShared) _maybeHydrateDetails(entry);
@@ -148,7 +150,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final vehicle = entry?.vehicleId == null
         ? activeVehicle
         : vehicles.where((v) => v.id == entry!.vehicleId).firstOrNull ??
-            activeVehicle;
+              activeVehicle;
     final isEv = vehicle?.type == VehicleType.ev;
 
     // Production callers pass widget.samples = const [] so the screen
@@ -159,13 +161,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final List<TripDetailSample> samples = widget.samples.isNotEmpty
         ? widget.samples
         : (entry?.samples.map(toDetailSample).toList(growable: false) ??
-            const []);
+              const []);
 
     return PageScaffold(
-      title: l?.tripHistoryTitle ?? 'Trip history',
+      title: l.tripHistoryTitle,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => context.pop(),
       ),
       actions: entry == null
@@ -174,7 +176,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               PopupMenuButton<String>(
                 key: const Key('trip_detail_share_menu'),
                 icon: const Icon(Icons.share),
-                tooltip: l?.trajetDetailShareAction ?? 'Share',
+                tooltip: l.trajetDetailShareAction,
                 onSelected: (value) {
                   switch (value) {
                     case 'image':
@@ -202,7 +204,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 IconButton(
                   key: const Key('trip_detail_delete_button'),
                   icon: const Icon(Icons.delete_outline),
-                  tooltip: l?.trajetDetailDeleteAction ?? 'Delete',
+                  tooltip: l.trajetDetailDeleteAction,
                   onPressed: () => _onDelete(context, ref, l),
                 ),
             ],
@@ -212,7 +214,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               child: Padding(
                 padding: const EdgeInsets.all(24),
                 child: Text(
-                  l?.tripHistoryEmptyTitle ?? 'No trips yet',
+                  l.tripHistoryEmptyTitle,
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -235,8 +237,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   void _maybeHydrateDetails(TripHistoryEntry? entry) {
     if (_detailsHydrationAttempted) return;
     if (entry == null) return;
-    if (entry.samples.isNotEmpty ||
-        entry.gpsSampleDiagnostics.isNotEmpty) {
+    if (entry.samples.isNotEmpty || entry.gpsSampleDiagnostics.isNotEmpty) {
       // Already hydrated locally — either the trip was recorded on
       // this device or a previous mount already downloaded the
       // details. Nothing to do.
@@ -245,8 +246,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     _detailsHydrationAttempted = true;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       try {
-        final fetcher = debugTripDetailFetchDetailsOverride ??
-            TripsSync.fetchDetails;
+        final fetcher =
+            debugTripDetailFetchDetailsOverride ?? TripsSync.fetchDetails;
         final data = await fetcher(entry.id);
         if (data == null) return;
         // Round-trip the merged JSON through fromJson so the
@@ -258,7 +259,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         if (!mounted) return;
         await ref.read(tripHistoryListProvider.notifier).save(hydrated);
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen lazy-fetch'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {'where': 'TripDetailScreen lazy-fetch'},
+          ),
+        );
       }
     });
   }
@@ -275,24 +283,29 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         // #3159 — capture the count notifier BEFORE the awaits so the
         // refresh below never reads the WidgetRef after the screen
         // unmounted (Riverpod 3 throws a StateError there).
-        final countNotifier =
-            ref.read(autoRecordBadgeCountProvider.notifier);
-        final badge =
-            await ref.read(autoRecordBadgeServiceProvider.future);
+        final countNotifier = ref.read(autoRecordBadgeCountProvider.notifier);
+        final badge = await ref.read(autoRecordBadgeServiceProvider.future);
         await badge.decrement();
         // Phase 6: also refresh the reactive count so the
         // trip-history "Mark all as read" badge updates without
         // waiting for a route change.
         await countNotifier.refresh();
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen badge decrement'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {'where': 'TripDetailScreen badge decrement'},
+          ),
+        );
       }
     });
   }
 
   Future<void> _onShare(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     TripHistoryEntry entry,
     VehicleProfile? vehicle,
   ) async {
@@ -301,10 +314,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     // instead of a bare filename.
     final locale = Localizations.localeOf(context);
     final shareDate = entry.summary.startedAt ?? DateTime.now();
-    final formattedDate =
-        DateFormat.yMMMd(locale.toString()).format(shareDate);
-    final subject = l?.trajetDetailShareSubject(formattedDate) ??
-        'Sparkilo — trip on $formattedDate';
+    final formattedDate = DateFormat.yMMMd(locale.toString()).format(shareDate);
+    final subject = l.trajetDetailShareSubject(formattedDate);
     final messenger = ScaffoldMessenger.maybeOf(context);
     final scheme = Theme.of(context).colorScheme;
     final renderer = debugTripDetailShareOverride ?? shareWidgetAsImage;
@@ -318,10 +329,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       // Surface the failure to the user instead of silently swallowing
       // it — the snackbar tells them the share didn't go through, and
       // the debugPrint keeps the cause in `flutter logs` for support.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen share image'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'TripDetailScreen share image'},
+        ),
+      );
       if (messenger == null) return;
-      final errorMsg = l?.trajetDetailShareError ??
-          "Couldn't generate share image";
+      final errorMsg = l.trajetDetailShareError;
       messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }
   }
@@ -329,31 +346,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   Future<void> _onDelete(
     BuildContext context,
     WidgetRef ref,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(
-          l?.trajetDetailDeleteConfirmTitle ?? 'Delete this trip?',
-        ),
-        content: Text(
-          l?.trajetDetailDeleteConfirmBody ??
-              'This trip will be permanently removed from your history.',
-        ),
+        title: Text(l.trajetDetailDeleteConfirmTitle),
+        content: Text(l.trajetDetailDeleteConfirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(
-              l?.trajetDetailDeleteConfirmCancel ?? 'Cancel',
-            ),
+            child: Text(l.trajetDetailDeleteConfirmCancel),
           ),
           TextButton(
             key: const Key('trip_detail_delete_confirm'),
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              l?.trajetDetailDeleteConfirmConfirm ?? 'Delete',
-            ),
+            child: Text(l.trajetDetailDeleteConfirmConfirm),
           ),
         ],
       ),
@@ -364,4 +372,3 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     context.pop();
   }
 }
-

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -57,10 +57,7 @@ class TripSaveResult {
   final String entryId;
   final TripSummary summary;
 
-  const TripSaveResult({
-    required this.entryId,
-    required this.summary,
-  });
+  const TripSaveResult({required this.entryId, required this.summary});
 }
 
 /// Live view of the app-wide trip recording. The trip itself lives
@@ -230,8 +227,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     messenger.showSnackBar(
       SnackBarHelper.iconatedInfoSnackBar(
         Icons.eco,
-        l?.hapticEcoCoachSnackBarMessage ??
-            'Easy on the throttle — coasting saves more',
+        l.hapticEcoCoachSnackBarMessage,
         key: const Key('hapticEcoCoachSnackBar'),
         duration: const Duration(seconds: 4),
       ),
@@ -281,9 +277,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     messenger.showSnackBar(
       SnackBarHelper.iconatedInfoSnackBar(
         Icons.gps_off,
-        l?.tripRecordingUnpinnedWarning ??
-            'Pin the screen to keep GPS active during the trip '
-                '— Android may throttle GPS during sleep.',
+        l.tripRecordingUnpinnedWarning,
         key: const Key('tripRecordingUnpinnedWarningSnackBar'),
         duration: const Duration(seconds: 8),
       ),
@@ -314,10 +308,8 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           if (!mounted) return;
           final l10n = AppLocalizations.of(context);
           final msg = wasEnabled
-              ? (l10n?.obd2DebugOverlayDisabledSnack ??
-                  'OBD2 diagnostic overlay disabled')
-              : (l10n?.obd2DebugOverlayEnabledSnack ??
-                  'OBD2 diagnostic overlay enabled');
+              ? (l10n.obd2DebugOverlayDisabledSnack)
+              : (l10n.obd2DebugOverlayEnabledSnack);
           ScaffoldMessenger.of(context)
             ..hideCurrentSnackBar()
             ..showSnackBar(SnackBarHelper.infoSnackBar(msg));
@@ -358,10 +350,9 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       final l = AppLocalizations.of(context);
       ScaffoldMessenger.maybeOf(context)
         ?..hideCurrentSnackBar()
-        ..showSnackBar(SnackBarHelper.infoSnackBar(
-          l?.tripRecordingDiscardedNoMovement ??
-              'Recording discarded — no movement detected',
-        ));
+        ..showSnackBar(
+          SnackBarHelper.infoSnackBar(l.tripRecordingDiscardedNoMovement),
+        );
     }
     setState(() {
       _stopped = result;
@@ -419,8 +410,9 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       // build-time listener retries this the moment it goes active.
       if (!recordingState.isActive) return;
       _autoPinEvaluated = true;
-      final vehicleId =
-          ref.read(tripRecordingProvider.notifier).lastTripVehicleId;
+      final vehicleId = ref
+          .read(tripRecordingProvider.notifier)
+          .lastTripVehicleId;
       final profile = ref
           .read(recordingProfileControllerProvider.notifier)
           .effectiveFor(vehicleId);
@@ -432,9 +424,16 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       // A missing Riverpod override in a widget test that pumps this
       // screen without the profile graph must not crash the mount — the
       // safe fallback is "not auto-pinned", matching the default.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'TripRecordingScreen: auto-pin apply failed',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'TripRecordingScreen: auto-pin apply failed',
+          },
+        ),
+      );
     }
   }
 
@@ -459,15 +458,13 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final r = _stopped!;
     // Match the id derivation in `TripRecording._saveToHistory` so
     // the popped id resolves to the entry that was just written.
-    final entryId = r.summary.startedAt?.toIso8601String() ??
+    final entryId =
+        r.summary.startedAt?.toIso8601String() ??
         DateTime.now().toIso8601String();
     ref.read(tripRecordingProvider.notifier).reset();
-    Navigator.of(context).pop(
-      TripSaveResult(
-        entryId: entryId,
-        summary: r.summary,
-      ),
-    );
+    Navigator.of(
+      context,
+    ).pop(TripSaveResult(entryId: entryId, summary: r.summary));
   }
 
   void _onDiscard() {
@@ -486,63 +483,59 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   /// effect is visible without waiting for the next drive.
   void _showPinHelp() {
     final l = AppLocalizations.of(context);
-    unawaited(showModalBottomSheet<void>(
-      context: context,
-      builder: (ctx) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    const Icon(Icons.push_pin, size: 24),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        l?.tripRecordingPinHelpTitle ?? 'About pin',
-                        style: Theme.of(ctx).textTheme.titleLarge,
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        builder: (ctx) {
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.push_pin, size: 24),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          l.tripRecordingPinHelpTitle,
+                          style: Theme.of(ctx).textTheme.titleLarge,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  l?.tripRecordingPinHelpBody ??
-                      'Pin keeps the screen on and hides system bars '
-                          'so the form stays readable on a dashboard '
-                          'mount. Tap again to release. Auto-releases '
-                          'when the trip stops.',
-                ),
-                const SizedBox(height: 8),
-                _AutoPinToggle(
-                  onChanged: (value) async {
-                    await ref
-                        .read(recordingProfileControllerProvider.notifier)
-                        .setAutoPin(value);
-                    // Reflect the opt-in on THIS live screen at once.
-                    if (value && !_pinned) {
-                      if (mounted) setState(() => _pinned = true);
-                      await _enablePin();
-                    }
-                  },
-                ),
-                const SizedBox(height: 16),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton(
-                    onPressed: () => Navigator.of(ctx).pop(),
-                    child: Text(l?.tooltipBack ?? 'Close'),
+                    ],
                   ),
-                ),
-              ],
+                  const SizedBox(height: 12),
+                  Text(l.tripRecordingPinHelpBody),
+                  const SizedBox(height: 8),
+                  _AutoPinToggle(
+                    onChanged: (value) async {
+                      await ref
+                          .read(recordingProfileControllerProvider.notifier)
+                          .setAutoPin(value);
+                      // Reflect the opt-in on THIS live screen at once.
+                      if (value && !_pinned) {
+                        if (mounted) setState(() => _pinned = true);
+                        await _enablePin();
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () => Navigator.of(ctx).pop(),
+                      child: Text(l.tooltipBack),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-        );
-      },
-    ));
+          );
+        },
+      ),
+    );
   }
 
   /// #1273 — handle the back-press. If the trip is still recording
@@ -563,9 +556,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         // announce; Key + duration preserved, no visual change).
         messenger.showSnackBar(
           SnackBarHelper.infoSnackBar(
-            l?.tripRecordingResumeHintMessage ??
-                'Recording continues in the background. Tap the red '
-                    'banner at the top of any screen to return.',
+            l.tripRecordingResumeHintMessage,
             key: const Key('tripRecordingResumeHintSnackBar'),
             duration: const Duration(seconds: 5),
           ),
@@ -574,10 +565,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       // Persist the dismissal so the hint never fires twice. Awaited
       // so the test that asserts post-state can read it back without
       // racing the pop.
-      await settings.putSetting(
-        StorageKeys.tripRecordingResumeHintShown,
-        true,
-      );
+      await settings.putSetting(StorageKeys.tripRecordingResumeHintShown, true);
     }
     if (!mounted) return;
     if (Navigator.canPop(context)) {
@@ -607,8 +595,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         previousBand == BrokenMapBand.hardDisable) {
       return;
     }
-    final warned =
-        ref.read(brokenMapWarnedVehiclesProvider.notifier);
+    final warned = ref.read(brokenMapWarnedVehiclesProvider.notifier);
     if (!warned.markIfFirst(vehicleId)) return;
     final messenger = ScaffoldMessenger.maybeOf(context);
     if (messenger == null) return;
@@ -616,9 +603,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     // #2173 — plain info through SnackBarHelper (Key + duration kept).
     messenger.showSnackBar(
       SnackBarHelper.infoSnackBar(
-        l?.brokenMapSnackbarUnreliable ??
-            'MAP sensor reads incorrectly — fuel readings may be '
-                '50–80% too low. Try a different adapter.',
+        l.brokenMapSnackbarUnreliable,
         key: const Key('brokenMapWarningSnackBar'),
         duration: const Duration(seconds: 8),
       ),
@@ -706,10 +691,8 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           brokenMapBeliefByVehicleProvider,
           (previous, next) {
             final vehicleId = activeVehicle.id;
-            final prev =
-                previous?[vehicleId]?.pointEstimate ?? 0.0;
-            final curr =
-                next[vehicleId]?.pointEstimate ?? 0.0;
+            final prev = previous?[vehicleId]?.pointEstimate ?? 0.0;
+            final curr = next[vehicleId]?.pointEstimate ?? 0.0;
             if (prev == curr) return;
             _maybeFireBrokenMapSnackbar(
               vehicleId,
@@ -720,23 +703,25 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         );
       }
     } catch (e, st) {
-      debugPrint('TripRecordingScreen broken-MAP listener wiring failed: '
-          '$e\n$st');
+      debugPrint(
+        'TripRecordingScreen broken-MAP listener wiring failed: '
+        '$e\n$st',
+      );
     }
 
     final title = stopped != null
-        ? (l?.tripSummaryTitle ?? 'Trip summary')
+        ? (l.tripSummaryTitle)
         // #2548 — the staged save view's title, the stop-side bookend to
         // the #2274 connecting title.
         : state.isSaving
-            ? (l?.tripRecordingSavingTitle ?? 'Saving trip…')
-            : state.isConnecting
-                // #2274 concern 2 — the connecting view is up while the link
-                // warms; title it accordingly rather than "Recording".
-                ? (l?.tripRecordingConnectingTitle ?? 'Starting recording…')
-                : state.phase == TripRecordingPhase.paused
-                    ? (l?.tripBannerPaused ?? 'Trip paused')
-                    : (l?.tripRecordingTitle ?? 'Recording trip');
+        ? (l.tripRecordingSavingTitle)
+        : state.isConnecting
+        // #2274 concern 2 — the connecting view is up while the link
+        // warms; title it accordingly rather than "Recording".
+        ? (l.tripRecordingConnectingTitle)
+        : state.phase == TripRecordingPhase.paused
+        ? (l.tripBannerPaused)
+        : (l.tripRecordingTitle);
 
     // After stop: show the summary. Until then: live view.
     // #1395 — wrap the title in a GestureDetector so the hidden
@@ -751,14 +736,11 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         behavior: HitTestBehavior.opaque,
         excludeFromSemantics: true,
         onTap: _bumpDebugTapCount,
-        child: Semantics(
-          header: true,
-          child: Text(title),
-        ),
+        child: Semantics(header: true, child: Text(title)),
       ),
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         // Back from the recording screen DOES NOT stop the trip —
         // it stays alive via the provider. The banner is the
         // user's way back in. #1273 — first back-out while
@@ -821,7 +803,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
 
   Widget _buildRecording(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     TripRecordingState state,
   ) {
     // #2548 — staged save-progress: while `stop()` runs, the screen stays
@@ -892,57 +874,54 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-        // #2380 — closest-station radar leads the column; coaching card
-        // moved to the bottom. See [TripRadarCard] for the data sources.
-        const TripRadarCard(),
-        const SizedBox(height: 8),
-        _MetricCard(
-          icon: Icons.route,
-          label: l?.tripMetricDistance ?? 'Distance',
-          value: r == null
-              ? '—'
-              : '${r.distanceKmSoFar.toStringAsFixed(2)} km',
-        ),
-        const SizedBox(height: 8),
-        _MetricCard(
-          icon: Icons.speed,
-          label: l?.tripMetricSpeed ?? 'Speed',
-          value: r?.speedKmh == null
-              ? '—'
-              : '${r!.speedKmh!.toStringAsFixed(0)} km/h',
-        ),
-        const SizedBox(height: 8),
-        _MetricCard(
-          icon: Icons.local_gas_station,
-          label: l?.tripMetricFuelUsed ?? 'Fuel used',
-          // #2391 — measured litres, else the GPS estimator's running
-          // integral with `~` (GPS-only trips no longer show `—` all
-          // drive), else `—`.
-          value: r?.fuelLitersSoFar != null
-              ? '${r!.fuelLitersSoFar!.toStringAsFixed(2)} L'
-              : r?.gpsEstimatedFuelLitersSoFar != null
-                  ? '~${r!.gpsEstimatedFuelLitersSoFar!.toStringAsFixed(2)} L'
-                  : '—',
-        ),
-        const SizedBox(height: 8),
-        // #2391 — Avg card: measured (OBD2, no `~`) vs GPS-only estimate
-        // (`~X.X L/100 km` + calibration-maturity badge + info tooltip).
-        TripAvgConsumptionCard(
-          live: r,
-          brokenMapOverride: brokenMapOverride,
-        ),
-        const BrokenMapDisclaimerChip(),
-        const SizedBox(height: 8),
-        _MetricCard(
-          icon: Icons.timer,
-          label: l?.tripMetricElapsed ?? 'Elapsed',
-          value: r == null ? '—' : _fmtElapsed(r.elapsed),
-        ),
-        const SizedBox(height: 8),
-        // #2380 — instant L/100 km + coaching symbols; moved from the
-        // top to the bottom so the radar card leads the screen.
-        const MinimalDriveSummary(),
-      ],
+          // #2380 — closest-station radar leads the column; coaching card
+          // moved to the bottom. See [TripRadarCard] for the data sources.
+          const TripRadarCard(),
+          const SizedBox(height: 8),
+          _MetricCard(
+            icon: Icons.route,
+            label: l.tripMetricDistance,
+            value: r == null
+                ? '—'
+                : '${r.distanceKmSoFar.toStringAsFixed(2)} km',
+          ),
+          const SizedBox(height: 8),
+          _MetricCard(
+            icon: Icons.speed,
+            label: l.tripMetricSpeed,
+            value: r?.speedKmh == null
+                ? '—'
+                : '${r!.speedKmh!.toStringAsFixed(0)} km/h',
+          ),
+          const SizedBox(height: 8),
+          _MetricCard(
+            icon: Icons.local_gas_station,
+            label: l.tripMetricFuelUsed,
+            // #2391 — measured litres, else the GPS estimator's running
+            // integral with `~` (GPS-only trips no longer show `—` all
+            // drive), else `—`.
+            value: r?.fuelLitersSoFar != null
+                ? '${r!.fuelLitersSoFar!.toStringAsFixed(2)} L'
+                : r?.gpsEstimatedFuelLitersSoFar != null
+                ? '~${r!.gpsEstimatedFuelLitersSoFar!.toStringAsFixed(2)} L'
+                : '—',
+          ),
+          const SizedBox(height: 8),
+          // #2391 — Avg card: measured (OBD2, no `~`) vs GPS-only estimate
+          // (`~X.X L/100 km` + calibration-maturity badge + info tooltip).
+          TripAvgConsumptionCard(live: r, brokenMapOverride: brokenMapOverride),
+          const BrokenMapDisclaimerChip(),
+          const SizedBox(height: 8),
+          _MetricCard(
+            icon: Icons.timer,
+            label: l.tripMetricElapsed,
+            value: r == null ? '—' : _fmtElapsed(r.elapsed),
+          ),
+          const SizedBox(height: 8),
+          // #2380 — instant L/100 km + coaching symbols; moved from the
+          // top to the bottom so the radar card leads the screen.
+          const MinimalDriveSummary(),
+        ],
       ),
     );
   }
@@ -968,14 +947,23 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     } catch (e, st) {
       // A malformed fill-up set must not crash the summary card —
       // but log the cause rather than hiding it silently (#1682).
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripRecordingScreen: consumption summary calc failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'TripRecordingScreen: consumption summary calc failed',
+          },
+        ),
+      );
       return null;
     }
   }
 
   Widget _buildSummary(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     StoppedTripResult r,
   ) {
     final s = r.summary;
@@ -986,19 +974,19 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       children: [
         _MetricCard(
           icon: Icons.route,
-          label: l?.tripMetricDistance ?? 'Distance',
+          label: l.tripMetricDistance,
           value: '${s.distanceKm.toStringAsFixed(2)} km',
         ),
         const SizedBox(height: 8),
         _MetricCard(
           icon: Icons.local_gas_station,
-          label: l?.tripMetricFuelUsed ?? 'Fuel used',
+          label: l.tripMetricFuelUsed,
           value: liters == null ? '—' : '${liters.toStringAsFixed(2)} L',
         ),
         const SizedBox(height: 8),
         _MetricCard(
           icon: Icons.eco,
-          label: l?.tripMetricAvgConsumption ?? 'Avg',
+          label: l.tripMetricAvgConsumption,
           value: s.avgLPer100Km == null
               ? '—'
               : UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: false),
@@ -1006,7 +994,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         const SizedBox(height: 8),
         _MetricCard(
           icon: Icons.speed,
-          label: l?.tripMetricOdometer ?? 'Odometer',
+          label: l.tripMetricOdometer,
           value: endKm == null ? '—' : '${endKm.toStringAsFixed(0)} km',
         ),
         const Spacer(),
@@ -1014,13 +1002,13 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           key: const Key('tripSaveButton'),
           onPressed: _onSave,
           icon: const Icon(Icons.save),
-          label: Text(l?.tripSaveRecording ?? 'Save trip'),
+          label: Text(l.tripSaveRecording),
         ),
         const SizedBox(height: 8),
         TextButton(
           key: const Key('tripDiscardButton'),
           onPressed: _onDiscard,
-          child: Text(l?.tripDiscard ?? 'Discard'),
+          child: Text(l.tripDiscard),
         ),
       ],
     );
@@ -1045,21 +1033,14 @@ class _AutoPinToggle extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
-    final autoPin =
-        ref.watch(recordingProfileControllerProvider).autoPin;
+    final autoPin = ref.watch(recordingProfileControllerProvider).autoPin;
     return SwitchListTile(
       key: const Key('tripRecordingAutoPinToggle'),
       contentPadding: EdgeInsets.zero,
       value: autoPin,
       onChanged: onChanged,
-      title: Text(
-        l?.tripRecordingAutoPinTitle ?? 'Always pin when recording starts',
-      ),
-      subtitle: Text(
-        l?.tripRecordingAutoPinSubtitle ??
-            'Pin the form automatically every drive instead of tapping '
-                'each time. Uses more battery.',
-      ),
+      title: Text(l.tripRecordingAutoPinTitle),
+      subtitle: Text(l.tripRecordingAutoPinSubtitle),
     );
   }
 }
@@ -1099,7 +1080,8 @@ class _MetricCard extends StatelessWidget {
             Text(
               value,
               style: theme.textTheme.titleLarge?.copyWith(
-                  fontFeatures: const [FontFeature.tabularFigures()]),
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
             ),
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
+++ b/lib/features/consumption/presentation/widgets/add_fill_up_form_fields.dart
@@ -125,14 +125,14 @@ class AddFillUpFormFields extends StatelessWidget {
         if (stationName != null) ...[
           FillUpStationPreFillBanner(
             stationName: stationName!,
-            label: l?.stationPreFilled ?? 'Station pre-filled',
+            label: l.stationPreFilled,
           ),
           const SizedBox(height: 16),
         ],
         // Card 1: "What you filled" — date, vehicle, fuel, liters, cost.
         FormSectionCard(
-          title: l?.fillUpSectionWhatTitle ?? 'What you filled',
-          subtitle: l?.fillUpSectionWhatSubtitle ?? 'Fuel, amount, price',
+          title: l.fillUpSectionWhatTitle,
+          subtitle: l.fillUpSectionWhatSubtitle,
           icon: Icons.local_gas_station_outlined,
           children: [
             FormFieldTile(
@@ -142,7 +142,7 @@ class AddFillUpFormFields extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
                 child: InputDecorator(
                   decoration: InputDecoration(
-                    labelText: l?.fillUpDate ?? 'Date',
+                    labelText: l.fillUpDate,
                     border: const OutlineInputBorder(),
                   ),
                   child: Text(dateLabel),
@@ -172,7 +172,7 @@ class AddFillUpFormFields extends StatelessWidget {
               icon: Icons.opacity_outlined,
               content: FillUpNumericField(
                 controller: litersCtrl,
-                label: l?.liters ?? 'Liters',
+                label: l.liters,
                 icon: Icons.water_drop_outlined,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
@@ -184,7 +184,7 @@ class AddFillUpFormFields extends StatelessWidget {
                 children: [
                   FillUpNumericField(
                     controller: costCtrl,
-                    label: l?.totalCost ?? 'Total cost',
+                    label: l.totalCost,
                     icon: Icons.euro,
                     validator: (v) => AddFillUpValidators.positiveNumber(v, l),
                   ),
@@ -206,12 +206,8 @@ class AddFillUpFormFields extends StatelessWidget {
               content: SwitchListTile(
                 key: const Key('add_fill_up_is_full_tank_toggle'),
                 contentPadding: EdgeInsets.zero,
-                title: Text(l?.addFillUpIsFullTankLabel ?? 'Full tank'),
-                subtitle: Text(
-                  l?.addFillUpIsFullTankSubtitle ??
-                      'Tank filled to the brim — uncheck if this was a '
-                          'partial fill',
-                ),
+                title: Text(l.addFillUpIsFullTankLabel),
+                subtitle: Text(l.addFillUpIsFullTankSubtitle),
                 value: isFullTank,
                 onChanged: onIsFullTankChanged,
               ),
@@ -221,16 +217,15 @@ class AddFillUpFormFields extends StatelessWidget {
         const SizedBox(height: 16),
         // Card 2: "Where you were" — odometer, notes.
         FormSectionCard(
-          title: l?.fillUpSectionWhereTitle ?? 'Where you were',
-          subtitle:
-              l?.fillUpSectionWhereSubtitle ?? 'Station, odometer, notes',
+          title: l.fillUpSectionWhereTitle,
+          subtitle: l.fillUpSectionWhereSubtitle,
           icon: Icons.place_outlined,
           children: [
             FormFieldTile(
               icon: Icons.speed_outlined,
               content: FillUpNumericField(
                 controller: odoCtrl,
-                label: l?.odometerKm ?? 'Odometer (km)',
+                label: l.odometerKm,
                 icon: Icons.speed,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
@@ -246,9 +241,7 @@ class AddFillUpFormFields extends StatelessWidget {
                 child: TextButton.icon(
                   onPressed: onReportBadScan,
                   icon: const Icon(Icons.flag_outlined, size: 18),
-                  label: Text(
-                    l?.reportScanError ?? 'Report scan error',
-                  ),
+                  label: Text(l.reportScanError),
                 ),
               ),
             ],

--- a/lib/features/consumption/presentation/widgets/backup_restore_flow.dart
+++ b/lib/features/consumption/presentation/widgets/backup_restore_flow.dart
@@ -57,14 +57,16 @@ class BackupRestoreFlow {
     try {
       bytes = await (debugFilePickerOverride ?? _pickZipBytes)();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'BackupRestoreFlow: file pick failed'}));
-      if (!context.mounted) return;
-      SnackBarHelper.showError(
-        context,
-        l?.restoreBackupFailed ??
-            'Restore failed — the file could not be read',
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BackupRestoreFlow: file pick failed'},
+        ),
       );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(context, l.restoreBackupFailed);
       return;
     }
     if (bytes == null) return; // user cancelled the picker
@@ -83,7 +85,7 @@ class BackupRestoreFlow {
       // stack on that dialog.
       final result = await runWithBackupProgress(
         context,
-        label: l?.backupImportProgress ?? 'Restoring your backup…',
+        label: l.backupImportProgress,
         icon: Icons.settings_backup_restore,
         // bytes is non-null here (early-returned above); the `!` is needed
         // because promotion doesn't cross the closure boundary.
@@ -108,48 +110,56 @@ class BackupRestoreFlow {
       // carries the counts + mode).
       final String msg;
       if (result.total == 0) {
-        msg = l?.restoreBackupEmpty ??
-            'Backup restored — it contained no records';
+        msg = l.restoreBackupEmpty;
       } else if (result.mode == BackupImportMode.replace) {
-        msg = l?.restoreBackupReplacedSummary(result.vehicles, result.fillUps,
-                result.trips, result.chargingLogs) ??
-            'Replaced all data with ${result.vehicles} vehicles, '
-                '${result.fillUps} fill-ups, ${result.trips} trips, '
-                '${result.chargingLogs} charging logs';
+        msg = l.restoreBackupReplacedSummary(
+          result.vehicles,
+          result.fillUps,
+          result.trips,
+          result.chargingLogs,
+        );
       } else {
-        msg = l?.restoreBackupMergedSummary(result.vehicles, result.fillUps,
-                result.trips, result.chargingLogs) ??
-            'Merged ${result.vehicles} vehicles, ${result.fillUps} fill-ups, '
-                '${result.trips} trips, ${result.chargingLogs} charging logs';
+        msg = l.restoreBackupMergedSummary(
+          result.vehicles,
+          result.fillUps,
+          result.trips,
+          result.chargingLogs,
+        );
       }
       SnackBarHelper.showSuccess(context, msg);
     } on BackupZipReadException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'BackupRestoreFlow: corrupt zip'}));
-      if (!context.mounted) return;
-      SnackBarHelper.showError(
-        context,
-        l?.restoreBackupCorrupt ??
-            'Restore failed — this file is not a valid Tankstellen backup',
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BackupRestoreFlow: corrupt zip'},
+        ),
       );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(context, l.restoreBackupCorrupt);
     } on BackupXmlReadException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'BackupRestoreFlow: bad XML/version'}));
-      if (!context.mounted) return;
-      SnackBarHelper.showError(
-        context,
-        l?.restoreBackupCorrupt ??
-            'Restore failed — this file is not a valid Tankstellen backup',
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BackupRestoreFlow: bad XML/version'},
+        ),
       );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(context, l.restoreBackupCorrupt);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'BackupRestoreFlow: import failed'}));
-      if (!context.mounted) return;
-      SnackBarHelper.showError(
-        context,
-        l?.restoreBackupFailed ??
-            'Restore failed — the file could not be read',
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BackupRestoreFlow: import failed'},
+        ),
       );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(context, l.restoreBackupFailed);
     }
   }
 
@@ -182,33 +192,27 @@ class BackupRestoreFlow {
   /// styling and an explicit warning line in the body.
   static Future<BackupImportMode?> _confirmMode(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) {
     return showDialog<BackupImportMode>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text(l?.restoreBackupDialogTitle ?? 'Restore backup'),
-        content: Text(
-          l?.restoreBackupDialogBody ??
-              'Merge adds and updates records from the backup and keeps '
-                  'everything already on this device. Replace deletes all '
-                  'current data first, then restores only the backup — this '
-                  'cannot be undone.',
-        ),
+        title: Text(l.restoreBackupDialogTitle),
+        content: Text(l.restoreBackupDialogBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           TextButton(
             onPressed: () =>
                 Navigator.of(dialogContext).pop(BackupImportMode.replace),
-            child: Text(l?.restoreBackupReplaceAction ?? 'Replace all'),
+            child: Text(l.restoreBackupReplaceAction),
           ),
           FilledButton(
             onPressed: () =>
                 Navigator.of(dialogContext).pop(BackupImportMode.merge),
-            child: Text(l?.restoreBackupMergeAction ?? 'Merge'),
+            child: Text(l.restoreBackupMergeAction),
           ),
         ],
       ),

--- a/lib/features/consumption/presentation/widgets/bad_scan_diff_table.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_diff_table.dart
@@ -36,15 +36,13 @@ class BadScanDiffTable extends StatelessWidget {
       defaultVerticalAlignment: TableCellVerticalAlignment.middle,
       children: [
         TableRow(
-          decoration:
-              BoxDecoration(color: theme.colorScheme.surfaceContainerHighest),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+          ),
           children: [
-            _cell(l?.badScanReportHeaderField ?? 'Field',
-                bold: true, theme: theme),
-            _cell(l?.badScanReportHeaderScanned ?? 'Scanned',
-                bold: true, theme: theme),
-            _cell(l?.badScanReportHeaderYouTyped ?? 'You typed',
-                bold: true, theme: theme),
+            _cell(l.badScanReportHeaderField, bold: true, theme: theme),
+            _cell(l.badScanReportHeaderScanned, bold: true, theme: theme),
+            _cell(l.badScanReportHeaderYouTyped, bold: true, theme: theme),
           ],
         ),
         for (final row in rows)

--- a/lib/features/consumption/presentation/widgets/bad_scan_form_view.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_form_view.dart
@@ -46,14 +46,13 @@ class BadScanFormView extends StatelessWidget {
       children: [
         Text(
           resolveBadScanTitle(kind, l),
-          style: theme.textTheme.titleMedium
-              ?.copyWith(fontWeight: FontWeight.bold),
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
         ),
         const SizedBox(height: 4),
         Text(
-          l?.badScanReportHint ??
-              "We'll share the receipt photo and both sets of values so "
-                  'the next build can learn this layout.',
+          l.badScanReportHint,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -79,14 +78,12 @@ class BadScanFormView extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.bug_report_outlined),
-          label: Text(
-            l?.badScanReportCreateTicket ?? 'Create issue',
-          ),
+          label: Text(l.badScanReportCreateTicket),
         ),
         const SizedBox(height: 8),
         TextButton(
           onPressed: submitting ? null : onCancel,
-          child: Text(l?.cancel ?? 'Cancel'),
+          child: Text(l.cancel),
         ),
       ],
     );

--- a/lib/features/consumption/presentation/widgets/bad_scan_issue_created_surface.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_issue_created_surface.dart
@@ -46,15 +46,10 @@ class BadScanIssueCreatedSurface extends StatelessWidget {
         FilledButton.icon(
           onPressed: onOpenInBrowser,
           icon: const Icon(Icons.open_in_new),
-          label: Text(
-            l?.badScanReportOpenInBrowser ?? 'Open in browser',
-          ),
+          label: Text(l.badScanReportOpenInBrowser),
         ),
         const SizedBox(height: 8),
-        TextButton(
-          onPressed: onClose,
-          child: Text(l?.close ?? 'Close'),
-        ),
+        TextButton(onPressed: onClose, child: Text(l.close)),
       ],
     );
   }

--- a/lib/features/consumption/presentation/widgets/bad_scan_report_formatters.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_report_formatters.dart
@@ -25,43 +25,39 @@ List<BadScanDiffRow> buildBadScanDiffRows({
   required PumpDisplayScanOutcome? pumpScan,
   required double? enteredLiters,
   required double? enteredTotalCost,
-  required AppLocalizations? l,
+  required AppLocalizations l,
 }) {
   if (kind == ScanKind.receipt) {
     final p = receiptScan!.parse;
     return [
       BadScanDiffRow(
-        l?.badScanReportFieldBrandLayout ?? 'Brand layout',
+        l.badScanReportFieldBrandLayout,
         p.brandLayout,
         p.brandLayout,
       ),
       BadScanDiffRow(
-        l?.liters ?? 'Liters',
+        l.liters,
         p.liters?.toStringAsFixed(2) ?? '—',
         enteredLiters?.toStringAsFixed(2) ?? '—',
       ),
       BadScanDiffRow(
-        l?.badScanReportFieldTotal ?? 'Total',
+        l.badScanReportFieldTotal,
         p.totalCost?.toStringAsFixed(2) ?? '—',
         enteredTotalCost?.toStringAsFixed(2) ?? '—',
       ),
       BadScanDiffRow(
-        l?.badScanReportFieldPricePerLiter ?? 'Price/L',
+        l.badScanReportFieldPricePerLiter,
         p.pricePerLiter?.toStringAsFixed(3) ?? '—',
         '—',
       ),
+      BadScanDiffRow(l.badScanReportFieldStation, p.stationName ?? '—', '—'),
       BadScanDiffRow(
-        l?.badScanReportFieldStation ?? 'Station',
-        p.stationName ?? '—',
-        '—',
-      ),
-      BadScanDiffRow(
-        l?.badScanReportFieldFuel ?? 'Fuel',
+        l.badScanReportFieldFuel,
         p.fuelType?.displayName ?? '—',
         '—',
       ),
       BadScanDiffRow(
-        l?.badScanReportFieldDate ?? 'Date',
+        l.badScanReportFieldDate,
         p.date?.toIso8601String().split('T').first ?? '—',
         '—',
       ),
@@ -70,17 +66,17 @@ List<BadScanDiffRow> buildBadScanDiffRows({
   final p = pumpScan!.parse;
   return [
     BadScanDiffRow(
-      l?.liters ?? 'Liters',
+      l.liters,
       p.liters?.toStringAsFixed(2) ?? '—',
       enteredLiters?.toStringAsFixed(2) ?? '—',
     ),
     BadScanDiffRow(
-      l?.badScanReportFieldTotal ?? 'Total',
+      l.badScanReportFieldTotal,
       p.totalCost?.toStringAsFixed(2) ?? '—',
       enteredTotalCost?.toStringAsFixed(2) ?? '—',
     ),
     BadScanDiffRow(
-      l?.badScanReportFieldPricePerLiter ?? 'Price/L',
+      l.badScanReportFieldPricePerLiter,
       p.pricePerLiter?.toStringAsFixed(3) ?? '—',
       '—',
     ),
@@ -111,10 +107,14 @@ String buildBadScanShareBody({
       ..writeln()
       ..writeln('Scanned → Corrected')
       ..writeln('-------------------')
-      ..writeln('Liters:   ${p.liters?.toStringAsFixed(2) ?? '—'}'
-          '   →   ${enteredLiters?.toStringAsFixed(2) ?? '(please fill)'}')
-      ..writeln('Total:    ${p.totalCost?.toStringAsFixed(2) ?? '—'}'
-          '   →   ${enteredTotalCost?.toStringAsFixed(2) ?? '(please fill)'}')
+      ..writeln(
+        'Liters:   ${p.liters?.toStringAsFixed(2) ?? '—'}'
+        '   →   ${enteredLiters?.toStringAsFixed(2) ?? '(please fill)'}',
+      )
+      ..writeln(
+        'Total:    ${p.totalCost?.toStringAsFixed(2) ?? '—'}'
+        '   →   ${enteredTotalCost?.toStringAsFixed(2) ?? '(please fill)'}',
+      )
       ..writeln('Price/L:  ${p.pricePerLiter?.toStringAsFixed(3) ?? '—'}')
       ..writeln('Station:  ${p.stationName ?? '—'}')
       ..writeln('Fuel:     ${p.fuelType?.apiValue ?? '—'}')
@@ -128,10 +128,14 @@ String buildBadScanShareBody({
       ..writeln()
       ..writeln('Scanned → Corrected')
       ..writeln('-------------------')
-      ..writeln('Liters:   ${p.liters?.toStringAsFixed(2) ?? '—'}'
-          '   →   ${enteredLiters?.toStringAsFixed(2) ?? '(please fill)'}')
-      ..writeln('Total:    ${p.totalCost?.toStringAsFixed(2) ?? '—'}'
-          '   →   ${enteredTotalCost?.toStringAsFixed(2) ?? '(please fill)'}')
+      ..writeln(
+        'Liters:   ${p.liters?.toStringAsFixed(2) ?? '—'}'
+        '   →   ${enteredLiters?.toStringAsFixed(2) ?? '(please fill)'}',
+      )
+      ..writeln(
+        'Total:    ${p.totalCost?.toStringAsFixed(2) ?? '—'}'
+        '   →   ${enteredTotalCost?.toStringAsFixed(2) ?? '(please fill)'}',
+      )
       ..writeln('Price/L:  ${p.pricePerLiter?.toStringAsFixed(3) ?? '—'}')
       ..writeln('Pump #:   ${p.pumpNumber?.toString() ?? '—'}')
       ..writeln('Confidence: ${p.confidence.toStringAsFixed(2)}');
@@ -192,14 +196,11 @@ Map<String, String?> buildBadScanUserCorrections({
 /// "Report a scan error" string for both kinds when localization is
 /// not available, then layers per-kind suffixes on top via the
 /// kind-specific keys (#953).
-String resolveBadScanTitle(ScanKind kind, AppLocalizations? l) {
+String resolveBadScanTitle(ScanKind kind, AppLocalizations l) {
   switch (kind) {
     case ScanKind.receipt:
-      return l?.badScanReportTitleReceipt ??
-          l?.badScanReportTitle ??
-          'Report a scan error — Receipt';
+      return l.badScanReportTitleReceipt;
     case ScanKind.pumpDisplay:
-      return l?.badScanReportTitlePumpDisplay ??
-          'Report a scan error — Pump display';
+      return l.badScanReportTitlePumpDisplay;
   }
 }

--- a/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
@@ -24,8 +24,8 @@ import '../../../../core/logging/error_logger.dart';
 
 /// Test seams: widget tests substitute these for the real
 /// platform-channel / secure-storage backed implementations.
-typedef ConsentPrompter = Future<FeedbackConsentChoice> Function(
-    BuildContext context);
+typedef ConsentPrompter =
+    Future<FeedbackConsentChoice> Function(BuildContext context);
 typedef ConsentReader = Future<FeedbackConsentState> Function();
 typedef ConsentWriter = Future<void> Function(FeedbackConsentState state);
 typedef ShareFallback = Future<void> Function(ShareParams params);
@@ -95,13 +95,11 @@ class BadScanReportSheet extends ConsumerStatefulWidget {
     this.consentPrompter,
     this.consentReader,
     this.consentWriter,
-  })  : assert(
-          kind == ScanKind.receipt
-              ? scan != null
-              : pumpScan != null,
-          'BadScanReportSheet: scan must be set for ScanKind.receipt, '
-          'pumpScan must be set for ScanKind.pumpDisplay.',
-        );
+  }) : assert(
+         kind == ScanKind.receipt ? scan != null : pumpScan != null,
+         'BadScanReportSheet: scan must be set for ScanKind.receipt, '
+         'pumpScan must be set for ScanKind.pumpDisplay.',
+       );
 
   /// Path of the scanned image on disk. Resolves to either the receipt
   /// or the pump-display capture depending on [kind].
@@ -113,8 +111,7 @@ class BadScanReportSheet extends ConsumerStatefulWidget {
       kind == ScanKind.receipt ? scan!.ocrText : pumpScan!.ocrText;
 
   @override
-  ConsumerState<BadScanReportSheet> createState() =>
-      _BadScanReportSheetState();
+  ConsumerState<BadScanReportSheet> createState() => _BadScanReportSheetState();
 }
 
 class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
@@ -162,8 +159,7 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
   Future<void> _handleCreateTicket() async {
     setState(() => _submitting = true);
     try {
-      final reporter =
-          await ref.read(githubIssueReporterProvider.future);
+      final reporter = await ref.read(githubIssueReporterProvider.future);
       if (reporter == null) {
         // No token configured — fall back silently to the system share
         // sheet. The settings screen exposes a token-entry UI
@@ -179,8 +175,7 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
       var consent = await reader();
       if (consent == FeedbackConsentState.unset) {
         if (!mounted) return;
-        final prompter =
-            widget.consentPrompter ?? FeedbackConsentDialog.show;
+        final prompter = widget.consentPrompter ?? FeedbackConsentDialog.show;
         final choice = await prompter(context);
         switch (choice) {
           case FeedbackConsentChoice.granted:
@@ -221,12 +216,28 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
       if (!mounted) return;
       setState(() => _createdIssueUrl = url);
     } on GithubReporterException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: GitHub submission failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'BadScanReportSheet: GitHub submission failed',
+          },
+        ),
+      );
       await _runShareFallback(showSnackbar: true);
     } catch (e, st) {
       // Secure-storage / image-read / unexpected errors — still fall
       // back so the user can always ship a report.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: unexpected failure'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BadScanReportSheet: unexpected failure'},
+        ),
+      );
       await _runShareFallback(showSnackbar: true);
     } finally {
       if (mounted) setState(() => _submitting = false);
@@ -260,17 +271,23 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     // outlives this modal sheet.
     if (showSnackbar) {
       messenger?.showSnackBar(
-        SnackBarHelper.infoSnackBar(
-          l?.badScanReportFallbackToShare ??
-              'Submission failed — manual share',
-        ),
+        SnackBarHelper.infoSnackBar(l.badScanReportFallbackToShare),
       );
     }
 
     try {
       await share(params);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: share fallback itself failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'BadScanReportSheet: share fallback itself failed',
+          },
+        ),
+      );
     }
   }
 
@@ -281,7 +298,14 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     try {
       await launcher(url);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: launchUrl failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'BadScanReportSheet: launchUrl failed'},
+        ),
+      );
     }
   }
 
@@ -289,7 +313,16 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     try {
       return await File(path).readAsBytes();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: could not read scan image'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'BadScanReportSheet: could not read scan image',
+          },
+        ),
+      );
       return Uint8List(0);
     }
   }

--- a/lib/features/consumption/presentation/widgets/broken_map_widgets.dart
+++ b/lib/features/consumption/presentation/widgets/broken_map_widgets.dart
@@ -95,18 +95,12 @@ class BrokenMapBanner extends ConsumerWidget {
     return MaterialBanner(
       key: const Key('brokenMapBanner'),
       backgroundColor: theme.colorScheme.errorContainer,
-      contentTextStyle: TextStyle(
-        color: theme.colorScheme.onErrorContainer,
-      ),
+      contentTextStyle: TextStyle(color: theme.colorScheme.onErrorContainer),
       leading: Icon(
         Icons.warning_amber_outlined,
         color: theme.colorScheme.onErrorContainer,
       ),
-      content: Text(
-        l?.brokenMapBannerHardDisable ??
-            'MAP sensor unreliable. Showing fill-up averages instead of '
-                'live fuel rate.',
-      ),
+      content: Text(l.brokenMapBannerHardDisable),
       actions: const [SizedBox.shrink()],
     );
   }
@@ -145,9 +139,7 @@ class BrokenMapDisclaimerChip extends ConsumerWidget {
             size: 14,
             color: theme.colorScheme.onErrorContainer,
           ),
-          label: Text(
-            l?.brokenMapChipDisclaimer ?? 'MAP readings suspicious',
-          ),
+          label: Text(l.brokenMapChipDisclaimer),
         ),
       ),
     );
@@ -200,23 +192,19 @@ class BrokenMapOverlayRow extends ConsumerWidget {
         // because observationCount > 0 means we DO want to show the
         // user the live posterior rather than hide it entirely.
         if (belief.isVerifiedClean) {
-          text = l?.brokenMapOverlayPosteriorVerified(pePct, marginPct) ??
-              'MAP sensor: $pePct% ± $marginPct% (verified)';
+          text = l.brokenMapOverlayPosteriorVerified(pePct, marginPct);
         } else {
-          text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
-              'MAP sensor: $pePct% ± $marginPct%';
+          text = l.brokenMapOverlayPosterior(pePct, marginPct);
         }
         color = DarkModeColors.success(context);
         break;
       case BrokenMapBand.verifying:
-        text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
-            'MAP sensor: $pePct% ± $marginPct%';
+        text = l.brokenMapOverlayPosterior(pePct, marginPct);
         color = DarkModeColors.warning(context);
         break;
       case BrokenMapBand.warning:
       case BrokenMapBand.hardDisable:
-        text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
-            'MAP sensor: $pePct% ± $marginPct%';
+        text = l.brokenMapOverlayPosterior(pePct, marginPct);
         color = DarkModeColors.error(context);
         break;
     }
@@ -291,9 +279,7 @@ class _BrokenMapDiagnosticsCardState
     try {
       // Watch the state so the card rebuilds when the belief map flips.
       ref.watch(brokenMapBeliefByVehicleProvider);
-      return ref
-          .read(brokenMapBeliefByVehicleProvider.notifier)
-          .beliefFor(id);
+      return ref.read(brokenMapBeliefByVehicleProvider.notifier).beliefFor(id);
     } catch (_) {
       return null;
     }
@@ -314,7 +300,7 @@ class _BrokenMapDiagnosticsCardState
         final l = AppLocalizations.of(context);
         final theme = Theme.of(context);
         return SectionCard(
-          title: l?.brokenMapDiagnosticsCardTitle ?? 'MAP sensor diagnostics',
+          title: l.brokenMapDiagnosticsCardTitle,
           leadingIcon: Icons.sensors,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -322,15 +308,13 @@ class _BrokenMapDiagnosticsCardState
               _beliefSection(l, theme, belief, hasBelief),
               const SizedBox(height: 12),
               Text(
-                l?.brokenMapDiagnosticsBlocklistHeading ??
-                    'Blocklisted adapters',
+                l.brokenMapDiagnosticsBlocklistHeading,
                 style: theme.textTheme.titleSmall,
               ),
               const SizedBox(height: 4),
               if (blocklist.isEmpty)
                 Text(
-                  l?.brokenMapDiagnosticsBlocklistEmpty ??
-                      'No adapters are blocklisted.',
+                  l.brokenMapDiagnosticsBlocklistEmpty,
                   style: theme.textTheme.bodyMedium,
                 )
               else
@@ -348,12 +332,15 @@ class _BrokenMapDiagnosticsCardState
     );
   }
 
-  Widget _beliefSection(AppLocalizations? l, ThemeData theme,
-      BrokenMapBelief? belief, bool hasBelief) {
+  Widget _beliefSection(
+    AppLocalizations l,
+    ThemeData theme,
+    BrokenMapBelief? belief,
+    bool hasBelief,
+  ) {
     if (!hasBelief) {
       return Text(
-        l?.brokenMapDiagnosticsBeliefNone ??
-            "This vehicle's MAP sensor hasn't been observed yet.",
+        l.brokenMapDiagnosticsBeliefNone,
         style: theme.textTheme.bodyMedium,
       );
     }
@@ -365,14 +352,12 @@ class _BrokenMapDiagnosticsCardState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l?.brokenMapDiagnosticsBeliefLine(pePct, marginPct) ??
-              'Broken-MAP confidence: $pePct% ± $marginPct%',
+          l.brokenMapDiagnosticsBeliefLine(pePct, marginPct),
           style: theme.textTheme.bodyMedium,
         ),
         const SizedBox(height: 2),
         Text(
-          l?.brokenMapDiagnosticsObservationCount(belief.observationCount) ??
-              '${belief.observationCount} observations recorded',
+          l.brokenMapDiagnosticsObservationCount(belief.observationCount),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -381,11 +366,14 @@ class _BrokenMapDiagnosticsCardState
           const SizedBox(height: 4),
           Row(
             children: [
-              Icon(Icons.verified_outlined,
-                  size: 16, color: theme.colorScheme.primary),
+              Icon(
+                Icons.verified_outlined,
+                size: 16,
+                color: theme.colorScheme.primary,
+              ),
               const SizedBox(width: 4),
               Text(
-                l?.brokenMapDiagnosticsVerifiedBadge ?? 'Verified clean',
+                l.brokenMapDiagnosticsVerifiedBadge,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.primary,
                 ),
@@ -423,17 +411,14 @@ class _BlocklistRow extends StatelessWidget {
         children: [
           Expanded(
             child: Text(
-              l?.brokenMapDiagnosticsBlocklistEntry(elmId, pct) ??
-                  '$elmId — flagged $pct% broken',
+              l.brokenMapDiagnosticsBlocklistEntry(elmId, pct),
               style: theme.textTheme.bodyMedium,
             ),
           ),
           TextButton(
             key: Key('brokenMapBlocklistClear_$elmId'),
             onPressed: onClear,
-            child: Text(
-              l?.brokenMapDiagnosticsClearButton ?? 'Clear',
-            ),
+            child: Text(l.brokenMapDiagnosticsClearButton),
           ),
         ],
       ),

--- a/lib/features/consumption/presentation/widgets/charging_cost_trend_chart.dart
+++ b/lib/features/consumption/presentation/widgets/charging_cost_trend_chart.dart
@@ -49,7 +49,7 @@ class ChargingCostTrendChart extends StatelessWidget {
         height: 140,
         child: Center(
           child: Text(
-            l?.chargingChartsEmpty ?? 'Not enough data yet',
+            l.chargingChartsEmpty,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),

--- a/lib/features/consumption/presentation/widgets/charging_efficiency_chart.dart
+++ b/lib/features/consumption/presentation/widgets/charging_efficiency_chart.dart
@@ -41,13 +41,15 @@ class ChargingEfficiencyChart extends StatelessWidget {
     final effective = color ?? theme.colorScheme.primary;
     final entries = monthlyEfficiency.entries.toList(growable: false)
       ..sort((a, b) => a.key.compareTo(b.key));
-    final points = entries.where((e) => e.value != null).toList(growable: false);
+    final points = entries
+        .where((e) => e.value != null)
+        .toList(growable: false);
     if (entries.isEmpty || points.isEmpty) {
       return SizedBox(
         height: 140,
         child: Center(
           child: Text(
-            l?.chargingChartsEmpty ?? 'Not enough data yet',
+            l.chargingChartsEmpty,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -114,7 +116,8 @@ class _EfficiencyPainter extends CustomPainter {
     final yMax = maxV + padding;
 
     double xForIndex(int i) =>
-        leftInset + (entries.length == 1
+        leftInset +
+        (entries.length == 1
             ? chartWidth / 2
             : (i / (entries.length - 1)) * chartWidth);
     double yForValue(double v) =>
@@ -173,11 +176,7 @@ class _EfficiencyPainter extends CustomPainter {
     for (int i = 0; i < entries.length; i++) {
       final v = entries[i].value;
       if (v == null) continue;
-      canvas.drawCircle(
-        Offset(xForIndex(i), yForValue(v)),
-        3,
-        dotPaint,
-      );
+      canvas.drawCircle(Offset(xForIndex(i), yForValue(v)), 3, dotPaint);
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/charging_log_card.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_card.dart
@@ -29,7 +29,7 @@ class ChargingLogCard extends StatelessWidget {
         '${log.date.year}-${_pad(log.date.month)}-${_pad(log.date.day)}';
     final title = log.stationName?.trim().isNotEmpty == true
         ? log.stationName!
-        : (l?.chargingStationName ?? 'Station');
+        : (l.chargingStationName);
     final kwhStr = log.kWh.toStringAsFixed(1);
     // #2491 — a charging-session cost is a TOTAL: route it through
     // formatTotal (locale-aware 2 dp + the active currency symbol)

--- a/lib/features/consumption/presentation/widgets/charging_log_derived_readout_panel.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_derived_readout_panel.dart
@@ -36,7 +36,7 @@ class ChargingLogDerivedReadoutPanel extends StatelessWidget {
       return Padding(
         padding: const EdgeInsets.only(top: 6, left: 12),
         child: Text(
-          l?.chargingDerivedHelper ?? 'Need a previous log to compare',
+          l.chargingDerivedHelper,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -51,14 +51,17 @@ class ChargingLogDerivedReadoutPanel extends StatelessWidget {
       child: Row(
         key: const Key('charging_derived_readout'),
         children: [
-          Icon(Icons.insights_outlined,
-              size: 16, color: theme.colorScheme.primary),
+          Icon(
+            Icons.insights_outlined,
+            size: 16,
+            color: theme.colorScheme.primary,
+          ),
           const SizedBox(width: 6),
           Flexible(
             child: Text(
-              '${l?.chargingEurPer100km(eurStr) ?? '$eurStr EUR / 100 km'}'
+              '${l.chargingEurPer100km(eurStr)}'
               '  •  '
-              '${l?.chargingKwhPer100km(kwhStr) ?? '$kwhStr kWh / 100 km'}',
+              '${l.chargingKwhPer100km(kwhStr)}',
               style: style,
             ),
           ),

--- a/lib/features/consumption/presentation/widgets/charging_log_form_fields.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_form_fields.dart
@@ -75,7 +75,7 @@ class ChargingLogFormFields extends StatelessWidget {
         FillUpNumericField(
           key: const Key('charging_kwh_field'),
           controller: kwhCtrl,
-          label: l?.chargingKwh ?? 'Energy (kWh)',
+          label: l.chargingKwh,
           icon: Icons.bolt_outlined,
           validator: (v) => ChargingLogValidators.positiveNumber(v, l),
         ),
@@ -83,7 +83,7 @@ class ChargingLogFormFields extends StatelessWidget {
         FillUpNumericField(
           key: const Key('charging_cost_field'),
           controller: costCtrl,
-          label: l?.chargingCost ?? 'Total cost',
+          label: l.chargingCost,
           icon: Icons.euro,
           validator: (v) => ChargingLogValidators.positiveNumber(v, l),
         ),
@@ -92,7 +92,7 @@ class ChargingLogFormFields extends StatelessWidget {
         FillUpNumericField(
           key: const Key('charging_time_field'),
           controller: timeMinCtrl,
-          label: l?.chargingTimeMin ?? 'Charge time (min)',
+          label: l.chargingTimeMin,
           icon: Icons.timer_outlined,
           validator: (v) => ChargingLogValidators.nonNegativeInt(v, l),
         ),
@@ -100,7 +100,7 @@ class ChargingLogFormFields extends StatelessWidget {
         FillUpNumericField(
           key: const Key('charging_odo_field'),
           controller: odoCtrl,
-          label: l?.odometerKm ?? 'Odometer (km)',
+          label: l.odometerKm,
           icon: Icons.speed,
           validator: (v) => ChargingLogValidators.positiveNumber(v, l),
         ),
@@ -109,11 +109,9 @@ class ChargingLogFormFields extends StatelessWidget {
           key: const Key('charging_station_field'),
           controller: stationCtrl,
           textCapitalization: TextCapitalization.words,
-          inputFormatters: [
-            LengthLimitingTextInputFormatter(80),
-          ],
+          inputFormatters: [LengthLimitingTextInputFormatter(80)],
           decoration: InputDecoration(
-            labelText: l?.chargingStationName ?? 'Station (optional)',
+            labelText: l.chargingStationName,
             prefixIcon: const Icon(Icons.place_outlined),
           ),
         ),
@@ -128,7 +126,7 @@ class ChargingLogFormFields extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.save),
-          label: Text(l?.save ?? 'Save'),
+          label: Text(l.save),
         ),
         SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
       ],

--- a/lib/features/consumption/presentation/widgets/charging_tab.dart
+++ b/lib/features/consumption/presentation/widgets/charging_tab.dart
@@ -26,7 +26,7 @@ import 'charging_log_card.dart';
 /// already uses.
 class ChargingTab extends ConsumerWidget {
   final AsyncValue<List<ChargingLog>> async;
-  final AppLocalizations? l;
+  final AppLocalizations l;
 
   const ChargingTab({super.key, required this.async, required this.l});
 
@@ -34,18 +34,14 @@ class ChargingTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return async.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(
-        child: Text('Failed to load charging logs: $e'),
-      ),
+      error: (e, _) => Center(child: Text('Failed to load charging logs: $e')),
       data: (logs) {
         if (logs.isEmpty) {
           return EmptyState(
             key: const Key('charging_empty_state'),
             icon: Icons.ev_station_outlined,
-            title: l?.noChargingLogsTitle ?? 'No charging logs yet',
-            subtitle: l?.noChargingLogsSubtitle ??
-                'Log your first charging session to start tracking '
-                    'EUR/100 km and kWh/100 km.',
+            title: l.noChargingLogsTitle,
+            subtitle: l.noChargingLogsSubtitle,
           );
         }
         final ordered = logs.reversed.toList(growable: false);
@@ -73,7 +69,9 @@ class ChargingTab extends ConsumerWidget {
                 child: const Icon(Icons.delete, color: Colors.white),
               ),
               onDismissed: (_) {
-                unawaited(ref.read(chargingLogsProvider.notifier).remove(log.id));
+                unawaited(
+                  ref.read(chargingLogsProvider.notifier).remove(log.id),
+                );
               },
               child: ChargingLogCard(log: log),
             );
@@ -111,7 +109,7 @@ class _ChargingChartsSection extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    l?.chargingCostTrendTitle ?? 'Charging cost trend',
+                    l.chargingCostTrendTitle,
                     style: theme.textTheme.titleSmall,
                   ),
                   const SizedBox(height: 6),
@@ -131,8 +129,7 @@ class _ChargingChartsSection extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    l?.chargingEfficiencyTitle ??
-                        'Efficiency (kWh/100 km)',
+                    l.chargingEfficiencyTitle,
                     style: theme.textTheme.titleSmall,
                   ),
                   const SizedBox(height: 6),

--- a/lib/features/consumption/presentation/widgets/coaching_chip.dart
+++ b/lib/features/consumption/presentation/widgets/coaching_chip.dart
@@ -14,11 +14,7 @@ import '../../domain/driving_coaching.dart';
 /// with no dependencies on the banner's situation / palette logic
 /// beyond the foreground / background colours it's handed.
 class CoachingChip extends StatelessWidget {
-  const CoachingChip({
-    super.key,
-    required this.hint,
-    required this.foreground,
-  });
+  const CoachingChip({super.key, required this.hint, required this.foreground});
 
   final DrivingCoachingHint hint;
 
@@ -31,30 +27,21 @@ class CoachingChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final (icon, label) = switch (hint) {
-      DrivingCoachingHint.shiftUp => (
-          Icons.arrow_upward,
-          l?.coachingShiftUp ?? 'Shift up',
-        ),
+      DrivingCoachingHint.shiftUp => (Icons.arrow_upward, l.coachingShiftUp),
       DrivingCoachingHint.shiftDown => (
-          Icons.arrow_downward,
-          l?.coachingShiftDown ?? 'Shift down',
-        ),
-      DrivingCoachingHint.easePedal => (
-          Icons.eco,
-          l?.coachingEasePedal ?? 'Ease off',
-        ),
-      DrivingCoachingHint.gpsLiftOffCoast => (
-          Icons.eco,
-          l?.coachingGpsLiftOff ?? 'Lift off',
-        ),
+        Icons.arrow_downward,
+        l.coachingShiftDown,
+      ),
+      DrivingCoachingHint.easePedal => (Icons.eco, l.coachingEasePedal),
+      DrivingCoachingHint.gpsLiftOffCoast => (Icons.eco, l.coachingGpsLiftOff),
       DrivingCoachingHint.gpsAnticipateBrake => (
-          Icons.visibility,
-          l?.coachingGpsAnticipateBrake ?? 'Anticipate',
-        ),
+        Icons.visibility,
+        l.coachingGpsAnticipateBrake,
+      ),
       DrivingCoachingHint.gpsSmoothAccel => (
-          Icons.swipe_up,
-          l?.coachingGpsSmoothAccel ?? 'Smooth accel',
-        ),
+        Icons.swipe_up,
+        l.coachingGpsSmoothAccel,
+      ),
     };
     return Semantics(
       label: label,

--- a/lib/features/consumption/presentation/widgets/confidence_tier_badge.dart
+++ b/lib/features/consumption/presentation/widgets/confidence_tier_badge.dart
@@ -42,8 +42,7 @@ class ConfidenceTierBadge extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final spec = _specFor(tier, l, theme.colorScheme);
-    final label = l?.consumptionAccuracyLabel(spec.levelWord, spec.band) ??
-        'Accuracy: ${spec.levelWord} · ${spec.band}';
+    final label = l.consumptionAccuracyLabel(spec.levelWord, spec.band);
     return Tooltip(
       message: spec.tooltip,
       child: Container(
@@ -75,41 +74,33 @@ class ConfidenceTierBadge extends StatelessWidget {
   /// the badge colours.
   _AccuracySpec _specFor(
     CalibrationConfidenceTier tier,
-    AppLocalizations? l,
+    AppLocalizations l,
     ColorScheme scheme,
   ) {
     switch (tier) {
       case CalibrationConfidenceTier.a:
         return _AccuracySpec(
-          levelWord: l?.consumptionAccuracyLow ?? 'Low',
+          levelWord: l.consumptionAccuracyLow,
           band: '±40-60%', // i18n-ignore: language-neutral error-band mask
-          tooltip: l?.consumptionAccuracyTooltipLow ??
-              'GPS-only — no fill-ups have anchored the consumption model '
-                  'yet. Add a couple of full fill-ups to improve the '
-                  'accuracy.',
+          tooltip: l.consumptionAccuracyTooltipLow,
           filledDots: 1,
           bg: scheme.errorContainer,
           fg: scheme.onErrorContainer,
         );
       case CalibrationConfidenceTier.b:
         return _AccuracySpec(
-          levelWord: l?.consumptionAccuracyMedium ?? 'Medium',
+          levelWord: l.consumptionAccuracyMedium,
           band: '±10-20%', // i18n-ignore: language-neutral error-band mask
-          tooltip: l?.consumptionAccuracyTooltipMedium ??
-              'Fill-ups have anchored the consumption model, but no OBD2 '
-                  'trip has fed the loop yet. Record one with OBD2 connected '
-                  'to reach High accuracy.',
+          tooltip: l.consumptionAccuracyTooltipMedium,
           filledDots: 2,
           bg: scheme.tertiaryContainer,
           fg: scheme.onTertiaryContainer,
         );
       case CalibrationConfidenceTier.c:
         return _AccuracySpec(
-          levelWord: l?.consumptionAccuracyHigh ?? 'High',
+          levelWord: l.consumptionAccuracyHigh,
           band: '±3-7%', // i18n-ignore: language-neutral error-band mask
-          tooltip: l?.consumptionAccuracyTooltipHigh ??
-              'Full calibration: fill-ups plus OBD2-recorded trips. The '
-                  'L/100 km figure tracks reality to within a few percent.',
+          tooltip: l.consumptionAccuracyTooltipHigh,
           filledDots: 3,
           bg: scheme.primaryContainer,
           fg: scheme.onPrimaryContainer,

--- a/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_app_bar_actions.dart
@@ -77,14 +77,14 @@ class ConsumptionAppBarActions extends ConsumerWidget {
       // existing `ConsumptionScreen.debugExporterOverride = …` widget
       // tests keep driving a recording exporter through this extracted
       // action widget (#2756).
-      // ignore: invalid_use_of_visible_for_testing_member
-      final exporter = ConsumptionScreen.debugExporterOverride ??
-          FullBackupExporter();
+      final exporter =
+          // ignore: invalid_use_of_visible_for_testing_member
+          ConsumptionScreen.debugExporterOverride ?? FullBackupExporter();
       // #2815 — show an indeterminate progress modal while the XML builds,
       // zips, and writes (1-3 s, previously a silent freeze).
       final result = await runWithBackupProgress(
         context,
-        label: l?.backupExportProgress ?? 'Exporting your backup…',
+        label: l.backupExportProgress,
         icon: Icons.archive_outlined,
         work: () => exporter.export(
           vehicles: vehicles,
@@ -99,19 +99,22 @@ class ConsumptionAppBarActions extends ConsumerWidget {
       // folder, name the file so the user can find it (e.g. in the restore
       // picker, which now also opens on Downloads).
       final message = (result.savedPath != null)
-          ? (l?.exportBackupSavedAs(result.fileName) ??
-              'Saved to Downloads as ${result.fileName}')
-          : (l?.exportBackupReady ?? 'Backup ready — pick a destination');
+          ? (l.exportBackupSavedAs(result.fileName))
+          : (l.exportBackupReady);
       SnackBarHelper.showSuccess(context, message);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'ConsumptionAppBarActions._runBackupExport failed',
-      }));
-      if (!context.mounted) return;
-      SnackBarHelper.showError(
-        context,
-        l?.exportBackupFailed ?? 'Backup export failed — please try again',
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'ConsumptionAppBarActions._runBackupExport failed',
+          },
+        ),
       );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(context, l.exportBackupFailed);
     }
   }
 
@@ -125,8 +128,9 @@ class ConsumptionAppBarActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
-    final carbonEnabled =
-        ref.watch(enabledFeaturesProvider).contains(Feature.carbonDashboard);
+    final carbonEnabled = ref
+        .watch(enabledFeaturesProvider)
+        .contains(Feature.carbonDashboard);
     final ids = tripIds;
 
     return Row(
@@ -139,20 +143,22 @@ class ConsumptionAppBarActions extends ConsumerWidget {
         if (ids != null)
           IconButton(
             key: const Key('trajets_view_all_on_map'),
-            tooltip: l?.trajetsViewAllOnMap ?? 'View all on map',
+            tooltip: l.trajetsViewAllOnMap,
             icon: const Icon(Icons.map_outlined),
             onPressed: () {
-              unawaited(Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => TrajetsMapScreen(tripIds: ids),
+              unawaited(
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => TrajetsMapScreen(tripIds: ids),
+                  ),
                 ),
-              ));
+              );
             },
           ),
         PopupMenuButton<_OverflowAction>(
           key: const Key('consumption_overflow_menu'),
           icon: const Icon(Icons.more_vert),
-          tooltip: l?.moreActionsTooltip ?? 'More',
+          tooltip: l.moreActionsTooltip,
           onSelected: (action) => _onSelected(context, action),
           // The outer `context` (not the menu's) is captured by every
           // `onTap` below: PopupMenuItem.onTap fires after the menu
@@ -164,7 +170,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
               onTap: () => unawaited(_runBackupExport(context, ref)),
               child: _MenuRow(
                 icon: Icons.download_outlined,
-                label: l?.exportBackupMenuLabel ?? 'Export backup',
+                label: l.exportBackupMenuLabel,
               ),
             ),
             // #2571 — full-backup restore. The flow (pick .zip →
@@ -175,7 +181,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
               onTap: () => unawaited(BackupRestoreFlow.run(context, ref)),
               child: _MenuRow(
                 icon: Icons.restore_outlined,
-                label: l?.restoreBackupMenuLabel ?? 'Restore backup',
+                label: l.restoreBackupMenuLabel,
               ),
             ),
             if (carbonEnabled)
@@ -184,7 +190,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
                 onTap: () => context.push(RoutePaths.carbon),
                 child: _MenuRow(
                   icon: Icons.eco_outlined,
-                  label: l?.carbonDashboardMenuLabel ?? 'Carbon dashboard',
+                  label: l.carbonDashboardMenuLabel,
                 ),
               ),
             const PopupMenuDivider(),
@@ -192,7 +198,7 @@ class ConsumptionAppBarActions extends ConsumerWidget {
               value: _OverflowAction.settings,
               child: _MenuRow(
                 icon: Icons.settings_outlined,
-                label: l?.settingsMenuLabel ?? 'Settings',
+                label: l.settingsMenuLabel,
               ),
             ),
           ],

--- a/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
@@ -98,7 +98,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
         !showResolveGapBanner && stats.correctionShare > 0.05;
 
     final titleText = Text(
-      l?.consumptionStatsTitle ?? 'Consumption stats',
+      l.consumptionStatsTitle,
       style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
     );
     // #2698 — when tappable, the title gains a trailing chevron so the
@@ -124,12 +124,9 @@ class ConsumptionStatsCard extends ConsumerWidget {
         children: [
           if (showOpenWindowBanner) ...[
             _OpenWindowBanner(
-              text:
-                  l?.consumptionStatsOpenWindowBanner(
-                    stats.openWindowFillCount,
-                  ) ??
-                  '${stats.openWindowFillCount} partial fill(s) pending '
-                      'plein complet — not in average',
+              text: l.consumptionStatsOpenWindowBanner(
+                stats.openWindowFillCount,
+              ),
             ),
             const SizedBox(height: 8),
           ],
@@ -139,12 +136,9 @@ class ConsumptionStatsCard extends ConsumerWidget {
           ],
           if (showCorrectionHint) ...[
             _CorrectionShareHint(
-              text:
-                  l?.consumptionStatsCorrectionShareHint(
-                    (stats.correctionShare * 100).round(),
-                  ) ??
-                  '${(stats.correctionShare * 100).round()}% of fuel from '
-                      'auto-corrections — review entries',
+              text: l.consumptionStatsCorrectionShareHint(
+                (stats.correctionShare * 100).round(),
+              ),
             ),
             const SizedBox(height: 8),
           ],
@@ -182,7 +176,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
               Expanded(
                 child: _StatTile(
                   icon: Icons.speed,
-                  label: l?.statAvgConsumption ?? 'Avg L/100km',
+                  label: l.statAvgConsumption,
                   value: avgConsumption != null
                       ? avgConsumption.toStringAsFixed(2)
                       : '—',
@@ -191,7 +185,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
               Expanded(
                 child: _StatTile(
                   icon: Icons.euro,
-                  label: l?.statAvgCostPerKm ?? 'Avg /km',
+                  label: l.statAvgCostPerKm,
                   // #2491 — locale-aware 3 dp via formatPerKm.
                   value: avgCostKm != null
                       ? PriceFormatter.formatPerKm(avgCostKm)
@@ -206,14 +200,14 @@ class ConsumptionStatsCard extends ConsumerWidget {
               Expanded(
                 child: _StatTile(
                   icon: Icons.local_gas_station,
-                  label: l?.statTotalLiters ?? 'Total L',
+                  label: l.statTotalLiters,
                   value: stats.totalLiters.toStringAsFixed(1),
                 ),
               ),
               Expanded(
                 child: _StatTile(
                   icon: Icons.payments_outlined,
-                  label: l?.statTotalSpent ?? 'Total spent',
+                  label: l.statTotalSpent,
                   // #2491 — locale-aware 2 dp + currency symbol.
                   value: PriceFormatter.formatTotal(stats.totalSpent),
                 ),
@@ -223,7 +217,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
           if (stats.fillUpCount > 0) ...[
             const SizedBox(height: 8),
             Text(
-              '${l?.statFillUpCount ?? 'Fill-ups'}: ${stats.fillUpCount}',
+              '${l.statFillUpCount}: ${stats.fillUpCount}',
               style: theme.textTheme.bodySmall,
             ),
           ],
@@ -235,10 +229,9 @@ class ConsumptionStatsCard extends ConsumerWidget {
           if (stats.correctionLitersTotal > 0) ...[
             const SizedBox(height: 4),
             Text(
-              l?.statCorrectionLiters(
-                    stats.correctionLitersTotal.toStringAsFixed(1),
-                  ) ??
-                  'Corrections: +${stats.correctionLitersTotal.toStringAsFixed(1)} L',
+              l.statCorrectionLiters(
+                stats.correctionLitersTotal.toStringAsFixed(1),
+              ),
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/lib/features/consumption/presentation/widgets/consumption_stats_card_parts.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_stats_card_parts.dart
@@ -106,15 +106,11 @@ class _CalibrationChip extends StatelessWidget {
     final eta = volumetricEfficiency.toStringAsFixed(2);
     final String label;
     if (samples == 0) {
-      label =
-          l?.calibrationLearnerStatusNoSamples ??
-          'η_v: ?? — no plein-complet yet';
+      label = l.calibrationLearnerStatusNoSamples;
     } else {
       // #2112 — single label shape across learning + calibrated;
       // confidence tier carries the maturity colour.
-      label =
-          l?.calibrationLearnerEtaCompact(eta, samples) ??
-          'η_v: $eta · $samples samples';
+      label = l.calibrationLearnerEtaCompact(eta, samples);
     }
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),

--- a/lib/features/consumption/presentation/widgets/diesel_rev_prompt.dart
+++ b/lib/features/consumption/presentation/widgets/diesel_rev_prompt.dart
@@ -83,25 +83,16 @@ class _DieselRevPromptState extends State<DieselRevPrompt>
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            l?.brokenMapRevPromptTitle ?? 'Rev the engine',
-            style: theme.textTheme.titleMedium,
-          ),
+          Text(l.brokenMapRevPromptTitle, style: theme.textTheme.titleMedium),
           const SizedBox(height: 8),
-          Text(
-            l?.brokenMapRevPromptBody ??
-                'Briefly blip the throttle so the app can check the MAP '
-                    'sensor responds.',
-            style: theme.textTheme.bodyMedium,
-          ),
+          Text(l.brokenMapRevPromptBody, style: theme.textTheme.bodyMedium),
           const SizedBox(height: 16),
           // Counts down the rev window — full at the start, empty when
           // it elapses.
           AnimatedBuilder(
             animation: _controller,
-            builder: (context, _) => LinearProgressIndicator(
-              value: 1.0 - _controller.value,
-            ),
+            builder: (context, _) =>
+                LinearProgressIndicator(value: 1.0 - _controller.value),
           ),
           const SizedBox(height: 16),
           Align(
@@ -109,7 +100,7 @@ class _DieselRevPromptState extends State<DieselRevPrompt>
             child: FilledButton(
               key: const Key('dieselRevPromptConfirm'),
               onPressed: () => _finish(revved: true),
-              child: Text(l?.brokenMapRevPromptConfirm ?? 'Done — I revved'),
+              child: Text(l.brokenMapRevPromptConfirm),
             ),
           ),
         ],

--- a/lib/features/consumption/presentation/widgets/driving_analysis_trace_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_analysis_trace_card.dart
@@ -38,8 +38,9 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final debugOn =
-        ref.watch(enabledFeaturesProvider).contains(Feature.debugMode);
+    final debugOn = ref
+        .watch(enabledFeaturesProvider)
+        .contains(Feature.debugMode);
     if (!debugOn) return const SizedBox.shrink();
 
     final l = AppLocalizations.of(context);
@@ -51,27 +52,16 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              l?.drivingTraceCardTitle ?? 'Driving-analysis trace (dev)',
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(l.drivingTraceCardTitle, style: theme.textTheme.titleMedium),
             const SizedBox(height: 4),
-            Text(
-              l?.drivingTraceCardBody ??
-                  "Export this trip's GPS KPIs, score and lessons as JSON, "
-                      'write how the drive felt in the comment field, and '
-                      'share it back to calibrate the thresholds.',
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(l.drivingTraceCardBody, style: theme.textTheme.bodySmall),
             const SizedBox(height: 12),
             Align(
               alignment: Alignment.centerLeft,
               child: FilledButton.tonalIcon(
                 onPressed: () => _export(context),
                 icon: const Icon(Icons.bug_report_outlined),
-                label: Text(
-                  l?.drivingTraceExportAction ?? 'Export analysis trace',
-                ),
+                label: Text(l.drivingTraceExportAction),
               ),
             ),
           ],
@@ -95,11 +85,7 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
     messenger.showSnackBar(
       SnackBar(
         content: Text(
-          ok
-              ? (l?.drivingTraceExported ??
-                  'Analysis trace saved to Downloads.')
-              : (l?.drivingTraceExportFailed ??
-                  "Couldn't export the analysis trace."),
+          ok ? (l.drivingTraceExported) : (l.drivingTraceExportFailed),
         ),
       ),
     );

--- a/lib/features/consumption/presentation/widgets/driving_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_insights_card.dart
@@ -36,10 +36,7 @@ class DrivingInsightsCard extends StatelessWidget {
   /// → empty-state row.
   final List<DrivingLesson> lessons;
 
-  const DrivingInsightsCard({
-    super.key,
-    required this.lessons,
-  });
+  const DrivingInsightsCard({super.key, required this.lessons});
 
   @override
   Widget build(BuildContext context) {
@@ -53,16 +50,10 @@ class DrivingInsightsCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              l?.insightCardTitle ?? 'Top wasteful behaviours',
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(l.insightCardTitle, style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
             if (lessons.isEmpty)
-              _EmptyState(
-                message: l?.insightEmptyState ??
-                    'No notable inefficiencies — keep it up!',
-              )
+              _EmptyState(message: l.insightEmptyState)
             else
               for (final lesson in lessons) _LessonTile(lesson: lesson),
           ],
@@ -90,10 +81,7 @@ class _LessonTile extends StatelessWidget {
     return ListTile(
       key: ValueKey('insight_tile_${lesson.id}'),
       contentPadding: EdgeInsets.zero,
-      leading: Icon(
-        _iconFor(lesson),
-        color: _colorFor(lesson.polarity, theme),
-      ),
+      leading: Icon(_iconFor(lesson), color: _colorFor(lesson.polarity, theme)),
       title: Text(lesson.title),
       subtitle: subtitle == null
           ? null
@@ -164,17 +152,9 @@ class _EmptyState extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: Row(
         children: [
-          Icon(
-            Icons.thumb_up_alt_outlined,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.thumb_up_alt_outlined, color: theme.colorScheme.primary),
           const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              message,
-              style: theme.textTheme.bodyMedium,
-            ),
-          ),
+          Expanded(child: Text(message, style: theme.textTheme.bodyMedium)),
         ],
       ),
     );

--- a/lib/features/consumption/presentation/widgets/driving_score_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_score_card.dart
@@ -48,11 +48,8 @@ class DrivingScoreCard extends StatelessWidget {
     final theme = Theme.of(context);
 
     final scoreText = score.score.toString();
-    final outOf =
-        l?.drivingScoreCardOutOf ?? '/100';
-    final scoreSemanticsLabel =
-        l?.drivingScoreCardSemanticsLabel(scoreText) ??
-            'Driving score $scoreText out of 100';
+    final outOf = l.drivingScoreCardOutOf;
+    final scoreSemanticsLabel = l.drivingScoreCardSemanticsLabel(scoreText);
 
     final topPenalties = _topPenalties(l);
     final classLabel = _classLabel(l, score.styleClass);
@@ -64,10 +61,7 @@ class DrivingScoreCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              l?.drivingScoreCardTitle ?? 'Driving score',
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(l.drivingScoreCardTitle, style: theme.textTheme.titleMedium),
             const SizedBox(height: 4),
             // #2460 — the coarse VERY-GOOD / GOOD / AVERAGE / BAD band, so
             // the driver reads a verdict before the bare number.
@@ -113,9 +107,7 @@ class DrivingScoreCard extends StatelessWidget {
               // Placeholder for the future "Better than X% of past
               // trips" sub-text — see the class docstring for why it's
               // a follow-up.
-              l?.drivingScoreCardSubtitle ??
-                  'Composite score from idling, hard accelerations, '
-                      'hard braking, and high-RPM time.',
+              l.drivingScoreCardSubtitle,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -141,48 +133,48 @@ class DrivingScoreCard extends StatelessWidget {
   /// chips. Returns an empty list when every category is below a
   /// 1-point floor (the trip was clean enough that singling out a
   /// "biggest" contributor would be misleading).
-  List<String> _topPenalties(AppLocalizations? l) {
+  List<String> _topPenalties(AppLocalizations l) {
     final entries = <_NamedPenalty>[
       _NamedPenalty(
         value: score.idlingPenalty,
-        label: l?.drivingScorePenaltyIdling ?? 'Idling',
+        label: l.drivingScorePenaltyIdling,
       ),
       _NamedPenalty(
         value: score.hardAccelPenalty,
-        label: l?.drivingScorePenaltyHardAccel ?? 'Hard accelerations',
+        label: l.drivingScorePenaltyHardAccel,
       ),
       _NamedPenalty(
         value: score.hardBrakePenalty,
-        label: l?.drivingScorePenaltyHardBrake ?? 'Hard braking',
+        label: l.drivingScorePenaltyHardBrake,
       ),
       _NamedPenalty(
         value: score.highRpmPenalty,
-        label: l?.drivingScorePenaltyHighRpm ?? 'High RPM',
+        label: l.drivingScorePenaltyHighRpm,
       ),
       _NamedPenalty(
         value: score.fullThrottlePenalty,
-        label: l?.drivingScorePenaltyFullThrottle ?? 'Full throttle',
+        label: l.drivingScorePenaltyFullThrottle,
       ),
       // #2460 — the new canonical sub-scores join the breakdown ranking.
       _NamedPenalty(
         value: score.luggingPenalty,
-        label: l?.drivingScorePenaltyLugging ?? 'Lugging',
+        label: l.drivingScorePenaltyLugging,
       ),
       _NamedPenalty(
         value: score.smoothnessPenalty,
-        label: l?.drivingScorePenaltySmoothness ?? 'Jerky driving',
+        label: l.drivingScorePenaltySmoothness,
       ),
       _NamedPenalty(
         value: score.speedEfficiencyPenalty,
-        label: l?.drivingScorePenaltyHighSpeed ?? 'High speed',
+        label: l.drivingScorePenaltyHighSpeed,
       ),
       _NamedPenalty(
         value: score.pedalVelocityPenalty,
-        label: l?.drivingScorePenaltyPedalVelocity ?? 'Aggressive pedal',
+        label: l.drivingScorePenaltyPedalVelocity,
       ),
       _NamedPenalty(
         value: score.lambdaEnrichmentPenalty,
-        label: l?.drivingScorePenaltyLambda ?? 'Rich mixture',
+        label: l.drivingScorePenaltyLambda,
       ),
     ]..sort((a, b) => b.value.compareTo(a.value));
 
@@ -193,16 +185,16 @@ class DrivingScoreCard extends StatelessWidget {
   }
 
   /// Localized headline for the coarse classification band (#2460).
-  String _classLabel(AppLocalizations? l, DrivingStyleClass c) {
+  String _classLabel(AppLocalizations l, DrivingStyleClass c) {
     switch (c) {
       case DrivingStyleClass.veryGood:
-        return l?.drivingScoreClassVeryGood ?? 'Very good';
+        return l.drivingScoreClassVeryGood;
       case DrivingStyleClass.good:
-        return l?.drivingScoreClassGood ?? 'Good';
+        return l.drivingScoreClassGood;
       case DrivingStyleClass.average:
-        return l?.drivingScoreClassAverage ?? 'Average';
+        return l.drivingScoreClassAverage;
       case DrivingStyleClass.bad:
-        return l?.drivingScoreClassBad ?? 'Needs work';
+        return l.drivingScoreClassBad;
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/eco_score_badge.dart
+++ b/lib/features/consumption/presentation/widgets/eco_score_badge.dart
@@ -4,7 +4,6 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
-import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/eco_score.dart';
 
@@ -35,16 +34,11 @@ class EcoScoreBadge extends StatelessWidget {
 
     // Compose the badge text from the localised consumption unit +
     // the raw delta; the delta itself (+/− and %) is locale-neutral.
-    final consumptionText = l10n?.ecoScoreConsumption(lp100Text) ??
-        UnitFormatter.formatConsumption(score.litersPer100Km, isEv: false);
+    final consumptionText = l10n.ecoScoreConsumption(lp100Text);
     final badgeText = '$consumptionText · $deltaText';
 
-    final tooltip = l10n?.ecoScoreTooltip(avgText) ??
-        'Compared to the rolling average over your last 3 fill-ups '
-            '($avgText L/100 km).';
-    final semanticsLabel = l10n?.ecoScoreSemantics(lp100Text, deltaText) ??
-        'Consumption $lp100Text L/100 km, $deltaText versus your '
-            'rolling average';
+    final tooltip = l10n.ecoScoreTooltip(avgText);
+    final semanticsLabel = l10n.ecoScoreSemantics(lp100Text, deltaText);
 
     return Semantics(
       label: semanticsLabel,

--- a/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
@@ -134,8 +134,7 @@ class _EditCorrectionFillUpSheetState
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final correctionColor = DarkModeColors.warning(context);
-    final dateStr =
-        '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
+    final dateStr = '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
 
     return Padding(
       // The sheet is summoned with `isScrollControlled: true` so it can
@@ -154,14 +153,11 @@ class _EditCorrectionFillUpSheetState
             children: [
               Row(
                 children: [
-                  Icon(
-                    Icons.auto_fix_high,
-                    color: correctionColor,
-                  ),
+                  Icon(Icons.auto_fix_high, color: correctionColor),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      l?.fillUpCorrectionEditTitle ?? 'Edit auto-correction',
+                      l.fillUpCorrectionEditTitle,
                       style: theme.textTheme.titleLarge,
                     ),
                   ),
@@ -169,41 +165,38 @@ class _EditCorrectionFillUpSheetState
               ),
               const SizedBox(height: 12),
               Text(
-                l?.fillUpCorrectionEditExplainer ??
-                    'This entry was auto-generated to close the gap '
-                        'between recorded trips and pumped fuel. Adjust '
-                        'the values if you know the actual figures.',
+                l.fillUpCorrectionEditExplainer,
                 style: theme.textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
               ListTile(
                 contentPadding: EdgeInsets.zero,
                 leading: const Icon(Icons.calendar_today),
-                title: Text(l?.fillUpDate ?? 'Date'),
+                title: Text(l.fillUpDate),
                 subtitle: Text(dateStr),
                 onTap: _pickDate,
               ),
               const SizedBox(height: 8),
               FillUpNumericField(
                 controller: _litersCtrl,
-                label: l?.liters ?? 'Liters',
+                label: l.liters,
                 icon: Icons.local_drink,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
               const SizedBox(height: 8),
               FillUpNumericField(
                 controller: _costCtrl,
-                label: l?.totalCost ?? 'Total cost',
+                label: l.totalCost,
                 icon: Icons.attach_money,
                 // Cost may legitimately be 0 for a correction (no
                 // receipt, synthesised entry); accept >= 0 here.
                 validator: (v) {
                   if (v == null || v.trim().isEmpty) {
-                    return l?.fieldRequired ?? 'Required';
+                    return l.fieldRequired;
                   }
                   final parsed = double.tryParse(v.replaceAll(',', '.'));
                   if (parsed == null || parsed < 0) {
-                    return l?.fieldInvalidNumber ?? 'Invalid number';
+                    return l.fieldInvalidNumber;
                   }
                   return null;
                 },
@@ -211,7 +204,7 @@ class _EditCorrectionFillUpSheetState
               const SizedBox(height: 8),
               FillUpNumericField(
                 controller: _odoCtrl,
-                label: l?.odometerKm ?? 'Odometer (km)',
+                label: l.odometerKm,
                 icon: Icons.speed,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
@@ -219,8 +212,7 @@ class _EditCorrectionFillUpSheetState
               TextFormField(
                 controller: _stationCtrl,
                 decoration: InputDecoration(
-                  labelText:
-                      l?.fillUpCorrectionStation ?? 'Station name (optional)',
+                  labelText: l.fillUpCorrectionStation,
                   prefixIcon: const Icon(Icons.local_gas_station),
                 ),
               ),
@@ -228,7 +220,7 @@ class _EditCorrectionFillUpSheetState
               TextFormField(
                 controller: _notesCtrl,
                 decoration: InputDecoration(
-                  labelText: l?.notesOptional ?? 'Notes (optional)',
+                  labelText: l.notesOptional,
                   prefixIcon: const Icon(Icons.notes),
                 ),
                 maxLines: 2,
@@ -243,9 +235,7 @@ class _EditCorrectionFillUpSheetState
                         foregroundColor: theme.colorScheme.error,
                       ),
                       icon: const Icon(Icons.delete_outline),
-                      label: Text(
-                        l?.fillUpCorrectionDelete ?? 'Delete correction',
-                      ),
+                      label: Text(l.fillUpCorrectionDelete),
                     ),
                   ),
                 ],
@@ -256,15 +246,12 @@ class _EditCorrectionFillUpSheetState
                   Expanded(
                     child: TextButton(
                       onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l?.cancel ?? 'Cancel'),
+                      child: Text(l.cancel),
                     ),
                   ),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: FilledButton(
-                      onPressed: _save,
-                      child: Text(l?.save ?? 'Save'),
-                    ),
+                    child: FilledButton(onPressed: _save, child: Text(l.save)),
                   ),
                 ],
               ),

--- a/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
@@ -89,7 +89,9 @@ class _EditVirtualTrajetSheetState
     final color = DarkModeColors.warning(context);
 
     return Padding(
-      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       child: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
         child: Form(
@@ -104,7 +106,7 @@ class _EditVirtualTrajetSheetState
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      l?.reconcileVirtualTrajetEditTitle ?? 'Edit virtual trip',
+                      l.reconcileVirtualTrajetEditTitle,
                       style: theme.textTheme.titleLarge,
                     ),
                   ),
@@ -112,24 +114,20 @@ class _EditVirtualTrajetSheetState
               ),
               const SizedBox(height: 12),
               Text(
-                l?.reconcileVirtualTrajetEditExplainer ??
-                    'This trip was added to account for fuel you used while '
-                        'driving without recording. Adjust the distance or '
-                        'fuel, or delete it.',
+                l.reconcileVirtualTrajetEditExplainer,
                 style: theme.textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
               FillUpNumericField(
                 controller: _distanceCtrl,
-                label: l?.reconcileWorkflowVirtualDistanceLabel ??
-                    'How far was the unrecorded drive? (km)',
+                label: l.reconcileWorkflowVirtualDistanceLabel,
                 icon: Icons.straighten,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
               const SizedBox(height: 8),
               FillUpNumericField(
                 controller: _fuelCtrl,
-                label: l?.liters ?? 'Liters',
+                label: l.liters,
                 icon: Icons.local_drink,
                 validator: (v) => AddFillUpValidators.positiveNumber(v, l),
               ),
@@ -140,9 +138,7 @@ class _EditVirtualTrajetSheetState
                   foregroundColor: theme.colorScheme.error,
                 ),
                 icon: const Icon(Icons.delete_outline),
-                label: Text(
-                  l?.reconcileVirtualTrajetDelete ?? 'Delete virtual trip',
-                ),
+                label: Text(l.reconcileVirtualTrajetDelete),
               ),
               const SizedBox(height: 8),
               Row(
@@ -150,15 +146,12 @@ class _EditVirtualTrajetSheetState
                   Expanded(
                     child: TextButton(
                       onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l?.cancel ?? 'Cancel'),
+                      child: Text(l.cancel),
                     ),
                   ),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: FilledButton(
-                      onPressed: _save,
-                      child: Text(l?.save ?? 'Save'),
-                    ),
+                    child: FilledButton(onPressed: _save, child: Text(l.save)),
                   ),
                 ],
               ),

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -33,6 +33,7 @@ import 'eco_score_badge.dart';
 class FillUpCard extends StatelessWidget {
   final FillUp fillUp;
   final EcoScore? ecoScore;
+
   /// Raw per-fill-up L/100 km without the comparison-to-baseline
   /// chip (#2060). Rendered only when [ecoScore] is null AND this
   /// value is non-null — entries that have enough data to compute
@@ -74,8 +75,10 @@ class FillUpCard extends StatelessWidget {
     final costStr = PriceFormatter.formatTotal(fillUp.totalCost);
     // #3198 — thread the fill-up's fuel so a per-fuel suffix override
     // applies (AR GNC is priced per m³, not per litre).
-    final ppl = UnitFormatter.formatPricePerUnit(fillUp.pricePerLiter,
-        fuelType: fillUp.fuelType);
+    final ppl = UnitFormatter.formatPricePerUnit(
+      fillUp.pricePerLiter,
+      fuelType: fillUp.fuelType,
+    );
     // #1401 phase 7b — only render the verified-by-adapter chip when
     // both fuel-level captures are present. Either missing → no chip.
     final isVerifiedByAdapter = FillUpVariance.hasAdapterCapture(fillUp);
@@ -97,17 +100,15 @@ class FillUpCard extends StatelessWidget {
           fillUp.stationName ?? fillUp.fuelType.apiValue.toUpperCase(),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.titleSmall
-              ?.copyWith(fontWeight: FontWeight.bold),
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
         ),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('$dateStr · $distance'),
-            Text(
-              '$volume · $costStr · $ppl',
-              style: theme.textTheme.bodySmall,
-            ),
+            Text('$volume · $costStr · $ppl', style: theme.textTheme.bodySmall),
             if (isVerifiedByAdapter) ...[
               const SizedBox(height: 4),
               // #1401 phase 7b — small "Verified by adapter" chip. Uses
@@ -135,8 +136,7 @@ class FillUpCard extends StatelessWidget {
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        l?.fillUpReconciliationVerifiedBadgeLabel ??
-                            'Verified by adapter',
+                        l.fillUpReconciliationVerifiedBadgeLabel,
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: theme.colorScheme.onPrimaryContainer,
                           fontWeight: FontWeight.w600,
@@ -156,13 +156,7 @@ class FillUpCard extends StatelessWidget {
               // enough preceding same-fuel history for an EcoScoreBadge
               // trend chip. Plain text, no arrow, no comparison.
               Text(
-                l?.ecoScoreConsumption(
-                      rawLPer100Km!.toStringAsFixed(1),
-                    ) ??
-                    UnitFormatter.formatConsumption(
-                      rawLPer100Km!,
-                      isEv: false,
-                    ),
+                l.ecoScoreConsumption(rawLPer100Km!.toStringAsFixed(1)),
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                   fontWeight: FontWeight.w600,
@@ -174,7 +168,7 @@ class FillUpCard extends StatelessWidget {
         trailing: Text(
           fillUp.fuelType.apiValue.toUpperCase(),
           style: theme.textTheme.labelSmall,
-          semanticsLabel: l?.fuelType ?? 'Fuel type',
+          semanticsLabel: l.fuelType,
         ),
       ),
     );
@@ -228,8 +222,7 @@ class _CorrectionRow extends StatelessWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  l?.fillUpCorrectionLabel ??
-                      'Auto-correction — tap to edit',
+                  l.fillUpCorrectionLabel,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: theme.textTheme.labelMedium?.copyWith(

--- a/lib/features/consumption/presentation/widgets/fill_up_date_row.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_date_row.dart
@@ -32,7 +32,7 @@ class FillUpDateRow extends StatelessWidget {
     return ListTile(
       contentPadding: EdgeInsets.zero,
       leading: const Icon(Icons.calendar_today),
-      title: Text(l?.fillUpDate ?? 'Date'),
+      title: Text(l.fillUpDate),
       subtitle: Text(dateLabel),
       onTap: onTap,
     );

--- a/lib/features/consumption/presentation/widgets/fill_up_import_buttons_pair.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_import_buttons_pair.dart
@@ -77,7 +77,7 @@ class FillUpImportButtonsPair extends ConsumerWidget {
                     )
                   : const Icon(Icons.document_scanner_outlined),
               label: Text(
-                l?.fillUpImportReceiptLabel ?? 'Receipt',
+                l.fillUpImportReceiptLabel,
                 maxLines: 2,
                 textAlign: TextAlign.center,
                 overflow: TextOverflow.visible,
@@ -98,7 +98,7 @@ class FillUpImportButtonsPair extends ConsumerWidget {
                     )
                   : const Icon(Icons.local_gas_station_outlined),
               label: Text(
-                l?.fillUpImportPumpLabel ?? 'Pump display',
+                l.fillUpImportPumpLabel,
                 maxLines: 2,
                 textAlign: TextAlign.center,
                 overflow: TextOverflow.visible,
@@ -115,15 +115,14 @@ class FillUpImportButtonsPair extends ConsumerWidget {
             key: const Key('import_paste_receipt_button'),
             onPressed: onPasteReceipt,
             icon: const Icon(Icons.content_paste_outlined, size: 18),
-            label: Text(l?.fillUpImportPasteLabel ?? 'Paste text'),
+            label: Text(l.fillUpImportPasteLabel),
           )
         : null;
 
     final scanRow = Row(
       children: [
         ?receiptBtn,
-        if (receiptBtn != null && pumpBtn != null)
-          const SizedBox(width: 8),
+        if (receiptBtn != null && pumpBtn != null) const SizedBox(width: 8),
         ?pumpBtn,
       ],
     );
@@ -133,10 +132,7 @@ class FillUpImportButtonsPair extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         scanRow,
-        Align(
-          alignment: AlignmentDirectional.centerStart,
-          child: pasteBtn,
-        ),
+        Align(alignment: AlignmentDirectional.centerStart, child: pasteBtn),
       ],
     );
   }

--- a/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_no_vehicle_cta.dart
@@ -25,10 +25,10 @@ class FillUpNoVehicleCta extends StatelessWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     return PageScaffold(
-      title: l?.addFillUp ?? 'Add fill-up',
+      title: l.addFillUp,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l?.tooltipBack ?? 'Back',
+        tooltip: l.tooltipBack,
         onPressed: () => context.pop(),
       ),
       bodyPadding: const EdgeInsets.all(32),
@@ -43,15 +43,13 @@ class FillUpNoVehicleCta extends StatelessWidget {
             ),
             const SizedBox(height: 24),
             Text(
-              l?.consumptionNoVehicleTitle ?? 'Add a vehicle first',
+              l.consumptionNoVehicleTitle,
               style: theme.textTheme.headlineSmall,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 12),
             Text(
-              l?.consumptionNoVehicleBody ??
-                  'Fill-ups are attributed to a vehicle. Add your car '
-                      'to start logging consumption.',
+              l.consumptionNoVehicleBody,
               style: theme.textTheme.bodyMedium,
               textAlign: TextAlign.center,
             ),
@@ -59,7 +57,7 @@ class FillUpNoVehicleCta extends StatelessWidget {
             FilledButton.icon(
               onPressed: () => const EditVehicleRoute().push<void>(context),
               icon: const Icon(Icons.add),
-              label: Text(l?.vehicleAdd ?? 'Add vehicle'),
+              label: Text(l.vehicleAdd),
             ),
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/fill_up_notes_field.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_notes_field.dart
@@ -27,7 +27,7 @@ class FillUpNotesField extends StatelessWidget {
     return TextFormField(
       controller: controller,
       decoration: InputDecoration(
-        labelText: l?.notesOptional ?? 'Notes (optional)',
+        labelText: l.notesOptional,
         prefixIcon: const Icon(Icons.edit_note),
         alignLabelWithHint: true,
         border: const OutlineInputBorder(),

--- a/lib/features/consumption/presentation/widgets/fill_up_paste_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_paste_receipt_handler.dart
@@ -55,12 +55,7 @@ Future<void> runPasteReceiptText(
     final parsed = parser.parse(text, countryCode: state.activeCountry);
     if (!parsed.hasData) {
       if (state.isMounted() && context.mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.pasteReceiptNoData ??
-              "Couldn't read any fuel data from that text — check it's a "
-                  'fuel receipt and try again.',
-        );
+        SnackBarHelper.show(context, l.pasteReceiptNoData);
       }
       return;
     }
@@ -78,16 +73,16 @@ Future<void> runPasteReceiptText(
       SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
     }
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'AddFillUp: paste-receipt parse failed',
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {'where': 'AddFillUp: paste-receipt parse failed'},
+      ),
+    );
     if (state.isMounted() && context.mounted) {
-      SnackBarHelper.show(
-        context,
-        l?.pasteReceiptNoData ??
-            "Couldn't read any fuel data from that text — check it's a "
-                'fuel receipt and try again.',
-      );
+      SnackBarHelper.show(context, l.pasteReceiptNoData);
     }
   }
 }
@@ -124,18 +119,14 @@ class _PasteReceiptDialogState extends State<_PasteReceiptDialog> {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      title: Text(l?.pasteReceiptDialogTitle ?? 'Paste receipt text'),
+      title: Text(l.pasteReceiptDialogTitle),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              l?.pasteReceiptDialogHint ??
-                  'Paste the text of a fuel receipt — e-mail, SMS, or a '
-                      'shared PDF. The litres, price per litre, fuel grade, '
-                      'total and station are read on-device and used to '
-                      'pre-fill the form. Nothing is sent to a server.',
+              l.pasteReceiptDialogHint,
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
@@ -148,7 +139,7 @@ class _PasteReceiptDialogState extends State<_PasteReceiptDialog> {
               keyboardType: TextInputType.multiline,
               textInputAction: TextInputAction.newline,
               decoration: InputDecoration(
-                hintText: l?.pasteReceiptFieldHint ?? 'Receipt text',
+                hintText: l.pasteReceiptFieldHint,
                 border: const OutlineInputBorder(),
               ),
             ),
@@ -158,12 +149,12 @@ class _PasteReceiptDialogState extends State<_PasteReceiptDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l?.cancel ?? 'Cancel'),
+          child: Text(l.cancel),
         ),
         FilledButton(
           key: const Key('paste_receipt_confirm_button'),
           onPressed: () => Navigator.of(context).pop(_controller.text),
-          child: Text(l?.pasteReceiptParseAction ?? 'Pre-fill'),
+          child: Text(l.pasteReceiptParseAction),
         ),
       ],
     );

--- a/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
@@ -38,7 +38,7 @@ class FillUpPinnedSaveBar extends StatelessWidget {
               minimumSize: const Size.fromHeight(52),
             ),
             icon: const Icon(Icons.save_outlined),
-            label: Text(l?.save ?? 'Save'),
+            label: Text(l.save),
           ),
         ),
       ),

--- a/lib/features/consumption/presentation/widgets/fill_up_price_per_liter_readout.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_price_per_liter_readout.dart
@@ -34,21 +34,18 @@ class FillUpPricePerLiterReadout extends StatelessWidget {
     return AnimatedBuilder(
       animation: Listenable.merge([litersController, costController]),
       builder: (context, _) {
-        final liters =
-            double.tryParse(litersController.text.replaceAll(',', '.'));
-        final cost =
-            double.tryParse(costController.text.replaceAll(',', '.'));
-        if (liters == null ||
-            liters <= 0 ||
-            cost == null ||
-            cost <= 0) {
+        final liters = double.tryParse(
+          litersController.text.replaceAll(',', '.'),
+        );
+        final cost = double.tryParse(costController.text.replaceAll(',', '.'));
+        if (liters == null || liters <= 0 || cost == null || cost <= 0) {
           return const SizedBox.shrink();
         }
         final pricePerLiter = cost / liters;
         // Semantics-exposed node — TalkBack WILL read this (the
         // computed value is useful context), but the label is baked
         // into one string so only a single announcement fires.
-        final label = l?.fillUpPricePerLiterLabel ?? 'Price per liter';
+        final label = l.fillUpPricePerLiterLabel;
         final value = pricePerLiter.toStringAsFixed(3);
         return Padding(
           padding: const EdgeInsets.only(top: 6, left: 56),

--- a/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
@@ -127,10 +127,7 @@ Future<void> runReceiptScan(
 
     if (!outcome.parse.hasData) {
       if (context.mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.scanReceiptNoData ?? 'No receipt data found — try again',
-        );
+        SnackBarHelper.show(context, l.scanReceiptNoData);
       }
       return;
     }
@@ -141,14 +138,16 @@ Future<void> runReceiptScan(
       SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
     }
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'runReceiptScan: receipt scan failed'
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {'where': 'runReceiptScan: receipt scan failed'},
+      ),
+    );
     if (state.isMounted() && context.mounted) {
-      SnackBarHelper.showError(
-        context,
-        l?.scanReceiptFailed(e.toString()) ?? 'Scan failed: $e',
-      );
+      SnackBarHelper.showError(context, l.scanReceiptFailed(e.toString()));
     }
   } finally {
     if (state.isMounted()) state.setScanning(false);
@@ -188,12 +187,7 @@ Future<void> runPumpDisplayScan(
     if (outcome.glareRejected) {
       await state.readService()?.deleteCapturedImage(outcome.imagePath);
       if (state.isMounted() && context.mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.scanPumpGlare ??
-              'Too much glare on the display — try again at a slight '
-                  'angle so the numbers aren\'t washed out.',
-        );
+        SnackBarHelper.show(context, l.scanPumpGlare);
       }
       return;
     }
@@ -211,11 +205,7 @@ Future<void> runPumpDisplayScan(
         // ask the user to enter the values manually.
         await state.readService()?.deleteCapturedImage(outcome.imagePath);
         if (state.isMounted() && context.mounted) {
-          SnackBarHelper.show(
-            context,
-            l?.scanPumpInconsistent ??
-                'The scanned values don\'t add up — please enter them manually.',
-          );
+          SnackBarHelper.show(context, l.scanPumpInconsistent);
         }
         return;
       case PumpScanDisposition.autofill:
@@ -228,20 +218,21 @@ Future<void> runPumpDisplayScan(
       state.costCtrl.text = result.totalCost!.toStringAsFixed(2);
     }
     if (state.isMounted() && context.mounted) {
-      SnackBarHelper.show(
-        context,
-        l?.scanPumpSuccess ?? 'Pump display scanned — verify the values.',
-      );
+      SnackBarHelper.show(context, l.scanPumpSuccess);
     }
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'runPumpDisplayScan: pump display scan failed'
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {
+          'where': 'runPumpDisplayScan: pump display scan failed',
+        },
+      ),
+    );
     if (state.isMounted() && context.mounted) {
-      SnackBarHelper.showError(
-        context,
-        l?.scanPumpFailed(e.toString()) ?? 'Pump scan failed: $e',
-      );
+      SnackBarHelper.showError(context, l.scanPumpFailed(e.toString()));
     }
   } finally {
     if (state.isMounted()) state.setScanningPump(false);
@@ -293,8 +284,7 @@ Future<void> reportBadPumpScan(
   FillUpScanHostState state,
   PumpDisplayScanOutcome outcome,
 ) async {
-  final liters =
-      double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
+  final liters = double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
   final cost = double.tryParse(state.costCtrl.text.replaceAll(',', '.'));
   await showModalBottomSheet<void>(
     context: context,
@@ -318,8 +308,7 @@ Future<void> reportBadReceiptScan(
   FillUpScanHostState state,
   ReceiptScanOutcome scan,
 ) async {
-  final liters =
-      double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
+  final liters = double.tryParse(state.litersCtrl.text.replaceAll(',', '.'));
   final cost = double.tryParse(state.costCtrl.text.replaceAll(',', '.'));
   await showModalBottomSheet<void>(
     context: context,

--- a/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
@@ -40,7 +40,10 @@ import 'fill_up_scan_handlers.dart';
 /// Caller contract: only invoke when `outcome.parse.hasData` is true —
 /// the snackbar mapping (`scanReceiptNoData` vs `scanReceiptSuccess`)
 /// stays with the flow entry-points so each can drive its own UI.
-void applyReceiptOutcome(FillUpScanHostState state, ReceiptScanOutcome outcome) {
+void applyReceiptOutcome(
+  FillUpScanHostState state,
+  ReceiptScanOutcome outcome,
+) {
   final result = outcome.parse;
   if (result.liters != null) {
     state.litersCtrl.text = result.liters!.toStringAsFixed(2);
@@ -73,12 +76,10 @@ void applyReceiptOutcome(FillUpScanHostState state, ReceiptScanOutcome outcome) 
 /// prefill. Both [runReceiptScan] and [runSharedReceiptScan] route their
 /// success snackbar through this so the station hint reaches both flows.
 String receiptScanSuccessMessage(
-  AppLocalizations? l,
+  AppLocalizations l,
   ReceiptScanOutcome outcome,
 ) {
-  final base = l?.scanReceiptSuccess ??
-      'Receipt scanned — verify values. Tap "Report scan error" '
-          'below if anything is off.';
+  final base = l.scanReceiptSuccess;
   final station = outcome.parse.stationName?.trim();
   if (station == null || station.isEmpty) return base;
   // i18n-ignore: station name is a proper noun / brand surfaced inline (#2734)
@@ -122,10 +123,7 @@ Future<void> runSharedReceiptScan(
 
     if (!outcome.parse.hasData) {
       if (context.mounted) {
-        SnackBarHelper.show(
-          context,
-          l?.scanReceiptNoData ?? 'No receipt data found — try again',
-        );
+        SnackBarHelper.show(context, l.scanReceiptNoData);
       }
       return;
     }
@@ -136,14 +134,18 @@ Future<void> runSharedReceiptScan(
       SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
     }
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'runSharedReceiptScan: shared receipt scan failed'
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {
+          'where': 'runSharedReceiptScan: shared receipt scan failed',
+        },
+      ),
+    );
     if (state.isMounted() && context.mounted) {
-      SnackBarHelper.showError(
-        context,
-        l?.scanReceiptFailed(e.toString()) ?? 'Scan failed: $e',
-      );
+      SnackBarHelper.showError(context, l.scanReceiptFailed(e.toString()));
     }
   } finally {
     if (state.isMounted()) state.setScanning(false);
@@ -188,12 +190,18 @@ void scheduleSharedReceiptScanIfPending(
 ) {
   String? path;
   try {
-    path =
-        ref.read(pendingSharedReceiptProvider.notifier).consumeDeferred();
+    path = ref.read(pendingSharedReceiptProvider.notifier).consumeDeferred();
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'AddFillUp: pending shared-receipt read failed',
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {
+          'where': 'AddFillUp: pending shared-receipt read failed',
+        },
+      ),
+    );
     return;
   }
   if (path == null) return;
@@ -224,12 +232,20 @@ void scheduleSharedReceiptTextIfPending(
 ) {
   ReceiptParseResult? result;
   try {
-    result =
-        ref.read(pendingSharedReceiptTextProvider.notifier).consumeDeferred();
+    result = ref
+        .read(pendingSharedReceiptTextProvider.notifier)
+        .consumeDeferred();
   } catch (e, st) {
-    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-      'where': 'AddFillUp: pending shared-receipt text read failed',
-    }));
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: const {
+          'where': 'AddFillUp: pending shared-receipt text read failed',
+        },
+      ),
+    );
     return;
   }
   if (result == null || !result.hasData) return;
@@ -248,9 +264,16 @@ void scheduleSharedReceiptTextIfPending(
         SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'AddFillUp: shared-receipt text prefill failed',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'AddFillUp: shared-receipt text prefill failed',
+          },
+        ),
+      );
     }
   });
 }

--- a/lib/features/consumption/presentation/widgets/fill_up_variance_prompt.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_variance_prompt.dart
@@ -35,33 +35,21 @@ Future<FillUpVarianceChoice> showFillUpVarianceDialog({
     barrierDismissible: true,
     builder: (dialogContext) {
       return AlertDialog(
-        title: Text(
-          l?.fillUpReconciliationVarianceDialogTitle ??
-              "Doesn't match adapter reading",
-        ),
+        title: Text(l.fillUpReconciliationVarianceDialogTitle),
         content: Text(
-          l?.fillUpReconciliationVarianceDialogBody(userL, adapterL) ??
-              'Your entry: $userL L. Adapter says: $adapterL L (delta from '
-                  'before/after fuel-level capture). Use adapter value?',
+          l.fillUpReconciliationVarianceDialogBody(userL, adapterL),
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(
-              FillUpVarianceChoice.keepUser,
-            ),
-            child: Text(
-              l?.fillUpReconciliationVarianceDialogKeepMine ??
-                  'Keep my entry',
-            ),
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(FillUpVarianceChoice.keepUser),
+            child: Text(l.fillUpReconciliationVarianceDialogKeepMine),
           ),
           FilledButton(
-            onPressed: () => Navigator.of(dialogContext).pop(
-              FillUpVarianceChoice.useAdapter,
-            ),
-            child: Text(
-              l?.fillUpReconciliationVarianceDialogUseAdapter ??
-                  'Use adapter value',
-            ),
+            onPressed: () => Navigator.of(
+              dialogContext,
+            ).pop(FillUpVarianceChoice.useAdapter),
+            child: Text(l.fillUpReconciliationVarianceDialogUseAdapter),
           ),
         ],
       );

--- a/lib/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_vehicle_dropdown.dart
@@ -36,19 +36,15 @@ class FillUpVehicleDropdown extends StatelessWidget {
     return DropdownButtonFormField<String>(
       initialValue: vehicleId,
       decoration: InputDecoration(
-        labelText: l?.fillUpVehicleLabel ?? 'Vehicle',
+        labelText: l.fillUpVehicleLabel,
         prefixIcon: const Icon(Icons.directions_car_outlined),
       ),
       items: vehicles
           .map(
-            (v) => DropdownMenuItem<String>(
-              value: v.id,
-              child: Text(v.name),
-            ),
+            (v) => DropdownMenuItem<String>(value: v.id, child: Text(v.name)),
           )
           .toList(),
-      validator: (v) =>
-          v == null ? (l?.fillUpVehicleRequired ?? 'Required') : null,
+      validator: (v) => v == null ? (l.fillUpVehicleRequired) : null,
       onChanged: (v) {
         if (v == null) return;
         final selected = vehicles.firstWhere((x) => x.id == v);

--- a/lib/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_vehicle_fuel_picker.dart
@@ -46,8 +46,7 @@ class FillUpVehicleFuelPicker extends StatelessWidget {
     final vehicleFuel =
         AddFillUpFuelResolver.fuelForVehicle(vehicle) ?? FuelType.e10;
     final compatible = compatibleFuelsFor(vehicleFuel);
-    final value =
-        compatible.contains(fuelType) ? fuelType : compatible.first;
+    final value = compatible.contains(fuelType) ? fuelType : compatible.first;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -59,13 +58,13 @@ class FillUpVehicleFuelPicker extends StatelessWidget {
                 value: value,
                 options: compatible,
                 prefixIcon: const Icon(Icons.local_gas_station),
-                labelText: '${l?.fuelType ?? 'Fuel type'} • ${vehicle.name}',
+                labelText: '${l.fuelType} • ${vehicle.name}',
                 onChanged: onChanged,
               ),
             ),
             IconButton(
               icon: const Icon(Icons.open_in_new),
-              tooltip: l?.vehicleEditTitle ?? 'Edit vehicle',
+              tooltip: l.vehicleEditTitle,
               onPressed: onOpenVehicle,
               style: IconButton.styleFrom(
                 foregroundColor: theme.colorScheme.primary,
@@ -89,9 +88,7 @@ class FillUpVehicleFuelPicker extends StatelessWidget {
               const SizedBox(width: 6),
               Expanded(
                 child: Text(
-                  l?.fillUpMultiFuelHint ??
-                      'This vehicle can use different fuels — log the one '
-                          'you actually pumped',
+                  l.fillUpMultiFuelHint,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.primary,
                   ),

--- a/lib/features/consumption/presentation/widgets/fill_up_warning_dialog.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_warning_dialog.dart
@@ -30,20 +30,15 @@ Future<bool> showFillUpWarningDialog({
   final lines = <String>[
     for (final w in warnings)
       switch (w) {
-        FillUpWarning.fuelEngineMismatch => l?.fillUpWarningFuelMismatch(
-              chosenFuel.displayName,
-              vehicleFuel?.displayName ?? chosenFuel.displayName,
-            ) ??
-            'You picked ${chosenFuel.displayName}, but this vehicle runs on '
-                '${vehicleFuel?.displayName ?? chosenFuel.displayName}.',
+        FillUpWarning.fuelEngineMismatch => l.fillUpWarningFuelMismatch(
+          chosenFuel.displayName,
+          vehicleFuel?.displayName ?? chosenFuel.displayName,
+        ),
         FillUpWarning.odometerBelowPrevious =>
-          l?.fillUpWarningOdometerBelowPrevious(
-                enteredOdoKm,
-                previousOdoKm ?? enteredOdoKm,
-              ) ??
-              'Odometer $enteredOdoKm km is below the previous fill-up\'s '
-                  '${previousOdoKm ?? enteredOdoKm} km — distance can\'t go '
-                  'backwards.',
+          l.fillUpWarningOdometerBelowPrevious(
+            enteredOdoKm,
+            previousOdoKm ?? enteredOdoKm,
+          ),
       },
   ];
 
@@ -51,7 +46,7 @@ Future<bool> showFillUpWarningDialog({
     context: context,
     barrierDismissible: true,
     builder: (dialogContext) => AlertDialog(
-      title: Text(l?.fillUpWarningDialogTitle ?? 'Check this fill-up'),
+      title: Text(l.fillUpWarningDialogTitle),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -73,11 +68,11 @@ Future<bool> showFillUpWarningDialog({
       actions: [
         TextButton(
           onPressed: () => Navigator.of(dialogContext).pop(false),
-          child: Text(l?.fillUpWarningGoBack ?? 'Go back and fix'),
+          child: Text(l.fillUpWarningGoBack),
         ),
         FilledButton(
           onPressed: () => Navigator.of(dialogContext).pop(true),
-          child: Text(l?.fillUpWarningSaveAnyway ?? 'Save anyway'),
+          child: Text(l.fillUpWarningSaveAnyway),
         ),
       ],
     ),

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -34,7 +34,7 @@ import 'tank_level_card.dart';
 class FuelTab extends ConsumerWidget {
   final List<FillUp> fillUps;
   final ConsumptionStats stats;
-  final AppLocalizations? l;
+  final AppLocalizations l;
 
   const FuelTab({
     super.key,
@@ -48,10 +48,8 @@ class FuelTab extends ConsumerWidget {
     if (fillUps.isEmpty) {
       return EmptyState(
         icon: Icons.local_gas_station_outlined,
-        title: l?.noFillUpsTitle ?? 'No fill-ups yet',
-        subtitle:
-            l?.noFillUpsSubtitle ??
-            'Log your first fill-up to start tracking consumption.',
+        title: l.noFillUpsTitle,
+        subtitle: l.noFillUpsSubtitle,
         topBiased: true,
       );
     }
@@ -66,11 +64,7 @@ class FuelTab extends ConsumerWidget {
       HelpBanner(
         storageKey: StorageKeys.helpBannerConsumption,
         icon: Icons.tips_and_updates_outlined,
-        message:
-            l?.helpBannerConsumption ??
-            'Log every fill-up to track your real-world '
-                'consumption and CO₂ footprint. Swipe left '
-                'to delete an entry.',
+        message: l.helpBannerConsumption,
       ),
       if (showGamification) const BadgeShelf(),
       const TankLevelCard(),
@@ -149,11 +143,13 @@ class FuelTab extends ConsumerWidget {
   }
 
   void _openCorrectionEditor(BuildContext context, FillUp fillUp) {
-    unawaited(showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (_) => EditCorrectionFillUpSheet(fillUp: fillUp),
-    ));
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        useSafeArea: true,
+        builder: (_) => EditCorrectionFillUpSheet(fillUp: fillUp),
+      ),
+    );
   }
 }

--- a/lib/features/consumption/presentation/widgets/fuel_type_efficiency_card.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_type_efficiency_card.dart
@@ -62,10 +62,9 @@ class FuelTypeEfficiencyCard extends ConsumerWidget {
     // aggregator already guarantees this, but the gate is cheap and hardens
     // the chip against any future change to `cheapestPerKm` (a crowned-but-
     // null bucket would otherwise render "Cheapest per km: … (--)").
-    final winner =
-        (crowned != null && _costPerKmOf(withFills, crowned) != null)
-            ? crowned
-            : null;
+    final winner = (crowned != null && _costPerKmOf(withFills, crowned) != null)
+        ? crowned
+        : null;
     // Best (lowest) non-null €/km — the sentiment baseline for the delta
     // arrows. Independent of the verdict gate so arrows render even when no
     // crown is awarded.
@@ -76,9 +75,8 @@ class FuelTypeEfficiencyCard extends ConsumerWidget {
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: SectionCard(
         key: const ValueKey('fuel_type_efficiency_card'),
-        title: l?.fuelEfficiencyCardTitle ?? 'Cost per kilometre by fuel',
-        subtitle: l?.fuelEfficiencyCardSubtitle ??
-            'Which fuel mix is actually cheapest to drive on',
+        title: l.fuelEfficiencyCardTitle,
+        subtitle: l.fuelEfficiencyCardSubtitle,
         leadingIcon: Icons.eco_outlined,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -100,19 +98,11 @@ class FuelTypeEfficiencyCard extends ConsumerWidget {
             ],
             if (winner == null) ...[
               const SizedBox(height: 2),
-              _Footnote(
-                text: l?.fuelEfficiencyInsufficientData ??
-                    'Log at least two full tanks per composition to crown the '
-                        'cheapest.',
-              ),
+              _Footnote(text: l.fuelEfficiencyInsufficientData),
             ],
             if (anyMix) ...[
               const SizedBox(height: 4),
-              _Footnote(
-                text: l?.fuelEfficiencyCompositionFootnote ??
-                    'Tanks are grouped by composition: a tank is pure when '
-                        'one fuel is at least 85% of it, otherwise a blend.',
-              ),
+              _Footnote(text: l.fuelEfficiencyCompositionFootnote),
             ],
           ],
         ),
@@ -161,8 +151,7 @@ class _WinnerChip extends StatelessWidget {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final cost = PriceFormatter.formatPerKm(costPerKm);
-    final text = l?.fuelEfficiencyWinnerChip(label, cost) ??
-        'Cheapest per km: $label ($cost)';
+    final text = l.fuelEfficiencyWinnerChip(label, cost);
     return Container(
       key: const ValueKey('fuel_efficiency_winner_chip'),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/features/consumption/presentation/widgets/fuel_type_efficiency_rows.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_type_efficiency_rows.dart
@@ -33,17 +33,16 @@ class _BucketRow extends StatelessWidget {
     // Capture the field into a local so the analyzer can promote it past the
     // null check.
     final best = bestCostPerKm;
-    final delta =
-        (costPerKm != null && best != null) ? costPerKm - best : 0.0;
+    final delta = (costPerKm != null && best != null) ? costPerKm - best : 0.0;
 
     final badge = stats.isMix
-        ? (l?.fuelEfficiencyMixBadge ?? 'Blend')
-        : (l?.fuelEfficiencyPureBadge ?? 'Pure');
+        ? (l.fuelEfficiencyMixBadge)
+        : (l.fuelEfficiencyPureBadge);
     final dominantName = localizedFuelName(l, bucket.dominant);
     // Secondary line: a blend names its dominant fuel; a pure bucket names
     // its (single) fuel so the row is never just an opaque grade code.
     final secondaryLine = stats.isMix
-        ? (l?.fuelEfficiencyMixDominant(dominantName) ?? 'Mostly $dominantName')
+        ? (l.fuelEfficiencyMixDominant(dominantName))
         : dominantName;
 
     return Row(
@@ -65,8 +64,9 @@ class _BucketRow extends StatelessWidget {
                       // code / A/B mix mask (see FuelEfficiencyBucket.label).
                       bucket.label,
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        fontWeight:
-                            isWinner ? FontWeight.w700 : FontWeight.w600,
+                        fontWeight: isWinner
+                            ? FontWeight.w700
+                            : FontWeight.w600,
                       ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -93,7 +93,7 @@ class _BucketRow extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               _MetricLine(
-                label: l?.fuelEfficiencyColCostPerKm ?? 'Cost/km',
+                label: l.fuelEfficiencyColCostPerKm,
                 value: costPerKm != null
                     ? PriceFormatter.formatPerKm(costPerKm)
                     : '—',
@@ -101,16 +101,15 @@ class _BucketRow extends StatelessWidget {
                 emphasised: true,
               ),
               _MetricLine(
-                label: l?.fuelEfficiencyColL100km ?? 'L/100km',
+                label: l.fuelEfficiencyColL100km,
                 value: l100 != null ? l100.toStringAsFixed(1) : '—',
               ),
               _MetricLine(
-                label: l?.fuelEfficiencyColTotalSpent ?? 'Total spent',
+                label: l.fuelEfficiencyColTotalSpent,
                 value: PriceFormatter.formatTotal(stats.totalSpent),
               ),
               Text(
-                l?.fuelEfficiencyFillCount(stats.fillCount) ??
-                    '${stats.fillCount} fills',
+                l.fuelEfficiencyFillCount(stats.fillCount),
                 style: theme.textTheme.labelSmall?.copyWith(
                   color: scheme.onSurfaceVariant,
                 ),
@@ -135,8 +134,9 @@ class _CompositionBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
-    final bg =
-        isMix ? scheme.tertiaryContainer : scheme.surfaceContainerHighest;
+    final bg = isMix
+        ? scheme.tertiaryContainer
+        : scheme.surfaceContainerHighest;
     final fg = isMix ? scheme.onTertiaryContainer : scheme.onSurfaceVariant;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
@@ -188,13 +188,14 @@ class _MetricLine extends StatelessWidget {
         const SizedBox(width: 6),
         Text(
           value,
-          style: (emphasised
-                  ? theme.textTheme.titleSmall
-                  : theme.textTheme.bodyMedium)
-              ?.copyWith(
-            fontFeatures: const [FontFeature.tabularFigures()],
-            fontWeight: emphasised ? FontWeight.w700 : null,
-          ),
+          style:
+              (emphasised
+                      ? theme.textTheme.titleSmall
+                      : theme.textTheme.bodyMedium)
+                  ?.copyWith(
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                    fontWeight: emphasised ? FontWeight.w700 : null,
+                  ),
         ),
         if (trailing != null) ...[
           const SizedBox(width: 2),

--- a/lib/features/consumption/presentation/widgets/gps_degraded_banner.dart
+++ b/lib/features/consumption/presentation/widgets/gps_degraded_banner.dart
@@ -191,10 +191,8 @@ class _GpsDegradedBannerState extends ConsumerState<GpsDegradedBanner> {
       ),
       content: Text(
         passiveWaiting
-            ? (l?.obd2GpsDegradedPassiveWaitingBanner ??
-                'Recording with GPS — waiting for the OBD2 adapter')
-            : (l?.obd2GpsDegradedBannerTitle ??
-                'Recording with GPS — OBD2 reconnecting'),
+            ? (l.obd2GpsDegradedPassiveWaitingBanner)
+            : (l.obd2GpsDegradedBannerTitle),
       ),
       // No Resume / End: recording continues automatically. A
       // MaterialBanner requires a non-empty actions list, so a single

--- a/lib/features/consumption/presentation/widgets/gps_diagnostics_card.dart
+++ b/lib/features/consumption/presentation/widgets/gps_diagnostics_card.dart
@@ -39,20 +39,14 @@ class GpsDiagnosticsCard extends StatelessWidget {
     final theme = Theme.of(context);
     final summary = computeGpsDiagnosticsSummary(diagnostics);
 
-    final title = l?.gpsDiagnosticsTitle ?? 'GPS sampling diagnostics';
-    final headerLine = l?.gpsDiagnosticsHeader(
-          summary.sampleCount.toString(),
-          _formatDuration(summary.timeSpan),
-          summary.gapCount,
-        ) ??
-        '${summary.sampleCount} samples · ${_formatDuration(summary.timeSpan)} · '
-            '${_pluralizeGaps(summary.gapCount)}';
-    final cadenceLine = l?.gpsDiagnosticsCadence(
-          summary.medianIntervalMs,
-        ) ??
-        'Median interval: ${summary.medianIntervalMs} ms';
-    final explainLine = l?.gpsDiagnosticsExplain ??
-        'Captured during recording to verify GPS cadence under phone-sleep.';
+    final title = l.gpsDiagnosticsTitle;
+    final headerLine = l.gpsDiagnosticsHeader(
+      summary.sampleCount.toString(),
+      _formatDuration(summary.timeSpan),
+      summary.gapCount,
+    );
+    final cadenceLine = l.gpsDiagnosticsCadence(summary.medianIntervalMs);
+    final explainLine = l.gpsDiagnosticsExplain;
 
     return Card(
       margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
@@ -73,10 +67,7 @@ class GpsDiagnosticsCard extends StatelessWidget {
         children: [
           Align(
             alignment: AlignmentDirectional.centerStart,
-            child: Text(
-              cadenceLine,
-              style: theme.textTheme.bodyMedium,
-            ),
+            child: Text(cadenceLine, style: theme.textTheme.bodyMedium),
           ),
           const SizedBox(height: 8),
           Align(
@@ -90,8 +81,7 @@ class GpsDiagnosticsCard extends StatelessWidget {
           Align(
             alignment: AlignmentDirectional.centerStart,
             child: Text(
-              l?.gpsDiagnosticsLargestGap(summary.largestGap.inSeconds) ??
-                  'Largest gap: ${summary.largestGap.inSeconds} s',
+              l.gpsDiagnosticsLargestGap(summary.largestGap.inSeconds),
               style: theme.textTheme.bodyMedium,
             ),
           ),
@@ -180,15 +170,15 @@ class GpsDiagnosticsSummary {
 
   @override
   int get hashCode => Object.hash(
-        sampleCount,
-        timeSpan,
-        medianIntervalMs,
-        gapCount,
-        largestGap,
-        Object.hashAllUnordered(lifecyclePercent.entries.map(
-          (e) => Object.hash(e.key, e.value),
-        )),
-      );
+    sampleCount,
+    timeSpan,
+    medianIntervalMs,
+    gapCount,
+    largestGap,
+    Object.hashAllUnordered(
+      lifecyclePercent.entries.map((e) => Object.hash(e.key, e.value)),
+    ),
+  );
 }
 
 /// Compute the read-only diagnostic summary for a list of GPS sample
@@ -221,9 +211,7 @@ GpsDiagnosticsSummary computeGpsDiagnosticsSummary(
       sampleCount: 1,
       timeSpan: Duration.zero,
       medianIntervalMs: 0,
-      lifecyclePercent: <String, int>{
-        diagnostics.first.lifecycleState: 100,
-      },
+      lifecyclePercent: <String, int>{diagnostics.first.lifecycleState: 100},
       gapCount: 0,
       largestGap: Duration.zero,
     );
@@ -241,7 +229,9 @@ GpsDiagnosticsSummary computeGpsDiagnosticsSummary(
   // Per-interval deltas in milliseconds.
   final intervals = <int>[];
   for (var i = 1; i < sorted.length; i++) {
-    final ms = sorted[i].timestamp.difference(sorted[i - 1].timestamp).inMilliseconds;
+    final ms = sorted[i].timestamp
+        .difference(sorted[i - 1].timestamp)
+        .inMilliseconds;
     // Defensive clamp: backwards-clock anomalies become 0 rather than
     // contaminating the median.
     intervals.add(ms < 0 ? 0 : ms);
@@ -265,8 +255,9 @@ GpsDiagnosticsSummary computeGpsDiagnosticsSummary(
   final gapThreshold = medianRaw * 3;
   // When the median is 0 (all samples on the same millisecond — degenerate
   // input), gaps are not a meaningful signal, so report 0.
-  final gapCount =
-      medianRaw == 0 ? 0 : intervals.where((d) => d >= gapThreshold).length;
+  final gapCount = medianRaw == 0
+      ? 0
+      : intervals.where((d) => d >= gapThreshold).length;
 
   // Lifecycle breakdown.
   final lifecycleCounts = <String, int>{};
@@ -303,15 +294,6 @@ String _formatDuration(Duration d) {
   return '${hours}h ${minutes}min';
 }
 
-/// Tiny English-only fallback used when [AppLocalizations] is not
-/// available (defensive — pumpApp tests always provide it). Never
-/// reached in production on non-English locales.
-String _pluralizeGaps(int gapCount) {
-  if (gapCount == 0) return 'no gaps';
-  if (gapCount == 1) return '1 gap';
-  return '$gapCount gaps';
-}
-
 /// Format the lifecycle-percent map into a "Resumed 92% · Paused 5% · …"
 /// line. The map is already sorted by count desc by the helper. Each
 /// lifecycle key is mapped to a localized label via [_lifecycleLabel];
@@ -319,7 +301,7 @@ String _pluralizeGaps(int gapCount) {
 /// onto every non-English locale (#2765).
 String _formatLifecycleBreakdown(
   Map<String, int> lifecyclePercent,
-  AppLocalizations? l,
+  AppLocalizations l,
 ) {
   if (lifecyclePercent.isEmpty) return '';
   return lifecyclePercent.entries
@@ -332,14 +314,14 @@ String _formatLifecycleBreakdown(
 /// keys fall back to the raw key so a future lifecycle value never
 /// renders as a blank — but the three states the recorder actually
 /// captures are all covered.
-String _lifecycleLabel(String key, AppLocalizations? l) {
+String _lifecycleLabel(String key, AppLocalizations l) {
   switch (key) {
     case 'resumed':
-      return l?.gpsLifecycleResumed ?? 'Resumed';
+      return l.gpsLifecycleResumed;
     case 'paused':
-      return l?.gpsLifecyclePaused ?? 'Paused';
+      return l.gpsLifecyclePaused;
     case 'inactive':
-      return l?.gpsLifecycleInactive ?? 'Inactive';
+      return l.gpsLifecycleInactive;
     default:
       return key;
   }

--- a/lib/features/consumption/presentation/widgets/gps_efficiency_kpi_card.dart
+++ b/lib/features/consumption/presentation/widgets/gps_efficiency_kpi_card.dart
@@ -58,60 +58,90 @@ class GpsEfficiencyKpiCard extends StatelessWidget {
     // aggressive so the raw figure carries a verdict + colour, mirroring
     // DrivingScoreCard's class band. Climb energy is terrain, not driving
     // style, so it stays an un-banded plain row.
-    final rpaVerdict = GpsKpiVerdicts.rpa(features.relativePositiveAcceleration);
+    final rpaVerdict = GpsKpiVerdicts.rpa(
+      features.relativePositiveAcceleration,
+    );
     final pkeVerdict = GpsKpiVerdicts.pke(features.positiveKineticEnergy);
     final vaposVerdict = GpsKpiVerdicts.vapos(features.meanPositiveVa);
     final coastVerdict = GpsKpiVerdicts.coast(features.coastShare);
 
     final rows = <Widget>[
-      _kpiRow(theme, l, key: const Key('gps_kpi_rpa'),
-          label: l?.gpsKpiRpa ?? 'Positive acceleration (RPA)',
-          value: features.relativePositiveAcceleration.toStringAsFixed(2),
-          verdict: rpaVerdict),
-      _kpiRow(theme, l, key: const Key('gps_kpi_pke'),
-          label: l?.gpsKpiPke ?? 'Kinetic energy demand (PKE)',
-          value: features.positiveKineticEnergy.toStringAsFixed(2),
-          verdict: pkeVerdict),
-      _kpiRow(theme, l, key: const Key('gps_kpi_vapos'),
-          label: l?.gpsKpiVapos ?? 'Acceleration intensity (VAPOS)',
-          value: features.meanPositiveVa.toStringAsFixed(2),
-          verdict: vaposVerdict),
-      _kpiRow(theme, l, key: const Key('gps_kpi_coast'),
-          label: l?.gpsKpiCoast ?? 'Coasting share',
-          value: '${(features.coastShare * 100).toStringAsFixed(0)}%',
-          verdict: coastVerdict),
-      _kpiRow(theme, l, key: const Key('gps_kpi_climb'),
-          label: l?.gpsKpiClimbEnergy ?? 'Climb energy',
-          value: '${features.climbEnergyPerKm.toStringAsFixed(0)} m/km'),
+      _kpiRow(
+        theme,
+        l,
+        key: const Key('gps_kpi_rpa'),
+        label: l.gpsKpiRpa,
+        value: features.relativePositiveAcceleration.toStringAsFixed(2),
+        verdict: rpaVerdict,
+      ),
+      _kpiRow(
+        theme,
+        l,
+        key: const Key('gps_kpi_pke'),
+        label: l.gpsKpiPke,
+        value: features.positiveKineticEnergy.toStringAsFixed(2),
+        verdict: pkeVerdict,
+      ),
+      _kpiRow(
+        theme,
+        l,
+        key: const Key('gps_kpi_vapos'),
+        label: l.gpsKpiVapos,
+        value: features.meanPositiveVa.toStringAsFixed(2),
+        verdict: vaposVerdict,
+      ),
+      _kpiRow(
+        theme,
+        l,
+        key: const Key('gps_kpi_coast'),
+        label: l.gpsKpiCoast,
+        value: '${(features.coastShare * 100).toStringAsFixed(0)}%',
+        verdict: coastVerdict,
+      ),
+      _kpiRow(
+        theme,
+        l,
+        key: const Key('gps_kpi_climb'),
+        label: l.gpsKpiClimbEnergy,
+        value: '${features.climbEnergyPerKm.toStringAsFixed(0)} m/km',
+      ),
     ];
 
     // Overall verdict = the worst of the four style KPIs, so the one-line
     // interpretation is conservative + actionable (a single aggressive
     // metric is worth flagging even amid otherwise calm figures).
-    final overall = _worst(
-        [rpaVerdict, pkeVerdict, vaposVerdict, coastVerdict]);
+    final overall = _worst([
+      rpaVerdict,
+      pkeVerdict,
+      vaposVerdict,
+      coastVerdict,
+    ]);
     rows.add(const SizedBox(height: 10));
-    rows.add(Text(
-      _interpretation(l, overall),
-      key: const Key('gps_kpi_interpretation'),
-      style: theme.textTheme.bodyMedium?.copyWith(
-        color: _verdictColor(theme, overall),
-        fontWeight: FontWeight.w600,
+    rows.add(
+      Text(
+        _interpretation(l, overall),
+        key: const Key('gps_kpi_interpretation'),
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: _verdictColor(theme, overall),
+          fontWeight: FontWeight.w600,
+        ),
       ),
-    ));
+    );
 
     final delta = baselineDeltaPercent;
     if (delta != null) {
       final sign = delta >= 0 ? '+' : '';
       final pct = '$sign${delta.toStringAsFixed(0)}%';
       rows.add(const SizedBox(height: 8));
-      rows.add(Text(
-        l?.drivingScoreBaselineDelta(pct) ?? '$pct vs your efficient baseline',
-        key: const Key('gps_kpi_baseline_delta'),
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurfaceVariant,
+      rows.add(
+        Text(
+          l.drivingScoreBaselineDelta(pct),
+          key: const Key('gps_kpi_baseline_delta'),
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         ),
-      ));
+      );
     }
 
     return Card(
@@ -122,7 +152,7 @@ class GpsEfficiencyKpiCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.gpsKpiCardTitle ?? 'GPS efficiency',
+              l.gpsKpiCardTitle,
               key: const Key('gps_kpi_card_title'),
               style: theme.textTheme.titleMedium,
             ),
@@ -136,7 +166,7 @@ class GpsEfficiencyKpiCard extends StatelessWidget {
 
   Widget _kpiRow(
     ThemeData theme,
-    AppLocalizations? l, {
+    AppLocalizations l, {
     required Key key,
     required String label,
     required String value,
@@ -148,9 +178,7 @@ class GpsEfficiencyKpiCard extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Expanded(
-            child: Text(label, style: theme.textTheme.bodyMedium),
-          ),
+          Expanded(child: Text(label, style: theme.textTheme.bodyMedium)),
           if (verdict != null) ...[
             Text(
               _verdictLabel(l, verdict),
@@ -175,31 +203,26 @@ class GpsEfficiencyKpiCard extends StatelessWidget {
 
   /// Localized per-KPI verdict badge ("Efficient" / "Moderate" /
   /// "Aggressive").
-  String _verdictLabel(AppLocalizations? l, GpsKpiVerdict v) {
+  String _verdictLabel(AppLocalizations l, GpsKpiVerdict v) {
     switch (v) {
       case GpsKpiVerdict.good:
-        return l?.gpsKpiVerdictGood ?? 'Efficient';
+        return l.gpsKpiVerdictGood;
       case GpsKpiVerdict.moderate:
-        return l?.gpsKpiVerdictModerate ?? 'Moderate';
+        return l.gpsKpiVerdictModerate;
       case GpsKpiVerdict.aggressive:
-        return l?.gpsKpiVerdictAggressive ?? 'Aggressive';
+        return l.gpsKpiVerdictAggressive;
     }
   }
 
   /// One-line overall interpretation under the KPI rows.
-  String _interpretation(AppLocalizations? l, GpsKpiVerdict v) {
+  String _interpretation(AppLocalizations l, GpsKpiVerdict v) {
     switch (v) {
       case GpsKpiVerdict.good:
-        return l?.gpsKpiInterpretationGood ??
-            'Smooth, energy-light driving — this is what efficient looks like.';
+        return l.gpsKpiInterpretationGood;
       case GpsKpiVerdict.moderate:
-        return l?.gpsKpiInterpretationModerate ??
-            'Fairly typical driving — a little smoother on the throttle would '
-                'save more.';
+        return l.gpsKpiInterpretationModerate;
       case GpsKpiVerdict.aggressive:
-        return l?.gpsKpiInterpretationAggressive ??
-            'Energy-heavy driving — easing off the accelerator and coasting '
-                'more would cut fuel use.';
+        return l.gpsKpiInterpretationAggressive;
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/gps_matrix_maturity_badge.dart
+++ b/lib/features/consumption/presentation/widgets/gps_matrix_maturity_badge.dart
@@ -34,38 +34,25 @@ class GpsMatrixMaturityBadge extends StatelessWidget {
     final tier = matrix.maturity;
     final (label, tooltip, bgColor, fgColor) = switch (tier) {
       GpsCalibrationMaturity.cold => (
-          l10n?.gpsMatrixMaturityCold ?? 'Cold',
-          l10n?.gpsMatrixMaturityColdTooltip(
-                matrix.fillUpReconciliationCount,
-              ) ??
-              'GPS matrix is still warming up '
-                  '(${matrix.fillUpReconciliationCount} fill-up '
-                  'refinements so far). Estimates are provisional.',
-          theme.colorScheme.errorContainer,
-          theme.colorScheme.onErrorContainer,
-        ),
+        l10n.gpsMatrixMaturityCold,
+        l10n.gpsMatrixMaturityColdTooltip(matrix.fillUpReconciliationCount),
+        theme.colorScheme.errorContainer,
+        theme.colorScheme.onErrorContainer,
+      ),
       GpsCalibrationMaturity.warming => (
-          l10n?.gpsMatrixMaturityWarming ?? 'Warming',
-          l10n?.gpsMatrixMaturityWarmingTooltip(
-                matrix.fillUpReconciliationCount,
-              ) ??
-              'GPS matrix is converging '
-                  '(${matrix.fillUpReconciliationCount} fill-ups). '
-                  'Estimates are usable but may drift a few %.',
-          theme.colorScheme.tertiaryContainer,
-          theme.colorScheme.onTertiaryContainer,
-        ),
+        l10n.gpsMatrixMaturityWarming,
+        l10n.gpsMatrixMaturityWarmingTooltip(matrix.fillUpReconciliationCount),
+        theme.colorScheme.tertiaryContainer,
+        theme.colorScheme.onTertiaryContainer,
+      ),
       GpsCalibrationMaturity.converged => (
-          l10n?.gpsMatrixMaturityConverged ?? 'Converged',
-          l10n?.gpsMatrixMaturityConvergedTooltip(
-                matrix.fillUpReconciliationCount,
-              ) ??
-              'GPS matrix has converged '
-                  '(${matrix.fillUpReconciliationCount} fill-ups). '
-                  'Estimates are within ~2 % of real-world burn.',
-          theme.colorScheme.primaryContainer,
-          theme.colorScheme.onPrimaryContainer,
+        l10n.gpsMatrixMaturityConverged,
+        l10n.gpsMatrixMaturityConvergedTooltip(
+          matrix.fillUpReconciliationCount,
         ),
+        theme.colorScheme.primaryContainer,
+        theme.colorScheme.onPrimaryContainer,
+      ),
     };
 
     return Tooltip(
@@ -83,8 +70,8 @@ class GpsMatrixMaturityBadge extends StatelessWidget {
               tier == GpsCalibrationMaturity.converged
                   ? Icons.check_circle
                   : tier == GpsCalibrationMaturity.warming
-                      ? Icons.hourglass_bottom
-                      : Icons.fiber_new_outlined,
+                  ? Icons.hourglass_bottom
+                  : Icons.fiber_new_outlined,
               size: 14,
               color: fgColor,
             ),

--- a/lib/features/consumption/presentation/widgets/gps_road_usage_card.dart
+++ b/lib/features/consumption/presentation/widgets/gps_road_usage_card.dart
@@ -48,25 +48,25 @@ class GpsRoadUsageCard extends StatelessWidget {
     final speedBars = <_ShareBar>[
       _ShareBar(
         key: const Key('gps_road_use_speed_idle'),
-        label: l?.gpsRoadUseSpeedIdle ?? 'Stopped (<5 km/h)',
+        label: l.gpsRoadUseSpeedIdle,
         share: features.idleShare,
         color: theme.colorScheme.onSurfaceVariant,
       ),
       _ShareBar(
         key: const Key('gps_road_use_speed_low'),
-        label: l?.gpsRoadUseSpeedLow ?? 'Town (5–50 km/h)',
+        label: l.gpsRoadUseSpeedLow,
         share: features.lowSpeedShare,
         color: theme.colorScheme.primary,
       ),
       _ShareBar(
         key: const Key('gps_road_use_speed_cruise'),
-        label: l?.gpsRoadUseSpeedCruise ?? 'Cruise (50–110 km/h)',
+        label: l.gpsRoadUseSpeedCruise,
         share: features.cruiseShare,
         color: theme.colorScheme.primary,
       ),
       _ShareBar(
         key: const Key('gps_road_use_speed_high'),
-        label: l?.gpsRoadUseSpeedHigh ?? 'Fast (≥110 km/h)',
+        label: l.gpsRoadUseSpeedHigh,
         share: features.highSpeedShare,
         color: theme.colorScheme.tertiary,
       ),
@@ -75,19 +75,19 @@ class GpsRoadUsageCard extends StatelessWidget {
     final phaseBars = <_ShareBar>[
       _ShareBar(
         key: const Key('gps_road_use_phase_accel'),
-        label: l?.gpsRoadUsePhaseAccel ?? 'Accelerating',
+        label: l.gpsRoadUsePhaseAccel,
         share: features.accelShare,
         color: theme.colorScheme.tertiary,
       ),
       _ShareBar(
         key: const Key('gps_road_use_phase_steady'),
-        label: l?.gpsRoadUsePhaseSteady ?? 'Holding speed',
+        label: l.gpsRoadUsePhaseSteady,
         share: features.steadyShare,
         color: theme.colorScheme.primary,
       ),
       _ShareBar(
         key: const Key('gps_road_use_phase_coast'),
-        label: l?.gpsRoadUsePhaseCoast ?? 'Coasting',
+        label: l.gpsRoadUsePhaseCoast,
         share: features.coastShare,
         color: theme.colorScheme.primary,
       ),
@@ -104,36 +104,29 @@ class GpsRoadUsageCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.gpsRoadUseCardTitle ?? 'How you used the road',
+              l.gpsRoadUseCardTitle,
               key: const Key('gps_road_use_card_title'),
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 12),
-            _SectionHeader(
-              label: l?.gpsRoadUseSpeedSection ?? 'Where you spent your time',
-            ),
+            _SectionHeader(label: l.gpsRoadUseSpeedSection),
             const SizedBox(height: 8),
             for (final b in speedBars) b,
             const SizedBox(height: 16),
-            _SectionHeader(
-              label: l?.gpsRoadUsePhaseSection ?? 'How you moved',
-            ),
+            _SectionHeader(label: l.gpsRoadUsePhaseSection),
             const SizedBox(height: 8),
             for (final b in phaseBars) b,
             if (showCoastPraise) ...[
               const SizedBox(height: 12),
-              _CoastPraise(
-                message: l?.gpsRoadUseCoastPraise ??
-                    'Lots of coasting — letting the car roll instead of '
-                        'braking saves fuel. Nice.',
-              ),
+              _CoastPraise(message: l.gpsRoadUseCoastPraise),
             ],
             const SizedBox(height: 8),
             Text(
-              l?.gpsRoadUseSource ?? 'From your GPS track',
+              l.gpsRoadUseSource,
               key: const Key('gps_road_use_source'),
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),
@@ -183,7 +176,7 @@ class _ShareBar extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final pct = (share.clamp(0.0, 1.0) * 100).toStringAsFixed(0);
-    final pctLabel = l?.gpsRoadUseShare(pct) ?? '$pct%';
+    final pctLabel = l.gpsRoadUseShare(pct);
 
     final filled = (share.clamp(0.0, 1.0) * 1000).round();
     final empty = 1000 - filled;
@@ -218,10 +211,7 @@ class _ShareBar extends StatelessWidget {
                       ),
                     ),
                   if (empty > 0)
-                    Flexible(
-                      flex: empty,
-                      child: const SizedBox.shrink(),
-                    ),
+                    Flexible(flex: empty, child: const SizedBox.shrink()),
                 ],
               ),
             ),
@@ -258,11 +248,7 @@ class _CoastPraise extends StatelessWidget {
       key: const Key('gps_road_use_coast_praise'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(
-          Icons.eco_outlined,
-          size: 20,
-          color: theme.colorScheme.primary,
-        ),
+        Icon(Icons.eco_outlined, size: 20, color: theme.colorScheme.primary),
         const SizedBox(width: 8),
         Expanded(
           child: Text(

--- a/lib/features/consumption/presentation/widgets/guided_reconciliation_workflow.dart
+++ b/lib/features/consumption/presentation/widgets/guided_reconciliation_workflow.dart
@@ -88,10 +88,8 @@ class _GuidedReconciliationDialogState
   @override
   void initState() {
     super.initState();
-    _litersCtrl =
-        TextEditingController(text: _fmt(widget.gapLiters));
-    _distanceCtrl =
-        TextEditingController(text: _fmt(widget.defaultDistanceKm));
+    _litersCtrl = TextEditingController(text: _fmt(widget.gapLiters));
+    _distanceCtrl = TextEditingController(text: _fmt(widget.defaultDistanceKm));
   }
 
   @override
@@ -107,10 +105,9 @@ class _GuidedReconciliationDialogState
   /// Maintainer decision logic: a fill-up missing/wrong → Path A;
   /// otherwise (fill-ups correct, including the "both individually
   /// correct" elimination case) → Path B.
-  ReconciliationPath get _resolvedPath =>
-      _fillUpsComplete == false
-          ? ReconciliationPath.correctFillUp
-          : ReconciliationPath.virtualTrajet;
+  ReconciliationPath get _resolvedPath => _fillUpsComplete == false
+      ? ReconciliationPath.correctFillUp
+      : ReconciliationPath.virtualTrajet;
 
   bool get _attributed => _fillUpsComplete != null && _drivesRecorded != null;
 
@@ -139,7 +136,7 @@ class _GuidedReconciliationDialogState
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      title: Text(l?.reconcileWorkflowTitle ?? 'Reconcile your fuel'),
+      title: Text(l.reconcileWorkflowTitle),
       content: SingleChildScrollView(
         child: switch (_step) {
           _Step.explain => _buildExplain(l),
@@ -151,7 +148,7 @@ class _GuidedReconciliationDialogState
     );
   }
 
-  Widget _buildExplain(AppLocalizations? l) {
+  Widget _buildExplain(AppLocalizations l) {
     final theme = Theme.of(context);
     return Column(
       key: const Key('reconcile-step-explain'),
@@ -159,39 +156,29 @@ class _GuidedReconciliationDialogState
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          l?.reconcileWorkflowExplainHeadline(widget.gapText) ??
-              'We found a ${widget.gapText} L gap',
+          l.reconcileWorkflowExplainHeadline(widget.gapText),
           style: theme.textTheme.titleMedium,
         ),
         const SizedBox(height: 12),
         Text(
-          l?.reconcileWorkflowExplainBody(
-                widget.pumpedText,
-                widget.consumedText,
-                widget.gapText,
-              ) ??
-              'You pumped ${widget.pumpedText} L, but your recorded trips '
-                  'only account for ${widget.consumedText} L. That leaves '
-                  '${widget.gapText} L unexplained.',
+          l.reconcileWorkflowExplainBody(
+            widget.pumpedText,
+            widget.consumedText,
+            widget.gapText,
+          ),
         ),
         const SizedBox(height: 12),
-        Text(
-          l?.reconcileWorkflowExplainCauses ??
-              "This usually means a drive wasn't recorded, or a fill-up is "
-                  'missing or mistyped.',
-        ),
+        Text(l.reconcileWorkflowExplainCauses),
         const SizedBox(height: 12),
         Text(
-          l?.reconcileWorkflowExplainConsequence ??
-              'Until this is resolved, your fuel total and your trips total '
-                  "won't match.",
+          l.reconcileWorkflowExplainConsequence,
           style: theme.textTheme.bodySmall,
         ),
       ],
     );
   }
 
-  Widget _buildAttribute(AppLocalizations? l) {
+  Widget _buildAttribute(AppLocalizations l) {
     final theme = Theme.of(context);
     return Column(
       key: const Key('reconcile-step-attribute'),
@@ -199,32 +186,30 @@ class _GuidedReconciliationDialogState
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          l?.reconcileWorkflowAttributeQuestion ?? 'Help us attribute the gap',
+          l.reconcileWorkflowAttributeQuestion,
           style: theme.textTheme.titleMedium,
         ),
         const SizedBox(height: 16),
         _YesNoQuestion(
-          question: l?.reconcileWorkflowFillUpsCompleteQuestion ??
-              'Are all your fill-ups for this tank complete and correct?',
+          question: l.reconcileWorkflowFillUpsCompleteQuestion,
           value: _fillUpsComplete,
-          yesLabel: l?.reconcileWorkflowAnswerYes ?? 'Yes',
-          noLabel: l?.reconcileWorkflowAnswerNo ?? 'No',
+          yesLabel: l.reconcileWorkflowAnswerYes,
+          noLabel: l.reconcileWorkflowAnswerNo,
           onChanged: (v) => setState(() => _fillUpsComplete = v),
         ),
         const SizedBox(height: 16),
         _YesNoQuestion(
-          question: l?.reconcileWorkflowDrivesRecordedQuestion ??
-              'Are all your drives recorded?',
+          question: l.reconcileWorkflowDrivesRecordedQuestion,
           value: _drivesRecorded,
-          yesLabel: l?.reconcileWorkflowAnswerYes ?? 'Yes',
-          noLabel: l?.reconcileWorkflowAnswerNo ?? 'No',
+          yesLabel: l.reconcileWorkflowAnswerYes,
+          noLabel: l.reconcileWorkflowAnswerNo,
           onChanged: (v) => setState(() => _drivesRecorded = v),
         ),
       ],
     );
   }
 
-  Widget _buildGather(AppLocalizations? l) {
+  Widget _buildGather(AppLocalizations l) {
     final pathA = _resolvedPath == ReconciliationPath.correctFillUp;
     return Form(
       key: _formKey,
@@ -235,22 +220,19 @@ class _GuidedReconciliationDialogState
         children: [
           Text(
             pathA
-                ? (l?.reconcileWorkflowPathAHint ??
-                    "A fill-up is missing or wrong — we'll add a correction.")
-                : (l?.reconcileWorkflowPathBHint ??
-                    'Your fill-ups are right and a drive went unrecorded — '
-                        "we'll add a virtual trip."),
+                ? (l.reconcileWorkflowPathAHint)
+                : (l.reconcileWorkflowPathBHint),
           ),
           const SizedBox(height: 16),
           if (pathA)
             TextFormField(
               key: const Key('reconcile-correction-liters'),
               controller: _litersCtrl,
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
               decoration: InputDecoration(
-                labelText: l?.reconcileWorkflowCorrectionLitersLabel ??
-                    'Correction litres',
+                labelText: l.reconcileWorkflowCorrectionLitersLabel,
                 prefixIcon: const Icon(Icons.local_drink),
               ),
               validator: (v) => AddFillUpValidators.positiveNumber(v, l),
@@ -259,11 +241,11 @@ class _GuidedReconciliationDialogState
             TextFormField(
               key: const Key('reconcile-virtual-distance'),
               controller: _distanceCtrl,
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
               decoration: InputDecoration(
-                labelText: l?.reconcileWorkflowVirtualDistanceLabel ??
-                    'How far was the unrecorded drive? (km)',
+                labelText: l.reconcileWorkflowVirtualDistanceLabel,
                 prefixIcon: const Icon(Icons.straighten),
               ),
               validator: (v) => AddFillUpValidators.positiveNumber(v, l),
@@ -273,11 +255,11 @@ class _GuidedReconciliationDialogState
     );
   }
 
-  List<Widget> _buildActions(AppLocalizations? l) {
+  List<Widget> _buildActions(AppLocalizations l) {
     final deferBtn = TextButton(
       key: const Key('reconcile-decide-later'),
       onPressed: _defer,
-      child: Text(l?.reconcileWorkflowDecideLater ?? 'Decide later'),
+      child: Text(l.reconcileWorkflowDecideLater),
     );
     switch (_step) {
       case _Step.explain:
@@ -286,14 +268,14 @@ class _GuidedReconciliationDialogState
           FilledButton(
             key: const Key('reconcile-next'),
             onPressed: () => setState(() => _step = _Step.attribute),
-            child: Text(l?.reconcileWorkflowNext ?? 'Next'),
+            child: Text(l.reconcileWorkflowNext),
           ),
         ];
       case _Step.attribute:
         return [
           TextButton(
             onPressed: () => setState(() => _step = _Step.explain),
-            child: Text(l?.reconcileWorkflowBack ?? 'Back'),
+            child: Text(l.reconcileWorkflowBack),
           ),
           deferBtn,
           FilledButton(
@@ -301,20 +283,20 @@ class _GuidedReconciliationDialogState
             onPressed: _attributed
                 ? () => setState(() => _step = _Step.gather)
                 : null,
-            child: Text(l?.reconcileWorkflowNext ?? 'Next'),
+            child: Text(l.reconcileWorkflowNext),
           ),
         ];
       case _Step.gather:
         return [
           TextButton(
             onPressed: () => setState(() => _step = _Step.attribute),
-            child: Text(l?.reconcileWorkflowBack ?? 'Back'),
+            child: Text(l.reconcileWorkflowBack),
           ),
           deferBtn,
           FilledButton(
             key: const Key('reconcile-apply'),
             onPressed: _apply,
-            child: Text(l?.reconcileWorkflowApply ?? 'Apply'),
+            child: Text(l.reconcileWorkflowApply),
           ),
         ];
     }

--- a/lib/features/consumption/presentation/widgets/imu_accel_brake_card.dart
+++ b/lib/features/consumption/presentation/widgets/imu_accel_brake_card.dart
@@ -27,7 +27,8 @@ class ImuAccelBrakeCard extends StatelessWidget {
   /// sensor-absent). OBD2 / legacy trips (no IMU signal) are skipped.
   static TripSummary? summaryFor(TripSummary summary) {
     if (summary.kind != TripKind.gpsOnly) return null;
-    final hasEvents = summary.imuHardAccelCount > 0 ||
+    final hasEvents =
+        summary.imuHardAccelCount > 0 ||
         summary.imuHardBrakeCount > 0 ||
         summary.sharpCornerCount > 0;
     return hasEvents ? summary : null;
@@ -49,29 +50,36 @@ class ImuAccelBrakeCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.accelBrakeCardTitle ?? 'Acceleration & braking',
+              l.accelBrakeCardTitle,
               key: const Key('accel_brake_card_title'),
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
-            _row(theme,
-                key: const Key('accel_brake_hard_accel'),
-                label: l?.accelBrakeHardAccel ?? 'Hard accelerations',
-                value: fmt(summary.imuHardAccelCount, summary.imuHardAccelPerKm)),
-            _row(theme,
-                key: const Key('accel_brake_hard_brake'),
-                label: l?.accelBrakeHardBrake ?? 'Hard braking',
-                value: fmt(summary.imuHardBrakeCount, summary.imuHardBrakePerKm)),
-            _row(theme,
-                key: const Key('accel_brake_sharp_corner'),
-                label: l?.accelBrakeSharpCorner ?? 'Sharp corners',
-                value: fmt(summary.sharpCornerCount, summary.sharpCornersPerKm)),
+            _row(
+              theme,
+              key: const Key('accel_brake_hard_accel'),
+              label: l.accelBrakeHardAccel,
+              value: fmt(summary.imuHardAccelCount, summary.imuHardAccelPerKm),
+            ),
+            _row(
+              theme,
+              key: const Key('accel_brake_hard_brake'),
+              label: l.accelBrakeHardBrake,
+              value: fmt(summary.imuHardBrakeCount, summary.imuHardBrakePerKm),
+            ),
+            _row(
+              theme,
+              key: const Key('accel_brake_sharp_corner'),
+              label: l.accelBrakeSharpCorner,
+              value: fmt(summary.sharpCornerCount, summary.sharpCornersPerKm),
+            ),
             const SizedBox(height: 8),
             Text(
-              l?.accelBrakeSource ?? "From the phone's motion sensors",
+              l.accelBrakeSource,
               key: const Key('accel_brake_source'),
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/localized_fuel_name.dart
+++ b/lib/features/consumption/presentation/widgets/localized_fuel_name.dart
@@ -10,11 +10,8 @@ import '../../../../core/domain/fuel_type.dart';
 /// hard-coded English/French strings like "Super E5" / "GPL / LPG") and
 /// from `shortFuelLabel` (language-neutral grade CODES like "E10"). The
 /// per-fuel efficiency card needs a full, translated fuel name, so this
-/// routes every grade through an ARB key and falls back to the
-/// non-localized [FuelType.displayName] only when no localization is
-/// available (the standard defensive-fallback pattern).
-String localizedFuelName(AppLocalizations? l, FuelType fuel) {
-  if (l == null) return fuel.displayName;
+/// routes every grade through an ARB key.
+String localizedFuelName(AppLocalizations l, FuelType fuel) {
   return switch (fuel) {
     FuelTypeE5() => l.fuelNameE5,
     FuelTypeE10() => l.fuelNameE10,

--- a/lib/features/consumption/presentation/widgets/maintenance_suggestion_card.dart
+++ b/lib/features/consumption/presentation/widgets/maintenance_suggestion_card.dart
@@ -28,10 +28,7 @@ import '../../providers/maintenance_provider.dart';
 class MaintenanceSuggestionCard extends ConsumerWidget {
   final MaintenanceSuggestion suggestion;
 
-  const MaintenanceSuggestionCard({
-    super.key,
-    required this.suggestion,
-  });
+  const MaintenanceSuggestionCard({super.key, required this.suggestion});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -50,10 +47,8 @@ class MaintenanceSuggestionCard extends ConsumerWidget {
     // ask a sighted partner about.
     final mergedLabel = '$title. $body';
 
-    final dismissLabel =
-        l?.maintenanceActionDismiss ?? 'Dismiss';
-    final snoozeLabel =
-        l?.maintenanceActionSnooze ?? 'Snooze 30 days';
+    final dismissLabel = l.maintenanceActionDismiss;
+    final snoozeLabel = l.maintenanceActionSnooze;
 
     return Semantics(
       container: true,
@@ -81,15 +76,9 @@ class MaintenanceSuggestionCard extends ConsumerWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            title,
-                            style: theme.textTheme.titleMedium,
-                          ),
+                          Text(title, style: theme.textTheme.titleMedium),
                           const SizedBox(height: 4),
-                          Text(
-                            body,
-                            style: theme.textTheme.bodyMedium,
-                          ),
+                          Text(body, style: theme.textTheme.bodyMedium),
                         ],
                       ),
                     ),
@@ -104,20 +93,24 @@ class MaintenanceSuggestionCard extends ConsumerWidget {
                   children: [
                     TextButton(
                       key: ValueKey(
-                          'maintenance-${suggestion.signal.name}-dismiss'),
+                        'maintenance-${suggestion.signal.name}-dismiss',
+                      ),
                       onPressed: () => ref
                           .read(
-                              maintenanceSuggestionsControllerProvider.notifier)
+                            maintenanceSuggestionsControllerProvider.notifier,
+                          )
                           .dismissForToday(suggestion.signal),
                       child: Text(dismissLabel),
                     ),
                     const SizedBox(width: 4),
                     TextButton(
                       key: ValueKey(
-                          'maintenance-${suggestion.signal.name}-snooze'),
+                        'maintenance-${suggestion.signal.name}-snooze',
+                      ),
                       onPressed: () => ref
                           .read(
-                              maintenanceSuggestionsControllerProvider.notifier)
+                            maintenanceSuggestionsControllerProvider.notifier,
+                          )
                           .snoozeForDefault(suggestion.signal),
                       child: Text(snoozeLabel),
                     ),
@@ -131,34 +124,26 @@ class MaintenanceSuggestionCard extends ConsumerWidget {
     );
   }
 
-  String _titleFor(AppLocalizations? l, MaintenanceSignal signal) {
+  String _titleFor(AppLocalizations l, MaintenanceSignal signal) {
     switch (signal) {
       case MaintenanceSignal.idleRpmCreep:
-        return l?.maintenanceSignalIdleRpmCreepTitle ??
-            'Idle RPM creep detected';
+        return l.maintenanceSignalIdleRpmCreepTitle;
       case MaintenanceSignal.mafDeviation:
-        return l?.maintenanceSignalMafDeviationTitle ??
-            'Possible intake restriction';
+        return l.maintenanceSignalMafDeviationTitle;
     }
   }
 
   String _bodyFor(
-    AppLocalizations? l,
+    AppLocalizations l,
     MaintenanceSignal signal,
     String percent,
     int tripCount,
   ) {
     switch (signal) {
       case MaintenanceSignal.idleRpmCreep:
-        return l?.maintenanceSignalIdleRpmCreepBody(percent, tripCount) ??
-            'Idle RPM has crept up by $percent% over your last $tripCount '
-                'trips. Possible early sign of a clogged air filter or '
-                'sensor drift.';
+        return l.maintenanceSignalIdleRpmCreepBody(percent, tripCount);
       case MaintenanceSignal.mafDeviation:
-        return l?.maintenanceSignalMafDeviationBody(percent, tripCount) ??
-            'Cruise fuel rate has dropped by $percent% over your last '
-                '$tripCount trips. Possible sign of a clogged air filter '
-                'or restricted intake — worth a check-up.';
+        return l.maintenanceSignalMafDeviationBody(percent, tripCount);
     }
   }
 }

--- a/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
+++ b/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
@@ -48,8 +48,7 @@ class MinimalDriveSummary extends ConsumerWidget {
     // logic and keeps the widget's single responsibility.
     final belief = readActiveVehicleBelief(ref);
     if (belief != null &&
-        brokenMapBandFor(belief.pointEstimate) ==
-            BrokenMapBand.hardDisable) {
+        brokenMapBandFor(belief.pointEstimate) == BrokenMapBand.hardDisable) {
       return const SizedBox.shrink();
     }
 
@@ -77,19 +76,19 @@ class MinimalDriveSummary extends ConsumerWidget {
         ? <Widget>[
             _CoachingSymbol(
               icon: Icons.eco,
-              label: l?.coachingGpsLiftOff ?? 'Lift off',
+              label: l.coachingGpsLiftOff,
               active: gpsHint == DrivingCoachingHint.gpsLiftOffCoast,
               scheme: scheme,
             ),
             _CoachingSymbol(
               icon: Icons.visibility,
-              label: l?.coachingGpsAnticipateBrake ?? 'Anticipate',
+              label: l.coachingGpsAnticipateBrake,
               active: gpsHint == DrivingCoachingHint.gpsAnticipateBrake,
               scheme: scheme,
             ),
             _CoachingSymbol(
               icon: Icons.swipe_up,
-              label: l?.coachingGpsSmoothAccel ?? 'Smooth accel',
+              label: l.coachingGpsSmoothAccel,
               active: gpsHint == DrivingCoachingHint.gpsSmoothAccel,
               scheme: scheme,
             ),
@@ -97,19 +96,19 @@ class MinimalDriveSummary extends ConsumerWidget {
         : <Widget>[
             _CoachingSymbol(
               icon: Icons.keyboard_double_arrow_up,
-              label: l?.coachingShiftUp ?? 'Shift up',
+              label: l.coachingShiftUp,
               active: hint == DrivingCoachingHint.shiftUp,
               scheme: scheme,
             ),
             _CoachingSymbol(
               icon: Icons.keyboard_double_arrow_down,
-              label: l?.coachingShiftDown ?? 'Shift down',
+              label: l.coachingShiftDown,
               active: hint == DrivingCoachingHint.shiftDown,
               scheme: scheme,
             ),
             _CoachingSymbol(
               icon: Icons.eco,
-              label: l?.coachingEasePedal ?? 'Ease pedal',
+              label: l.coachingEasePedal,
               active: hint == DrivingCoachingHint.easePedal,
               scheme: scheme,
             ),
@@ -123,7 +122,7 @@ class MinimalDriveSummary extends ConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              l?.minimalDriveInstantConsumption ?? 'Instant consumption',
+              l.minimalDriveInstantConsumption,
               style: theme.textTheme.labelSmall?.copyWith(
                 color: scheme.onSurfaceVariant,
               ),

--- a/lib/features/consumption/presentation/widgets/monthly_fuel_charts.dart
+++ b/lib/features/consumption/presentation/widgets/monthly_fuel_charts.dart
@@ -68,7 +68,7 @@ class MonthlyFuelCharts extends StatelessWidget {
         _chart(
           context,
           key: const Key('monthly_litres_chart'),
-          title: l?.consumptionStatsChartLiters ?? 'Litres per month',
+          title: l.consumptionStatsChartLiters,
           summaries: rows((m) => m.stats.totalLiters),
           color: theme.colorScheme.primary,
           unitLabel: 'L',
@@ -76,7 +76,7 @@ class MonthlyFuelCharts extends StatelessWidget {
         _chart(
           context,
           key: const Key('monthly_spend_chart'),
-          title: l?.consumptionStatsChartSpend ?? 'Spend per month',
+          title: l.consumptionStatsChartSpend,
           summaries: rows((m) => m.stats.totalSpent),
           color: theme.colorScheme.tertiary,
           unitLabel: PriceFormatter.currency,
@@ -84,7 +84,7 @@ class MonthlyFuelCharts extends StatelessWidget {
         _chart(
           context,
           key: const Key('monthly_price_per_litre_chart'),
-          title: l?.consumptionStatsChartPricePerLiter ?? 'Price per litre',
+          title: l.consumptionStatsChartPricePerLiter,
           summaries: rows((m) => m.stats.avgPricePerLiter ?? 0),
           color: theme.colorScheme.secondary,
           unitLabel: PriceFormatter.currency,
@@ -93,7 +93,7 @@ class MonthlyFuelCharts extends StatelessWidget {
           _chart(
             context,
             key: const Key('monthly_consumption_chart'),
-            title: l?.consumptionStatsChartConsumption ?? 'L/100km per month',
+            title: l.consumptionStatsChartConsumption,
             summaries: consumptionRows,
             color: theme.colorScheme.primary,
             unitLabel: 'L/100km',

--- a/lib/features/consumption/presentation/widgets/monthly_fuel_comparison_card.dart
+++ b/lib/features/consumption/presentation/widgets/monthly_fuel_comparison_card.dart
@@ -40,7 +40,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
     final rows = <Widget>[
       _row(
         context,
-        label: l?.statTotalLiters ?? 'Total liters',
+        label: l.statTotalLiters,
         current: current?.totalLiters,
         previous: previous?.totalLiters,
         format: _fmtLiters,
@@ -49,7 +49,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       ),
       _row(
         context,
-        label: l?.statTotalSpent ?? 'Total spent',
+        label: l.statTotalSpent,
         current: current?.totalSpent,
         previous: previous?.totalSpent,
         format: PriceFormatter.formatTotal,
@@ -58,7 +58,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       ),
       _row(
         context,
-        label: l?.consumptionStatsPricePerLiter ?? 'Avg price/L',
+        label: l.consumptionStatsPricePerLiter,
         current: current?.avgPricePerLiter,
         previous: previous?.avgPricePerLiter,
         format: PriceFormatter.formatPriceCompact,
@@ -67,7 +67,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       ),
       _row(
         context,
-        label: l?.statAvgConsumption ?? 'Avg L/100km',
+        label: l.statAvgConsumption,
         current: current?.avgConsumptionL100km,
         previous: previous?.avgConsumptionL100km,
         format: _fmtConsumption,
@@ -76,7 +76,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       ),
       _row(
         context,
-        label: l?.statAvgCostPerKm ?? 'Avg cost/km',
+        label: l.statAvgCostPerKm,
         current: current?.avgCostPerKm,
         previous: previous?.avgCostPerKm,
         format: PriceFormatter.formatPerKm,
@@ -85,7 +85,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       ),
       _row(
         context,
-        label: l?.statFillUpCount ?? 'Fill-ups',
+        label: l.statFillUpCount,
         current: current?.fillUpCount.toDouble(),
         previous: previous?.fillUpCount.toDouble(),
         format: _fmtCount,
@@ -103,14 +103,13 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.consumptionStatsComparisonTitle ?? 'This month vs last month',
+              l.consumptionStatsComparisonTitle,
               style: theme.textTheme.titleMedium,
             ),
             if (!hasComparison) ...[
               const SizedBox(height: 4),
               Text(
-                l?.consumptionStatsNeedTwoMonths ??
-                    'Log fill-ups across at least two months to compare.',
+                l.consumptionStatsNeedTwoMonths,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                   fontStyle: FontStyle.italic,
@@ -148,7 +147,7 @@ class MonthlyFuelComparisonCard extends StatelessWidget {
       final sign = pct > 0 ? '+' : '';
       // i18n-ignore: numeric value forwarded into the ARB {pct} mask.
       final value = '$sign${pct.toStringAsFixed(0)}';
-      percentText = l?.consumptionStatsDeltaPercent(value) ?? '$value%';
+      percentText = l.consumptionStatsDeltaPercent(value);
     }
     return _MetricRow(
       label: label,

--- a/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
@@ -46,7 +46,7 @@ class MonthlyInsightsCard extends StatelessWidget {
     final reliable = summary.isComparisonReliable;
 
     final tripsRow = _MetricRow(
-      label: l?.consumptionMonthlyTripsLabel ?? 'Trips',
+      label: l.consumptionMonthlyTripsLabel,
       currentValue: _fmtCount(summary.currentMonthTripCount),
       previousValue: _fmtCount(summary.previousMonthTripCount),
       delta: summary.tripCountDelta,
@@ -55,7 +55,7 @@ class MonthlyInsightsCard extends StatelessWidget {
     );
 
     final driveTimeRow = _MetricRow(
-      label: l?.consumptionMonthlyDriveTimeLabel ?? 'Drive time',
+      label: l.consumptionMonthlyDriveTimeLabel,
       currentValue: _fmtDuration(summary.currentMonthDriveTime),
       previousValue: _fmtDuration(summary.previousMonthDriveTime),
       delta: summary.driveTimeDelta.inMinutes,
@@ -64,7 +64,7 @@ class MonthlyInsightsCard extends StatelessWidget {
     );
 
     final distanceRow = _MetricRow(
-      label: l?.consumptionMonthlyDistanceLabel ?? 'Distance',
+      label: l.consumptionMonthlyDistanceLabel,
       currentValue: _fmtDistance(summary.currentMonthDistanceKm),
       previousValue: _fmtDistance(summary.previousMonthDistanceKm),
       // Convert to a comparable scalar for the arrow: 1-decimal km.
@@ -78,7 +78,7 @@ class MonthlyInsightsCard extends StatelessWidget {
     final showClimbRow = summary.currentMonthClimbMeters > 0;
     final climbRow = showClimbRow
         ? _MetricRow(
-            label: l?.consumptionMonthlyClimbLabel ?? 'Climbed',
+            label: l.consumptionMonthlyClimbLabel,
             currentValue: _fmtClimb(summary.currentMonthClimbMeters),
             previousValue: _fmtClimb(summary.previousMonthClimbMeters),
             delta: summary.climbMetersDelta.round(),
@@ -93,7 +93,7 @@ class MonthlyInsightsCard extends StatelessWidget {
         summary.currentMonthAvgConsumptionLPer100km != null;
     final consumptionRow = showConsumptionRow
         ? _MetricRow(
-            label: l?.consumptionMonthlyAvgConsumptionLabel ?? 'Avg consumption',
+            label: l.consumptionMonthlyAvgConsumptionLabel,
             currentValue: _fmtConsumption(
               summary.currentMonthAvgConsumptionLPer100km,
             ),
@@ -104,7 +104,8 @@ class MonthlyInsightsCard extends StatelessWidget {
             // a coloured arrow when the displayed numbers are equal.
             delta: ((summary.consumptionDeltaLPer100km ?? 0) * 10).round(),
             sentiment: _Sentiment.lowerIsBetter,
-            showPrevious: reliable &&
+            showPrevious:
+                reliable &&
                 summary.previousMonthAvgConsumptionLPer100km != null,
           )
         : null;
@@ -119,14 +120,13 @@ class MonthlyInsightsCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.consumptionMonthlyInsightsTitle ?? 'This month vs last month',
+              l.consumptionMonthlyInsightsTitle,
               style: theme.textTheme.titleMedium,
             ),
             if (!reliable) ...[
               const SizedBox(height: 4),
               Text(
-                l?.consumptionMonthlyComparisonNotReliable ??
-                    'Need at least 3 trips per month for comparison',
+                l.consumptionMonthlyComparisonNotReliable,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                   fontStyle: FontStyle.italic,
@@ -139,10 +139,7 @@ class MonthlyInsightsCard extends StatelessWidget {
             driveTimeRow,
             const SizedBox(height: 6),
             distanceRow,
-            if (climbRow != null) ...[
-              const SizedBox(height: 6),
-              climbRow,
-            ],
+            if (climbRow != null) ...[const SizedBox(height: 6), climbRow],
             if (consumptionRow != null) ...[
               const SizedBox(height: 6),
               consumptionRow,

--- a/lib/features/consumption/presentation/widgets/ocr_trace_steps_panel.dart
+++ b/lib/features/consumption/presentation/widgets/ocr_trace_steps_panel.dart
@@ -64,9 +64,7 @@ class OcrTraceStepsPanel extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (_fallbackFired)
-          _FallbackBanner(text: l?.ocrTesterFallbackBanner ??
-              'A field was recovered via magnitude fallback — verify it.'),
+        if (_fallbackFired) _FallbackBanner(text: l.ocrTesterFallbackBanner),
         for (final stage in _stages)
           _StageTile(
             key: Key('ocr_step_${stage.name}'),
@@ -80,29 +78,27 @@ class OcrTraceStepsPanel extends StatelessWidget {
 
   bool get _fallbackFired => package.magnitudeFallback.isNotEmpty;
 
-  String _stageLabel(AppLocalizations? l, OcrTraceStage stage) =>
+  String _stageLabel(AppLocalizations l, OcrTraceStage stage) =>
       switch (stage) {
-        OcrTraceStage.glare => l?.ocrTesterStageGlare ?? 'Capture / glare',
-        OcrTraceStage.mlkit => l?.ocrTesterStageMlkit ?? 'ML Kit',
-        OcrTraceStage.classify => l?.ocrTesterStageClassify ?? 'Classify',
-        OcrTraceStage.assemble => l?.ocrTesterStageAssemble ?? 'Assemble',
-        OcrTraceStage.anchor => l?.ocrTesterStageAnchor ?? 'Anchor',
-        OcrTraceStage.fallback => l?.ocrTesterStageFallback ?? 'Fallback',
-        OcrTraceStage.crossCheck =>
-          l?.ocrTesterStageCrossCheck ?? 'Cross-check',
-        OcrTraceStage.confidence =>
-          l?.ocrTesterStageConfidence ?? 'Confidence',
-        OcrTraceStage.gate => l?.ocrTesterStageGate ?? 'Gate',
-        OcrTraceStage.brand => l?.ocrTesterStageBrand ?? 'Brand',
-        OcrTraceStage.overrides => l?.ocrTesterStageOverrides ?? 'Overrides',
-        OcrTraceStage.reconcile => l?.ocrTesterStageReconcile ?? 'Reconcile',
-        OcrTraceStage.result => l?.ocrTesterStageResult ?? 'Result',
+        OcrTraceStage.glare => l.ocrTesterStageGlare,
+        OcrTraceStage.mlkit => l.ocrTesterStageMlkit,
+        OcrTraceStage.classify => l.ocrTesterStageClassify,
+        OcrTraceStage.assemble => l.ocrTesterStageAssemble,
+        OcrTraceStage.anchor => l.ocrTesterStageAnchor,
+        OcrTraceStage.fallback => l.ocrTesterStageFallback,
+        OcrTraceStage.crossCheck => l.ocrTesterStageCrossCheck,
+        OcrTraceStage.confidence => l.ocrTesterStageConfidence,
+        OcrTraceStage.gate => l.ocrTesterStageGate,
+        OcrTraceStage.brand => l.ocrTesterStageBrand,
+        OcrTraceStage.overrides => l.ocrTesterStageOverrides,
+        OcrTraceStage.reconcile => l.ocrTesterStageReconcile,
+        OcrTraceStage.result => l.ocrTesterStageResult,
       };
 
   /// The detail rows for [stage], or an empty list (→ "did not run").
   List<Widget> _stageChildren(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     OcrTraceStage stage,
   ) {
     return switch (stage) {
@@ -144,8 +140,7 @@ class OcrTraceStepsPanel extends StatelessWidget {
   List<Widget> _classifyRows(BuildContext context) {
     if (package.classification.isEmpty) return const [];
     return [
-      for (final c in package.classification)
-        _ClassifyRow(classification: c),
+      for (final c in package.classification) _ClassifyRow(classification: c),
     ];
   }
 
@@ -159,10 +154,7 @@ class OcrTraceStepsPanel extends StatelessWidget {
 
   List<Widget> _anchorRows(BuildContext context) {
     if (package.anchors.isEmpty) return const [];
-    return [
-      for (final a in package.anchors)
-        _AnchorRow(anchor: a),
-    ];
+    return [for (final a in package.anchors) _AnchorRow(anchor: a)];
   }
 
   List<Widget> _fallbackRows() {
@@ -197,12 +189,12 @@ class OcrTraceStepsPanel extends StatelessWidget {
     ];
   }
 
-  List<Widget> _gateRows(BuildContext context, AppLocalizations? l) {
+  List<Widget> _gateRows(BuildContext context, AppLocalizations l) {
     final g = package.gate;
     if (g == null) return const [];
     final verdict = g.accepted
-        ? (l?.ocrTesterGateAccepted ?? 'Accepted')
-        : (l?.ocrTesterGateRejected ?? 'Rejected');
+        ? (l.ocrTesterGateAccepted)
+        : (l.ocrTesterGateRejected);
     return [
       _kv('verdict', verdict),
       _kv('reason', g.reason),
@@ -226,8 +218,11 @@ class OcrTraceStepsPanel extends StatelessWidget {
     if (r == null || r.overrides.isEmpty) return const [];
     return [
       for (final o in r.overrides)
-        _kv(o.field, '/${o.pattern}/ → "${o.match}"'
-            '${o.value != null ? ' = ${o.value}' : ''}'),
+        _kv(
+          o.field,
+          '/${o.pattern}/ → "${o.match}"'
+          '${o.value != null ? ' = ${o.value}' : ''}',
+        ),
     ];
   }
 
@@ -243,16 +238,28 @@ class OcrTraceStepsPanel extends StatelessWidget {
     ];
   }
 
-  List<Widget> _resultRows(BuildContext context, AppLocalizations? l) {
+  List<Widget> _resultRows(BuildContext context, AppLocalizations l) {
     final r = package.result;
     if (r == null) return const [];
     return [
-      _ResultRow(label: 'total', value: r.totalCost, derived: r.derived,
-          field: 'total'),
-      _ResultRow(label: 'volume', value: r.liters, derived: r.derived,
-          field: 'volume'),
-      _ResultRow(label: 'pricePerLitre', value: r.pricePerLiter,
-          derived: r.derived, field: 'pricePerLitre'),
+      _ResultRow(
+        label: 'total',
+        value: r.totalCost,
+        derived: r.derived,
+        field: 'total',
+      ),
+      _ResultRow(
+        label: 'volume',
+        value: r.liters,
+        derived: r.derived,
+        field: 'volume',
+      ),
+      _ResultRow(
+        label: 'pricePerLitre',
+        value: r.pricePerLiter,
+        derived: r.derived,
+        field: 'pricePerLitre',
+      ),
       _kv('confidence', r.confidence.toStringAsFixed(2)),
       _kv('validated', '${r.validated}'),
       if (r.validationReason != null) _kv('reason', r.validationReason!),

--- a/lib/features/consumption/presentation/widgets/ocr_trace_steps_panel_rows.dart
+++ b/lib/features/consumption/presentation/widgets/ocr_trace_steps_panel_rows.dart
@@ -41,7 +41,7 @@ class _StageTile extends StatelessWidget {
               Align(
                 alignment: AlignmentDirectional.centerStart,
                 child: Text(
-                  l?.ocrTesterStageNoData ?? 'Stage did not run.',
+                  l.ocrTesterStageNoData,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -69,13 +69,14 @@ class _KvRow extends StatelessWidget {
         children: [
           SizedBox(
             width: 120,
-            child: Text(label,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           ),
-          Expanded(
-            child: Text(value, style: theme.textTheme.bodySmall),
-          ),
+          Expanded(child: Text(value, style: theme.textTheme.bodySmall)),
         ],
       ),
     );
@@ -96,7 +97,8 @@ class _ClassifyRow extends StatelessWidget {
       'numeric' => OcrBlockOverlayColors.numeric,
       _ => OcrBlockOverlayColors.noise,
     };
-    final detail = classification.field ??
+    final detail =
+        classification.field ??
         (classification.value != null ? '${classification.value}' : '');
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -163,8 +165,8 @@ class _ResultRow extends StatelessWidget {
     if (value == null) return const SizedBox.shrink();
     final isDerived = derived.contains(field);
     final chipText = isDerived
-        ? (l?.ocrTesterChipDerived ?? 'DERIVED')
-        : (l?.ocrTesterChipRead ?? 'READ');
+        ? (l.ocrTesterChipDerived)
+        : (l.ocrTesterChipRead);
     final chipColor = isDerived
         ? OcrBlockOverlayColors.derived
         : OcrBlockOverlayColors.numeric;
@@ -174,9 +176,12 @@ class _ResultRow extends StatelessWidget {
         children: [
           SizedBox(
             width: 120,
-            child: Text(label,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           ),
           Text('$value', style: theme.textTheme.bodyMedium),
           const SizedBox(width: 8),
@@ -220,8 +225,11 @@ class _FallbackBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.warning_amber_outlined,
-              color: OcrBlockOverlayColors.derived, size: 18),
+          const Icon(
+            Icons.warning_amber_outlined,
+            color: OcrBlockOverlayColors.derived,
+            size: 18,
+          ),
           const SizedBox(width: 8),
           Expanded(child: Text(text, style: theme.textTheme.bodySmall)),
         ],

--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -81,7 +81,7 @@ class ProximityFillBar extends StatelessWidget {
     final percent = (fill * 100).round();
 
     return Semantics(
-      label: l?.fuelStationRadarProximity(percent) ?? 'Proximity $percent%',
+      label: l.fuelStationRadarProximity(percent),
       value: '$percent%',
       child: ClipRRect(
         borderRadius: AppRadius.sm,

--- a/lib/features/consumption/presentation/widgets/pump_camera_message.dart
+++ b/lib/features/consumption/presentation/widgets/pump_camera_message.dart
@@ -37,9 +37,11 @@ class PumpCameraMessage extends StatelessWidget {
           children: [
             Icon(icon, color: Colors.white70, size: 48),
             const SizedBox(height: 16),
-            Text(text,
-                textAlign: TextAlign.center,
-                style: const TextStyle(color: Colors.white)),
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white),
+            ),
             const SizedBox(height: 24),
             Row(
               mainAxisSize: MainAxisSize.min,
@@ -48,15 +50,17 @@ class PumpCameraMessage extends StatelessWidget {
                   OutlinedButton(
                     onPressed: () => retry(),
                     style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.white),
-                    child: Text(retryLabel ?? 'Try again'),
+                      foregroundColor: Colors.white,
+                    ),
+                    child: Text(
+                      retryLabel ?? AppLocalizations.of(context).retry,
+                    ),
                   ),
                   const SizedBox(width: 12),
                 ],
                 FilledButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text(
-                      AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+                  child: Text(AppLocalizations.of(context).cancel),
                 ),
               ],
             ),

--- a/lib/features/consumption/presentation/widgets/pump_live_feedback_bar.dart
+++ b/lib/features/consumption/presentation/widgets/pump_live_feedback_bar.dart
@@ -56,21 +56,17 @@ class PumpLiveFeedbackBar extends StatelessWidget {
     final IconData icon;
     if (isPortrait) {
       // Highest priority — block capture until the phone is sideways.
-      text = l10n?.pumpCameraRotateToLandscape ??
-          'Turn your phone sideways — the pump display is wide, so the '
-              'numbers come out larger and upright';
+      text = l10n.pumpCameraRotateToLandscape;
       bg = Colors.redAccent.withValues(alpha: 0.92);
       textColor = Colors.white;
       icon = Icons.screen_rotation_outlined;
     } else if (isOverGlared) {
-      text = l10n?.pumpCameraGlareWarning ??
-          'Too much glare — tilt slightly to avoid reflections';
+      text = l10n.pumpCameraGlareWarning;
       bg = Colors.amber.withValues(alpha: 0.88);
       textColor = Colors.black87;
       icon = Icons.wb_sunny_outlined;
     } else {
-      text = l10n?.pumpCameraAlignHint ??
-          'Line up the display inside the frame, then capture';
+      text = l10n.pumpCameraAlignHint;
       bg = Colors.black.withValues(alpha: 0.55);
       textColor = Colors.white;
       icon = Icons.center_focus_weak;

--- a/lib/features/consumption/presentation/widgets/pump_scan_failure_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/pump_scan_failure_sheet.dart
@@ -51,43 +51,39 @@ class PumpScanFailureSheet extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              l?.pumpScanFailureTitle ?? 'Display unreadable',
-              style: theme.textTheme.titleMedium
-                  ?.copyWith(fontWeight: FontWeight.bold),
+              l.pumpScanFailureTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
             const SizedBox(height: 4),
             Text(
-              l?.pumpScanFailureBody ??
-                  "We couldn't read the pump display. What would you like "
-                      'to do?',
+              l.pumpScanFailureBody,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
             const SizedBox(height: 16),
             FilledButton.icon(
-              onPressed: () => Navigator.of(context)
-                  .pop(PumpScanFailureAction.correctManually),
+              onPressed: () => Navigator.of(
+                context,
+              ).pop(PumpScanFailureAction.correctManually),
               icon: const Icon(Icons.edit_outlined),
-              label: Text(
-                l?.pumpScanFailureCorrectManually ?? 'Correct manually',
-              ),
+              label: Text(l.pumpScanFailureCorrectManually),
             ),
             const SizedBox(height: 8),
             OutlinedButton.icon(
-              onPressed: () => Navigator.of(context)
-                  .pop(PumpScanFailureAction.report),
+              onPressed: () =>
+                  Navigator.of(context).pop(PumpScanFailureAction.report),
               icon: const Icon(Icons.flag_outlined),
-              label: Text(l?.pumpScanFailureReport ?? 'Report'),
+              label: Text(l.pumpScanFailureReport),
             ),
             const SizedBox(height: 8),
             TextButton.icon(
-              onPressed: () => Navigator.of(context)
-                  .pop(PumpScanFailureAction.removePhoto),
+              onPressed: () =>
+                  Navigator.of(context).pop(PumpScanFailureAction.removePhoto),
               icon: const Icon(Icons.delete_outline),
-              label: Text(
-                l?.pumpScanFailureRemove ?? 'Remove photo',
-              ),
+              label: Text(l.pumpScanFailureRemove),
             ),
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/pump_shutter_button.dart
+++ b/lib/features/consumption/presentation/widgets/pump_shutter_button.dart
@@ -38,7 +38,7 @@ class PumpShutterButton extends StatelessWidget {
     return FilledButton.icon(
       onPressed: enabled ? onCapture : null,
       icon: const Icon(Icons.camera_alt),
-      label: Text(l10n?.pumpCameraCapture ?? 'Capture'),
+      label: Text(l10n.pumpCameraCapture),
     );
   }
 }

--- a/lib/features/consumption/presentation/widgets/radar_swipe_wrapper.dart
+++ b/lib/features/consumption/presentation/widgets/radar_swipe_wrapper.dart
@@ -66,8 +66,8 @@ class RadarSwipeWrapper extends ConsumerWidget {
     final swipeable = candidates.length > 1;
     final maxIndex = candidates.length - 1;
 
-    final nearerLabel = l?.fuelStationRadarNearer ?? 'Nearer station';
-    final fartherLabel = l?.fuelStationRadarFarther ?? 'Farther station';
+    final nearerLabel = l.fuelStationRadarNearer;
+    final fartherLabel = l.fuelStationRadarFarther;
 
     final card = RadarCard(
       title: title,
@@ -131,10 +131,7 @@ class RadarSwipeWrapper extends ConsumerWidget {
         // Fade the new station in as the page advances.
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 200),
-          child: KeyedSubtree(
-            key: ValueKey(station.id),
-            child: card,
-          ),
+          child: KeyedSubtree(key: ValueKey(station.id), child: card),
         ),
       ),
     );

--- a/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
@@ -82,20 +82,20 @@ class RecordingAppBarActions extends StatelessWidget {
         IconButton(
           key: const Key('tripPauseButton'),
           icon: Icon(isPaused ? Icons.play_arrow : Icons.pause),
-          tooltip: isPaused ? (l?.tripResume ?? 'Resume') : (l?.tripPause ?? 'Pause'),
+          tooltip: isPaused ? (l.tripResume) : (l.tripPause),
           onPressed: isActive ? onTogglePause : null,
         ),
         IconButton(
           key: const Key('tripStopButton'),
           icon: const Icon(Icons.stop_circle_outlined),
-          tooltip: l?.tripStop ?? 'Stop recording',
+          tooltip: l.tripStop,
           onPressed: stopping || !isActive ? null : onStop,
         ),
         // Pin / Help / PiP collapse into one kebab so the title keeps room.
         PopupMenuButton<_RecordingOverflowAction>(
           key: const Key('recording_overflow_menu'),
           icon: const Icon(Icons.more_vert),
-          tooltip: l?.moreActionsTooltip ?? 'More',
+          tooltip: l.moreActionsTooltip,
           onSelected: _onSelected,
           itemBuilder: (_) => [
             // #891 — the pin item reflects + toggles `_pinned`. Its
@@ -113,12 +113,12 @@ class RecordingAppBarActions extends StatelessWidget {
                 toggled: pinned,
                 child: _MenuRow(
                   icon: pinned ? Icons.push_pin : Icons.push_pin_outlined,
-                  iconColor:
-                      pinned ? Theme.of(context).colorScheme.primary : null,
+                  iconColor: pinned
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
                   label: pinned
-                      ? (l?.tripRecordingPinSemanticOn ?? 'Unpin recording form')
-                      : (l?.tripRecordingPinSemanticOff ??
-                          'Pin recording form'),
+                      ? (l.tripRecordingPinSemanticOn)
+                      : (l.tripRecordingPinSemanticOff),
                 ),
               ),
             ),
@@ -128,7 +128,7 @@ class RecordingAppBarActions extends StatelessWidget {
               value: _RecordingOverflowAction.help,
               child: _MenuRow(
                 icon: Icons.help_outline,
-                label: l?.tripRecordingPinHelpTooltip ?? 'What does pin do?',
+                label: l.tripRecordingPinHelpTooltip,
               ),
             ),
             // #1884 — minimise to PiP; Android-only.
@@ -138,8 +138,7 @@ class RecordingAppBarActions extends StatelessWidget {
                 value: _RecordingOverflowAction.pip,
                 child: _MenuRow(
                   icon: Icons.picture_in_picture_alt,
-                  label: l?.tripRecordingMinimiseTooltip ??
-                      'Minimise to a floating tile',
+                  label: l.tripRecordingMinimiseTooltip,
                 ),
               ),
           ],

--- a/lib/features/consumption/presentation/widgets/resolve_gap_banner.dart
+++ b/lib/features/consumption/presentation/widgets/resolve_gap_banner.dart
@@ -32,10 +32,8 @@ class ResolveGapBanner extends ConsumerWidget {
     final locale = Localizations.localeOf(context).toString();
     final nf = NumberFormat.decimalPattern(locale)..maximumFractionDigits = 1;
     final gapText = nf.format(pending.gap);
-    final label = l?.reconcileResolveGapBanner(gapText) ??
-        'Unresolved fuel/trip gap of $gapText L — tap to resolve';
-    final semanticLabel = l?.reconcileResolveGapSemanticLabel ??
-        'Resolve unresolved fuel and trip gap';
+    final label = l.reconcileResolveGapBanner(gapText);
+    final semanticLabel = l.reconcileResolveGapSemanticLabel;
 
     return Semantics(
       button: true,
@@ -62,9 +60,7 @@ class ResolveGapBanner extends ConsumerWidget {
               children: [
                 Icon(Icons.error_outline, size: 18, color: orange),
                 const SizedBox(width: 8),
-                Expanded(
-                  child: Text(label, style: theme.textTheme.bodySmall),
-                ),
+                Expanded(child: Text(label, style: theme.textTheme.bodySmall)),
                 Icon(
                   Icons.chevron_right,
                   size: 18,

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
@@ -64,8 +64,8 @@ class ShareReceiptHandler {
     this._ref, {
     ReceiptPdfRasterizer? pdfRasterizer,
     EReceiptTextParser textParser = const EReceiptTextParser(),
-  })  : _pdfRasterizer = pdfRasterizer ?? const ReceiptPdfRasterizer(),
-        _textParser = textParser;
+  }) : _pdfRasterizer = pdfRasterizer ?? const ReceiptPdfRasterizer(),
+       _textParser = textParser;
 
   /// Handle one inbound [intent]. No-op for a null intent, an empty item
   /// list, or — defensively — when the feature is gated off.
@@ -97,8 +97,9 @@ class ShareReceiptHandler {
       // No image — a shared PDF (#2737) is rasterised to a bitmap and then
       // takes the same path. The render is async, so `handle` stays
       // synchronous + never-throws by fire-and-forgetting it.
-      final pdf =
-          items.where((i) => i.kind == SharedReceiptItemKind.pdf).firstOrNull;
+      final pdf = items
+          .where((i) => i.kind == SharedReceiptItemKind.pdf)
+          .firstOrNull;
       if (pdf?.path != null) {
         unawaited(_rasterizeAndRoute(pdf!.path!));
         return;
@@ -106,8 +107,9 @@ class ShareReceiptHandler {
 
       // No image / PDF — a shared text e-receipt (#2838) is parsed on the
       // spot and the result stashed for the form to apply.
-      final text =
-          items.where((i) => i.kind == SharedReceiptItemKind.text).firstOrNull;
+      final text = items
+          .where((i) => i.kind == SharedReceiptItemKind.text)
+          .firstOrNull;
       if (text?.text != null) {
         _parseTextAndRoute(text!.text!, intent.countryCode);
         return;
@@ -116,9 +118,14 @@ class ShareReceiptHandler {
       // Any other type (video / arbitrary file) is genuinely unsupported.
       _showUnsupportedFormat();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'ShareReceiptHandler.handle',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'ShareReceiptHandler.handle'},
+        ),
+      );
     }
   }
 
@@ -143,9 +150,14 @@ class ShareReceiptHandler {
       }
       _stashAndRoute(jpegPath);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'ShareReceiptHandler._rasterizeAndRoute',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'ShareReceiptHandler._rasterizeAndRoute'},
+        ),
+      );
       _showReadFailed();
     }
   }
@@ -173,9 +185,14 @@ class ShareReceiptHandler {
           .read(enabledFeaturesProvider)
           .contains(Feature.addFillUpShareIntentReceipt);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'ShareReceiptHandler._featureEnabled',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'ShareReceiptHandler._featureEnabled'},
+        ),
+      );
       return false;
     }
   }
@@ -184,9 +201,14 @@ class ShareReceiptHandler {
     try {
       unawaited(_ref.read(routerProvider).push(path));
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {
-        'where': 'ShareReceiptHandler: push failed for $path',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {'where': 'ShareReceiptHandler: push failed for $path'},
+        ),
+      );
     }
   }
 
@@ -197,12 +219,7 @@ class ShareReceiptHandler {
     final context = rootNavigatorKey.currentContext;
     if (context == null || !context.mounted) return;
     final l = AppLocalizations.of(context);
-    SnackBarHelper.show(
-      context,
-      l?.shareReceiptUnsupportedFormat ??
-          'That file type can\'t be imported yet — share a photo of the '
-              'receipt instead.',
-    );
+    SnackBarHelper.show(context, l.shareReceiptUnsupportedFormat);
   }
 
   /// Surfaces the localized "couldn't read the receipt" snackbar for a PDF
@@ -213,12 +230,7 @@ class ShareReceiptHandler {
     final context = rootNavigatorKey.currentContext;
     if (context == null || !context.mounted) return;
     final l = AppLocalizations.of(context);
-    SnackBarHelper.show(
-      context,
-      l?.shareReceiptFailed ??
-          'Couldn\'t read the shared receipt — try sharing it again or add '
-              'the fill-up manually.',
-    );
+    SnackBarHelper.show(context, l.shareReceiptFailed);
   }
 }
 
@@ -231,6 +243,6 @@ ReceiptPdfRasterizer receiptPdfRasterizer(Ref ref) =>
 
 @riverpod
 ShareReceiptHandler shareReceiptHandler(Ref ref) => ShareReceiptHandler(
-      ref,
-      pdfRasterizer: ref.read(receiptPdfRasterizerProvider),
-    );
+  ref,
+  pdfRasterizer: ref.read(receiptPdfRasterizerProvider),
+);

--- a/lib/features/consumption/presentation/widgets/shared_trips_section.dart
+++ b/lib/features/consumption/presentation/widgets/shared_trips_section.dart
@@ -40,11 +40,14 @@ class SharedTripsSection extends ConsumerWidget {
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
           child: Row(
             children: [
-              Icon(Icons.group_outlined,
-                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+              Icon(
+                Icons.group_outlined,
+                size: 18,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               const SizedBox(width: 8),
               Text(
-                l?.trajetsSharedSectionTitle ?? 'Shared with me',
+                l.trajetsSharedSectionTitle,
                 style: theme.textTheme.titleSmall,
               ),
             ],

--- a/lib/features/consumption/presentation/widgets/tank_level_card.dart
+++ b/lib/features/consumption/presentation/widgets/tank_level_card.dart
@@ -56,7 +56,7 @@ class TankLevelCard extends ConsumerWidget {
 }
 
 class _EmptyTankLevelCard extends StatelessWidget {
-  final AppLocalizations? l;
+  final AppLocalizations l;
 
   const _EmptyTankLevelCard({required this.l});
 
@@ -70,14 +70,10 @@ class _EmptyTankLevelCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              l?.tankLevelTitle ?? 'Tank level',
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(l.tankLevelTitle, style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
             Text(
-              l?.tankLevelEmptyNoFillUp ??
-                  'Log a fill-up to see your tank level',
+              l.tankLevelEmptyNoFillUp,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -124,13 +120,10 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                l?.tankLevelTitle ?? 'Tank level',
-                style: theme.textTheme.titleMedium,
-              ),
+              Text(l.tankLevelTitle, style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
               Text(
-                l?.tankLevelLitersFormat(litresText) ?? '$litresText L',
+                l.tankLevelLitersFormat(litresText),
                 key: const Key('tank_level_big_number'),
                 // #1914 — was `displayMedium` (~45 sp), which dominated
                 // the card; `titleLarge` (~22 sp) roughly halves it
@@ -144,8 +137,7 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
               if (rangeKm != null) ...[
                 const SizedBox(height: 4),
                 Text(
-                  l?.tankLevelRangeFormat(rangeKm.round().toString()) ??
-                      '≈ ${rangeKm.round()} km of range',
+                  l.tankLevelRangeFormat(rangeKm.round().toString()),
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -173,11 +165,10 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
     );
   }
 
-  String _captionFor(AppLocalizations? l, TankLevelEstimate estimate) {
+  String _captionFor(AppLocalizations l, TankLevelEstimate estimate) {
     final dateText = _formatDate(estimate.lastFillUpDate);
     final countText = estimate.tripsSince.toString();
-    final lastFillUpLine = l?.tankLevelLastFillUpFormat(dateText, countText) ??
-        'Last fill-up: $dateText · $countText trip(s) since';
+    final lastFillUpLine = l.tankLevelLastFillUpFormat(dateText, countText);
     final methodLabel = _methodLabel(l, estimate.method);
     return '$lastFillUpLine · $methodLabel';
   }
@@ -189,15 +180,14 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
     return '${date.year}-$m-$d';
   }
 
-  String _methodLabel(AppLocalizations? l, TankLevelEstimationMethod method) {
+  String _methodLabel(AppLocalizations l, TankLevelEstimationMethod method) {
     switch (method) {
       case TankLevelEstimationMethod.obd2:
-        return l?.tankLevelMethodObd2 ?? 'OBD2 measured';
+        return l.tankLevelMethodObd2;
       case TankLevelEstimationMethod.distanceFallback:
-        return l?.tankLevelMethodDistanceFallback ??
-            'distance-based estimate';
+        return l.tankLevelMethodDistanceFallback;
       case TankLevelEstimationMethod.mixed:
-        return l?.tankLevelMethodMixed ?? 'mixed measurement';
+        return l.tankLevelMethodMixed;
     }
   }
 
@@ -225,18 +215,16 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  l?.tankLevelDetailSheetTitle ??
-                      'Trips since last fill-up',
+                  l.tankLevelDetailSheetTitle,
                   style: theme.textTheme.titleMedium,
                 ),
                 const SizedBox(height: 12),
                 if (relevant.isEmpty)
                   Text(
-                    l?.tankLevelLastFillUpFormat(
-                          _formatDate(lastFillUpDate),
-                          '0',
-                        ) ??
-                        'No trips yet',
+                    l.tankLevelLastFillUpFormat(
+                      _formatDate(lastFillUpDate),
+                      '0',
+                    ),
                     style: theme.textTheme.bodyMedium,
                   )
                 else
@@ -248,8 +236,8 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
                         final trip = relevant[index];
                         final startedAt = trip.summary.startedAt;
                         final dateText = _formatDate(startedAt);
-                        final distance =
-                            trip.summary.distanceKm.toStringAsFixed(1);
+                        final distance = trip.summary.distanceKm
+                            .toStringAsFixed(1);
                         final litres = trip.summary.fuelLitersConsumed;
                         final litresText = litres == null
                             ? ''

--- a/lib/features/consumption/presentation/widgets/throttle_rpm_histogram_card.dart
+++ b/lib/features/consumption/presentation/widgets/throttle_rpm_histogram_card.dart
@@ -58,51 +58,38 @@ class ThrottleRpmHistogramCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.throttleRpmHistogramTitle ?? 'How you used the engine',
+              l.throttleRpmHistogramTitle,
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 12),
             if (!histogram.hasData)
-              _EmptyState(
-                message: l?.throttleRpmHistogramEmpty ??
-                    'No throttle or RPM samples in this trip.',
-              )
+              _EmptyState(message: l.throttleRpmHistogramEmpty)
             else ...[
-              _SectionHeader(
-                label: l?.throttleRpmHistogramThrottleSection ??
-                    'Throttle position',
-              ),
+              _SectionHeader(label: l.throttleRpmHistogramThrottleSection),
               const SizedBox(height: 8),
               _BarGroup(
                 shares: histogram.throttleQuartiles,
                 labels: <String>[
-                  l?.throttleRpmHistogramThrottleCoast ?? 'Coast (0–25%)',
-                  l?.throttleRpmHistogramThrottleLight ?? 'Light (25–50%)',
-                  l?.throttleRpmHistogramThrottleFirm ?? 'Firm (50–75%)',
-                  l?.throttleRpmHistogramThrottleWide ??
-                      'Wide-open (75–100%)',
+                  l.throttleRpmHistogramThrottleCoast,
+                  l.throttleRpmHistogramThrottleLight,
+                  l.throttleRpmHistogramThrottleFirm,
+                  l.throttleRpmHistogramThrottleWide,
                 ],
-                emptyCaption: l?.throttleRpmHistogramEmpty ??
-                    'No throttle or RPM samples in this trip.',
+                emptyCaption: l.throttleRpmHistogramEmpty,
                 color: theme.colorScheme.primary,
               ),
               const SizedBox(height: 16),
-              _SectionHeader(
-                label:
-                    l?.throttleRpmHistogramRpmSection ?? 'Engine RPM',
-              ),
+              _SectionHeader(label: l.throttleRpmHistogramRpmSection),
               const SizedBox(height: 8),
               _BarGroup(
                 shares: histogram.rpmBands,
                 labels: <String>[
-                  l?.throttleRpmHistogramRpmIdle ?? 'Idle (≤900)',
-                  l?.throttleRpmHistogramRpmCruise ?? 'Cruise (901–2000)',
-                  l?.throttleRpmHistogramRpmSpirited ??
-                      'Spirited (2001–3000)',
-                  l?.throttleRpmHistogramRpmHard ?? 'Hard (>3000)',
+                  l.throttleRpmHistogramRpmIdle,
+                  l.throttleRpmHistogramRpmCruise,
+                  l.throttleRpmHistogramRpmSpirited,
+                  l.throttleRpmHistogramRpmHard,
                 ],
-                emptyCaption: l?.throttleRpmHistogramEmpty ??
-                    'No throttle or RPM samples in this trip.',
+                emptyCaption: l.throttleRpmHistogramEmpty,
                 color: theme.colorScheme.tertiary,
               ),
             ],
@@ -172,11 +159,7 @@ class _BarGroup extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         for (int i = 0; i < shares.length; i++)
-          _BarRow(
-            label: labels[i],
-            share: shares[i],
-            color: color,
-          ),
+          _BarRow(label: labels[i], share: shares[i], color: color),
       ],
     );
   }
@@ -207,8 +190,7 @@ class _BarRow extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final pctFormatted = (share * 100).toStringAsFixed(0);
-    final pctLabel = l?.throttleRpmHistogramBarShare(pctFormatted) ??
-        '$pctFormatted%';
+    final pctLabel = l.throttleRpmHistogramBarShare(pctFormatted);
 
     // Convert share to integer flex so Flexible(flex:) stays consistent
     // across rows. 1000 ticks gives 0.1 %-precision — far finer than
@@ -248,10 +230,7 @@ class _BarRow extends StatelessWidget {
                       ),
                     ),
                   if (empty > 0)
-                    Flexible(
-                      flex: empty,
-                      child: const SizedBox.shrink(),
-                    ),
+                    Flexible(flex: empty, child: const SizedBox.shrink()),
                 ],
               ),
             ),
@@ -290,17 +269,9 @@ class _EmptyState extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 12),
       child: Row(
         children: [
-          Icon(
-            Icons.info_outline,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.info_outline, color: theme.colorScheme.primary),
           const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              message,
-              style: theme.textTheme.bodyMedium,
-            ),
-          ),
+          Expanded(child: Text(message, style: theme.textTheme.bodyMedium)),
         ],
       ),
     );

--- a/lib/features/consumption/presentation/widgets/trajet_row.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_row.dart
@@ -4,7 +4,6 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
-import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
@@ -16,7 +15,7 @@ import 'trajet_stripe_colors.dart';
 class TrajetRow extends StatelessWidget {
   final TripHistoryEntry entry;
   final VehicleProfile? vehicle;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final ThemeData theme;
   final VoidCallback onTap;
 
@@ -81,9 +80,7 @@ class TrajetRow extends StatelessWidget {
         onTap: onTap,
         child: Container(
           decoration: BoxDecoration(
-            border: Border(
-              left: BorderSide(color: stripeColor, width: 4),
-            ),
+            border: Border(left: BorderSide(color: stripeColor, width: 4)),
           ),
           padding: innerPadding,
           child: Row(
@@ -96,7 +93,7 @@ class TrajetRow extends StatelessWidget {
                   children: [
                     Text(
                       startedAt == null
-                          ? (l?.tripHistoryUnknownDate ?? 'Unknown date')
+                          ? (l.tripHistoryUnknownDate)
                           : _fmtDate(startedAt),
                       style: compact
                           ? theme.textTheme.bodyMedium
@@ -108,45 +105,33 @@ class TrajetRow extends StatelessWidget {
                       runSpacing: 4,
                       children: [
                         if (shared)
-                          _Chip(
-                            icon: Icons.group,
-                            text: l?.trajetsSharedBadge ?? 'Shared',
-                          ),
+                          _Chip(icon: Icons.group, text: l.trajetsSharedBadge),
                         _Chip(
                           icon: Icons.straighten,
-                          text: l?.trajetsRowDistance(
-                                s.distanceKm.toStringAsFixed(1),
-                              ) ??
-                              '${s.distanceKm.toStringAsFixed(1)} km',
+                          text: l.trajetsRowDistance(
+                            s.distanceKm.toStringAsFixed(1),
+                          ),
                         ),
                         if (durationMinutes != null && durationMinutes > 0)
                           _Chip(
                             icon: Icons.timer,
-                            text: l?.trajetsRowDuration(
-                                  durationMinutes.toString(),
-                                ) ??
-                                '$durationMinutes min',
+                            text: l.trajetsRowDuration(
+                              durationMinutes.toString(),
+                            ),
                           ),
                         if (s.avgLPer100Km != null)
                           _Chip(
                             icon: Icons.eco,
-                            text: l?.trajetsRowAvgConsumption(
-                                  s.avgLPer100Km!.toStringAsFixed(1),
-                                  avgUnit,
-                                ) ??
-                                UnitFormatter.formatConsumption(
-                                  s.avgLPer100Km!,
-                                  isEv: isEv,
-                                ),
+                            text: l.trajetsRowAvgConsumption(
+                              s.avgLPer100Km!.toStringAsFixed(1),
+                              avgUnit,
+                            ),
                           ),
                         if (s.coldStartSurcharge)
                           _Chip(
                             icon: Icons.ac_unit,
-                            text: l?.trajetsRowColdStartChip ?? 'Cold start',
-                            tooltip: l?.trajetsRowColdStartTooltip ??
-                                "Engine didn't reach operating temperature "
-                                    'during this trip — fuel consumption '
-                                    'was higher than usual.',
+                            text: l.trajetsRowColdStartChip,
+                            tooltip: l.trajetsRowColdStartTooltip,
                           ),
                       ],
                     ),
@@ -177,7 +162,7 @@ class TrajetRow extends StatelessWidget {
 /// that opens the virtual-trip edit sheet.
 class _VirtualTrajetRow extends StatelessWidget {
   final TripHistoryEntry entry;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final ThemeData theme;
   final VoidCallback onTap;
 
@@ -214,7 +199,7 @@ class _VirtualTrajetRow extends StatelessWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  l?.reconcileVirtualTrajetLabel ?? 'Virtual trip — tap to edit',
+                  l.reconcileVirtualTrajetLabel,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: theme.textTheme.labelMedium?.copyWith(

--- a/lib/features/consumption/presentation/widgets/trajets_record_fab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_record_fab.dart
@@ -43,8 +43,9 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
     // #2274 concern 3 — kick the BLE pre-warm after the first frame so
     // it never competes with the tab's initial layout, and read
     // providers off a post-frame callback where `ref` is safe to use.
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _starter.maybePrewarm(ref));
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _starter.maybePrewarm(ref),
+    );
   }
 
   @override
@@ -71,9 +72,7 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
       await notifier.startGpsOnly();
       if (!mounted) return;
       await Navigator.of(context).push<TripSaveResult?>(
-        MaterialPageRoute(
-          builder: (_) => const TripRecordingScreen(),
-        ),
+        MaterialPageRoute(builder: (_) => const TripRecordingScreen()),
       );
       return;
     }
@@ -81,9 +80,7 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
     // the live recording screen without re-connecting.
     if (ref.read(tripRecordingProvider).isActive) {
       await Navigator.of(context).push<TripSaveResult?>(
-        MaterialPageRoute(
-          builder: (_) => const TripRecordingScreen(),
-        ),
+        MaterialPageRoute(builder: (_) => const TripRecordingScreen()),
       );
       return;
     }
@@ -100,35 +97,37 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
     // Fire the connect concurrently — do NOT await before pushing, or
     // the screen wouldn't open until the connect finished (the old
     // behaviour). The coordinator owns its own error surfacing + teardown.
-    unawaited(_starter.connectAndStart(
-      ref,
-      notifier: notifier,
-      isMounted: () => mounted,
-      openPicker: () {
-        // #1188 — silent `connectByMac` fast path for a paired adapter;
-        // the picker opens the modal sheet only when that fails. Plumbing
-        // both the MAC + display name lets it surface a concrete fallback
-        // snackbar ("Couldn't reach 'X' …") rather than a generic one.
-        final activeVehicle = ref.read(activeVehicleProfileProvider);
-        return showObd2AdapterPicker(
-          context,
-          pinnedMac: activeVehicle?.obd2AdapterMac,
-          pinnedAdapterName: activeVehicle?.obd2AdapterName,
-        );
-      },
-      onConnectionError: (error) {
-        // Only an OBD2 connection error carries user-facing copy; other
-        // failures are logged by the coordinator and stay silent.
-        if (error is Obd2ConnectionError && mounted) {
-          SnackBarHelper.showError(
-              context, error.localizedMessage(AppLocalizations.of(context)));
-        }
-      },
-    ));
-    await Navigator.of(context).push<TripSaveResult?>(
-      MaterialPageRoute(
-        builder: (_) => const TripRecordingScreen(),
+    unawaited(
+      _starter.connectAndStart(
+        ref,
+        notifier: notifier,
+        isMounted: () => mounted,
+        openPicker: () {
+          // #1188 — silent `connectByMac` fast path for a paired adapter;
+          // the picker opens the modal sheet only when that fails. Plumbing
+          // both the MAC + display name lets it surface a concrete fallback
+          // snackbar ("Couldn't reach 'X' …") rather than a generic one.
+          final activeVehicle = ref.read(activeVehicleProfileProvider);
+          return showObd2AdapterPicker(
+            context,
+            pinnedMac: activeVehicle?.obd2AdapterMac,
+            pinnedAdapterName: activeVehicle?.obd2AdapterName,
+          );
+        },
+        onConnectionError: (error) {
+          // Only an OBD2 connection error carries user-facing copy; other
+          // failures are logged by the coordinator and stay silent.
+          if (error is Obd2ConnectionError && mounted) {
+            SnackBarHelper.showError(
+              context,
+              error.localizedMessage(AppLocalizations.of(context)),
+            );
+          }
+        },
       ),
+    );
+    await Navigator.of(context).push<TripSaveResult?>(
+      MaterialPageRoute(builder: (_) => const TripRecordingScreen()),
     );
   }
 
@@ -143,13 +142,15 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
     // #3153 — select the two booleans this FAB renders from instead of
     // the whole trip state, so the 4 Hz live emits during a recording
     // don't rebuild the FAB 4×/s.
-    final isRecordingActive =
-        ref.watch(tripRecordingProvider.select((s) => s.isActive));
+    final isRecordingActive = ref.watch(
+      tripRecordingProvider.select((s) => s.isActive),
+    );
     // #2274 concern 2 — while a start is connecting, the recording
     // screen is already foreground showing the inline progress; reflect
     // that on the CTA too so a glance at the tab matches.
-    final isConnecting =
-        ref.watch(tripRecordingProvider.select((s) => s.isConnecting));
+    final isConnecting = ref.watch(
+      tripRecordingProvider.select((s) => s.isConnecting),
+    );
     return FloatingActionButton.extended(
       key: const Key('trajets_start_recording_button'),
       onPressed: isConnecting ? null : _onStartRecording,
@@ -160,11 +161,10 @@ class _TrajetsRecordFabState extends ConsumerState<TrajetsRecordFab> {
       ),
       label: Text(
         isConnecting
-            ? (l?.tripStartProgressConnectingAdapter ??
-                'Connecting to OBD2 adapter…')
+            ? (l.tripStartProgressConnectingAdapter)
             : isRecordingActive
-                ? (l?.trajetsResumeRecordingButton ?? 'Resume recording')
-                : (l?.trajetsStartRecordingButton ?? 'Start recording'),
+            ? (l.trajetsResumeRecordingButton)
+            : (l.trajetsStartRecordingButton),
       ),
     );
   }

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -53,18 +53,18 @@ class TrajetsTab extends ConsumerWidget {
     final filteredUnsorted = vehicleId == null
         ? trips.toList(growable: false)
         : trips
-            .where((t) => t.vehicleId == null || t.vehicleId == vehicleId)
-            .toList(growable: false);
+              .where((t) => t.vehicleId == null || t.vehicleId == vehicleId)
+              .toList(growable: false);
     // Defensive sort: `TripHistoryRepository.loadAll` already returns
     // newest-first, but we don't want to assume the provider was
     // populated by the repo path (tests, future sync sources). Sort
     // by `startedAt` descending here so the UI contract is tab-level.
     final filtered = List<TripHistoryEntry>.from(filteredUnsorted)
       ..sort((a, b) {
-        final ax = a.summary.startedAt ??
-            DateTime.fromMillisecondsSinceEpoch(0);
-        final bx = b.summary.startedAt ??
-            DateTime.fromMillisecondsSinceEpoch(0);
+        final ax =
+            a.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final bx =
+            b.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
         return bx.compareTo(ax);
       });
 
@@ -81,9 +81,8 @@ class TrajetsTab extends ConsumerWidget {
             child: EmptyState(
               key: const Key('trajets_empty_state'),
               icon: Icons.route_outlined,
-              title: l?.trajetsEmptyStateTitle ?? 'No trips yet',
-              subtitle: l?.trajetsEmptyStateBody ??
-                  'Tap Start recording to begin logging your drives.',
+              title: l.trajetsEmptyStateTitle,
+              subtitle: l.trajetsEmptyStateBody,
               topBiased: true,
             ),
           ),
@@ -112,7 +111,7 @@ class TrajetsTab extends ConsumerWidget {
         final vehicle = entry.vehicleId == null
             ? activeVehicle
             : vehicles.where((v) => v.id == entry.vehicleId).firstOrNull ??
-                activeVehicle;
+                  activeVehicle;
         return TrajetRow(
           entry: entry,
           vehicle: vehicle,

--- a/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
@@ -114,10 +114,7 @@ class TripAvgConsumptionCard extends ConsumerWidget {
       if (isEstimate)
         Tooltip(
           key: const Key('tripAvgEstimateTooltip'),
-          message: l?.tripAvgGpsEstimateTooltip ??
-              'GPS estimate (~) — no fuel sensor on this trip. The figure '
-                  'is modelled from speed + your vehicle\'s calibration; '
-                  'accuracy improves as the matrix matures.',
+          message: l.tripAvgGpsEstimateTooltip,
           child: Icon(
             Icons.info_outline,
             size: 16,
@@ -132,8 +129,9 @@ class TripAvgConsumptionCard extends ConsumerWidget {
       Text(
         value,
         key: const Key('tripAvgConsumptionValue'),
-        style: theme.textTheme.titleLarge
-            ?.copyWith(fontFeatures: const [FontFeature.tabularFigures()]),
+        style: theme.textTheme.titleLarge?.copyWith(
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
       ),
     ];
 
@@ -153,16 +151,13 @@ class TripAvgConsumptionCard extends ConsumerWidget {
             const SizedBox(width: 16),
             Expanded(
               child: Text(
-                l?.tripMetricAvgConsumption ?? 'Avg',
+                l.tripMetricAvgConsumption,
                 style: theme.textTheme.bodySmall,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: trailing,
-            ),
+            Row(mainAxisSize: MainAxisSize.min, children: trailing),
           ],
         ),
       ),

--- a/lib/features/consumption/presentation/widgets/trip_chart_crosshair.dart
+++ b/lib/features/consumption/presentation/widgets/trip_chart_crosshair.dart
@@ -59,8 +59,11 @@ class _TripDetailLineChartState extends State<_TripDetailLineChart> {
 
   void _scrub(Offset localPos, Size size, List<_ChartPoint> points) {
     if (points.length < 2) return;
-    final nearest =
-        _TripChartGeometry.nearestPointIndex(localPos, size, points);
+    final nearest = _TripChartGeometry.nearestPointIndex(
+      localPos,
+      size,
+      points,
+    );
     if (nearest != _selected) {
       setState(() => _selected = nearest);
     }
@@ -87,7 +90,7 @@ class _TripDetailLineChartState extends State<_TripDetailLineChart> {
         height: 140,
         child: Center(
           child: Text(
-            l?.trajetDetailChartEmpty ?? 'No samples recorded',
+            l.trajetDetailChartEmpty,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -97,8 +100,9 @@ class _TripDetailLineChartState extends State<_TripDetailLineChart> {
     }
     points.sort((a, b) => a.timestamp.compareTo(b.timestamp));
 
-    final selected =
-        (_selected != null && _selected! < points.length) ? _selected : null;
+    final selected = (_selected != null && _selected! < points.length)
+        ? _selected
+        : null;
     final locale = Localizations.localeOf(context);
 
     final chart = SizedBox(
@@ -109,8 +113,7 @@ class _TripDetailLineChartState extends State<_TripDetailLineChart> {
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTapDown: (d) => _scrub(d.localPosition, size, points),
-            onHorizontalDragStart: (d) =>
-                _scrub(d.localPosition, size, points),
+            onHorizontalDragStart: (d) => _scrub(d.localPosition, size, points),
             onHorizontalDragUpdate: (d) =>
                 _scrub(d.localPosition, size, points),
             child: Stack(
@@ -156,7 +159,7 @@ class _TripDetailLineChartState extends State<_TripDetailLineChart> {
               borderRadius: BorderRadius.circular(6),
             ),
             child: Text(
-              '~ ${l?.trajetDetailChartEstimatedBadge ?? 'estimated'}',
+              '~ ${l.trajetDetailChartEstimatedBadge}',
               style: theme.textTheme.labelSmall?.copyWith(
                 color: theme.colorScheme.onSecondaryContainer,
               ),
@@ -197,12 +200,12 @@ class _TripChartGeometry {
     required int tSpan,
     required double chartWidth,
     required double chartHeight,
-  })  : _yMin = yMin,
-        _ySpan = ySpan,
-        _firstTs = firstTs,
-        _tSpan = tSpan,
-        _chartWidth = chartWidth,
-        _chartHeight = chartHeight;
+  }) : _yMin = yMin,
+       _ySpan = ySpan,
+       _firstTs = firstTs,
+       _tSpan = tSpan,
+       _chartWidth = chartWidth,
+       _chartHeight = chartHeight;
 
   factory _TripChartGeometry.forSize(Size size, List<_ChartPoint> points) {
     final chartWidth = size.width - leftInset - rightInset;

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -114,8 +114,11 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
       DrivingLessonRegistry.standard();
 
   /// GPS-only efficiency features (#2697 P3) — null for OBD2/EV/empty.
-  late final GpsDrivingFeatures? _gpsFeatures = GpsEfficiencyKpiCard
-      .featuresFor(widget.samples.map(tripDetailToTripSample), isEv: widget.isEv);
+  late final GpsDrivingFeatures? _gpsFeatures =
+      GpsEfficiencyKpiCard.featuresFor(
+        widget.samples.map(tripDetailToTripSample),
+        isEv: widget.isEv,
+      );
 
   List<DrivingInsight> _computeInsights() {
     if (widget.samples.isEmpty) return const [];
@@ -126,9 +129,9 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // Skip the analysis for EVs entirely; phase 4 will revisit once
     // the kWh equivalent lands.
     if (widget.isEv) return const [];
-    final tripSamples = widget.samples.map(tripDetailToTripSample).toList(
-          growable: false,
-        );
+    final tripSamples = widget.samples
+        .map(tripDetailToTripSample)
+        .toList(growable: false);
     // Epic #3015 — scale the hard-accel wasted-litres by the active
     // vehicle's engine power (a small engine wastes proportionally more for
     // the same hard pull). Trips aren't tagged with a vehicle, so the
@@ -153,9 +156,9 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
   DrivingScore _computeScore() {
     if (widget.samples.isEmpty) return DrivingScore.perfect;
     if (widget.isEv) return DrivingScore.perfect;
-    final tripSamples = widget.samples.map(tripDetailToTripSample).toList(
-          growable: false,
-        );
+    final tripSamples = widget.samples
+        .map(tripDetailToTripSample)
+        .toList(growable: false);
     final summary = widget.entry.summary;
     // #2460 — thread the trip-end lugging metric stored on the summary
     // into the canonical score so the over-rev/shift family includes it
@@ -217,22 +220,20 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // analyzer / score passes don't re-run on a theme / locale rebuild.
     // Empty for EV / empty trips on the same gating rule as the card
     // below, and the registry returns [] when no rule fires (the
-    // empty-state path). `l == null` only in degenerate test harnesses;
-    // fall back to no lessons rather than crash.
-    final List<DrivingLesson> lessons =
-        (l == null || widget.isEv || widget.samples.isEmpty)
-            ? const []
-            : _lessonRegistry.evaluateContext(
-                LessonContext(
-                  summary: widget.entry.summary,
-                  samples: widget.samples.map(tripDetailToTripSample).toList(
-                        growable: false,
-                      ),
-                  score: _score,
-                  insights: _insights,
-                ),
-                l,
-              );
+    // empty-state path).
+    final List<DrivingLesson> lessons = (widget.isEv || widget.samples.isEmpty)
+        ? const []
+        : _lessonRegistry.evaluateContext(
+            LessonContext(
+              summary: widget.entry.summary,
+              samples: widget.samples
+                  .map(tripDetailToTripSample)
+                  .toList(growable: false),
+              score: _score,
+              insights: _insights,
+            ),
+            l,
+          );
 
     // Wrap the report content in a [RepaintBoundary] so the Share
     // action (#1189) can call `boundary.toImage(...)` to produce a PNG
@@ -287,8 +288,7 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
         if (!widget.isEv && widget.samples.isNotEmpty && _gpsFeatures == null)
           ThrottleRpmHistogramCard(histogram: _histogram),
         // GPS-only efficiency KPIs (#2697 P3) — only for engine-signal-less trips.
-        if (_gpsFeatures != null)
-          GpsEfficiencyKpiCard(features: _gpsFeatures),
+        if (_gpsFeatures != null) GpsEfficiencyKpiCard(features: _gpsFeatures),
         // #2796 C7 — the GPS-only replacement for the throttle/RPM card: a
         // speed-only "how you used the road" panel (speed-band + movement-
         // phase shares + a positive coasting line). Same gate as the KPI
@@ -307,9 +307,7 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
         // service) is conditional on what this card surfaces during
         // field testing.
         if (widget.entry.gpsSampleDiagnostics.isNotEmpty)
-          GpsDiagnosticsCard(
-            diagnostics: widget.entry.gpsSampleDiagnostics,
-          ),
+          GpsDiagnosticsCard(diagnostics: widget.entry.gpsSampleDiagnostics),
         // OBD2 communication-health diagnostics (#2470). Dev-only — the
         // card self-hides unless Feature.debugMode is on AND a session was
         // captured, the OBD2 analogue of the GPS card above. #2912 — feeds
@@ -357,4 +355,3 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     );
   }
 }
-

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts_section.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts_section.dart
@@ -31,7 +31,9 @@ class TripDetailChartsSection extends StatelessWidget {
     final hasFuelRateSamples = samples.any(
       (s) => s.fuelRateLPerHour != null || s.estimatedFuelRateLPerHour != null,
     );
-    final hasEngineLoadSamples = samples.any((s) => s.engineLoadPercent != null);
+    final hasEngineLoadSamples = samples.any(
+      (s) => s.engineLoadPercent != null,
+    );
     final hasThrottleSamples = samples.any(
       (s) => s.pedalPercent != null || s.throttlePercent != null,
     );
@@ -43,7 +45,7 @@ class TripDetailChartsSection extends StatelessWidget {
       margin: const EdgeInsets.fromLTRB(12, 8, 12, 4),
       clipBehavior: Clip.antiAlias,
       child: ExpansionTile(
-        title: Text(l?.trajetDetailChartsSection ?? 'Charts'),
+        title: Text(l.trajetDetailChartsSection),
         initiallyExpanded: false,
         maintainState: true,
         shape: const Border(),
@@ -51,44 +53,44 @@ class TripDetailChartsSection extends StatelessWidget {
         childrenPadding: const EdgeInsets.only(bottom: 4),
         children: [
           TripChartSection(
-            title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
+            title: l.trajetDetailChartSpeed,
             chart: TripDetailSpeedChart(samples: samples),
           ),
           if (hasFuelRateSamples)
             TripChartSection(
-              title: l?.trajetDetailChartFuelRate ?? 'Fuel rate (L/h)',
+              title: l.trajetDetailChartFuelRate,
               chart: TripDetailFuelRateChart(samples: samples),
             ),
           if (hasRpmSamples)
             TripChartSection(
-              title: l?.trajetDetailChartRpm ?? 'RPM',
+              title: l.trajetDetailChartRpm,
               chart: TripDetailRpmChart(samples: samples),
             ),
           if (hasEngineLoadSamples)
             TripChartSection(
-              title: l?.trajetDetailChartEngineLoad ?? 'Engine load (%)',
+              title: l.trajetDetailChartEngineLoad,
               chart: TripDetailEngineLoadChart(samples: samples),
             ),
           // #2461 — driving-signal charts, each gated on its own
           // if-any-non-null signal (mirrors RPM / engine-load).
           if (hasThrottleSamples)
             TripChartSection(
-              title: l?.trajetDetailChartThrottle ?? 'Throttle / pedal (%)',
+              title: l.trajetDetailChartThrottle,
               chart: TripDetailThrottleChart(samples: samples),
             ),
           if (hasCoolantSamples)
             TripChartSection(
-              title: l?.trajetDetailChartCoolant ?? 'Coolant (°C)',
+              title: l.trajetDetailChartCoolant,
               chart: TripDetailCoolantChart(samples: samples),
             ),
           if (hasAltitudeSamples)
             TripChartSection(
-              title: l?.trajetDetailChartAltitude ?? 'Altitude (m)',
+              title: l.trajetDetailChartAltitude,
               chart: TripDetailAltitudeChart(samples: samples),
             ),
           if (hasLambdaSamples)
             TripChartSection(
-              title: l?.trajetDetailChartLambda ?? 'Commanded λ',
+              title: l.trajetDetailChartLambda,
               chart: TripDetailLambdaChart(samples: samples),
             ),
         ],

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -93,8 +93,8 @@ class TripPathMapCard extends StatelessWidget {
 
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
-    final title = l?.tripPathCardTitle ?? 'Trip path';
-    final subtitle = l?.tripPathCardSubtitle ?? 'GPS-recorded route';
+    final title = l.tripPathCardTitle;
+    final subtitle = l.tripPathCardSubtitle;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
@@ -121,10 +121,7 @@ class TripPathMapCard extends StatelessWidget {
             ),
             SizedBox(
               height: 220,
-              child: _TripPathMap(
-                points: points,
-                pointSamples: pointSamples,
-              ),
+              child: _TripPathMap(points: points, pointSamples: pointSamples),
             ),
             const _TripPathLegend(),
           ],
@@ -142,10 +139,7 @@ class _TripPathMap extends StatefulWidget {
   final List<LatLng> points;
   final List<TripDetailSample> pointSamples;
 
-  const _TripPathMap({
-    required this.points,
-    required this.pointSamples,
-  });
+  const _TripPathMap({required this.points, required this.pointSamples});
 
   @override
   State<_TripPathMap> createState() => _TripPathMapState();
@@ -286,11 +280,7 @@ class _TripPathMapState extends State<_TripPathMap> {
             point: widget.points[idx],
             width: 20,
             height: 20,
-            child: Icon(
-              Icons.bolt,
-              size: 16,
-              color: theme.colorScheme.error,
-            ),
+            child: Icon(Icons.bolt, size: 16, color: theme.colorScheme.error),
           ),
     ];
 
@@ -367,11 +357,9 @@ class _TripPathLegend extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final efficient =
-        l?.tripPathLegendEfficient ?? 'Efficient (< 6 L/100km)';
-    final borderline =
-        l?.tripPathLegendBorderline ?? 'Borderline (6–10 L/100km)';
-    final wasteful = l?.tripPathLegendWasteful ?? 'Wasteful (≥ 10 L/100km)';
+    final efficient = l.tripPathLegendEfficient;
+    final borderline = l.tripPathLegendBorderline;
+    final wasteful = l.tripPathLegendWasteful;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
       child: Wrap(
@@ -387,10 +375,7 @@ class _TripPathLegend extends StatelessWidget {
             color: DarkModeColors.warning(context),
             label: borderline,
           ),
-          _LegendSwatch(
-            color: DarkModeColors.error(context),
-            label: wasteful,
-          ),
+          _LegendSwatch(color: DarkModeColors.error(context), label: wasteful),
         ],
       ),
     );
@@ -441,10 +426,7 @@ class _PathPin extends StatelessWidget {
         shape: BoxShape.circle,
         border: Border.all(color: Colors.white, width: 2),
         boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.3),
-            blurRadius: 3,
-          ),
+          BoxShadow(color: Colors.black.withValues(alpha: 0.3), blurRadius: 3),
         ],
       ),
       child: Icon(icon, size: 16, color: Colors.white),

--- a/lib/features/consumption/presentation/widgets/trip_radar_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_radar_card.dart
@@ -77,10 +77,11 @@ class TripRadarCard extends ConsumerWidget {
       ApproachLeaving(:final lastStation) => lastStation,
       _ => null,
     };
-    final double? distanceMeters =
-        approach is ApproachInRadius ? approach.distanceMeters : null;
+    final double? distanceMeters = approach is ApproachInRadius
+        ? approach.distanceMeters
+        : null;
 
-    final title = l?.tripRadarClosestStation ?? 'Fuel Station Radar';
+    final title = l.tripRadarClosestStation;
 
     // The proximity fill bar's "indicated radius" is the user's default
     // radar radius (the same `profile.approachRadiusKm` the detector fences
@@ -126,7 +127,7 @@ class TripRadarCard extends ConsumerWidget {
           // A load COMPLETED with no priced station in range.
           return RadarPlaceholder(
             title: title,
-            message: l?.tripRadarNoStationNearby ?? 'No station nearby',
+            message: l.tripRadarNoStationNearby,
           );
         }
         // Clamp the page index against the live list length — a stale index
@@ -143,14 +144,10 @@ class TripRadarCard extends ConsumerWidget {
         );
       },
       // FIRST load only (no retained value) — the row is genuinely empty.
-      loading: () => RadarPlaceholder(
-        title: title,
-        message: l?.tripRadarScanning ?? 'Scanning for nearby stations',
-      ),
-      error: (_, _) => RadarPlaceholder(
-        title: title,
-        message: l?.tripRadarNoStationNearby ?? 'No station nearby',
-      ),
+      loading: () =>
+          RadarPlaceholder(title: title, message: l.tripRadarScanning),
+      error: (_, _) =>
+          RadarPlaceholder(title: title, message: l.tripRadarNoStationNearby),
     );
   }
 }
@@ -203,10 +200,8 @@ class RadarCard extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final price = station.priceFor(fuel);
-    final priceText =
-        price != null ? PriceFormatter.formatPrice(price) : '--';
-    final name =
-        station.name.isNotEmpty ? station.name : station.brand;
+    final priceText = price != null ? PriceFormatter.formatPrice(price) : '--';
+    final name = station.name.isNotEmpty ? station.name : station.brand;
 
     // In-radius shows sub-km precision (metres); the fallback radar page-set
     // shows km — the great-circle distance the driver still has to cover
@@ -214,22 +209,18 @@ class RadarCard extends StatelessWidget {
     final String? distanceLabel = distanceMeters == null
         ? null
         : live
-            ? (l?.approachStationDistance(distanceMeters!.toStringAsFixed(0)) ??
-                '${distanceMeters!.toStringAsFixed(0)} m')
-            : (l?.fuelStationRadarDistanceKm(
-                    (distanceMeters! / 1000.0).toStringAsFixed(1)) ??
-                '${(distanceMeters! / 1000.0).toStringAsFixed(1)} km');
-    final subtitleParts = <String>[
-      fuel.displayName,
-      ?distanceLabel,
-    ];
+        ? (l.approachStationDistance(distanceMeters!.toStringAsFixed(0)))
+        : (l.fuelStationRadarDistanceKm(
+            (distanceMeters! / 1000.0).toStringAsFixed(1),
+          ));
+    final subtitleParts = <String>[fuel.displayName, ?distanceLabel];
 
     // Tap → hand the station's coords to the SSoT navigation util, which
     // launches the OS's default driving/itinéraire app (geo: URI, Google-
     // Maps web fallback) — #2545. Reuses the existing `navigate` ARB key
     // for the tooltip/semantics affordance (no new key → no 23-locale
     // fan-out).
-    final navigateLabel = l?.navigate ?? 'Navigate';
+    final navigateLabel = l.navigate;
 
     return Card(
       margin: EdgeInsets.zero,
@@ -338,8 +329,11 @@ class RadarCard extends StatelessWidget {
 class RadarPlaceholder extends StatelessWidget {
   final String title;
   final String message;
-  const RadarPlaceholder(
-      {super.key, required this.title, required this.message});
+  const RadarPlaceholder({
+    super.key,
+    required this.title,
+    required this.message,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -74,13 +74,27 @@ class TripRecordingBanner extends ConsumerWidget {
       // leaves them null so the tile degrades to the consumption layout.
       Station? radarStation;
       double? radiusMeters;
-      try { approach = ref.watch(effectiveApproachStateProvider); } on Object { /* fall back to null */ }
-      try { fuel = ref.watch(effectiveFuelTypeProvider); } on Object { /* keep e10 */ }
-      try { radarStation = ref.watch(nearestStationRadarProvider).value; } on Object { /* no radar station */ }
+      try {
+        approach = ref.watch(effectiveApproachStateProvider);
+      } on Object {
+        /* fall back to null */
+      }
+      try {
+        fuel = ref.watch(effectiveFuelTypeProvider);
+      } on Object {
+        /* keep e10 */
+      }
+      try {
+        radarStation = ref.watch(nearestStationRadarProvider).value;
+      } on Object {
+        /* no radar station */
+      }
       try {
         final p = ref.watch(activeProfileProvider);
         if (p != null) radiusMeters = p.approachRadiusKm * 1000.0;
-      } on Object { /* no radius */ }
+      } on Object {
+        /* no radius */
+      }
       // #2677 — guarded fallback for the on-search Fuel Station Radar PiP
       // (no trip required): when the trip radar found nothing AND the
       // on-search radar is active, feed its nearest priced station into the
@@ -95,7 +109,9 @@ class TripRecordingBanner extends ConsumerWidget {
             radarStation = ref.watch(radarSearchNearestProvider);
             radiusMeters = ref.watch(searchRadiusProvider) * 1000.0;
           }
-        } on Object { /* no on-search radar */ }
+        } on Object {
+          /* no on-search radar */
+        }
       }
       // #2964 — tapping the floating PiP tile body restores the full app.
       // Built here where `ref` is in scope; the controller is the app-wide
@@ -127,7 +143,8 @@ class TripRecordingBanner extends ConsumerWidget {
     // "reconnecting…" / terminal "tap to retry" banner ABOVE every screen,
     // decoupled from any live trip — a drop while idle still recovers.
     final reconnectState = ref.watch(obd2ReconnectProvider);
-    final reconnectVisible = reconnectState == Obd2ReconnectState.reconnecting ||
+    final reconnectVisible =
+        reconnectState == Obd2ReconnectState.reconnecting ||
         reconnectState == Obd2ReconnectState.terminalFailed ||
         // #3035 — the terminal engine-off banner is user-actionable too.
         reconnectState == Obd2ReconnectState.terminalEngineOff;
@@ -194,9 +211,13 @@ class TripRecordingBanner extends ConsumerWidget {
                       ref.read(routerProvider).push(RoutePaths.tripRecording),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 6),
+                      horizontal: 12,
+                      vertical: 6,
+                    ),
                     child: TripRecordingBannerContent(
-                        state: state, palette: bandColor),
+                      state: state,
+                      palette: bandColor,
+                    ),
                   ),
                 ),
               ),
@@ -282,11 +303,11 @@ class TripRecordingBanner extends ConsumerWidget {
     );
   }
 
-  String _semanticsLabel(TripRecordingState state, AppLocalizations? l) {
+  String _semanticsLabel(TripRecordingState state, AppLocalizations l) {
     if (state.phase == TripRecordingPhase.paused) {
-      return l?.tripBannerPaused ?? 'Trip paused';
+      return l.tripBannerPaused;
     }
-    final prefix = l?.tripBannerRecording ?? 'Recording trip';
+    final prefix = l.tripBannerRecording;
     final situation = _situationLabel(state.situation, l);
     final parts = <String>[prefix, situation];
     final delta = state.liveDeltaFraction;
@@ -307,13 +328,11 @@ class TripRecordingBanner extends ConsumerWidget {
     if (live != null &&
         formatInstantConsumption(live) == null &&
         live.gpsEstimatedLPer100Km != null) {
-      parts.add(l?.tripRecordingEstimatedInfo ??
-          'Estimated value (~) — modelled from GPS speed, not measured.');
+      parts.add(l.tripRecordingEstimatedInfo);
     }
     return parts.join(', ');
   }
 
-  String _situationLabel(DrivingSituation s, AppLocalizations? l) =>
+  String _situationLabel(DrivingSituation s, AppLocalizations l) =>
       situationDisplayLabel(s, l);
 }
-

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner_content.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner_content.dart
@@ -15,31 +15,31 @@ import 'trip_recording_banner_palette.dart';
 /// accessibility label and its visible content strip (#2515 — extracted
 /// from the two byte-identical switches so the new buckets only need to
 /// be mapped once).
-String situationDisplayLabel(DrivingSituation s, AppLocalizations? l) {
+String situationDisplayLabel(DrivingSituation s, AppLocalizations l) {
   switch (s) {
     case DrivingSituation.idle:
-      return l?.situationIdle ?? 'Idle';
+      return l.situationIdle;
     case DrivingSituation.stopAndGo:
-      return l?.situationStopAndGo ?? 'Stop & go';
+      return l.situationStopAndGo;
     case DrivingSituation.urbanCruise:
-      return l?.situationUrban ?? 'Urban';
+      return l.situationUrban;
     case DrivingSituation.highwayCruise:
-      return l?.situationHighway ?? 'Highway';
+      return l.situationHighway;
     case DrivingSituation.deceleration:
-      return l?.situationDecel ?? 'Decelerating';
+      return l.situationDecel;
     case DrivingSituation.climbingOrLoaded:
-      return l?.situationClimbing ?? 'Climbing / loaded';
+      return l.situationClimbing;
     // #2515 — the three new persistent buckets.
     case DrivingSituation.coldStartWarmup:
-      return l?.situationColdStart ?? 'Cold start';
+      return l.situationColdStart;
     case DrivingSituation.sustainedLoadOrTowing:
-      return l?.situationSustainedLoad ?? 'Sustained load / towing';
+      return l.situationSustainedLoad;
     case DrivingSituation.partialThrottleDecel:
-      return l?.situationPartialDecel ?? 'Coasting';
+      return l.situationPartialDecel;
     case DrivingSituation.hardAccel:
-      return l?.situationHardAccel ?? 'Hard accel';
+      return l.situationHardAccel;
     case DrivingSituation.fuelCutCoast:
-      return l?.situationFuelCut ?? 'Fuel cut — coast';
+      return l.situationFuelCut;
   }
 }
 
@@ -69,7 +69,7 @@ class TripRecordingBannerContent extends StatelessWidget {
 
     final fg = palette.foreground;
     final situationLabel = paused
-        ? (l?.tripBannerPaused ?? 'Paused')
+        ? (l.tripBannerPaused)
         : situationDisplayLabel(state.situation, l);
     final bandIcon = paused
         ? Icons.pause_circle_filled
@@ -86,15 +86,18 @@ class TripRecordingBannerContent extends StatelessWidget {
     // token, leading `~` flagging it an estimate per ADR 0012). The OBD2
     // measured path stays tilde-free; a null estimate (warm-up / OBD2
     // trip) leaves the slot silent as before.
-    final gpsEstimate =
-        (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
-    final measured =
-        (live != null && !paused) ? formatInstantConsumption(live) : null;
+    final gpsEstimate = (live != null && !paused)
+        ? live.gpsEstimatedLPer100Km
+        : null;
+    final measured = (live != null && !paused)
+        ? formatInstantConsumption(live)
+        : null;
     // #2393 — true only when the value shown is the GPS estimate (no
     // measured value, estimate present). Drives the approximate tooltip /
     // accessibility disclaimer; the OBD2-measured value never carries it.
     final isEstimate = measured == null && gpsEstimate != null;
-    final instantConsumption = measured ??
+    final instantConsumption =
+        measured ??
         (isEstimate ? '~${gpsEstimate.toStringAsFixed(1)} L/100' : null);
     final coachingHintValue = (live != null && !paused)
         ? coachingHint(live, situation: state.situation, band: state.band)
@@ -125,9 +128,7 @@ class TripRecordingBannerContent extends StatelessWidget {
           // ExcludeSemantics.
           if (isEstimate)
             Tooltip(
-              message: l?.tripRecordingEstimatedInfo ??
-                  'Estimated value (~) — modelled from GPS speed, '
-                      'not measured.',
+              message: l.tripRecordingEstimatedInfo,
               child: Text(
                 instantConsumption,
                 style: TextStyle(

--- a/lib/features/consumption/presentation/widgets/trip_recording_landscape_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_landscape_body.dart
@@ -80,7 +80,7 @@ class TripRecordingLandscapeBody extends StatelessWidget {
                 child: _BigMetricTile(
                   key: const Key('landscapeSpeedTile'),
                   icon: Icons.speed,
-                  label: l?.tripMetricSpeed ?? 'Speed',
+                  label: l.tripMetricSpeed,
                   value: r?.speedKmh == null
                       ? '—'
                       : '${r!.speedKmh!.toStringAsFixed(0)} km/h',
@@ -112,7 +112,7 @@ class TripRecordingLandscapeBody extends StatelessWidget {
                             child: _BigMetricTile(
                               key: const Key('landscapeDistanceTile'),
                               icon: Icons.route,
-                              label: l?.tripMetricDistance ?? 'Distance',
+                              label: l.tripMetricDistance,
                               value: r == null
                                   ? '—'
                                   : '${r.distanceKmSoFar.toStringAsFixed(2)} km',
@@ -130,7 +130,7 @@ class TripRecordingLandscapeBody extends StatelessWidget {
                             child: _BigMetricTile(
                               key: const Key('landscapeAvgTile'),
                               icon: Icons.eco,
-                              label: l?.tripMetricAvgConsumption ?? 'Avg',
+                              label: l.tripMetricAvgConsumption,
                               value: TripAvgConsumptionCard.resolveDisplay(
                                 r,
                                 brokenMapOverride: brokenMapOverride,
@@ -149,7 +149,7 @@ class TripRecordingLandscapeBody extends StatelessWidget {
                             child: _BigMetricTile(
                               key: const Key('landscapeElapsedTile'),
                               icon: Icons.timer,
-                              label: l?.tripMetricElapsed ?? 'Elapsed',
+                              label: l.tripMetricElapsed,
                               value: r == null ? '—' : _fmtElapsed(r.elapsed),
                             ),
                           ),
@@ -158,12 +158,12 @@ class TripRecordingLandscapeBody extends StatelessWidget {
                             child: _BigMetricTile(
                               key: const Key('landscapeFuelTile'),
                               icon: Icons.local_gas_station,
-                              label: l?.tripMetricFuelUsed ?? 'Fuel used',
+                              label: l.tripMetricFuelUsed,
                               value: r?.fuelLitersSoFar != null
                                   ? '${r!.fuelLitersSoFar!.toStringAsFixed(2)} L'
                                   : r?.gpsEstimatedFuelLitersSoFar != null
-                                      ? '~${r!.gpsEstimatedFuelLitersSoFar!.toStringAsFixed(2)} L'
-                                      : '—',
+                                  ? '~${r!.gpsEstimatedFuelLitersSoFar!.toStringAsFixed(2)} L'
+                                  : '—',
                             ),
                           ),
                         ],

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
@@ -75,11 +75,8 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
     final String? distanceText = distance == null
         ? null
         : kmCaption
-            ? (l?.fuelStationRadarDistanceKm(
-                    (distance / 1000.0).toStringAsFixed(1)) ??
-                '${(distance / 1000.0).toStringAsFixed(1)} km')
-            : (l?.approachStationDistance(distance.toStringAsFixed(0)) ??
-                '${distance.toStringAsFixed(0)} m');
+        ? (l.fuelStationRadarDistanceKm((distance / 1000.0).toStringAsFixed(1)))
+        : (l.approachStationDistance(distance.toStringAsFixed(0)));
 
     final content = Column(
       mainAxisSize: MainAxisSize.min,
@@ -156,7 +153,10 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
           children: [
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
                 child: Center(
                   child: FittedBox(fit: BoxFit.scaleDown, child: content),
                 ),
@@ -175,10 +175,10 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
     final onTap = onBodyTap;
     if (onTap == null) return body;
     return Tooltip(
-      message: l?.pipTapToRestore ?? 'Tap to open the full app',
+      message: l.pipTapToRestore,
       child: Semantics(
         button: true,
-        label: l?.pipTapToRestore ?? 'Tap to open the full app',
+        label: l.pipTapToRestore,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: onTap,

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -94,8 +94,9 @@ class TripRecordingPipView extends StatelessWidget {
       final station = approach is ApproachInRadius
           ? approach.station
           : (approach as ApproachLeaving).lastStation;
-      final dist =
-          approach is ApproachInRadius ? approach.distanceMeters : null;
+      final dist = approach is ApproachInRadius
+          ? approach.distanceMeters
+          : null;
       return TripRecordingPipPriceLayout(
         station: station,
         fuel: fuel,
@@ -188,7 +189,7 @@ class TripRecordingPipView extends StatelessWidget {
       // (#2393) so the value reads distinctly from the OBD2-measured
       // "L/100 km"; the leading `~` carries the same meaning visually.
       bigFigure = '~${gpsEstimate.toStringAsFixed(1)}';
-      bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+      bigCaption = l.tripRecordingPipEstConsumptionCaption;
       isEstimate = true;
       secondaryRow = [
         if (distance != null) '${distance.toStringAsFixed(1)} km',
@@ -201,7 +202,7 @@ class TripRecordingPipView extends StatelessWidget {
       // L/100 km" caption; demote distance + elapsed to the secondary
       // row like the measured branches.
       bigFigure = '~';
-      bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+      bigCaption = l.tripRecordingPipEstConsumptionCaption;
       isEstimate = true;
       secondaryRow = [
         if (distance != null && distance >= 0.1)
@@ -212,7 +213,7 @@ class TripRecordingPipView extends StatelessWidget {
       // No data at all (shouldn't happen during an active recording,
       // but render a sane fallback rather than crashing).
       bigFigure = '0:00';
-      bigCaption = l?.tripRecordingPipElapsedCaption ?? 'elapsed';
+      bigCaption = l.tripRecordingPipElapsedCaption;
       secondaryRow = const <String>[];
     }
 
@@ -220,10 +221,7 @@ class TripRecordingPipView extends StatelessWidget {
     // approximate-explanation tooltip (long-press) and accessibility
     // label; OBD2-measured branches render the bare figure (real value,
     // no estimate disclaimer).
-    final estimateInfo = isEstimate
-        ? (l?.tripRecordingEstimatedInfo ??
-              'Estimated value (~) — modelled from GPS speed, not measured.')
-        : null;
+    final estimateInfo = isEstimate ? (l.tripRecordingEstimatedInfo) : null;
     Widget figureBlock = Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -297,7 +295,7 @@ class TripRecordingPipView extends StatelessWidget {
           if (paused) ...[
             const SizedBox(height: 4),
             Text(
-              l?.tripBannerPaused ?? 'Paused',
+              l.tripBannerPaused,
               style: TextStyle(
                 color: foregroundColor.withValues(alpha: 0.8),
                 fontSize: 11,
@@ -320,7 +318,7 @@ class TripRecordingPipView extends StatelessWidget {
   /// that brings the app back to the foreground in full screen (the user
   /// expects a tap on the floating window to restore full screen). Null
   /// leaves the body non-tappable (previews / widget tests without a host).
-  Widget _pipStack({required Widget child, AppLocalizations? l}) {
+  Widget _pipStack({required Widget child, required AppLocalizations l}) {
     final body = Material(
       color: backgroundColor,
       child: SafeArea(
@@ -334,7 +332,7 @@ class TripRecordingPipView extends StatelessWidget {
     );
     final onTap = onBodyTap;
     if (onTap == null) return body;
-    final label = l?.pipTapToRestore ?? 'Tap to open the full app';
+    final label = l.pipTapToRestore;
     return Tooltip(
       message: label,
       child: Semantics(

--- a/lib/features/consumption/presentation/widgets/trip_save_progress.dart
+++ b/lib/features/consumption/presentation/widgets/trip_save_progress.dart
@@ -61,14 +61,14 @@ class _TripSaveProgressState extends State<TripSaveProgress>
     }
   }
 
-  String _labelFor(AppLocalizations? l, TripSaveStage stage) {
+  String _labelFor(AppLocalizations l, TripSaveStage stage) {
     switch (stage) {
       case TripSaveStage.finalizingSummary:
-        return l?.tripSaveProgressFinalizingSummary ?? 'Finalizing summary…';
+        return l.tripSaveProgressFinalizingSummary;
       case TripSaveStage.savingToHistory:
-        return l?.tripSaveProgressSavingToHistory ?? 'Saving to history…';
+        return l.tripSaveProgressSavingToHistory;
       case TripSaveStage.syncingToCloud:
-        return l?.tripSaveProgressSyncingToCloud ?? 'Syncing in background…';
+        return l.tripSaveProgressSyncingToCloud;
     }
   }
 

--- a/lib/features/consumption/presentation/widgets/trip_share_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/trip_share_sheet.dart
@@ -94,7 +94,7 @@ class _TripShareSheetState extends State<TripShareSheet> {
     setState(() => _shares = shares);
   }
 
-  Future<void> _onShareEmail(AppLocalizations? l) async {
+  Future<void> _onShareEmail(AppLocalizations l) async {
     final email = _emailController.text.trim();
     if (email.isEmpty || _busy) return;
     setState(() => _busy = true);
@@ -104,56 +104,54 @@ class _TripShareSheetState extends State<TripShareSheet> {
     switch (result) {
       case TripShareResult.shared:
         _emailController.clear();
-        SnackBarHelper.showSuccess(
-            context, l?.tripShareSuccess ?? 'Trip shared.');
+        SnackBarHelper.showSuccess(context, l.tripShareSuccess);
         await _reloadShares();
       case TripShareResult.recipientNotFound:
-        SnackBarHelper.showError(
-            context,
-            l?.tripShareRecipientNotFound ??
-                'No TankSync account uses that email.');
+        SnackBarHelper.showError(context, l.tripShareRecipientNotFound);
       case TripShareResult.notAuthenticated:
       case TripShareResult.failed:
-        SnackBarHelper.showError(context,
-            l?.tripShareError ?? "Couldn't share this trip. Try again.");
+        SnackBarHelper.showError(context, l.tripShareError);
     }
   }
 
-  Future<void> _onCreateLink(AppLocalizations? l) async {
+  Future<void> _onCreateLink(AppLocalizations l) async {
     if (_busy) return;
     setState(() => _busy = true);
     final token = await _wire.createShareLink(widget.tripId);
     if (!mounted) return;
     setState(() => _busy = false);
     if (token == null) {
-      SnackBarHelper.showError(context,
-          l?.tripShareError ?? "Couldn't share this trip. Try again.");
+      SnackBarHelper.showError(context, l.tripShareError);
       return;
     }
     // The deep link the recipient taps to claim the share. The host is
     // the app's universal-link domain; the claim route reads `token`.
-    final link = 'https://sparkilo.app/share/trip?token=$token'; // i18n-ignore: URL
-    final sink = debugTripShareLinkSinkOverride ??
+    final link =
+        'https://sparkilo.app/share/trip?token=$token'; // i18n-ignore: URL
+    final sink =
+        debugTripShareLinkSinkOverride ??
         (params) => SharePlus.instance.share(params).then((_) {});
     try {
       await sink(ShareParams(text: link));
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'TripShareSheet share link'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'TripShareSheet share link'},
+        ),
+      );
     }
     if (!mounted) return;
-    SnackBarHelper.showSuccess(
-        context,
-        l?.tripShareLinkCreated ??
-            'Share link copied — paste it to the recipient.');
+    SnackBarHelper.showSuccess(context, l.tripShareLinkCreated);
     await _reloadShares();
   }
 
-  Future<void> _onRevoke(AppLocalizations? l, TripShare share) async {
+  Future<void> _onRevoke(AppLocalizations l, TripShare share) async {
     await _wire.revoke(share.id);
     if (!mounted) return;
-    SnackBarHelper.showSuccess(
-        context, l?.tripShareRevoked ?? 'Share revoked.');
+    SnackBarHelper.showSuccess(context, l.tripShareRevoked);
     await _reloadShares();
   }
 
@@ -169,17 +167,13 @@ class _TripShareSheetState extends State<TripShareSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(
-              l?.tripShareSheetTitle ?? 'Share this trip',
-              style: theme.textTheme.titleLarge,
-            ),
+            Text(l.tripShareSheetTitle, style: theme.textTheme.titleLarge),
             const SizedBox(height: 4),
             Text(
-              l?.tripShareSheetSubtitle ??
-                  'Give another TankSync account read-only access to '
-                      'this recorded trip.',
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              l.tripShareSheetSubtitle,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: 16),
             TextField(
@@ -188,8 +182,8 @@ class _TripShareSheetState extends State<TripShareSheet> {
               keyboardType: TextInputType.emailAddress,
               autocorrect: false,
               decoration: InputDecoration(
-                labelText: l?.tripShareEmailLabel ?? 'Recipient email',
-                hintText: l?.tripShareEmailHint ?? 'name@example.com',
+                labelText: l.tripShareEmailLabel,
+                hintText: l.tripShareEmailHint,
                 border: const OutlineInputBorder(),
               ),
               onSubmitted: (_) => unawaited(_onShareEmail(l)),
@@ -202,7 +196,7 @@ class _TripShareSheetState extends State<TripShareSheet> {
                     key: const Key('trip_share_send_button'),
                     onPressed: _busy ? null : () => unawaited(_onShareEmail(l)),
                     icon: const Icon(Icons.send),
-                    label: Text(l?.tripShareSendButton ?? 'Share'),
+                    label: Text(l.tripShareSendButton),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -211,35 +205,33 @@ class _TripShareSheetState extends State<TripShareSheet> {
                     key: const Key('trip_share_create_link_button'),
                     onPressed: _busy ? null : () => unawaited(_onCreateLink(l)),
                     icon: const Icon(Icons.link),
-                    label: Text(
-                      l?.tripShareCreateLinkButton ?? 'Create share link',
-                    ),
+                    label: Text(l.tripShareCreateLinkButton),
                   ),
                 ),
               ],
             ),
             const SizedBox(height: 20),
-            Text(
-              l?.tripShareExistingTitle ?? 'Shared with',
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(l.tripShareExistingTitle, style: theme.textTheme.titleMedium),
             const SizedBox(height: 4),
             if (_shares.isEmpty)
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 8),
                 child: Text(
-                  l?.tripShareExistingEmpty ?? 'Not shared with anyone yet.',
+                  l.tripShareExistingEmpty,
                   style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant),
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
               )
             else
-              ..._shares.map((s) => _ShareRow(
-                    key: Key('trip_share_row_${s.id}'),
-                    share: s,
-                    l: l,
-                    onRevoke: () => unawaited(_onRevoke(l, s)),
-                  )),
+              ..._shares.map(
+                (s) => _ShareRow(
+                  key: Key('trip_share_row_${s.id}'),
+                  share: s,
+                  l: l,
+                  onRevoke: () => unawaited(_onRevoke(l, s)),
+                ),
+              ),
           ],
         ),
       ),
@@ -249,7 +241,7 @@ class _TripShareSheetState extends State<TripShareSheet> {
 
 class _ShareRow extends StatelessWidget {
   final TripShare share;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final VoidCallback onRevoke;
 
   const _ShareRow({
@@ -263,8 +255,8 @@ class _ShareRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final isLink = share.sharedWithId == null && share.shareToken != null;
     final label = isLink
-        ? (l?.tripShareLinkRecipient ?? 'Share link (unclaimed)')
-        : (l?.tripShareDirectRecipient ?? 'An account');
+        ? (l.tripShareLinkRecipient)
+        : (l.tripShareDirectRecipient);
     return ListTile(
       contentPadding: EdgeInsets.zero,
       leading: Icon(isLink ? Icons.link : Icons.person_outline),
@@ -272,7 +264,7 @@ class _ShareRow extends StatelessWidget {
       trailing: IconButton(
         key: Key('trip_share_revoke_${share.id}'),
         icon: const Icon(Icons.close),
-        tooltip: l?.tripShareRevokeTooltip ?? 'Revoke',
+        tooltip: l.tripShareRevokeTooltip,
         onPressed: onRevoke,
       ),
     );

--- a/lib/features/consumption/presentation/widgets/trip_start_progress.dart
+++ b/lib/features/consumption/presentation/widgets/trip_start_progress.dart
@@ -55,17 +55,14 @@ class _TripStartProgressState extends State<TripStartProgress>
     }
   }
 
-  String _labelFor(AppLocalizations? l, TripStartStage stage) {
+  String _labelFor(AppLocalizations l, TripStartStage stage) {
     switch (stage) {
       case TripStartStage.connectingAdapter:
-        return l?.tripStartProgressConnectingAdapter ??
-            'Connecting to OBD2 adapter…';
+        return l.tripStartProgressConnectingAdapter;
       case TripStartStage.readingVehicleData:
-        return l?.tripStartProgressReadingVehicleData ??
-            'Reading vehicle data…';
+        return l.tripStartProgressReadingVehicleData;
       case TripStartStage.startingRecording:
-        return l?.tripStartProgressStartingRecording ??
-            'Starting recording…';
+        return l.tripStartProgressStartingRecording;
     }
   }
 
@@ -118,8 +115,8 @@ class _TripStartProgressState extends State<TripStartProgress>
               borderRadius: BorderRadius.circular(4),
               child: LinearProgressIndicator(
                 minHeight: 6,
-                backgroundColor:
-                    theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.15),
+                backgroundColor: theme.colorScheme.onPrimaryContainer
+                    .withValues(alpha: 0.15),
                 color: theme.colorScheme.onPrimaryContainer,
               ),
             ),

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -46,7 +46,7 @@ class TripSummaryCard extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final s = entry.summary;
-    final unknown = l?.trajetDetailFieldValueUnknown ?? '—';
+    final unknown = l.trajetDetailFieldValueUnknown;
 
     // #1209 — estimated trip cost from the most recent fill-up's
     // price-per-litre. Hidden on EV trips (the helper still returns
@@ -57,7 +57,8 @@ class TripSummaryCard extends ConsumerWidget {
     final date = s.startedAt == null ? unknown : _fmtDate(s.startedAt!);
     final vehicleName = vehicle?.name ?? unknown;
     final distance = '${s.distanceKm.toStringAsFixed(1)} km';
-    final duration = s.startedAt != null &&
+    final duration =
+        s.startedAt != null &&
             s.endedAt != null &&
             s.endedAt!.isAfter(s.startedAt!)
         ? _fmtDuration(s.endedAt!.difference(s.startedAt!))
@@ -79,18 +80,12 @@ class TripSummaryCard extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.trajetDetailSummaryTitle ?? 'Summary',
+              l.trajetDetailSummaryTitle,
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
-            _SummaryRow(
-              label: l?.trajetDetailFieldDate ?? 'Date',
-              value: date,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldVehicle ?? 'Vehicle',
-              value: vehicleName,
-            ),
+            _SummaryRow(label: l.trajetDetailFieldDate, value: date),
+            _SummaryRow(label: l.trajetDetailFieldVehicle, value: vehicleName),
             // #1312 — surface the OBD2 adapter identity directly
             // under Vehicle so device-test bug reports can name the
             // suspect device (different ELM327 clones expose different
@@ -102,29 +97,20 @@ class TripSummaryCard extends ConsumerWidget {
                 entry.adapterName != null ||
                 entry.adapterFirmware != null)
               _SummaryRow(
-                label: l?.trajetDetailFieldAdapter ?? 'OBD2 adapter',
+                label: l.trajetDetailFieldAdapter,
                 value: _formatAdapter(
                   entry.adapterName,
                   entry.adapterMac,
                   entry.adapterFirmware,
                 ),
               ),
+            _SummaryRow(label: l.trajetDetailFieldDistance, value: distance),
+            _SummaryRow(label: l.trajetDetailFieldDuration, value: duration),
             _SummaryRow(
-              label: l?.trajetDetailFieldDistance ?? 'Distance',
-              value: distance,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldDuration ?? 'Duration',
-              value: duration,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldAvgConsumption ?? 'Avg consumption',
+              label: l.trajetDetailFieldAvgConsumption,
               value: avgConsumption,
             ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldFuelUsed ?? 'Fuel used',
-              value: fuelUsed,
-            ),
+            _SummaryRow(label: l.trajetDetailFieldFuelUsed, value: fuelUsed),
             // #1209 — estimated euro/£/$ cost of the fuel used,
             // derived from the most recent fill-up before this trip.
             // Hidden when the provider returns null (no fill-ups, no
@@ -132,39 +118,27 @@ class TripSummaryCard extends ConsumerWidget {
             // shows a misleading "0,00 €" or "—" placeholder.
             if (fuelCost != null)
               _SummaryRow(
-                label: l?.trajetDetailFieldFuelCost ?? 'Fuel cost',
+                label: l.trajetDetailFieldFuelCost,
                 // #2491 — a trip cost is a TOTAL, not a per-litre price:
                 // route it through formatTotal (2 dp + currency symbol)
                 // so a 1.05 € trip reads "1,05 €", not "1,047 €".
                 value: PriceFormatter.formatTotal(fuelCost),
               ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldAvgSpeed ?? 'Avg speed',
-              value: avgSpeed,
-            ),
-            _SummaryRow(
-              label: l?.trajetDetailFieldMaxSpeed ?? 'Max speed',
-              value: maxSpeed,
-            ),
+            _SummaryRow(label: l.trajetDetailFieldAvgSpeed, value: avgSpeed),
+            _SummaryRow(label: l.trajetDetailFieldMaxSpeed, value: maxSpeed),
           ],
         ),
       ),
     );
   }
 
-  static String _avgSpeedLabel(
-    List<TripDetailSample> samples,
-    String unknown,
-  ) {
+  static String _avgSpeedLabel(List<TripDetailSample> samples, String unknown) {
     if (samples.isEmpty) return unknown;
     final avg = samples.map((s) => s.speedKmh).average;
     return '${avg.toStringAsFixed(1)} km/h';
   }
 
-  static String _maxSpeedLabel(
-    List<TripDetailSample> samples,
-    String unknown,
-  ) {
+  static String _maxSpeedLabel(List<TripDetailSample> samples, String unknown) {
     if (samples.isEmpty) return unknown;
     var maxV = samples.first.speedKmh;
     for (final s in samples) {
@@ -179,11 +153,7 @@ class TripSummaryCard extends ConsumerWidget {
   /// when known. Total length is capped at ~40 chars (head-truncated
   /// with an ellipsis) so the row doesn't push the summary card into
   /// a multi-line layout on narrow phones.
-  static String _formatAdapter(
-    String? name,
-    String? mac,
-    String? firmware,
-  ) {
+  static String _formatAdapter(String? name, String? mac, String? firmware) {
     final parts = <String>[];
     if (name != null && name.isNotEmpty) parts.add(name);
     if (mac != null && mac.isNotEmpty) parts.add(mac);
@@ -239,10 +209,7 @@ class _SummaryRow extends StatelessWidget {
               ),
             ),
           ),
-          Text(
-            value,
-            style: theme.textTheme.bodyMedium,
-          ),
+          Text(value, style: theme.textTheme.bodyMedium),
         ],
       ),
     );

--- a/lib/features/consumption/presentation/widgets/vehicle_adapter_section.dart
+++ b/lib/features/consumption/presentation/widgets/vehicle_adapter_section.dart
@@ -52,7 +52,7 @@ class VehicleAdapterSection extends ConsumerWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    l?.vehicleAdapterSectionTitle ?? 'OBD2 adapter',
+                    l.vehicleAdapterSectionTitle,
                     style: theme.textTheme.titleMedium,
                   ),
                 ),
@@ -61,9 +61,7 @@ class VehicleAdapterSection extends ConsumerWidget {
             const SizedBox(height: 12),
             if (paired) ...[
               Text(
-                name == null || name.isEmpty
-                    ? (l?.vehicleAdapterUnnamed ?? 'Unknown adapter')
-                    : name,
+                name == null || name.isEmpty ? (l.vehicleAdapterUnnamed) : name,
                 style: theme.textTheme.bodyLarge,
               ),
               const SizedBox(height: 4),
@@ -80,17 +78,11 @@ class VehicleAdapterSection extends ConsumerWidget {
                   key: const Key('vehicleAdapterForget'),
                   onPressed: onForget,
                   icon: const Icon(Icons.link_off),
-                  label: Text(
-                    l?.vehicleAdapterForget ?? 'Forget adapter',
-                  ),
+                  label: Text(l.vehicleAdapterForget),
                 ),
               ),
             ] else ...[
-              Text(
-                l?.vehicleAdapterEmpty ??
-                    'No adapter paired. Pair one so the app can reconnect automatically next time.',
-                style: theme.textTheme.bodySmall,
-              ),
+              Text(l.vehicleAdapterEmpty, style: theme.textTheme.bodySmall),
               const SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerRight,
@@ -98,7 +90,7 @@ class VehicleAdapterSection extends ConsumerWidget {
                   key: const Key('vehicleAdapterPair'),
                   onPressed: () => _onPair(context),
                   icon: const Icon(Icons.bluetooth_searching),
-                  label: Text(l?.vehicleAdapterPair ?? 'Pair adapter'),
+                  label: Text(l.vehicleAdapterPair),
                 ),
               ),
             ],

--- a/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
+++ b/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
@@ -66,8 +66,7 @@ class _VehicleBaselineSectionState
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final counts =
-        ref.watch(vehicleBaselineSummaryProvider(widget.vehicleId));
+    final counts = ref.watch(vehicleBaselineSummaryProvider(widget.vehicleId));
     final theme = Theme.of(context);
 
     // Persisted situations only — transients never accumulate. The
@@ -86,8 +85,10 @@ class _VehicleBaselineSectionState
     ];
 
     final target = widget.fullConfidenceSamples;
-    final totalSamples =
-        situations.fold<int>(0, (acc, s) => acc + (counts[s] ?? 0));
+    final totalSamples = situations.fold<int>(
+      0,
+      (acc, s) => acc + (counts[s] ?? 0),
+    );
     final maxTotal = situations.length * target;
 
     // #2514 — drive the aggregate bar off *coverage*, not raw volume.
@@ -132,8 +133,7 @@ class _VehicleBaselineSectionState
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    l?.vehicleBaselineSectionTitle ??
-                        'Baseline calibration',
+                    l.vehicleBaselineSectionTitle,
                     style: theme.textTheme.titleMedium,
                   ),
                 ),
@@ -142,10 +142,8 @@ class _VehicleBaselineSectionState
             const SizedBox(height: 4),
             Text(
               totalSamples == 0
-                  ? (l?.vehicleBaselineEmpty ??
-                      'No samples yet — start an OBD2 trip to begin learning this vehicle\'s fuel profile.')
-                  : (l?.vehicleBaselineProgress ??
-                      'Learned from $totalSamples sample(s) across driving situations.'),
+                  ? (l.vehicleBaselineEmpty)
+                  : (l.vehicleBaselineProgress),
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
@@ -195,14 +193,14 @@ class _VehicleBaselineSectionState
                 ),
                 label: Text(
                   showDetails
-                      ? (l?.vehicleBaselineHideDetails ??
-                          'Hide per-situation breakdown')
-                      : (l?.vehicleBaselineShowDetails ??
-                          'Show per-situation breakdown'),
+                      ? (l.vehicleBaselineHideDetails)
+                      : (l.vehicleBaselineShowDetails),
                 ),
                 style: TextButton.styleFrom(
                   padding: const EdgeInsets.symmetric(
-                      horizontal: 8, vertical: 4),
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
                   minimumSize: Size.zero,
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
@@ -229,10 +227,7 @@ class _VehicleBaselineSectionState
                 // behaviour" connotation — distinct from the η_v reset's
                 // local_gas_station_outlined icon (#1219).
                 icon: const Icon(Icons.tune_outlined),
-                label: Text(
-                  l?.vehicleBaselineReset ??
-                      'Reset driving-situation baseline',
-                ),
+                label: Text(l.vehicleBaselineReset),
               ),
             ),
           ],
@@ -244,31 +239,21 @@ class _VehicleBaselineSectionState
   Future<void> _confirmReset(
     BuildContext context,
     WidgetRef ref,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) async {
     final confirm = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(
-          l?.vehicleBaselineResetConfirmTitle ??
-              'Reset driving-situation baseline?',
-        ),
-        content: Text(
-          l?.vehicleBaselineResetConfirmBody ??
-              'This wipes every learned sample for this vehicle. '
-                  'You\'ll drift back to the cold-start defaults until '
-                  'new trips refill the profile.',
-        ),
+        title: Text(l.vehicleBaselineResetConfirmTitle),
+        content: Text(l.vehicleBaselineResetConfirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              l?.vehicleBaselineReset ?? 'Reset driving-situation baseline',
-            ),
+            child: Text(l.vehicleBaselineReset),
           ),
         ],
       ),
@@ -280,27 +265,27 @@ class _VehicleBaselineSectionState
     await ref.read(resetVehicleBaselinesProvider(widget.vehicleId).future);
   }
 
-  String _label(DrivingSituation s, AppLocalizations? l) {
+  String _label(DrivingSituation s, AppLocalizations l) {
     switch (s) {
       case DrivingSituation.idle:
-        return l?.situationIdle ?? 'Idle';
+        return l.situationIdle;
       case DrivingSituation.stopAndGo:
-        return l?.situationStopAndGo ?? 'Stop & go';
+        return l.situationStopAndGo;
       case DrivingSituation.urbanCruise:
-        return l?.situationUrban ?? 'Urban';
+        return l.situationUrban;
       case DrivingSituation.highwayCruise:
-        return l?.situationHighway ?? 'Highway';
+        return l.situationHighway;
       case DrivingSituation.deceleration:
-        return l?.situationDecel ?? 'Decelerating';
+        return l.situationDecel;
       case DrivingSituation.climbingOrLoaded:
-        return l?.situationClimbing ?? 'Climbing / loaded';
+        return l.situationClimbing;
       // #2515 — the three new persistent buckets.
       case DrivingSituation.coldStartWarmup:
-        return l?.situationColdStart ?? 'Cold start';
+        return l.situationColdStart;
       case DrivingSituation.sustainedLoadOrTowing:
-        return l?.situationSustainedLoad ?? 'Sustained load / towing';
+        return l.situationSustainedLoad;
       case DrivingSituation.partialThrottleDecel:
-        return l?.situationPartialDecel ?? 'Coasting';
+        return l.situationPartialDecel;
       // Transients are filtered out at the call site.
       case DrivingSituation.hardAccel:
       case DrivingSituation.fuelCutCoast:
@@ -334,10 +319,7 @@ class _BaselineRow extends StatelessWidget {
           ),
           Expanded(
             flex: 5,
-            child: LinearProgressIndicator(
-              value: progress,
-              minHeight: 6,
-            ),
+            child: LinearProgressIndicator(value: progress, minHeight: 6),
           ),
           const SizedBox(width: 8),
           SizedBox(
@@ -389,11 +371,10 @@ class _MissingSituationsWarning extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              l?.vehicleBaselineMissingWarning(joined) ??
-                  'Not detected yet: $joined. These driving situations '
-                      'still read 0 samples, so the baseline is incomplete.',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: scheme.onErrorContainer),
+              l.vehicleBaselineMissingWarning(joined),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: scheme.onErrorContainer,
+              ),
             ),
           ),
         ],

--- a/lib/features/consumption/providers/live_activity_provider.dart
+++ b/lib/features/consumption/providers/live_activity_provider.dart
@@ -107,9 +107,10 @@ class LiveActivitySync extends _$LiveActivitySync {
 
   /// Resolve [AppLocalizations] without a `BuildContext` (#2766 pattern
   /// — `lookupAppLocalizations` is a pure synchronous constructor).
-  /// Guarded twice so a harness without the language graph degrades to
-  /// English, then to the builder's literal fallbacks.
-  AppLocalizations? _l10n() {
+  /// Guarded so a harness without the language graph degrades to
+  /// English; the `en` lookup itself is total (it is the template
+  /// locale and always supported).
+  AppLocalizations _l10n() {
     String code;
     try {
       code = ref.read(activeLanguageProvider).code;
@@ -119,11 +120,7 @@ class LiveActivitySync extends _$LiveActivitySync {
     try {
       return lookupAppLocalizations(ui.Locale(code));
     } on Object {
-      try {
-        return lookupAppLocalizations(const ui.Locale('en'));
-      } on Object {
-        return null;
-      }
+      return lookupAppLocalizations(const ui.Locale('en'));
     }
   }
 }

--- a/lib/features/consumption/providers/live_activity_provider.g.dart
+++ b/lib/features/consumption/providers/live_activity_provider.g.dart
@@ -213,7 +213,7 @@ final class LiveActivitySyncProvider
   }
 }
 
-String _$liveActivitySyncHash() => r'6b551cc8f221281a76fc2a30cddff113188293f1';
+String _$liveActivitySyncHash() => r'f110ae1f32c596620c6682ea34c96bf7321d4050';
 
 /// Keeps the iOS Live Activity (lock screen + Dynamic Island, #3170) in
 /// lock-step with the live trip/approach state — the iOS counterpart of

--- a/lib/features/driving/presentation/widgets/driving_bottom_bar.dart
+++ b/lib/features/driving/presentation/widgets/driving_bottom_bar.dart
@@ -35,10 +35,9 @@ class DrivingBottomBar extends StatelessWidget {
       decoration: BoxDecoration(
         // #2117 — in-car bottom bar needs higher contrast for at-a-glance
         // legibility. surfaceContainerHighest lifts it cleanly off the map.
-        color: Theme.of(context)
-            .colorScheme
-            .surfaceContainerHighest
-            .withValues(alpha: 0.95),
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.95),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.3),
@@ -52,18 +51,18 @@ class DrivingBottomBar extends StatelessWidget {
         children: [
           _DrivingButton(
             icon: Icons.my_location,
-            label: l10n?.currentLocation ?? 'Location',
+            label: l10n.currentLocation,
             onTap: onRecenter,
           ),
           _DrivingButton(
             icon: Icons.local_gas_station,
-            label: l10n?.drivingNearestStation ?? 'Nearest',
+            label: l10n.drivingNearestStation,
             onTap: onNearestStation,
             isPrimary: true,
           ),
           _DrivingButton(
             icon: Icons.close,
-            label: l10n?.drivingExit ?? 'Exit',
+            label: l10n.drivingExit,
             onTap: onExit,
           ),
         ],

--- a/lib/features/driving/presentation/widgets/driving_lock_overlay.dart
+++ b/lib/features/driving/presentation/widgets/driving_lock_overlay.dart
@@ -26,7 +26,7 @@ class DrivingLockOverlay extends StatelessWidget {
                 const Icon(Icons.lock_outline, size: 64, color: Colors.white70),
                 const SizedBox(height: 16),
                 Text(
-                  l10n?.drivingTapToUnlock ?? 'Tap to unlock',
+                  l10n.drivingTapToUnlock,
                   style: const TextStyle(
                     fontSize: 24,
                     fontWeight: FontWeight.bold,

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -61,7 +61,8 @@ class DrivingSettingsSection extends ConsumerWidget {
     // in the central provider. When the parent is off (and the toggle
     // isn't already on) the switch is disabled rather than letting the
     // tap fail.
-    final canToggleEco = ecoEnabled ||
+    final canToggleEco =
+        ecoEnabled ||
         canEnable(
           Feature.hapticEcoCoach,
           ref.watch(featureManifestProvider),
@@ -84,17 +85,15 @@ class DrivingSettingsSection extends ConsumerWidget {
         //    clear header; the tile carries an accurate subtitle that
         //    describes what /vehicles manages for both fuel + EV cars.
         SectionHeader(
-          title: l?.consoGroupVehicles ?? 'Vehicles',
+          title: l.consoGroupVehicles,
           leadingIcon: Icons.directions_car,
           padding: const EdgeInsets.fromLTRB(0, Spacing.sm, 0, Spacing.sm),
         ),
         SettingsMenuTile(
           key: const Key('consoleVehiclesTile'),
           icon: Icons.directions_car,
-          title: l?.vehiclesMenuTitle ?? 'My vehicles',
-          subtitle: l?.vehiclesMenuSubtitle ??
-              'Your cars — fuel type, engine and tank size for accurate '
-                  'consumption estimates',
+          title: l.vehiclesMenuTitle,
+          subtitle: l.vehiclesMenuSubtitle,
           onTap: () => context.push(RoutePaths.vehicles),
         ),
 
@@ -104,25 +103,20 @@ class DrivingSettingsSection extends ConsumerWidget {
         //    beta keeps its `glideCoachEnabledProvider` visibility gate.
         const SizedBox(height: Spacing.md),
         SectionHeader(
-          title: l?.consoGroupCoaching ?? 'Coaching while driving',
+          title: l.consoGroupCoaching,
           leadingIcon: Icons.self_improvement,
           padding: const EdgeInsets.fromLTRB(0, Spacing.sm, 0, Spacing.sm),
         ),
         SwitchListTile(
           key: const Key('hapticEcoCoachToggle'),
           value: ecoEnabled,
-          title: Text(
-            l?.hapticEcoCoachSettingTitle ?? 'Real-time eco coaching',
-          ),
+          title: Text(l.hapticEcoCoachSettingTitle),
           subtitle: Text(
-            l?.hapticEcoCoachSettingSubtitle ??
-                'Gentle haptic + on-screen tip when you floor it '
-                    'during cruise',
+            l.hapticEcoCoachSettingSubtitle,
             style: theme.textTheme.bodySmall,
           ),
           onChanged: canToggleEco
-              ? (v) =>
-                  ref.read(hapticEcoCoachEnabledProvider.notifier).set(v)
+              ? (v) => ref.read(hapticEcoCoachEnabledProvider.notifier).set(v)
               : null,
           contentPadding: EdgeInsets.zero,
         ),
@@ -131,8 +125,7 @@ class DrivingSettingsSection extends ConsumerWidget {
         // in OBD2 *and* GPS-only trips and is unrelated to the station
         // overlay. Always visible so the user can mute it.
         const _VoiceCoachingToggleTile(),
-        if (ref.watch(glideCoachEnabledProvider))
-          const _GlideCoachToggleTile(),
+        if (ref.watch(glideCoachEnabledProvider)) const _GlideCoachToggleTile(),
         // #2569 — spoken nearby-cheap-fuel announcements. Visible only
         // when the `Feature.voiceAnnouncements` flag is effectively on
         // (it requires the approach overlay, so the gate is false unless
@@ -145,7 +138,7 @@ class DrivingSettingsSection extends ConsumerWidget {
         //    [Feature.loyaltyCards] is on) and the gamification opt-out.
         const SizedBox(height: Spacing.md),
         SectionHeader(
-          title: l?.consoGroupRewards ?? 'Rewards & savings',
+          title: l.consoGroupRewards,
           leadingIcon: Icons.emoji_events_outlined,
           padding: const EdgeInsets.fromLTRB(0, Spacing.sm, 0, Spacing.sm),
         ),
@@ -153,9 +146,8 @@ class DrivingSettingsSection extends ConsumerWidget {
           SettingsMenuTile(
             key: const Key('consoleFuelClubCardsTile'),
             icon: Icons.card_membership,
-            title: l?.loyaltyMenuTitle ?? 'Fuel club cards',
-            subtitle: l?.loyaltyMenuSubtitle ??
-                'Apply per-litre discounts from Total, Aral, Shell, …',
+            title: l.loyaltyMenuTitle,
+            subtitle: l.loyaltyMenuSubtitle,
             onTap: () => context.push(RoutePaths.loyaltySettings),
           ),
         const GamificationSettingsTile(),
@@ -167,7 +159,7 @@ class DrivingSettingsSection extends ConsumerWidget {
         if (mode == ConsoMode.fuelAndTrips) ...[
           const SizedBox(height: Spacing.md),
           SectionHeader(
-            title: l?.consoGroupTroubleshooting ?? 'Troubleshooting',
+            title: l.consoGroupTroubleshooting,
             leadingIcon: Icons.bug_report_outlined,
             padding: const EdgeInsets.fromLTRB(0, Spacing.sm, 0, Spacing.sm),
           ),
@@ -194,16 +186,13 @@ class _GlideCoachToggleTile extends ConsumerWidget {
     return SwitchListTile(
       key: const Key('glideCoachToggle'),
       value: settings.enabled,
-      title: Text(l?.glideCoachBetaTitle ?? 'Glide-coach beta (experimental)'),
+      title: Text(l.glideCoachBetaTitle),
       subtitle: Text(
-        l?.glideCoachBetaSubtitle ??
-            'Subtle haptic when slowing down ahead of a red light. '
-                'Off by default — distraction risk.',
+        l.glideCoachBetaSubtitle,
         style: theme.textTheme.bodySmall,
       ),
-      onChanged: (v) => ref
-          .read(glideCoachSettingsProvider.notifier)
-          .setEnabled(v),
+      onChanged: (v) =>
+          ref.read(glideCoachSettingsProvider.notifier).setEnabled(v),
       contentPadding: EdgeInsets.zero,
     );
   }
@@ -226,11 +215,9 @@ class _VoiceCoachingToggleTile extends ConsumerWidget {
     return SwitchListTile(
       key: const Key('voiceCoachingToggle'),
       value: enabled,
-      title: Text(l?.voiceCoachingSettingTitle ?? 'Spoken driving coaching'),
+      title: Text(l.voiceCoachingSettingTitle),
       subtitle: Text(
-        l?.voiceCoachingSettingSubtitle ??
-            'Hear spoken tips while you drive — hard acceleration, harsh '
-                'braking and gear hints',
+        l.voiceCoachingSettingSubtitle,
         style: theme.textTheme.bodySmall,
       ),
       onChanged: (v) =>
@@ -271,10 +258,9 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
         SwitchListTile(
           key: const Key('voiceAnnouncementsToggle'),
           value: config.enabled,
-          title: Text(l?.voiceAnnouncementsTitle ?? 'Voice Announcements'),
+          title: Text(l.voiceAnnouncementsTitle),
           subtitle: Text(
-            l?.voiceAnnouncementsDescription ??
-                'Announce nearby cheap stations while driving',
+            l.voiceAnnouncementsDescription,
             style: theme.textTheme.bodySmall,
           ),
           onChanged: (v) => notifier.setEnabled(v),
@@ -286,7 +272,7 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
           // bare `Slider.label` is only visible while dragging.
           LabeledValueSlider(
             sliderKey: const Key('voiceAnnouncementRadiusSlider'),
-            label: l?.voiceAnnouncementProximityRadius ?? 'Announcement radius',
+            label: l.voiceAnnouncementProximityRadius,
             // i18n-ignore: " km" is a language-neutral unit suffix (matches
             // ProfileRadiusSlider + the {km} ARB masks).
             valueLabel: '${radiusKm.toStringAsFixed(1)} km',
@@ -300,7 +286,7 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
           // Repeat cooldown — 5 … 60 minutes in 5-minute steps.
           LabeledValueSlider(
             sliderKey: const Key('voiceAnnouncementCooldownSlider'),
-            label: l?.voiceAnnouncementCooldown ?? 'Repeat interval',
+            label: l.voiceAnnouncementCooldown,
             // i18n-ignore: " min" is a language-neutral unit abbreviation.
             valueLabel: '$cooldownMin min',
             labelStyle: theme.textTheme.bodyMedium,
@@ -318,7 +304,7 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
           LabeledValueSlider(
             key: const Key('voiceAnnouncementThresholdTile'),
             sliderKey: const Key('voiceAnnouncementThresholdSlider'),
-            label: l?.voiceAnnouncementPriceLimit ?? 'Maximum price',
+            label: l.voiceAnnouncementPriceLimit,
             valueLabel: PriceFormatter.formatPrice(thresholdEur),
             labelStyle: theme.textTheme.bodyMedium,
             value: thresholdEur,
@@ -351,12 +337,9 @@ class _Obd2DebugLoggingToggleTile extends ConsumerWidget {
     return SwitchListTile(
       key: const Key('obd2DebugLoggingToggle'),
       value: enabled,
-      title: Text(l?.obd2DebugLoggingTitle ?? 'OBD2 debug logging'),
+      title: Text(l.obd2DebugLoggingTitle),
       subtitle: Text(
-        l?.obd2DebugLoggingSubtitle ??
-            'Record each OBD2 session — connection, handshake, data '
-                'gaps and reconnects — to an exportable XML log. Off by '
-                'default.',
+        l.obd2DebugLoggingSubtitle,
         style: theme.textTheme.bodySmall,
       ),
       onChanged: (v) =>

--- a/lib/features/driving/presentation/widgets/driving_station_sheet.dart
+++ b/lib/features/driving/presentation/widgets/driving_station_sheet.dart
@@ -76,9 +76,7 @@ class DrivingStationSheet extends StatelessWidget {
                 ),
               ),
               Text(
-                price != null
-                    ? PriceFormatter.formatPrice(price)
-                    : '--',
+                price != null ? PriceFormatter.formatPrice(price) : '--',
                 style: theme.textTheme.headlineMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: theme.colorScheme.primary,
@@ -94,10 +92,7 @@ class DrivingStationSheet extends StatelessWidget {
             child: FilledButton.icon(
               onPressed: () => _launchNavigation(context),
               icon: const Icon(Icons.navigation, size: 28),
-              label: Text(
-                l10n?.navigate ?? 'Navigate',
-                style: const TextStyle(fontSize: 20),
-              ),
+              label: Text(l10n.navigate, style: const TextStyle(fontSize: 20)),
             ),
           ),
         ],

--- a/lib/features/driving/presentation/widgets/driving_top_bar.dart
+++ b/lib/features/driving/presentation/widgets/driving_top_bar.dart
@@ -44,7 +44,7 @@ class DrivingTopBar extends StatelessWidget {
             Icon(Icons.drive_eta, color: theme.colorScheme.primary, size: 24),
             const SizedBox(width: 8),
             Text(
-              l10n?.drivingMode ?? 'Driving Mode',
+              l10n.drivingMode,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),

--- a/lib/features/driving/presentation/widgets/safety_disclaimer_dialog.dart
+++ b/lib/features/driving/presentation/widgets/safety_disclaimer_dialog.dart
@@ -31,22 +31,19 @@ class SafetyDisclaimerDialog extends StatelessWidget {
         size: 48,
         color: theme.colorScheme.error,
       ),
-      title: Text(l10n?.drivingSafetyTitle ?? 'Safety Notice'),
+      title: Text(l10n.drivingSafetyTitle),
       content: Text(
-        l10n?.drivingSafetyMessage ??
-            'Do not operate the app while driving. '
-                'Pull over to a safe location before interacting with the screen. '
-                'The driver is responsible for safe operation of the vehicle at all times.',
+        l10n.drivingSafetyMessage,
         style: theme.textTheme.bodyLarge,
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: Text(l10n?.cancel ?? 'Cancel'),
+          child: Text(l10n.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(true),
-          child: Text(l10n?.drivingSafetyAccept ?? 'I understand'),
+          child: Text(l10n.drivingSafetyAccept),
         ),
       ],
     );

--- a/lib/features/ev/presentation/widgets/connector_status_style.dart
+++ b/lib/features/ev/presentation/widgets/connector_status_style.dart
@@ -40,11 +40,11 @@ extension ConnectorStatusStyle on ConnectorStatus {
   String label(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return switch (this) {
-      ConnectorStatus.available => l10n?.evStatusAvailable ?? 'Available',
-      ConnectorStatus.occupied => l10n?.evStatusOccupied ?? 'Occupied',
-      ConnectorStatus.partial => l10n?.evStatusPartial ?? 'Partly available',
-      ConnectorStatus.outOfOrder => l10n?.evStatusOutOfOrder ?? 'Out of order',
-      ConnectorStatus.unknown => l10n?.evStatusUnknown ?? 'Unknown',
+      ConnectorStatus.available => l10n.evStatusAvailable,
+      ConnectorStatus.occupied => l10n.evStatusOccupied,
+      ConnectorStatus.partial => l10n.evStatusPartial,
+      ConnectorStatus.outOfOrder => l10n.evStatusOutOfOrder,
+      ConnectorStatus.unknown => l10n.evStatusUnknown,
     };
   }
 }

--- a/lib/features/ev/presentation/widgets/ev_filter_chips.dart
+++ b/lib/features/ev/presentation/widgets/ev_filter_chips.dart
@@ -5,8 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../l10n/app_localizations.dart';
-import '../../../../core/domain/vehicle_profile.dart'
-    show ConnectorType;
+import '../../../../core/domain/vehicle_profile.dart' show ConnectorType;
 import '../../providers/ev_providers.dart';
 
 /// Horizontal row of filter chips allowing the user to narrow displayed
@@ -27,7 +26,7 @@ class EvFilterChips extends ConsumerWidget {
       child: Row(
         children: [
           FilterChip(
-            label: Text(l10n?.evAvailableOnly ?? 'Available only'),
+            label: Text(l10n.evAvailableOnly),
             selected: filter.availableOnly,
             onSelected: notifier.setAvailableOnly,
           ),
@@ -57,19 +56,19 @@ class EvFilterChips extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     switch (type) {
       case ConnectorType.type2:
-        return l10n?.connectorType2 ?? 'Type 2';
+        return l10n.connectorType2;
       case ConnectorType.ccs:
-        return l10n?.connectorCcs ?? 'CCS';
+        return l10n.connectorCcs;
       case ConnectorType.chademo:
-        return l10n?.connectorChademo ?? 'CHAdeMO';
+        return l10n.connectorChademo;
       case ConnectorType.tesla:
-        return l10n?.connectorTesla ?? 'Tesla';
+        return l10n.connectorTesla;
       case ConnectorType.schuko:
-        return l10n?.connectorSchuko ?? 'Schuko';
+        return l10n.connectorSchuko;
       case ConnectorType.type1:
-        return l10n?.connectorType1 ?? 'Type 1';
+        return l10n.connectorType1;
       case ConnectorType.threePin:
-        return l10n?.connectorThreePin ?? '3-pin';
+        return l10n.connectorThreePin;
     }
   }
 }
@@ -85,14 +84,14 @@ class _PowerDropdown extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     return DropdownButton<double>(
       value: value,
-      hint: Text(l10n?.evMinPower ?? 'Min power'),
+      hint: Text(l10n.evMinPower),
       items: [
-        DropdownMenuItem(value: 0, child: Text(l10n?.evPowerAny ?? 'Any')),
-        DropdownMenuItem(value: 11, child: Text(l10n?.evPowerKw(11) ?? '11 kW+')),
-        DropdownMenuItem(value: 22, child: Text(l10n?.evPowerKw(22) ?? '22 kW+')),
-        DropdownMenuItem(value: 50, child: Text(l10n?.evPowerKw(50) ?? '50 kW+')),
-        DropdownMenuItem(value: 150, child: Text(l10n?.evPowerKw(150) ?? '150 kW+')),
-        DropdownMenuItem(value: 300, child: Text(l10n?.evPowerKw(300) ?? '300 kW+')),
+        DropdownMenuItem(value: 0, child: Text(l10n.evPowerAny)),
+        DropdownMenuItem(value: 11, child: Text(l10n.evPowerKw(11))),
+        DropdownMenuItem(value: 22, child: Text(l10n.evPowerKw(22))),
+        DropdownMenuItem(value: 50, child: Text(l10n.evPowerKw(50))),
+        DropdownMenuItem(value: 150, child: Text(l10n.evPowerKw(150))),
+        DropdownMenuItem(value: 300, child: Text(l10n.evPowerKw(300))),
       ],
       onChanged: (v) {
         if (v != null) onChanged(v);

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -111,7 +111,7 @@ class EvToggleButton extends ConsumerWidget {
         customBorder: const CircleBorder(),
         onTap: () => ref.read(evShowOnMapProvider.notifier).toggle(),
         child: Tooltip(
-          message: l10n?.evShowOnMap ?? 'Show EV stations',
+          message: l10n.evShowOnMap,
           child: Padding(
             padding: const EdgeInsets.all(8),
             child: Icon(

--- a/lib/features/ev/presentation/widgets/ev_marker_widget.dart
+++ b/lib/features/ev/presentation/widgets/ev_marker_widget.dart
@@ -20,11 +20,7 @@ class EvMarkerWidget extends StatelessWidget {
   final ChargingStation station;
   final VoidCallback? onTap;
 
-  const EvMarkerWidget({
-    super.key,
-    required this.station,
-    this.onTap,
-  });
+  const EvMarkerWidget({super.key, required this.station, this.onTap});
 
   static Color colorFor(BuildContext context, ChargingStation station) {
     if (station.connectors.isEmpty) return Colors.grey;
@@ -37,10 +33,7 @@ class EvMarkerWidget extends StatelessWidget {
   }
 
   /// Build a flutter_map [Marker] for this station.
-  static Marker buildMarker(
-    ChargingStation station, {
-    VoidCallback? onTap,
-  }) {
+  static Marker buildMarker(ChargingStation station, {VoidCallback? onTap}) {
     return Marker(
       point: LatLng(station.latitude, station.longitude),
       width: 44,
@@ -62,8 +55,7 @@ class EvMarkerWidget extends StatelessWidget {
       child: GestureDetector(
         onTap: onTap,
         child: Semantics(
-          label: l10n?.evChargingStationSemantic(station.name, maxPower) ??
-              'EV charging station ${station.name}, $maxPower kW',
+          label: l10n.evChargingStationSemantic(station.name, maxPower),
           button: true,
           child: Container(
             decoration: BoxDecoration(
@@ -77,11 +69,7 @@ class EvMarkerWidget extends StatelessWidget {
                 ),
               ],
             ),
-            child: const Icon(
-              Icons.ev_station,
-              color: Colors.white,
-              size: 24,
-            ),
+            child: const Icon(Icons.ev_station, color: Colors.white, size: 24),
           ),
         ),
       ),

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -46,9 +46,11 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     // when the user is on the Alerts tab (Share v1 only supports the
     // Favorites tab — see #1344).
     _tabController.addListener(_handleTabChange);
-    unawaited(Future.microtask(() {
-      unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
-    }));
+    unawaited(
+      Future.microtask(() {
+        unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
+      }),
+    );
   }
 
   void _handleTabChange() {
@@ -77,32 +79,31 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
 
     // Reload favorites when the auth identity changes
     // (anonymous -> email, reconnect, disconnect, etc.)
-    ref.listen(
-      syncStateProvider.select((s) => s.userId),
-      (prev, next) {
-        if (prev != next) {
-          unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
-        }
-      },
-    );
+    ref.listen(syncStateProvider.select((s) => s.userId), (prev, next) {
+      if (prev != next) {
+        unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
+      }
+    });
 
     return PageScaffold(
-      title: l10n?.favorites ?? 'Favorites',
+      title: l10n.favorites,
       actions: [
         if (favoriteIds.isNotEmpty && isFavoritesTab)
           IconButton(
             key: const Key('favorites_share_button'),
             icon: const Icon(Icons.share),
-            tooltip: l10n?.favoritesShareAction ?? 'Share',
+            tooltip: l10n.favoritesShareAction,
             onPressed: () => _onShare(context, l10n),
           ),
         if (favoriteIds.isNotEmpty)
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: () {
-              unawaited(ref.read(favoriteStationsProvider.notifier).loadAndRefresh());
+              unawaited(
+                ref.read(favoriteStationsProvider.notifier).loadAndRefresh(),
+              );
             },
-            tooltip: l10n?.refreshPrices ?? 'Refresh prices',
+            tooltip: l10n.refreshPrices,
           ),
         const SettingsAppBarAction(),
       ],
@@ -115,7 +116,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     );
   }
 
-  Widget _buildBody(BuildContext context, AppLocalizations? l10n) {
+  Widget _buildBody(BuildContext context, AppLocalizations l10n) {
     final media = MediaQuery.of(context);
     final isLandscape = media.orientation == Orientation.landscape;
     final isWide = media.size.width >= 600;
@@ -139,12 +140,9 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
         TabSwitcher(
           controller: _tabController,
           tabs: [
+            TabSwitcherEntry(label: l10n.favorites, icon: Icons.star_outline),
             TabSwitcherEntry(
-              label: l10n?.favorites ?? 'Favorites',
-              icon: Icons.star_outline,
-            ),
-            TabSwitcherEntry(
-              label: l10n?.priceAlerts ?? 'Price Alerts',
+              label: l10n.priceAlerts,
               icon: Icons.notifications_outlined,
             ),
           ],
@@ -165,18 +163,15 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     );
   }
 
-  Future<void> _onShare(
-    BuildContext context,
-    AppLocalizations? l10n,
-  ) async {
+  Future<void> _onShare(BuildContext context, AppLocalizations l10n) async {
     // Compose a friendly subject line so the OS share sheet (and the
     // receiving app's preview) shows "Tankstellen — favourites on
     // <date>" instead of a bare filename.
     final locale = Localizations.localeOf(context);
-    final formattedDate =
-        DateFormat.yMMMd(locale.toString()).format(DateTime.now());
-    final subject = l10n?.favoritesShareSubject(formattedDate) ??
-        'Sparkilo — favourites on $formattedDate';
+    final formattedDate = DateFormat.yMMMd(
+      locale.toString(),
+    ).format(DateTime.now());
+    final subject = l10n.favoritesShareSubject(formattedDate);
     // Filename stem uses ISO-style yyyyMMdd so the filename is stable
     // and locale-independent (the user-visible subject still carries
     // the localised date).
@@ -194,10 +189,16 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
       // Surface the failure to the user instead of silently swallowing
       // it — the snackbar tells them the share didn't go through, and
       // the debugPrint keeps the cause in `flutter logs` for support.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'FavoritesScreen share image'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'FavoritesScreen share image'},
+        ),
+      );
       if (messenger == null) return;
-      final errorMsg = l10n?.favoritesShareError ??
-          "Couldn't generate share image";
+      final errorMsg = l10n.favoritesShareError;
       messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }
   }

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -26,111 +26,119 @@ class AlertsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Consumer(builder: (context, ref, _) {
-      final alerts = ref.watch(alertProvider);
-      // The radius-alerts + statistics entry is always shown — it is
-      // the only navigation path to the `/alerts` screen (#1701), so it
-      // must be reachable whether or not the user has price alerts.
-      final body = alerts.isEmpty
-          ? EmptyState(
-              icon: Icons.notifications_off_outlined,
-              title: l10n?.noPriceAlerts ?? 'No price alerts',
-              subtitle: l10n?.noPriceAlertsHint ??
-                  'Create an alert from a station\'s detail page.',
-            )
-          : _priceAlertsList(context, ref, l10n);
-      return Column(
-        children: [
-          const _RadiusAlertsEntry(),
-          Expanded(child: body),
-        ],
-      );
-    });
+    return Consumer(
+      builder: (context, ref, _) {
+        final alerts = ref.watch(alertProvider);
+        // The radius-alerts + statistics entry is always shown — it is
+        // the only navigation path to the `/alerts` screen (#1701), so it
+        // must be reachable whether or not the user has price alerts.
+        final body = alerts.isEmpty
+            ? EmptyState(
+                icon: Icons.notifications_off_outlined,
+                title: l10n.noPriceAlerts,
+                subtitle: l10n.noPriceAlertsHint,
+              )
+            : _priceAlertsList(context, ref, l10n);
+        return Column(
+          children: [
+            const _RadiusAlertsEntry(),
+            Expanded(child: body),
+          ],
+        );
+      },
+    );
   }
 
   Widget _priceAlertsList(
     BuildContext context,
     WidgetRef ref,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) {
     // Re-read here (cheap, idempotent) so the helper carries no
     // explicit alert-model type — keeping favorites/presentation off a
     // direct import of the alerts feature's data layer.
     final alerts = ref.watch(alertProvider);
     return Column(
-        children: [
-          HelpBanner(
-            storageKey: StorageKeys.helpBannerAlerts,
-            icon: Icons.notifications_active_outlined,
-            message: l10n?.helpBannerAlerts ??
-                'Set a price threshold for a station. You\'ll be notified when prices drop below it. Checks run every 30 minutes.',
-          ),
-          Expanded(
-            child: ListView.builder(
-        itemCount: alerts.length,
-        itemBuilder: (context, index) {
-          final alert = alerts[index];
-          // Swipe left to delete alert
-          return Dismissible(
-            key: ValueKey(alert.id),
-            direction: DismissDirection.endToStart,
-            background: Container(
-              alignment: Alignment.centerRight,
-              padding: const EdgeInsets.only(right: 24),
-              color: DarkModeColors.error(context),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(l10n?.delete ?? 'Delete',
-                      style: const TextStyle(
-                          color: Colors.white, fontWeight: FontWeight.bold)),
-                  const SizedBox(width: 8),
-                  const Icon(Icons.delete, color: Colors.white, size: 20),
-                ],
-              ),
-            ),
-            onDismissed: (_) {
-              unawaited(ref.read(alertProvider.notifier).removeAlert(alert.id));
-              SnackBarHelper.show(
-                  context,
-                  l10n?.alertDeleted(alert.stationName) ??
-                      'Alert "${alert.stationName}" deleted');
-            },
-            child: ListTile(
-              leading: Icon(
-                alert.isActive
-                    ? Icons.notifications_active
-                    : Icons.notifications_off,
-                color: alert.isActive
-                    ? FuelColors.forType(alert.fuelType)
-                    : Colors.grey,
-              ),
-              // #2117 \u2014 Switch.adaptive gets the platform-correct
-              // toggle glyph on iOS without changing the ListTile's
-              // tap-to-detail navigation semantics (a full SwitchListTile
-              // would collide with onTap).
-              title: Text(alert.stationName),
-              subtitle: Text(
-                '${alert.fuelType.displayName} \u2264 ${PriceFormatter.formatPrice(alert.targetPrice)}',
-                style: TextStyle(
+      children: [
+        HelpBanner(
+          storageKey: StorageKeys.helpBannerAlerts,
+          icon: Icons.notifications_active_outlined,
+          message: l10n.helpBannerAlerts,
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: alerts.length,
+            itemBuilder: (context, index) {
+              final alert = alerts[index];
+              // Swipe left to delete alert
+              return Dismissible(
+                key: ValueKey(alert.id),
+                direction: DismissDirection.endToStart,
+                background: Container(
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 24),
+                  color: DarkModeColors.error(context),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        l10n.delete,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const Icon(Icons.delete, color: Colors.white, size: 20),
+                    ],
+                  ),
+                ),
+                onDismissed: (_) {
+                  unawaited(
+                    ref.read(alertProvider.notifier).removeAlert(alert.id),
+                  );
+                  SnackBarHelper.show(
+                    context,
+                    l10n.alertDeleted(alert.stationName),
+                  );
+                },
+                child: ListTile(
+                  leading: Icon(
+                    alert.isActive
+                        ? Icons.notifications_active
+                        : Icons.notifications_off,
                     color: alert.isActive
                         ? FuelColors.forType(alert.fuelType)
-                        : Colors.grey),
-              ),
-              trailing: Switch.adaptive(
-                value: alert.isActive,
-                onChanged: (_) =>
-                    ref.read(alertProvider.notifier).toggleAlert(alert.id),
-              ),
-              // Tap to open station detail (shows price history)
-              onTap: () => StationDetailRoute(alert.stationId).push<void>(context),
-            ),
-          );
-        },
-      ),
+                        : Colors.grey,
+                  ),
+                  // #2117 — Switch.adaptive gets the platform-correct
+                  // toggle glyph on iOS without changing the ListTile's
+                  // tap-to-detail navigation semantics (a full SwitchListTile
+                  // would collide with onTap).
+                  title: Text(alert.stationName),
+                  subtitle: Text(
+                    '${alert.fuelType.displayName} ≤ ${PriceFormatter.formatPrice(alert.targetPrice)}',
+                    style: TextStyle(
+                      color: alert.isActive
+                          ? FuelColors.forType(alert.fuelType)
+                          : Colors.grey,
+                    ),
+                  ),
+                  trailing: Switch.adaptive(
+                    value: alert.isActive,
+                    onChanged: (_) =>
+                        ref.read(alertProvider.notifier).toggleAlert(alert.id),
+                  ),
+                  // Tap to open station detail (shows price history)
+                  onTap: () =>
+                      StationDetailRoute(alert.stationId).push<void>(context),
+                ),
+              );
+            },
           ),
-        ],
-      );
+        ),
+      ],
+    );
   }
 }
 
@@ -166,14 +174,12 @@ class _RadiusAlertsEntry extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      l10n?.radiusAlertsEntryTitle ??
-                          'Radius alerts & statistics',
+                      l10n.radiusAlertsEntryTitle,
                       style: theme.textTheme.titleSmall,
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      l10n?.radiusAlertsEntrySubtitle ??
-                          'Get notified when prices drop near you',
+                      l10n.radiusAlertsEntrySubtitle,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
@@ -181,8 +187,10 @@ class _RadiusAlertsEntry extends StatelessWidget {
                   ],
                 ),
               ),
-              Icon(Icons.chevron_right,
-                  color: theme.colorScheme.onSurfaceVariant),
+              Icon(
+                Icons.chevron_right,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ],
           ),
         ),

--- a/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
@@ -50,7 +50,7 @@ class EvFavoriteCard extends StatelessWidget {
         .toSet()
         .toList();
 
-    final availableLabel = l10n?.evStatusAvailable ?? 'available';
+    final availableLabel = l10n.evStatusAvailable;
     // Screen-reader parity with the fuel card's semantic label: the
     // visual cards are intentionally identical except for the marker
     // colour (#2229), so a11y leans on this label to convey "EV".
@@ -121,8 +121,7 @@ class EvFavoriteCard extends StatelessWidget {
                 connectorTypes: connectorTypes,
                 availableLabel: availableLabel,
                 onFavoriteTap: onFavoriteTap,
-                removeFavoriteTooltip:
-                    l10n?.removeFavorite ?? 'Remove from favorites',
+                removeFavoriteTooltip: l10n.removeFavorite,
               ),
             ],
           ),

--- a/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
@@ -52,15 +52,14 @@ class EvFavoriteDismissible extends ConsumerWidget {
         final l10nSnack = AppLocalizations.of(context);
         SnackBarHelper.showWithUndo(
           context,
-          l10nSnack?.removedFromFavoritesName(label) ??
-              '$label removed from favorites',
-          undoLabel: l10nSnack?.undo ?? 'Undo',
+          l10nSnack.removedFromFavoritesName(label),
+          undoLabel: l10nSnack.undo,
           onUndo: () => favorites.add(station.id, stationData: station),
         );
         return true;
       },
       background: Semantics(
-        label: l10n?.semanticsNavigateTo(label) ?? 'Navigate to $label',
+        label: l10n.semanticsNavigateTo(label),
         child: Container(
           alignment: Alignment.centerLeft,
           padding: const EdgeInsets.only(left: 24),
@@ -71,17 +70,18 @@ class EvFavoriteDismissible extends ConsumerWidget {
               const Icon(Icons.navigation, color: Colors.white, size: 20),
               const SizedBox(width: 8),
               Text(
-                l10n?.navigate ?? 'Navigate',
+                l10n.navigate,
                 style: const TextStyle(
-                    color: Colors.white, fontWeight: FontWeight.bold),
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ],
           ),
         ),
       ),
       secondaryBackground: Semantics(
-        label: l10n?.semanticsRemoveFromFavorites(label) ??
-            'Remove $label from favorites',
+        label: l10n.semanticsRemoveFromFavorites(label),
         child: Container(
           alignment: Alignment.centerRight,
           padding: const EdgeInsets.only(right: 24),
@@ -90,9 +90,11 @@ class EvFavoriteDismissible extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                l10n?.remove ?? 'Remove',
+                l10n.remove,
                 style: const TextStyle(
-                    color: Colors.white, fontWeight: FontWeight.bold),
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
               const SizedBox(width: 8),
               const Icon(Icons.delete, color: Colors.white, size: 20),

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -59,15 +59,14 @@ class FavoriteStationDismissible extends ConsumerWidget {
         final l10nSnack = AppLocalizations.of(context);
         SnackBarHelper.showWithUndo(
           context,
-          l10nSnack?.removedFromFavoritesName(label) ??
-              '$label removed from favorites',
-          undoLabel: l10nSnack?.undo ?? 'Undo',
+          l10nSnack.removedFromFavoritesName(label),
+          undoLabel: l10nSnack.undo,
           onUndo: () => favorites.add(station.id, stationData: station),
         );
         return true;
       },
       background: Semantics(
-        label: l10n?.semanticsNavigateTo(label) ?? 'Navigate to $label',
+        label: l10n.semanticsNavigateTo(label),
         child: Container(
           alignment: Alignment.centerLeft,
           padding: const EdgeInsets.only(left: 24),
@@ -75,21 +74,21 @@ class FavoriteStationDismissible extends ConsumerWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.navigation,
-                  color: Colors.white, size: 20),
+              const Icon(Icons.navigation, color: Colors.white, size: 20),
               const SizedBox(width: 8),
               Text(
-                l10n?.navigate ?? 'Navigate',
+                l10n.navigate,
                 style: const TextStyle(
-                    color: Colors.white, fontWeight: FontWeight.bold),
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ],
           ),
         ),
       ),
       secondaryBackground: Semantics(
-        label: l10n?.semanticsRemoveFromFavorites(label) ??
-            'Remove $label from favorites',
+        label: l10n.semanticsRemoveFromFavorites(label),
         child: Container(
           alignment: Alignment.centerRight,
           padding: const EdgeInsets.only(right: 24),
@@ -98,9 +97,11 @@ class FavoriteStationDismissible extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                l10n?.remove ?? 'Remove',
+                l10n.remove,
                 style: const TextStyle(
-                    color: Colors.white, fontWeight: FontWeight.bold),
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
               const SizedBox(width: 8),
               const Icon(Icons.delete, color: Colors.white, size: 20),

--- a/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_loading_view.dart
@@ -73,11 +73,11 @@ class _FavoritesLoadingViewState extends State<FavoritesLoadingView>
                       style: theme.textTheme.titleSmall!.copyWith(
                         color: theme.colorScheme.onSurface,
                       ),
-                      child: Text(l?.updatingFavorites ?? 'Updating your favorites...'),
+                      child: Text(l.updatingFavorites),
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      l?.fetchingLatestPrices ?? 'Fetching the latest prices',
+                      l.fetchingLatestPrices,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),

--- a/lib/features/favorites/presentation/widgets/favorites_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_tab.dart
@@ -36,15 +36,13 @@ class FavoritesTab extends ConsumerWidget {
 
     if (favoriteIds.isEmpty) {
       return Semantics(
-        label: l10n?.noFavoritesSemanticLabel ??
-            'No favorites yet. Tap the star on a station to save it as a favorite.',
+        label: l10n.noFavoritesSemanticLabel,
         child: EmptyState(
           icon: Icons.star_outline,
           iconSize: 80,
-          title: l10n?.noFavorites ?? 'No favorites yet',
-          subtitle: l10n?.noFavoritesHint ??
-              'Tap the star on a station to save it here',
-          actionLabel: l10n?.search ?? 'Search Stations',
+          title: l10n.noFavorites,
+          subtitle: l10n.noFavoritesHint,
+          actionLabel: l10n.search,
           onAction: () => context.go(RoutePaths.search),
           topBiased: true,
         ),
@@ -68,8 +66,7 @@ class FavoritesTab extends ConsumerWidget {
           },
           child: Column(
             children: [
-              if (result.data.isNotEmpty)
-                ServiceStatusBanner(result: result),
+              if (result.data.isNotEmpty) ServiceStatusBanner(result: result),
               const SwipeTutorialBanner(),
               Expanded(
                 child: ListView.builder(
@@ -81,8 +78,9 @@ class FavoritesTab extends ConsumerWidget {
                         FavoriteStationDismissible(station: station),
                       // #1958 — EV favorites now swipe just like
                       // fuel-station favorites (navigate / remove).
-                      EVStationResult(:final station) =>
-                        EvFavoriteDismissible(station: station),
+                      EVStationResult(:final station) => EvFavoriteDismissible(
+                        station: station,
+                      ),
                     };
                   },
                 ),

--- a/lib/features/favorites/presentation/widgets/swipe_tutorial_banner.dart
+++ b/lib/features/favorites/presentation/widgets/swipe_tutorial_banner.dart
@@ -56,8 +56,7 @@ class _SwipeTutorialBannerState extends ConsumerState<SwipeTutorialBanner> {
     final theme = Theme.of(context);
 
     return Semantics(
-      label: l10n?.swipeTutorialMessage ??
-          'Swipe right to navigate, swipe left to remove',
+      label: l10n.swipeTutorialMessage,
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         padding: const EdgeInsets.all(12),
@@ -75,8 +74,7 @@ class _SwipeTutorialBannerState extends ConsumerState<SwipeTutorialBanner> {
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                l10n?.swipeTutorialMessage ??
-                    'Swipe right to navigate, swipe left to remove',
+                l10n.swipeTutorialMessage,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onPrimaryContainer,
                 ),
@@ -85,9 +83,7 @@ class _SwipeTutorialBannerState extends ConsumerState<SwipeTutorialBanner> {
             const SizedBox(width: 8),
             TextButton(
               onPressed: _dismiss,
-              child: Text(
-                l10n?.swipeTutorialDismiss ?? 'Got it',
-              ),
+              child: Text(l10n.swipeTutorialDismiss),
             ),
           ],
         ),

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -42,13 +42,13 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     final l10n = AppLocalizations.of(context);
 
     return PageScaffold(
-      title: l10n?.savedRoutes ?? 'Saved Routes',
+      title: l10n.savedRoutes,
       bodyPadding: EdgeInsets.zero,
       body: itineraries.isEmpty
           ? EmptyState(
               icon: Icons.route,
-              title: l10n?.noSavedRoutes ?? 'No saved routes',
-              subtitle: l10n?.noSavedRoutesHint ?? 'Search along a route and save it for quick access later.',
+              title: l10n.noSavedRoutes,
+              subtitle: l10n.noSavedRoutesHint,
             )
           : RefreshIndicator(
               onRefresh: () async {
@@ -59,17 +59,26 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
                 itemBuilder: (context, index) {
                   final it = itineraries[index];
                   final highwaysSuffix = it.avoidHighways
-                      ? ' · ${l10n?.avoidHighways ?? 'no highways'}'
+                      ? ' · ${l10n.avoidHighways}'
                       : '';
                   return SwipeToDelete(
                     dismissKey: ValueKey(it.id),
                     onDismissed: () {
-                      unawaited(ref.read(itineraryProvider.notifier).delete(it.id));
-                      SnackBarHelper.show(context, AppLocalizations.of(context)?.itineraryDeleted(it.name) ?? '${it.name} deleted');
+                      unawaited(
+                        ref.read(itineraryProvider.notifier).delete(it.id),
+                      );
+                      SnackBarHelper.show(
+                        context,
+                        AppLocalizations.of(context).itineraryDeleted(it.name),
+                      );
                     },
                     child: ListTile(
                       leading: const Icon(Icons.route),
-                      title: Text(it.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                      title: Text(
+                        it.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                       subtitle: Text(
                         '${it.distanceKm.round()} km · ${it.durationMinutes.round()} min'
                         '$highwaysSuffix',
@@ -108,16 +117,23 @@ class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
     final fuelType = FuelType.fromString(it.fuelType as String);
     final detourBudgetKm =
         ref.read(activeProfileProvider)?.routeDetourBudgetKm ?? 5.0;
-    unawaited(ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
-      waypoints: waypoints,
-      fuelType: fuelType,
-      searchRadiusKm: detourBudgetKm,
-    ));
+    unawaited(
+      ref
+          .read(routeSearchStateProvider.notifier)
+          .searchAlongRoute(
+            waypoints: waypoints,
+            fuelType: fuelType,
+            searchRadiusKm: detourBudgetKm,
+          ),
+    );
 
     // Navigate to search screen
     context.go(RoutePaths.search);
 
-    SnackBarHelper.show(context, AppLocalizations.of(context)?.loadingRoute(it.name as String) ?? 'Loading route: ${it.name}');
+    SnackBarHelper.show(
+      context,
+      AppLocalizations.of(context).loadingRoute(it.name as String),
+    );
   }
 
   String _formatDate(DateTime dt) {

--- a/lib/features/loyalty/presentation/loyalty_settings_screen.dart
+++ b/lib/features/loyalty/presentation/loyalty_settings_screen.dart
@@ -34,9 +34,8 @@ class LoyaltySettingsScreen extends ConsumerWidget {
     final cards = ref.watch(loyaltyCardsProvider);
 
     return PageScaffold(
-      title: l?.loyaltySettingsTitle ?? 'Fuel club cards',
-      subtitle: l?.loyaltySettingsSubtitle ??
-          'Apply your loyalty discount to displayed prices',
+      title: l.loyaltySettingsTitle,
+      subtitle: l.loyaltySettingsSubtitle,
       bannerIcon: Icons.card_membership,
       body: cards.isEmpty
           ? const LoyaltyEmptyState()
@@ -52,15 +51,16 @@ class LoyaltySettingsScreen extends ConsumerWidget {
                   onToggle: (enabled) => ref
                       .read(loyaltyCardsProvider.notifier)
                       .setEnabled(card.id, enabled: enabled),
-                  onDeleteRequested: () => _confirmAndDelete(context, ref, card),
+                  onDeleteRequested: () =>
+                      _confirmAndDelete(context, ref, card),
                 );
               },
             ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _openAddSheet(context, ref),
         icon: const Icon(Icons.add),
-        label: Text(l?.loyaltyAddCard ?? 'Add card'),
-        tooltip: l?.loyaltyAddCard ?? 'Add card',
+        label: Text(l.loyaltyAddCard),
+        tooltip: l.loyaltyAddCard,
       ),
     );
   }
@@ -90,19 +90,16 @@ class LoyaltySettingsScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text(l?.loyaltyDeleteConfirmTitle ?? 'Delete card?'),
-        content: Text(
-          l?.loyaltyDeleteConfirmBody ??
-              'This card will stop applying its discount.',
-        ),
+        title: Text(l.loyaltyDeleteConfirmTitle),
+        content: Text(l.loyaltyDeleteConfirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l?.delete ?? 'Delete'),
+            child: Text(l.delete),
           ),
         ],
       ),

--- a/lib/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_add_card_sheet.dart
@@ -51,14 +51,14 @@ class _LoyaltyAddCardSheetState extends State<LoyaltyAddCardSheet> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              l?.loyaltyAddCardSheetTitle ?? 'Add fuel club card',
+              l.loyaltyAddCardSheetTitle,
               style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<LoyaltyBrand>(
               initialValue: _brand,
               decoration: InputDecoration(
-                labelText: l?.loyaltyBrandLabel ?? 'Brand',
+                labelText: l.loyaltyBrandLabel,
                 border: const OutlineInputBorder(),
               ),
               items: [
@@ -76,7 +76,7 @@ class _LoyaltyAddCardSheetState extends State<LoyaltyAddCardSheet> {
             TextFormField(
               controller: _labelController,
               decoration: InputDecoration(
-                labelText: l?.loyaltyCardLabelLabel ?? 'Label (optional)',
+                labelText: l.loyaltyCardLabelLabel,
                 border: const OutlineInputBorder(),
               ),
               textInputAction: TextInputAction.next,
@@ -84,21 +84,21 @@ class _LoyaltyAddCardSheetState extends State<LoyaltyAddCardSheet> {
             const SizedBox(height: 12),
             TextFormField(
               controller: _discountController,
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
               inputFormatters: [
                 // Accept either '.' or ',' so a French keyboard works.
                 FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
               ],
               decoration: InputDecoration(
-                labelText: l?.loyaltyDiscountLabel ?? 'Discount (per litre)',
+                labelText: l.loyaltyDiscountLabel,
                 hintText: '0.05',
                 border: const OutlineInputBorder(),
               ),
               validator: (value) {
                 if (!isValidDiscountInput(value)) {
-                  return l?.loyaltyDiscountInvalid ??
-                      'Enter a positive number';
+                  return l.loyaltyDiscountInvalid;
                 }
                 return null;
               },
@@ -109,15 +109,12 @@ class _LoyaltyAddCardSheetState extends State<LoyaltyAddCardSheet> {
                 Expanded(
                   child: OutlinedButton(
                     onPressed: () => Navigator.of(context).pop(),
-                    child: Text(l?.cancel ?? 'Cancel'),
+                    child: Text(l.cancel),
                   ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: FilledButton(
-                    onPressed: _onSave,
-                    child: Text(l?.save ?? 'Save'),
-                  ),
+                  child: FilledButton(onPressed: _onSave, child: Text(l.save)),
                 ),
               ],
             ),

--- a/lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart
@@ -58,8 +58,9 @@ class LoyaltyCardTile extends StatelessWidget {
           ),
           title: Text(
             card.label.isEmpty ? card.brand.canonicalBrand : card.label,
-            style: theme.textTheme.titleSmall
-                ?.copyWith(fontWeight: FontWeight.bold),
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
           ),
           subtitle: Text(
             '${card.brand.canonicalBrand} · −$discountText',
@@ -68,13 +69,10 @@ class LoyaltyCardTile extends StatelessWidget {
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Switch(
-                value: card.enabled,
-                onChanged: onToggle,
-              ),
+              Switch(value: card.enabled, onChanged: onToggle),
               IconButton(
                 icon: const Icon(Icons.delete_outline),
-                tooltip: l?.delete ?? 'Delete',
+                tooltip: l.delete,
                 onPressed: onDeleteRequested,
               ),
             ],

--- a/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
+++ b/lib/features/loyalty/presentation/widgets/loyalty_empty_state.dart
@@ -34,15 +34,13 @@ class LoyaltyEmptyState extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Text(
-              l?.loyaltyEmptyTitle ?? 'No fuel club cards yet',
+              l.loyaltyEmptyTitle,
               style: theme.textTheme.titleMedium,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
-              l?.loyaltyEmptyBody ??
-                  'Add a card to apply your per-litre discount to '
-                      'matching stations automatically.',
+              l.loyaltyEmptyBody,
               style: theme.textTheme.bodyMedium,
               textAlign: TextAlign.center,
             ),

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -82,21 +82,29 @@ class _MapScreenState extends ConsumerState<MapScreen>
 
   /// Boundary around the map body — `shareWidgetAsImage` renders the
   /// widget under this key to a PNG for the Share action (#1959).
-  final GlobalKey _shareBoundaryKey =
-      GlobalKey(debugLabel: 'map_share_boundary');
+  final GlobalKey _shareBoundaryKey = GlobalKey(
+    debugLabel: 'map_share_boundary',
+  );
 
   /// Render the current map view to an image and hand it to the OS
   /// share sheet (#1959). Best-effort — a share failure is logged and
   /// swallowed so the action never crashes the map screen.
-  Future<void> _onShare(AppLocalizations? l10n) async {
+  Future<void> _onShare(AppLocalizations l10n) async {
     try {
       await shareWidgetAsImage(
         boundaryKey: _shareBoundaryKey,
-        subject: l10n?.map ?? 'Map',
+        subject: l10n.map,
         fileNameStem: 'tankstellen_map',
       );
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'MapScreen share image'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'MapScreen share image'},
+        ),
+      );
     }
   }
 
@@ -177,7 +185,7 @@ class _MapScreenState extends ConsumerState<MapScreen>
     }
 
     return PageScaffold(
-      title: l10n?.map ?? 'Map',
+      title: l10n.map,
       actions: [
         IconButton(
           icon: const Icon(Icons.refresh),
@@ -186,13 +194,13 @@ class _MapScreenState extends ConsumerState<MapScreen>
               ref.read(searchStateProvider.notifier).repeatLastSearch(),
             );
           },
-          tooltip: l10n?.refreshPrices ?? 'Refresh prices',
+          tooltip: l10n.refreshPrices,
         ),
         const EvToggleButton(),
         IconButton(
           icon: const Icon(Icons.share),
           onPressed: () => _onShare(l10n),
-          tooltip: l10n?.favoritesShareAction ?? 'Share',
+          tooltip: l10n.favoritesShareAction,
         ),
         const SettingsAppBarAction(),
       ],

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -85,8 +85,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
           if (result == null || (stations.isEmpty && !hasGeometry)) {
             return EmptyState(
               icon: Icons.route,
-              title: AppLocalizations.of(context)?.noStationsAlongRoute ??
-                  'No stations found along route',
+              title: AppLocalizations.of(context).noStationsAlongRoute,
             );
           }
           return _buildRouteMap(context, result, stations, selectedFuel);
@@ -118,7 +117,12 @@ class _InlineMapState extends ConsumerState<InlineMap> {
             .map((r) => r.station)
             .toList();
         return _buildMap(
-            context, stations, selectedFuel, searchRadius, sortMode);
+          context,
+          stations,
+          selectedFuel,
+          searchRadius,
+          sortMode,
+        );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (_, _) => _mapUnavailable(context),
@@ -137,8 +141,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
     if (stations.isEmpty) {
       return EmptyState(
         icon: Icons.map_outlined,
-        title: AppLocalizations.of(context)?.searchToSeeMap ??
-            'Search to see stations on the map',
+        title: AppLocalizations.of(context).searchToSeeMap,
       );
     }
 
@@ -215,23 +218,23 @@ class _InlineMapState extends ConsumerState<InlineMap> {
   }
 
   Widget _mapUnavailable(BuildContext context) => Center(
-        child: Text(
-          AppLocalizations.of(context)?.mapUnavailable ?? 'Map unavailable',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-        ),
-      );
+    child: Text(
+      AppLocalizations.of(context).mapUnavailable,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    ),
+  );
 
   /// The along-route fuel stations of [result] (drops EV/other result kinds),
   /// or `const []` when there is no result yet.
   static List<Station> _routeFuelStations(RouteSearchResult? result) =>
       result == null
-          ? const []
-          : result.stations
-              .whereType<FuelStationResult>()
-              .map((r) => r.station)
-              .toList();
+      ? const []
+      : result.stations
+            .whereType<FuelStationResult>()
+            .map((r) => r.station)
+            .toList();
 
   /// The [LatLngBounds] of the result [stations], with a tiny epsilon box for
   /// a single result so `CameraFit.bounds` cannot divide-by-zero (mirrors

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -81,9 +81,8 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         if (allItems.isEmpty) {
           return EmptyState(
             icon: Icons.map_outlined,
-            title: l10n?.startSearch ??
-                'Search for stations to see them on the map',
-            actionLabel: l10n?.search ?? 'Search now',
+            title: l10n.startSearch,
+            actionLabel: l10n.search,
             onAction: () => context.go(RoutePaths.search),
             iconSize: 80,
           );
@@ -103,8 +102,8 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         final center = stations.isNotEmpty
             ? StationMapLayers.centerOf(stations)
             : (userPos != null
-                ? LatLng(userPos.lat, userPos.lng)
-                : const LatLng(0, 0));
+                  ? LatLng(userPos.lat, userPos.lng)
+                  : const LatLng(0, 0));
         final zoom = StationMapLayers.zoomForRadius(searchRadiusKm);
 
         final evLat = center.latitude;
@@ -128,8 +127,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         // changed search centre. The old per-build post-frame `fitCamera`
         // here raced the (now-deleted) cold-start reset window and is
         // gone. `bounds` is still computed for the recenter button.
-        final bounds =
-            StationMapLayers.boundsForRadius(center, searchRadiusKm);
+        final bounds = StationMapLayers.boundsForRadius(center, searchRadiusKm);
 
         return Stack(
           children: [
@@ -191,7 +189,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
 
   Widget _buildInfoBar(
     BuildContext context,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     List<dynamic> stations,
     dynamic result,
   ) {
@@ -201,22 +199,27 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
       color: theme.colorScheme.surfaceContainerHighest,
       child: Row(
         children: [
-          Icon(Icons.local_gas_station,
-              size: 16, color: theme.colorScheme.primary),
+          Icon(
+            Icons.local_gas_station,
+            size: 16,
+            color: theme.colorScheme.primary,
+          ),
           const SizedBox(width: 8),
           Text(
-            l10n?.nStations(stations.length) ?? '${stations.length} stations',
+            l10n.nStations(stations.length),
             style: theme.textTheme.bodySmall?.copyWith(
               fontWeight: FontWeight.w600,
             ),
           ),
           const SizedBox(width: 16),
-          Icon(Icons.circle,
-              size: 8,
-              color: theme.colorScheme.primary.withValues(alpha: 0.3)),
+          Icon(
+            Icons.circle,
+            size: 8,
+            color: theme.colorScheme.primary.withValues(alpha: 0.3),
+          ),
           const SizedBox(width: 4),
           Text(
-            '${widget.searchRadiusKm.round()} km ${l10n?.searchRadius ?? "radius"}',
+            '${widget.searchRadiusKm.round()} km ${l10n.searchRadius}',
             style: theme.textTheme.bodySmall,
           ),
           const Spacer(),

--- a/lib/features/map/presentation/widgets/price_legend.dart
+++ b/lib/features/map/presentation/widgets/price_legend.dart
@@ -27,55 +27,63 @@ class PriceLegend extends StatelessWidget {
       decoration: BoxDecoration(
         color: overlayBg,
         borderRadius: BorderRadius.circular(8),
-        boxShadow: [
-          BoxShadow(color: shadowColor, blurRadius: 4),
-        ],
+        boxShadow: [BoxShadow(color: shadowColor, blurRadius: 4)],
       ),
-      child: Builder(builder: (context) {
-        final l10n = AppLocalizations.of(context);
-        return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(iconForPriceTier(PriceTier.cheap),
-              size: 12, color: DarkModeColors.success(context)),
-          _swatch(PriceBandColors.cheapTier),
-          const SizedBox(width: 4),
-          Text(l10n?.cheap ?? 'cheap', style: const TextStyle(fontSize: 10)),
-          Container(
-            width: 40,
-            height: 4,
-            margin: const EdgeInsets.symmetric(horizontal: 8),
-            decoration: const BoxDecoration(
-              // The full 4-stop ramp the markers use, not a 3-stop
-              // approximation, so the bar matches the bubbles exactly.
-              gradient: LinearGradient(colors: PriceBandColors.ramp),
-              borderRadius: BorderRadius.all(Radius.circular(2)),
-            ),
-          ),
-          // Middle "average" tier swatch + neutral dash icon (language-
-          // neutral, so no new string) — mirrors PriceTier.average.
-          _swatch(PriceBandColors.averageTier),
-          Icon(iconForPriceTier(PriceTier.average),
-              size: 12, color: DarkModeColors.warning(context)),
-          const SizedBox(width: 8),
-          Text(l10n?.expensive ?? 'expensive',
-              style: const TextStyle(fontSize: 10)),
-          const SizedBox(width: 4),
-          _swatch(PriceBandColors.expensiveTier),
-          Icon(iconForPriceTier(PriceTier.expensive),
-              size: 12, color: DarkModeColors.error(context)),
-        ],
-      );
-      }),
+      child: Builder(
+        builder: (context) {
+          final l10n = AppLocalizations.of(context);
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                iconForPriceTier(PriceTier.cheap),
+                size: 12,
+                color: DarkModeColors.success(context),
+              ),
+              _swatch(PriceBandColors.cheapTier),
+              const SizedBox(width: 4),
+              Text(l10n.cheap, style: const TextStyle(fontSize: 10)),
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.symmetric(horizontal: 8),
+                decoration: const BoxDecoration(
+                  // The full 4-stop ramp the markers use, not a 3-stop
+                  // approximation, so the bar matches the bubbles exactly.
+                  gradient: LinearGradient(colors: PriceBandColors.ramp),
+                  borderRadius: BorderRadius.all(Radius.circular(2)),
+                ),
+              ),
+              // Middle "average" tier swatch + neutral dash icon (language-
+              // neutral, so no new string) — mirrors PriceTier.average.
+              _swatch(PriceBandColors.averageTier),
+              Icon(
+                iconForPriceTier(PriceTier.average),
+                size: 12,
+                color: DarkModeColors.warning(context),
+              ),
+              const SizedBox(width: 8),
+              Text(l10n.expensive, style: const TextStyle(fontSize: 10)),
+              const SizedBox(width: 4),
+              _swatch(PriceBandColors.expensiveTier),
+              Icon(
+                iconForPriceTier(PriceTier.expensive),
+                size: 12,
+                color: DarkModeColors.error(context),
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 
   /// A 12dp colour dot for one price-band stop.
   static Widget _swatch(Color color) => Container(
-        width: 12,
-        height: 12,
-        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-      );
+    width: 12,
+    height: 12,
+    decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+  );
 }
 
 /// Circular zoom/location control button for the map.
@@ -100,7 +108,11 @@ class ZoomButton extends StatelessWidget {
             color: DarkModeColors.mapOverlay(context),
             borderRadius: BorderRadius.circular(8),
           ),
-          child: Icon(icon, size: 20, color: DarkModeColors.mapOverlayIcon(context)),
+          child: Icon(
+            icon,
+            size: 20,
+            color: DarkModeColors.mapOverlayIcon(context),
+          ),
         ),
       ),
     );

--- a/lib/features/map/presentation/widgets/route_info_bar.dart
+++ b/lib/features/map/presentation/widgets/route_info_bar.dart
@@ -36,15 +36,16 @@ class RouteInfoBar extends StatelessWidget {
           const SizedBox(width: 4),
           Text(
             '${distanceKm.round()}km \u00b7 ${durationMinutes.round()}min',
-            style: theme.textTheme.labelSmall
-                ?.copyWith(fontWeight: FontWeight.w600),
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
           ),
           const SizedBox(width: 6),
           Text(stationCountLabel, style: theme.textTheme.labelSmall),
           const Spacer(),
           IconButton(
             icon: const Icon(Icons.bookmark_add, size: 14),
-            tooltip: l10n?.saveRoute ?? 'Save route',
+            tooltip: l10n.saveRoute,
             onPressed: onSaveRoute,
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
@@ -52,7 +53,7 @@ class RouteInfoBar extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.navigation, size: 14),
-            tooltip: l10n?.openInMaps ?? 'Open in Maps',
+            tooltip: l10n.openInMaps,
             onPressed: onOpenInMaps,
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(minWidth: 28, minHeight: 28),

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -48,6 +48,7 @@ class RouteMapView extends ConsumerStatefulWidget {
   @override
   ConsumerState<RouteMapView> createState() => _RouteMapViewState();
 }
+
 class _RouteMapViewState extends ConsumerState<RouteMapView> {
   RouteViewMode _viewMode = RouteViewMode.allStations;
   final Set<String> _selectedStationIds = {};
@@ -113,8 +114,8 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
     if (allFuelStations.isEmpty && result.route.geometry.isEmpty) {
       return EmptyState(
         icon: Icons.route,
-        title: l10n?.noStationsAlongRoute ?? 'No stations found along route',
-        actionLabel: l10n?.search ?? 'Back to search',
+        title: l10n.noStationsAlongRoute,
+        actionLabel: l10n.search,
         onAction: () => context.go(RoutePaths.search),
       );
     }
@@ -180,8 +181,9 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             cameraFitBounds: _routeBounds,
             routePolyline: result.route.geometry,
             showSearchRadius: false,
-            selectedStationIds:
-                _selectedStationIds.isNotEmpty ? _selectedStationIds : null,
+            selectedStationIds: _selectedStationIds.isNotEmpty
+                ? _selectedStationIds
+                : null,
             fuelResolver: resolveFuel,
             // #3000 (Epic #2997) — adopt the radar clustered+cheapest-labelled
             // grammar, but SELECTION-AWARE: cluster the non-selected stations
@@ -210,40 +212,41 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
           distanceKm: result.route.distanceKm,
           durationMinutes: result.route.durationMinutes,
           stationCountLabel: _viewMode == RouteViewMode.bestStops
-              ? (l10n?.nBest(displayStations.length) ??
-                  '${displayStations.length} best')
-              : (l10n?.nStations(allFuelStations.length) ??
-                  '${allFuelStations.length}'),
+              ? (l10n.nBest(displayStations.length))
+              : (l10n.nStations(allFuelStations.length)),
           onSaveRoute: () => _showSaveRouteDialog(context, result),
           onOpenInMaps: () => _openSelectedInMaps(result),
         ),
       ],
     );
   }
+
   Future<void> _showSaveRouteDialog(
-      BuildContext context, RouteSearchResult result) async {
+    BuildContext context,
+    RouteSearchResult result,
+  ) async {
     final controller = TextEditingController();
     final l10n = AppLocalizations.of(context);
     final name = await showDialog<String>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(l10n?.saveRoute ?? 'Save Route'),
+        title: Text(l10n.saveRoute),
         content: TextField(
           controller: controller,
           decoration: InputDecoration(
-            labelText: l10n?.routeName ?? 'Route name',
-            hintText: l10n?.routeNameHintExample ?? 'e.g. Paris \u2192 Lyon',
+            labelText: l10n.routeName,
+            hintText: l10n.routeNameHintExample,
           ),
           autofocus: true,
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx),
-            child: Text(l10n?.cancel ?? 'Cancel'),
+            child: Text(l10n.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, controller.text),
-            child: Text(l10n?.save ?? 'Save'),
+            child: Text(l10n.save),
           ),
         ],
       ),
@@ -259,33 +262,42 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
       final end = result.route.geometry.last;
       final selectedIds = _selectedStationIds.toList();
       final profile = ref.read(activeProfileProvider);
-      final success = await ref.read(itineraryProvider.notifier).saveRoute(
+      // #3159 — capture everything ref-dependent BEFORE the await so the
+      // unmount race can't touch a dead WidgetRef.
+      final fuelType = ref.read(selectedFuelTypeProvider).apiValue;
+      final itineraries = ref.read(itineraryProvider.notifier);
+      final success = await itineraries.saveRoute(
         name: name,
         waypoints: [
           RouteWaypoint(
-              lat: start.latitude, lng: start.longitude, label: 'Start'),
+            lat: start.latitude,
+            lng: start.longitude,
+            label: 'Start',
+          ),
           RouteWaypoint(
-              lat: end.latitude, lng: end.longitude, label: 'Destination'),
+            lat: end.latitude,
+            lng: end.longitude,
+            label: 'Destination',
+          ),
         ],
         distanceKm: result.route.distanceKm,
         durationMinutes: result.route.durationMinutes,
         avoidHighways: profile?.avoidHighways ?? false,
-        fuelType: ref.read(selectedFuelTypeProvider).apiValue,
+        fuelType: fuelType,
         selectedStationIds: selectedIds,
       );
 
       if (context.mounted) {
         final l10n = AppLocalizations.of(context);
         if (success) {
-          SnackBarHelper.showSuccess(
-              context, l10n?.routeSaved ?? 'Route saved!');
+          SnackBarHelper.showSuccess(context, l10n.routeSaved);
         } else {
-          SnackBarHelper.showError(
-              context, l10n?.routeSaveFailed ?? 'Failed to save route');
+          SnackBarHelper.showError(context, l10n.routeSaveFailed);
         }
       }
     }
   }
+
   List<Station> _getBestStopStations(
     List<Station> allStations,
     RouteSearchResult result,
@@ -300,6 +312,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
     final bestIds = segmentMap.values.toSet();
     return allStations.where((s) => bestIds.contains(s.id)).toList();
   }
+
   void _openSelectedInMaps(RouteSearchResult result) {
     final start = result.route.geometry.first;
     final end = result.route.geometry.last;
@@ -317,19 +330,23 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         return aIdx.compareTo(bIdx);
       });
 
-    unawaited(NavigationUtils.openRouteInMaps(
-      origin: '${start.latitude},${start.longitude}',
-      destination: '${end.latitude},${end.longitude}',
-      waypoints: selectedStations.map((s) => '${s.lat},${s.lng}').toList(),
-    ));
+    unawaited(
+      NavigationUtils.openRouteInMaps(
+        origin: '${start.latitude},${start.longitude}',
+        destination: '${end.latitude},${end.longitude}',
+        waypoints: selectedStations.map((s) => '${s.lat},${s.lng}').toList(),
+      ),
+    );
   }
+
   int _nearestPolylineIndex(double lat, double lng, List<LatLng> polyline) {
     int bestIdx = 0;
     double bestDist = double.infinity;
     final step = polyline.length > 200 ? 5 : 1;
     for (int i = 0; i < polyline.length; i += step) {
       final p = polyline[i];
-      final d = (p.latitude - lat) * (p.latitude - lat) +
+      final d =
+          (p.latitude - lat) * (p.latitude - lat) +
           (p.longitude - lng) * (p.longitude - lng);
       if (d < bestDist) {
         bestDist = d;

--- a/lib/features/map/presentation/widgets/route_view_mode_bar.dart
+++ b/lib/features/map/presentation/widgets/route_view_mode_bar.dart
@@ -42,14 +42,14 @@ class RouteViewModeBar extends StatelessWidget {
       child: Row(
         children: [
           SelectablePill(
-            label: l10n?.allStations ?? 'All stations',
+            label: l10n.allStations,
             icon: Icons.local_gas_station,
             selected: allStationsSelected,
             onTap: onTapAllStations,
           ),
           const SizedBox(width: 8),
           SelectablePill(
-            label: l10n?.bestStops ?? 'Best stops',
+            label: l10n.bestStops,
             icon: Icons.star,
             selected: bestStopsSelected,
             onTap: onTapBestStops,
@@ -65,9 +65,12 @@ class RouteViewModeBar extends StatelessWidget {
             ),
             const SizedBox(width: 4),
             IconButton(
-              icon: Icon(Icons.navigation,
-                  size: 18, color: theme.colorScheme.primary),
-              tooltip: l10n?.openInMaps ?? 'Open in Maps',
+              icon: Icon(
+                Icons.navigation,
+                size: 18,
+                color: theme.colorScheme.primary,
+              ),
+              tooltip: l10n.openInMaps,
               onPressed: onOpenSelectedInMaps,
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(minWidth: 32, minHeight: 32),

--- a/lib/features/obd2/presentation/obd2_connection_error_l10n.dart
+++ b/lib/features/obd2/presentation/obd2_connection_error_l10n.dart
@@ -12,27 +12,20 @@ import '../data/obd2_connection_errors.dart';
 /// to the user (a snackbar, an error panel), call [localizedMessage]
 /// instead so the user sees a translated, actionable message.
 extension Obd2ConnectionErrorL10n on Obd2ConnectionError {
-  /// The localized, user-facing message for this error. Falls back to
-  /// the English diagnostic [message] when localizations are
-  /// unavailable.
-  String localizedMessage(AppLocalizations? l10n) => switch (this) {
-        Obd2PermissionDenied() =>
-          l10n?.obd2ErrorPermissionDenied ?? message,
-        Obd2BluetoothOff() => l10n?.obd2ErrorBluetoothOff ?? message,
-        Obd2ScanTimeout() => l10n?.obd2ErrorScanTimeout ?? message,
-        Obd2AdapterUnresponsive() =>
-          l10n?.obd2ErrorAdapterUnresponsive ?? message,
-        // #3009 — the adapter answered; the engine is off. Accurate
-        // "start the engine" message, not the adapter-blaming one.
-        Obd2EngineOff() => l10n?.obd2ErrorEngineOff ?? message,
-        Obd2ProtocolInitFailed() =>
-          l10n?.obd2ErrorProtocolInitFailed ?? message,
-        // #3181 — pairing failed / was never confirmed. Actionable
-        // power-cycle guidance: the OBDLink CX only accepts new bonds in
-        // the first ~5 minutes after power-on.
-        Obd2PairingRequired() =>
-          l10n?.obd2ErrorPairingRequired ?? message,
-        Obd2DisconnectedException() =>
-          l10n?.obd2ErrorDisconnected ?? message,
-      };
+  /// The localized, user-facing message for this error.
+  String localizedMessage(AppLocalizations l10n) => switch (this) {
+    Obd2PermissionDenied() => l10n.obd2ErrorPermissionDenied,
+    Obd2BluetoothOff() => l10n.obd2ErrorBluetoothOff,
+    Obd2ScanTimeout() => l10n.obd2ErrorScanTimeout,
+    Obd2AdapterUnresponsive() => l10n.obd2ErrorAdapterUnresponsive,
+    // #3009 — the adapter answered; the engine is off. Accurate
+    // "start the engine" message, not the adapter-blaming one.
+    Obd2EngineOff() => l10n.obd2ErrorEngineOff,
+    Obd2ProtocolInitFailed() => l10n.obd2ErrorProtocolInitFailed,
+    // #3181 — pairing failed / was never confirmed. Actionable
+    // power-cycle guidance: the OBDLink CX only accepts new bonds in
+    // the first ~5 minutes after power-on.
+    Obd2PairingRequired() => l10n.obd2ErrorPairingRequired,
+    Obd2DisconnectedException() => l10n.obd2ErrorDisconnected,
+  };
 }

--- a/lib/features/obd2/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_adapter_picker.dart
@@ -106,8 +106,7 @@ Future<Obd2Service?> _showPickerSheet(
     // #3181 — the pairing guidance wins over the generic fall-through.
     final text = pairingError != null
         ? pairingError.localizedMessage(l)
-        : l?.obd2PickerPinnedFallback(fallbackAdapterName!) ??
-            "Couldn't reach '$fallbackAdapterName' — pick another adapter";
+        : l.obd2PickerPinnedFallback(fallbackAdapterName!);
     if (messenger != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         messenger.showSnackBar(SnackBarHelper.infoSnackBar(text));
@@ -386,7 +385,7 @@ class _Obd2AdapterPickerSheetState
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              l?.obdPickerTitle ?? 'Pick an OBD2 adapter',
+              l.obdPickerTitle,
               style: Theme.of(context).textTheme.titleLarge,
               textAlign: TextAlign.center,
             ),
@@ -401,10 +400,10 @@ class _Obd2AdapterPickerSheetState
   /// #3103 — one tile shape for both sections. A recognized candidate shows
   /// its matched profile name; an unrecognized one (empty placeholder profile)
   /// shows the device's own advertised name + a muted "tap to try" hint.
-  Widget _candidateTile(ResolvedObd2Candidate c, AppLocalizations? l) {
+  Widget _candidateTile(ResolvedObd2Candidate c, AppLocalizations l) {
     final subtitle = c.recognized
         ? '${c.profile.displayName} · ${c.candidate.rssi} dBm'
-        : '${l?.obd2PickerTapToTry ?? 'Unrecognized — tap to try'} · '
+        : '${l.obd2PickerTapToTry} · '
             '${c.candidate.rssi} dBm';
     return ListTile(
       key: Key('obdPickerItem_${c.candidate.deviceId}'),
@@ -420,7 +419,7 @@ class _Obd2AdapterPickerSheetState
     );
   }
 
-  Widget _buildBody(AppLocalizations? l) {
+  Widget _buildBody(AppLocalizations l) {
     switch (_phase) {
       case _Phase.scanning:
         return Column(
@@ -428,7 +427,7 @@ class _Obd2AdapterPickerSheetState
           children: [
             const CircularProgressIndicator(),
             const SizedBox(height: 12),
-            Text(l?.obdPickerScanning ?? 'Scanning for adapters…'),
+            Text(l.obdPickerScanning),
           ],
         );
       case _Phase.selecting:
@@ -449,7 +448,7 @@ class _Obd2AdapterPickerSheetState
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
                 child: Text(
-                  l?.obd2PickerOtherDevices ?? 'Other Bluetooth devices',
+                  l.obd2PickerOtherDevices,
                   style: Theme.of(context).textTheme.labelMedium,
                 ),
               ),
@@ -460,10 +459,7 @@ class _Obd2AdapterPickerSheetState
                 key: const Key('obdPickerBleOnlyNotice'),
                 padding: const EdgeInsets.fromLTRB(8, 12, 8, 0),
                 child: Text(
-                  l?.obd2PickerBleOnlyNotice ??
-                      'iPhone works with Bluetooth-LE adapters only. A '
-                          'Classic-only adapter (e.g. vLinker BM, Konnwei '
-                          'KW902) must be used on Android.',
+                  l.obd2PickerBleOnlyNotice,
                   style: Theme.of(context).textTheme.bodySmall,
                   textAlign: TextAlign.center,
                 ),
@@ -476,14 +472,14 @@ class _Obd2AdapterPickerSheetState
           children: [
             const CircularProgressIndicator(),
             const SizedBox(height: 12),
-            Text(l?.obdPickerConnecting ?? 'Connecting…'),
+            Text(l.obdPickerConnecting),
             // #3181 — while a FIRST-connect setNotify is in flight the OS
             // pairing dialog may be waiting for the user; tell them to
             // confirm it instead of letting the spinner look hung.
             ValueListenableBuilder<bool>(
               valueListenable: Obd2PairingMode.pairingWaitPending,
               builder: (context, pending, _) {
-                if (!pending || l == null) return const SizedBox.shrink();
+                if (!pending) return const SizedBox.shrink();
                 return Padding(
                   key: const Key('obdPickerPairingHint'),
                   padding: const EdgeInsets.only(top: 12),
@@ -517,8 +513,7 @@ class _Obd2AdapterPickerSheetState
             const SizedBox(height: 8),
             Text(
               _error?.localizedMessage(l) ??
-                  l?.errorUnknown ??
-                  'Unknown error',
+                  l.errorUnknown,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 16),
@@ -526,7 +521,7 @@ class _Obd2AdapterPickerSheetState
               key: const Key('obdPickerRetry'),
               onPressed: _startScan,
               icon: const Icon(Icons.refresh),
-              label: Text(l?.retry ?? 'Retry'),
+              label: Text(l.retry),
             ),
             if (isPermissionError) ...[
               const SizedBox(height: 8),
@@ -541,8 +536,7 @@ class _Obd2AdapterPickerSheetState
                 },
                 icon: const Icon(Icons.settings),
                 label: Text(
-                  l?.obdPermissionDenied ??
-                      'Grant Bluetooth permission in system settings',
+                  l.obdPermissionDenied,
                 ),
               ),
             ],

--- a/lib/features/obd2/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -35,7 +35,6 @@ typedef Obd2DiagnosticShareSink = Future<void> Function(ShareParams params);
 @visibleForTesting
 Obd2DiagnosticShareSink? debugObd2DiagnosticShareSinkOverride;
 
-
 /// In-app overlay that renders the most recent fuel-rate breadcrumbs
 /// captured by [Obd2BreadcrumbsNotifier] (#1395). Sibling to the map
 /// debug breadcrumb overlay shipped in PR #1378.
@@ -65,7 +64,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
   /// messenger snackbar when [messenger] is supplied.
   Future<void> _shareDiagnosticLog(
     ScaffoldMessengerState? messenger,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) async {
     final String report = formatObd2DiagnosticReport(
       AutoRecordTraceLog.snapshot(),
@@ -79,7 +78,16 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       try {
         await sink(ShareParams(text: report));
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay diagnostic log sink'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {
+              'where': 'Obd2BreadcrumbOverlay diagnostic log sink',
+            },
+          ),
+        );
       }
     }
     await _alsoSaveToDownloads(
@@ -97,12 +105,12 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
   /// [_shareDiagnosticLog].
   Future<void> _shareSessionXml(
     ScaffoldMessengerState? messenger,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) async {
     final Obd2DebugSession? session = Obd2DebugSessionRecorder.latestSession;
     final String payload = session == null
         ? '<!-- No OBD2 debug session recorded. Enable "OBD2 debug '
-            'logging" in Settings, then reproduce the issue. -->'
+              'logging" in Settings, then reproduce the issue. -->'
         : formatObd2DebugSessionXml(session);
     // Same download-only policy as `_shareDiagnosticLog` — see note
     // there.
@@ -111,7 +119,14 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       try {
         await sink(ShareParams(text: payload));
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay session XML sink'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {'where': 'Obd2BreadcrumbOverlay session XML sink'},
+          ),
+        );
       }
     }
     await _alsoSaveToDownloads(
@@ -131,7 +146,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     required String text,
     required String fileName,
     required ScaffoldMessengerState? messenger,
-    required AppLocalizations? l10n,
+    required AppLocalizations l10n,
   }) async {
     try {
       await PublicFileExporter.saveTextToDownloads(
@@ -141,12 +156,19 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       );
       // #2173 — route through SnackBarHelper for the liveRegion announce.
       messenger?.showSnackBar(
-        SnackBarHelper.infoSnackBar(
-          l10n?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
-        ),
+        SnackBarHelper.infoSnackBar(l10n.savedToDownloadsFolder),
       );
     } on Object catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay save-to-downloads failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'Obd2BreadcrumbOverlay save-to-downloads failed',
+          },
+        ),
+      );
     }
   }
 
@@ -162,7 +184,14 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     try {
       flag = ref.watch(obd2DebugOverlayProvider);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay flag read failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'Obd2BreadcrumbOverlay flag read failed'},
+        ),
+      );
       flag = false;
     }
     final visible = kDebugMode || flag;
@@ -172,7 +201,14 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     try {
       crumbs = ref.watch(obd2BreadcrumbsProvider);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay crumbs read failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'Obd2BreadcrumbOverlay crumbs read failed'},
+        ),
+      );
       crumbs = const [];
     }
     final l10n = AppLocalizations.of(context);
@@ -188,144 +224,135 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       bottom: 8,
       child: ExcludeSemantics(
         child: Material(
-        color: Colors.transparent,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(
-            maxWidth: 280,
-            maxHeight: 360,
-            minWidth: 200,
-            minHeight: 100,
-          ),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.78),
-              borderRadius: BorderRadius.circular(8),
+          color: Colors.transparent,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxWidth: 280,
+              maxHeight: 360,
+              minWidth: 200,
+              minHeight: 100,
             ),
-            child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          l10n?.obd2DebugOverlayTitle ?? 'OBD2 breadcrumbs',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.78),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            l10n.obd2DebugOverlayTitle,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
                         ),
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          ref
-                              .read(obd2BreadcrumbsProvider.notifier)
-                              .clear();
-                        },
-                        style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
+                        TextButton(
+                          onPressed: () {
+                            ref.read(obd2BreadcrumbsProvider.notifier).clear();
+                          },
+                          style: TextButton.styleFrom(
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            minimumSize: const Size(0, 32),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          ),
+                          child: Text(l10n.obd2DebugOverlayClearButton),
+                        ),
+                        // #1920 — export the OBD2 connect/drop/reconnect
+                        // trace as plain text so a developer can analyse
+                        // a failed recording session. The trace ring is
+                        // process-wide, not tied to the fuel-rate
+                        // breadcrumbs above.
+                        IconButton(
+                          onPressed: () => _shareDiagnosticLog(
+                            ScaffoldMessenger.maybeOf(context),
+                            l10n,
+                          ),
+                          icon: const Icon(Icons.share, size: 18),
+                          color: Colors.white,
+                          tooltip: l10n.obd2DiagnosticShareLabel,
                           padding: const EdgeInsets.symmetric(horizontal: 4),
-                          minimumSize: const Size(0, 32),
-                          tapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
+                          constraints: const BoxConstraints(
+                            minWidth: 32,
+                            minHeight: 32,
+                          ),
+                          visualDensity: VisualDensity.compact,
                         ),
-                        child: Text(
-                          l10n?.obd2DebugOverlayClearButton ?? 'Clear',
-                        ),
-                      ),
-                      // #1920 — export the OBD2 connect/drop/reconnect
-                      // trace as plain text so a developer can analyse
-                      // a failed recording session. The trace ring is
-                      // process-wide, not tied to the fuel-rate
-                      // breadcrumbs above.
-                      IconButton(
-                        onPressed: () => _shareDiagnosticLog(
-                          ScaffoldMessenger.maybeOf(context),
-                          l10n,
-                        ),
-                        icon: const Icon(Icons.share, size: 18),
-                        color: Colors.white,
-                        tooltip: l10n?.obd2DiagnosticShareLabel ??
-                            'Share diagnostic log',
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        constraints: const BoxConstraints(
-                          minWidth: 32,
-                          minHeight: 32,
-                        ),
-                        visualDensity: VisualDensity.compact,
-                      ),
-                      // #1925 — export the most recent OBD2 debug
-                      // session (init handshake, data gaps, reconnects)
-                      // as XML when the user enabled debug logging.
-                      IconButton(
-                        onPressed: () => _shareSessionXml(
-                          ScaffoldMessenger.maybeOf(context),
-                          l10n,
-                        ),
-                        icon: const Icon(Icons.bug_report, size: 18),
-                        color: Colors.white,
-                        tooltip: l10n?.obd2DebugSessionShareLabel ??
-                            'Share OBD2 session log',
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        constraints: const BoxConstraints(
-                          minWidth: 32,
-                          minHeight: 32,
-                        ),
-                        visualDensity: VisualDensity.compact,
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          unawaited(ref
-                              .read(obd2DebugOverlayProvider.notifier)
-                              .disable());
-                        },
-                        style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
+                        // #1925 — export the most recent OBD2 debug
+                        // session (init handshake, data gaps, reconnects)
+                        // as XML when the user enabled debug logging.
+                        IconButton(
+                          onPressed: () => _shareSessionXml(
+                            ScaffoldMessenger.maybeOf(context),
+                            l10n,
+                          ),
+                          icon: const Icon(Icons.bug_report, size: 18),
+                          color: Colors.white,
+                          tooltip: l10n.obd2DebugSessionShareLabel,
                           padding: const EdgeInsets.symmetric(horizontal: 4),
-                          minimumSize: const Size(0, 32),
-                          tapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
+                          constraints: const BoxConstraints(
+                            minWidth: 32,
+                            minHeight: 32,
+                          ),
+                          visualDensity: VisualDensity.compact,
                         ),
-                        child: Text(
-                          l10n?.obd2DebugOverlayCloseButton ?? 'Close',
+                        TextButton(
+                          onPressed: () {
+                            unawaited(
+                              ref
+                                  .read(obd2DebugOverlayProvider.notifier)
+                                  .disable(),
+                            );
+                          },
+                          style: TextButton.styleFrom(
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            minimumSize: const Size(0, 32),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          ),
+                          child: Text(l10n.obd2DebugOverlayCloseButton),
                         ),
-                      ),
-                    ],
-                  ),
-                  const Divider(color: Colors.white24, height: 8),
-                  // #1423 phase 5 — broken-MAP belief diagnostic row,
-                  // self-hides when the active vehicle has zero
-                  // observations. Appears above the breadcrumb list so
-                  // the latest belief snapshot is always visible without
-                  // scrolling, even on long crumb sets.
-                  const BrokenMapOverlayRow(),
-                  Flexible(
-                    child: SingleChildScrollView(
-                      reverse: true,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          // Newest-first: walk reversed so the bottom
-                          // of the scroll view shows the most recent
-                          // sample. `reverse: true` on the scroll view
-                          // keeps the freshest row pinned at bottom.
-                          for (final c in crumbs.reversed)
-                            Obd2BreadcrumbRow(crumb: c),
-                        ],
+                      ],
+                    ),
+                    const Divider(color: Colors.white24, height: 8),
+                    // #1423 phase 5 — broken-MAP belief diagnostic row,
+                    // self-hides when the active vehicle has zero
+                    // observations. Appears above the breadcrumb list so
+                    // the latest belief snapshot is always visible without
+                    // scrolling, even on long crumb sets.
+                    const BrokenMapOverlayRow(),
+                    Flexible(
+                      child: SingleChildScrollView(
+                        reverse: true,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            // Newest-first: walk reversed so the bottom
+                            // of the scroll view shows the most recent
+                            // sample. `reverse: true` on the scroll view
+                            // keeps the freshest row pinned at bottom.
+                            for (final c in crumbs.reversed)
+                              Obd2BreadcrumbRow(crumb: c),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
         ),
       ),
-      ),
     );
   }
 }
-

--- a/lib/features/obd2/presentation/widgets/obd2_connect_trace_card.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_connect_trace_card.dart
@@ -46,50 +46,60 @@ class Obd2ConnectTraceCard extends StatelessWidget {
             Text(
               trace.adapterName ??
                   trace.requestedMac ??
-                  (l?.obd2HealthConnectUnknownAdapter ?? 'Unknown adapter'),
-              style: theme.textTheme.titleMedium
-                  ?.copyWith(fontWeight: FontWeight.bold),
+                  (l.obd2HealthConnectUnknownAdapter),
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
             const SizedBox(height: 4),
             // Outcome headline (bold) — the answer to "why didn't it connect".
             Row(
               children: [
-                Icon(failed ? Icons.error_outline : Icons.check_circle_outline,
-                    size: 18, color: accent),
+                Icon(
+                  failed ? Icons.error_outline : Icons.check_circle_outline,
+                  size: 18,
+                  color: accent,
+                ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    '${l?.obd2HealthConnectOutcome ?? 'Outcome'}: '
+                    '${l.obd2HealthConnectOutcome}: '
                     '${trace.outcome?.name ?? 'in progress'}',
-                    style: theme.textTheme.titleSmall
-                        ?.copyWith(color: accent, fontWeight: FontWeight.bold),
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: accent,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
                 if (trace.totalMs != null)
-                  Text('${trace.totalMs} ms', // i18n-ignore: ms unit format mask
-                      style: theme.textTheme.bodySmall?.copyWith(
-                          color: cs.onSurfaceVariant)),
+                  Text(
+                    '${trace.totalMs} ms', // i18n-ignore: ms unit format mask
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
               ],
             ),
             if (trace.failureDetail != null) ...[
               const SizedBox(height: 4),
-              Text(trace.failureDetail!,
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: cs.onSurfaceVariant)),
+              Text(
+                trace.failureDetail!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
             ],
             const SizedBox(height: 6),
-            _kv(theme, l?.obd2HealthConnectOrigin ?? 'Origin', trace.origin.name),
-            _kv(
-              theme,
-              l?.obd2HealthConnectTransport ?? 'Transport',
-              _transportLine(trace),
-            ),
+            _kv(theme, l.obd2HealthConnectOrigin, trace.origin.name),
+            _kv(theme, l.obd2HealthConnectTransport, _transportLine(trace)),
             if (trace.requestedMac != null)
               _kv(theme, 'MAC', trace.requestedMac!), // i18n-ignore: MAC label
             if (trace.scanned.isNotEmpty) ...[
               const SizedBox(height: 6),
-              Text(l?.obd2HealthConnectScanList ?? 'Scanned devices',
-                  style: theme.textTheme.labelMedium),
+              Text(
+                l.obd2HealthConnectScanList,
+                style: theme.textTheme.labelMedium,
+              ),
               for (final d in trace.scanned)
                 Text(
                   '· ${d.name ?? d.redactedMac ?? '?'}'
@@ -100,8 +110,10 @@ class Obd2ConnectTraceCard extends StatelessWidget {
             ],
             if (trace.steps.isNotEmpty) ...[
               const SizedBox(height: 6),
-              Text(l?.obd2HealthConnectSteps ?? 'Steps',
-                  style: theme.textTheme.labelMedium),
+              Text(
+                l.obd2HealthConnectSteps,
+                style: theme.textTheme.labelMedium,
+              ),
               for (final s in trace.steps)
                 Text(
                   '· ${s.label} — ${s.status.name}'
@@ -129,16 +141,19 @@ class Obd2ConnectTraceCard extends StatelessWidget {
   }
 
   Widget _kv(ThemeData theme, String k, String v) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 1),
-        child: Text.rich(
-          TextSpan(children: [
-            TextSpan(
-              text: '$k: ',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+    padding: const EdgeInsets.symmetric(vertical: 1),
+    child: Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: '$k: ',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
             ),
-            TextSpan(text: v, style: theme.textTheme.bodySmall),
-          ]),
-        ),
-      );
+          ),
+          TextSpan(text: v, style: theme.textTheme.bodySmall),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/obd2/presentation/widgets/obd2_diagnostics_card.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_diagnostics_card.dart
@@ -48,10 +48,11 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final summary =
-        enabled ? computeObd2DiagnosticsSummary(session) : Obd2DiagnosticsSummary.empty;
+    final summary = enabled
+        ? computeObd2DiagnosticsSummary(session)
+        : Obd2DiagnosticsSummary.empty;
 
-    final title = l?.obd2DiagnosticsTitle ?? 'OBD2 communication health';
+    final title = l.obd2DiagnosticsTitle;
 
     if (!summary.presentable) {
       return Card(
@@ -61,9 +62,7 @@ class Obd2DiagnosticsCard extends StatelessWidget {
           leading: const Icon(Icons.bluetooth_disabled_outlined),
           title: Text(title, style: theme.textTheme.titleMedium),
           subtitle: Text(
-            l?.obd2DiagnosticsEmpty ??
-                'No OBD2 session recorded yet — connect an adapter and '
-                    'record a trip with Developer mode on.',
+            l.obd2DiagnosticsEmpty,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -72,13 +71,11 @@ class Obd2DiagnosticsCard extends StatelessWidget {
       );
     }
 
-    final headerLine = l?.obd2DiagnosticsHeader(
-          summary.completenessPercent.toString(),
-          summary.activeDutyPercent.toString(),
-          summary.drops,
-        ) ??
-        '${summary.completenessPercent}% complete · '
-            '${summary.activeDutyPercent}% duty · ${summary.drops} drops';
+    final headerLine = l.obd2DiagnosticsHeader(
+      summary.completenessPercent.toString(),
+      summary.activeDutyPercent.toString(),
+      summary.drops,
+    );
 
     return Card(
       margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
@@ -114,9 +111,7 @@ class Obd2DiagnosticsCard extends StatelessWidget {
             ),
           const SizedBox(height: 12),
           Text(
-            l?.obd2DiagnosticsExplain ??
-                'Captured while recording to debug the dongle↔app '
-                    'communication — only collected in Developer mode.',
+            l.obd2DiagnosticsExplain,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -127,47 +122,41 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   }
 
   Widget _sectionHeader(ThemeData theme, String text) => Padding(
-        padding: const EdgeInsets.only(top: 12, bottom: 4),
-        child: Align(
-          alignment: AlignmentDirectional.centerStart,
-          child: Text(
-            text,
-            style: theme.textTheme.titleSmall?.copyWith(
-              color: theme.colorScheme.primary,
-            ),
-          ),
+    padding: const EdgeInsets.only(top: 12, bottom: 4),
+    child: Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: Text(
+        text,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.primary,
         ),
-      );
+      ),
+    ),
+  );
 
   Widget _line(ThemeData theme, String text, {Key? key}) => Align(
-        key: key,
-        alignment: AlignmentDirectional.centerStart,
-        child: Text(text, style: theme.textTheme.bodyMedium),
-      );
+    key: key,
+    alignment: AlignmentDirectional.centerStart,
+    child: Text(text, style: theme.textTheme.bodyMedium),
+  );
 
   // ---- Adapter identity -------------------------------------------------
   Widget _adapterSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
   ) {
     const dash = '—';
-    final identity = l?.obd2DiagnosticsAdapterIdentity(
-          session.redactedMac ?? dash,
-          session.elmVersion ?? dash,
-          session.protocolDigit ?? dash,
-          session.mtu?.toString() ?? dash,
-        ) ??
-        '${session.redactedMac ?? dash} · ${session.elmVersion ?? dash} · '
-            'protocol ${session.protocolDigit ?? dash} · '
-            'MTU ${session.mtu?.toString() ?? dash}';
+    final identity = l.obd2DiagnosticsAdapterIdentity(
+      session.redactedMac ?? dash,
+      session.elmVersion ?? dash,
+      session.protocolDigit ?? dash,
+      session.mtu?.toString() ?? dash,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsAdapterSection ?? 'Adapter',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsAdapterSection),
         _line(theme, identity, key: const Key('obd2_diag_adapter_line')),
       ],
     );
@@ -176,7 +165,7 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   // ---- Connection lifecycle --------------------------------------------
   Widget _connectionSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
     Obd2DiagnosticsSummary summary,
   ) {
@@ -184,28 +173,21 @@ class Obd2DiagnosticsCard extends StatelessWidget {
     final conn = session.connection;
     final p50 = conn.timeToConnectP50Ms?.toString() ?? dash;
     final p95 = conn.timeToConnectP95Ms?.toString() ?? dash;
-    final line = l?.obd2DiagnosticsConnectionLine(
-          conn.attempts,
-          conn.successes,
-          conn.drops,
-          p50,
-          p95,
-        ) ??
-        '${conn.attempts} attempts · ${conn.successes} ok · '
-            '${conn.drops} drops · time-to-connect p50 $p50 / p95 $p95';
-    final reconnects = l?.obd2DiagnosticsReconnectLine(
-          conn.silentReconnects,
-          conn.visibleReconnects,
-        ) ??
-        'Reconnects: ${conn.silentReconnects} silent · '
-            '${conn.visibleReconnects} visible';
+    final line = l.obd2DiagnosticsConnectionLine(
+      conn.attempts,
+      conn.successes,
+      conn.drops,
+      p50,
+      p95,
+    );
+    final reconnects = l.obd2DiagnosticsReconnectLine(
+      conn.silentReconnects,
+      conn.visibleReconnects,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsConnectionSection ?? 'Connection lifecycle',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsConnectionSection),
         _line(theme, line, key: const Key('obd2_diag_connection_line')),
         const SizedBox(height: 4),
         _line(theme, reconnects),
@@ -216,17 +198,14 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   // ---- Per-PID outcome table -------------------------------------------
   Widget _pidSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
     Obd2DiagnosticsSummary summary,
   ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsPidSection ?? 'Per-PID outcomes',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsPidSection),
         for (final row in summary.pidRows)
           _line(
             theme,
@@ -237,50 +216,41 @@ class Obd2DiagnosticsCard extends StatelessWidget {
     );
   }
 
-  String _pidRowText(AppLocalizations? l, Obd2PidRowView row) {
+  String _pidRowText(AppLocalizations l, Obd2PidRowView row) {
     final s = row.stat;
     final eff = s.effectiveHz.toStringAsFixed(2);
     final target = s.targetHz.toStringAsFixed(2);
-    return l?.obd2DiagnosticsPidRow(
-          row.pid,
-          s.polled,
-          s.ok,
-          s.noData,
-          s.timeout,
-          s.error,
-          s.latencyP50Ms,
-          s.latencyP95Ms,
-          eff,
-          target,
-        ) ??
-        '${row.pid}: ${s.polled} polled · ${s.ok} ok · ${s.noData} ND · '
-            '${s.timeout} TO · ${s.error} err · '
-            'p50 ${s.latencyP50Ms} / p95 ${s.latencyP95Ms} ms · '
-            '$eff/$target Hz';
+    return l.obd2DiagnosticsPidRow(
+      row.pid,
+      s.polled,
+      s.ok,
+      s.noData,
+      s.timeout,
+      s.error,
+      s.latencyP50Ms,
+      s.latencyP95Ms,
+      eff,
+      target,
+    );
   }
 
   // ---- Scheduler health -------------------------------------------------
   Widget _schedulerSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
   ) {
     final sch = session.scheduler;
     final tickRate = sch.tickRateHz.toStringAsFixed(1);
-    final line = l?.obd2DiagnosticsSchedulerLine(
-          tickRate,
-          sch.backpressureSkips,
-          sch.demotions,
-        ) ??
-        '$tickRate Hz tick · ${sch.backpressureSkips} back-pressure skips · '
-            '${sch.demotions} demotions';
+    final line = l.obd2DiagnosticsSchedulerLine(
+      tickRate,
+      sch.backpressureSkips,
+      sch.demotions,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsSchedulerSection ?? 'Scheduler health',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsSchedulerSection),
         _line(theme, line, key: const Key('obd2_diag_scheduler_line')),
         if (sch.starved) ...[
           const SizedBox(height: 4),
@@ -288,9 +258,7 @@ class Obd2DiagnosticsCard extends StatelessWidget {
             key: const Key('obd2_diag_starved'),
             alignment: AlignmentDirectional.centerStart,
             child: Text(
-              l?.obd2DiagnosticsStarved ??
-                  'Dynamics tier starved — RPM / speed fell below the '
-                      'governor floor.',
+              l.obd2DiagnosticsStarved,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.error,
               ),
@@ -304,29 +272,23 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   // ---- Completeness rollup ---------------------------------------------
   Widget _completenessSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
     Obd2DiagnosticsSummary summary,
   ) {
-    final overall = l?.obd2DiagnosticsCompletenessLine(
-          summary.completenessPercent.toString(),
-          summary.activeDutyPercent.toString(),
-        ) ??
-        'Overall ${summary.completenessPercent}% · '
-            'active duty ${summary.activeDutyPercent}%';
+    final overall = l.obd2DiagnosticsCompletenessLine(
+      summary.completenessPercent.toString(),
+      summary.activeDutyPercent.toString(),
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsCompletenessSection ?? 'Completeness',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsCompletenessSection),
         _line(theme, overall, key: const Key('obd2_diag_completeness_line')),
         for (final entry in summary.perTierPercent.entries)
           _line(
             theme,
-            l?.obd2DiagnosticsTierLine(entry.key, entry.value.toString()) ??
-                '${entry.key}: ${entry.value}%',
+            l.obd2DiagnosticsTierLine(entry.key, entry.value.toString()),
             key: Key('obd2_diag_tier_${entry.key}'),
           ),
       ],
@@ -336,25 +298,19 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   // ---- Discovered-supported tri-state ----------------------------------
   Widget _supportSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
     Obd2DiagnosticsSummary summary,
   ) {
-    final line = l?.obd2DiagnosticsSupportLine(
-          summary.supportedCount,
-          summary.unsupportedCount,
-          summary.unknownCount,
-        ) ??
-        '${summary.supportedCount} supported · '
-            '${summary.unsupportedCount} unsupported · '
-            '${summary.unknownCount} unknown';
+    final line = l.obd2DiagnosticsSupportLine(
+      summary.supportedCount,
+      summary.unsupportedCount,
+      summary.unknownCount,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsSupportSection ?? 'Discovered-supported PIDs',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsSupportSection),
         _line(theme, line, key: const Key('obd2_diag_support_line')),
       ],
     );
@@ -363,23 +319,18 @@ class Obd2DiagnosticsCard extends StatelessWidget {
   // ---- Fuel-tier rollup -------------------------------------------------
   Widget _fuelSection(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     ThemeData theme,
     Obd2DiagnosticsSummary summary,
   ) {
-    final line = l?.obd2DiagnosticsFuelLine(
-          summary.fuelSuspicious,
-          summary.fuelTotal,
-        ) ??
-        'Suspicious ${summary.fuelSuspicious} of ${summary.fuelTotal} '
-            'samples';
+    final line = l.obd2DiagnosticsFuelLine(
+      summary.fuelSuspicious,
+      summary.fuelTotal,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _sectionHeader(
-          theme,
-          l?.obd2DiagnosticsFuelSection ?? 'Fuel-tier rollup',
-        ),
+        _sectionHeader(theme, l.obd2DiagnosticsFuelSection),
         _line(theme, line, key: const Key('obd2_diag_fuel_line')),
       ],
     );

--- a/lib/features/obd2/presentation/widgets/obd2_init_transcript_section.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_init_transcript_section.dart
@@ -46,18 +46,15 @@ class Obd2InitTranscriptSection extends StatelessWidget {
     const dash = '—';
 
     final start = (session.warmStart ?? false)
-        ? (l?.obd2DiagnosticsInitWarm ?? 'warm')
-        : (l?.obd2DiagnosticsInitCold ?? 'cold');
-    final header = l?.obd2DiagnosticsInitHeader(
-          session.protocolDigit ?? dash,
-          start,
-          session.elmVersion ?? dash,
-          session.capabilityTier ?? dash,
-          supportedCount,
-        ) ??
-        'Protocol ${session.protocolDigit ?? dash} · $start · '
-            'firmware ${session.elmVersion ?? dash} · '
-            '${session.capabilityTier ?? dash} · $supportedCount PIDs';
+        ? (l.obd2DiagnosticsInitWarm)
+        : (l.obd2DiagnosticsInitCold);
+    final header = l.obd2DiagnosticsInitHeader(
+      session.protocolDigit ?? dash,
+      start,
+      session.elmVersion ?? dash,
+      session.capabilityTier ?? dash,
+      supportedCount,
+    );
 
     final mono = theme.textTheme.bodySmall?.copyWith(
       fontFamily: 'monospace',
@@ -72,7 +69,7 @@ class Obd2InitTranscriptSection extends StatelessWidget {
           child: Align(
             alignment: AlignmentDirectional.centerStart,
             child: Text(
-              l?.obd2DiagnosticsInitSection ?? 'Dongle init transcript',
+              l.obd2DiagnosticsInitSection,
               style: theme.textTheme.titleSmall?.copyWith(
                 color: theme.colorScheme.primary,
               ),
@@ -90,14 +87,11 @@ class Obd2InitTranscriptSection extends StatelessWidget {
             key: Key('obd2_diag_init_line_$i'),
             alignment: AlignmentDirectional.centerStart,
             child: Text(
-              l?.obd2DiagnosticsInitLine(
-                    session.initTranscript[i].cmd,
-                    session.initTranscript[i].response,
-                    session.initTranscript[i].latencyMs,
-                  ) ??
-                  '${session.initTranscript[i].cmd} → '
-                      '${session.initTranscript[i].response} '
-                      '(${session.initTranscript[i].latencyMs} ms)',
+              l.obd2DiagnosticsInitLine(
+                session.initTranscript[i].cmd,
+                session.initTranscript[i].response,
+                session.initTranscript[i].latencyMs,
+              ),
               style: mono,
             ),
           ),

--- a/lib/features/obd2/presentation/widgets/obd2_pause_banner.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_pause_banner.dart
@@ -38,9 +38,7 @@ class Obd2PauseBanner extends ConsumerWidget {
     // Watching only the phase (via select) means unrelated state
     // changes — live readings, band transitions — don't rebuild the
     // banner. The wider TripRecordingBanner already rebuilds on those.
-    final phase = ref.watch(
-      tripRecordingProvider.select((s) => s.phase),
-    );
+    final phase = ref.watch(tripRecordingProvider.select((s) => s.phase));
     if (phase != TripRecordingPhase.pausedDueToDrop) {
       return const SizedBox.shrink();
     }
@@ -54,9 +52,7 @@ class Obd2PauseBanner extends ConsumerWidget {
     return MaterialBanner(
       key: const Key('obd2PauseBanner'),
       backgroundColor: theme.colorScheme.errorContainer,
-      contentTextStyle: TextStyle(
-        color: theme.colorScheme.onErrorContainer,
-      ),
+      contentTextStyle: TextStyle(color: theme.colorScheme.onErrorContainer),
       leading: Icon(
         isSilentFailure
             ? Icons.report_gmailerrorred_outlined
@@ -65,25 +61,19 @@ class Obd2PauseBanner extends ConsumerWidget {
       ),
       content: Text(
         isSilentFailure
-            ? (l?.tripRecordingObd2NotResponding ??
-                'OBD2 adapter connected but not returning data. Try a '
-                "different adapter or check the vehicle's diagnostic "
-                'protocol.')
-            : (l?.obd2PauseBannerTitle ??
-                'OBD2 connection lost — recording paused'),
+            ? (l.tripRecordingObd2NotResponding)
+            : (l.obd2PauseBannerTitle),
       ),
       actions: [
         TextButton(
           key: const Key('obd2PauseBannerResume'),
-          onPressed: () =>
-              ref.read(tripRecordingProvider.notifier).resume(),
-          child: Text(l?.obd2PauseBannerResume ?? 'Resume recording'),
+          onPressed: () => ref.read(tripRecordingProvider.notifier).resume(),
+          child: Text(l.obd2PauseBannerResume),
         ),
         TextButton(
           key: const Key('obd2PauseBannerEnd'),
-          onPressed: () =>
-              ref.read(tripRecordingProvider.notifier).stop(),
-          child: Text(l?.obd2PauseBannerEnd ?? 'End recording'),
+          onPressed: () => ref.read(tripRecordingProvider.notifier).stop(),
+          child: Text(l.obd2PauseBannerEnd),
         ),
       ],
     );

--- a/lib/features/obd2/presentation/widgets/obd2_reconnect_retry_banner.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_reconnect_retry_banner.dart
@@ -57,19 +57,19 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
 
   Widget _reconnectingBanner(
     ThemeData theme,
-    AppLocalizations? l,
+    AppLocalizations l,
     String? adapterName,
   ) {
     final hasName = adapterName != null && adapterName.isNotEmpty;
     final text = hasName
-        ? (l?.obd2ReconnectInProgressNamed(adapterName) ??
-            'Reconnecting to $adapterName…')
-        : (l?.obd2ReconnectInProgress ?? 'Reconnecting to your OBD2 adapter…');
+        ? (l.obd2ReconnectInProgressNamed(adapterName))
+        : (l.obd2ReconnectInProgress);
     return MaterialBanner(
       key: const Key('obd2ReconnectingBanner'),
       backgroundColor: theme.colorScheme.secondaryContainer,
-      contentTextStyle:
-          TextStyle(color: theme.colorScheme.onSecondaryContainer),
+      contentTextStyle: TextStyle(
+        color: theme.colorScheme.onSecondaryContainer,
+      ),
       leading: SizedBox(
         width: 20,
         height: 20,
@@ -88,7 +88,7 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     ThemeData theme,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) {
     return MaterialBanner(
       key: const Key('obd2ReconnectFailedBanner'),
@@ -98,17 +98,12 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
         Icons.bluetooth_disabled,
         color: theme.colorScheme.onErrorContainer,
       ),
-      content: Text(
-        l?.obd2ReconnectFailedBody ??
-            'The OBD2 connection was lost and automatic reconnection didn’t '
-                'succeed. Check the adapter is powered and in range, then tap '
-                'retry.',
-      ),
+      content: Text(l.obd2ReconnectFailedBody),
       actions: [
         TextButton(
           key: const Key('obd2ReconnectRetryButton'),
           onPressed: () => ref.read(obd2ReconnectProvider.notifier).retry(),
-          child: Text(l?.obd2ReconnectRetry ?? 'Tap to retry'),
+          child: Text(l.obd2ReconnectRetry),
         ),
       ],
     );
@@ -125,26 +120,22 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     ThemeData theme,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) {
     return MaterialBanner(
       key: const Key('obd2ReconnectEngineOffBanner'),
       backgroundColor: theme.colorScheme.tertiaryContainer,
-      contentTextStyle:
-          TextStyle(color: theme.colorScheme.onTertiaryContainer),
+      contentTextStyle: TextStyle(color: theme.colorScheme.onTertiaryContainer),
       leading: Icon(
         Icons.power_settings_new,
         color: theme.colorScheme.onTertiaryContainer,
       ),
-      content: Text(
-        l?.obdAdapterUnresponsive ??
-            'Adapter didn’t answer — turn the ignition on and retry',
-      ),
+      content: Text(l.obdAdapterUnresponsive),
       actions: [
         TextButton(
           key: const Key('obd2ReconnectEngineOffRetryButton'),
           onPressed: () => ref.read(obd2ReconnectProvider.notifier).retry(),
-          child: Text(l?.obd2ReconnectRetry ?? 'Tap to retry'),
+          child: Text(l.obd2ReconnectRetry),
         ),
       ],
     );

--- a/lib/features/obd2/presentation/widgets/obd2_reconnect_section.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_reconnect_section.dart
@@ -29,16 +29,12 @@ class Obd2ReconnectSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final line = l?.obd2DiagnosticsReconnectAttemptsLine(
-          summary.reconnectAttemptCount,
-          summary.reconnectSuccessCount,
-          summary.transitionCount,
-          summary.disconnectExceptions,
-        ) ??
-        '${summary.reconnectAttemptCount} reconnect attempts · '
-            '${summary.reconnectSuccessCount} ok · '
-            '${summary.transitionCount} transitions · '
-            '${summary.disconnectExceptions} typed drops';
+    final line = l.obd2DiagnosticsReconnectAttemptsLine(
+      summary.reconnectAttemptCount,
+      summary.reconnectSuccessCount,
+      summary.transitionCount,
+      summary.disconnectExceptions,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -47,7 +43,7 @@ class Obd2ReconnectSection extends StatelessWidget {
           child: Align(
             alignment: AlignmentDirectional.centerStart,
             child: Text(
-              l?.obd2DiagnosticsReconnectSection ?? 'Reconnect telemetry',
+              l.obd2DiagnosticsReconnectSection,
               style: theme.textTheme.titleSmall?.copyWith(
                 color: theme.colorScheme.primary,
               ),
@@ -58,16 +54,14 @@ class Obd2ReconnectSection extends StatelessWidget {
         for (final entry in summary.reconnectReasonCounts.entries)
           _line(
             theme,
-            l?.obd2DiagnosticsReconnectReasonLine(entry.key, entry.value) ??
-                '${entry.key}: ${entry.value}',
+            l.obd2DiagnosticsReconnectReasonLine(entry.key, entry.value),
             key: Key('obd2_diag_reconnect_reason_${entry.key}'),
           ),
         if (summary.fallbackActivated) ...[
           const SizedBox(height: 4),
           _line(
             theme,
-            l?.obd2DiagnosticsFallbackLine ??
-                'GPS-only fallback activated this session.',
+            l.obd2DiagnosticsFallbackLine,
             key: const Key('obd2_diag_fallback_line'),
           ),
         ],
@@ -76,8 +70,8 @@ class Obd2ReconnectSection extends StatelessWidget {
   }
 
   Widget _line(ThemeData theme, String text, {Key? key}) => Align(
-        key: key,
-        alignment: AlignmentDirectional.centerStart,
-        child: Text(text, style: theme.textTheme.bodyMedium),
-      );
+    key: key,
+    alignment: AlignmentDirectional.centerStart,
+    child: Text(text, style: theme.textTheme.bodyMedium),
+  );
 }

--- a/lib/features/obd2/presentation/widgets/obd2_status_chip.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_status_chip.dart
@@ -38,8 +38,7 @@ class Obd2StatusChip extends ConsumerWidget {
 
     if (snapshot.state == Obd2ConnectionState.connected) {
       final name = snapshot.adapterName ?? '';
-      final tooltip = l?.obd2ConnectedTooltip(name) ??
-          'OBD2 connected: $name';
+      final tooltip = l.obd2ConnectedTooltip(name);
       return IconButton(
         key: const Key('obd2StatusChip'),
         tooltip: tooltip,
@@ -51,10 +50,7 @@ class Obd2StatusChip extends ConsumerWidget {
         // Shrink the hit region to keep the icon visually compact but
         // leave the real tap target at 48 dp so
         // androidTapTargetGuideline still passes.
-        constraints: const BoxConstraints(
-          minWidth: 48,
-          minHeight: 48,
-        ),
+        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
         padding: EdgeInsets.zero,
         onPressed: () => showObd2AdapterPicker(context),
       );
@@ -70,16 +66,13 @@ class Obd2StatusChip extends ConsumerWidget {
     }
     return IconButton(
       key: const Key('obd2PairChip'),
-      tooltip: l?.obd2PairChipTooltip ?? 'Pair an OBD2 adapter',
+      tooltip: l.obd2PairChipTooltip,
       icon: Icon(
         Icons.bluetooth_searching,
         size: 16,
         color: theme.colorScheme.onSurfaceVariant,
       ),
-      constraints: const BoxConstraints(
-        minWidth: 48,
-        minHeight: 48,
-      ),
+      constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
       padding: EdgeInsets.zero,
       onPressed: () => showObd2AdapterPicker(context),
     );

--- a/lib/features/obd2/presentation/widgets/obd2_status_dot.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_status_dot.dart
@@ -42,10 +42,7 @@ class Obd2StatusDot extends ConsumerWidget {
           child: Container(
             width: 10,
             height: 10,
-            decoration: BoxDecoration(
-              color: color,
-              shape: BoxShape.circle,
-            ),
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
           ),
         ),
       ),
@@ -55,20 +52,13 @@ class Obd2StatusDot extends ConsumerWidget {
   (Color, String) _styleFor(
     BuildContext context,
     Obd2ConnectionSnapshot s,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) {
     switch (s.state) {
       case Obd2ConnectionState.connected:
-        return (
-          DarkModeColors.success(context),
-          l?.obd2StatusConnected ?? 'OBD2 adapter: connected',
-        );
+        return (DarkModeColors.success(context), l.obd2StatusConnected);
       case Obd2ConnectionState.permissionDenied:
-        return (
-          DarkModeColors.error(context),
-          l?.obd2StatusPermissionDenied ??
-              'OBD2 adapter: Bluetooth permission needed',
-        );
+        return (DarkModeColors.error(context), l.obd2StatusPermissionDenied);
       case Obd2ConnectionState.idle:
         // Never reached — guarded by hasVisibleIndicator above.
         return (Colors.grey, '');
@@ -79,69 +69,63 @@ class Obd2StatusDot extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     Obd2ConnectionSnapshot snapshot,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) {
-    final name = snapshot.adapterName ??
-        (l?.obd2StatusNoAdapter ?? 'No adapter paired');
+    final name = snapshot.adapterName ?? (l.obd2StatusNoAdapter);
     final mac = snapshot.adapterMac;
-    unawaited(showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (ctx) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  name,
-                  style: Theme.of(ctx).textTheme.titleMedium,
-                ),
-                if (mac != null) ...[
-                  const SizedBox(height: 4),
-                  Text(mac, style: Theme.of(ctx).textTheme.bodySmall),
-                ],
-                const SizedBox(height: 12),
-                Text(
-                  _description(snapshot.state, l),
-                  style: Theme.of(ctx).textTheme.bodyMedium,
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      key: const Key('obd2StatusDotForget'),
-                      onPressed: () {
-                        ref
-                            .read(obd2ConnectionStatusProvider.notifier)
-                            .markIdle();
-                        Navigator.of(ctx).pop();
-                      },
-                      child: Text(
-                        l?.obd2StatusForget ?? 'Forget adapter',
-                      ),
-                    ),
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        showDragHandle: true,
+        builder: (ctx) {
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(name, style: Theme.of(ctx).textTheme.titleMedium),
+                  if (mac != null) ...[
+                    const SizedBox(height: 4),
+                    Text(mac, style: Theme.of(ctx).textTheme.bodySmall),
                   ],
-                ),
-              ],
+                  const SizedBox(height: 12),
+                  Text(
+                    _description(snapshot.state, l),
+                    style: Theme.of(ctx).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        key: const Key('obd2StatusDotForget'),
+                        onPressed: () {
+                          ref
+                              .read(obd2ConnectionStatusProvider.notifier)
+                              .markIdle();
+                          Navigator.of(ctx).pop();
+                        },
+                        child: Text(l.obd2StatusForget),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
-          ),
-        );
-      },
-    ));
+          );
+        },
+      ),
+    );
   }
 
-  String _description(Obd2ConnectionState s, AppLocalizations? l) {
+  String _description(Obd2ConnectionState s, AppLocalizations l) {
     switch (s) {
       case Obd2ConnectionState.connected:
-        return l?.obd2StatusConnectedBody ??
-            'Ready to record a trip.';
+        return l.obd2StatusConnectedBody;
       case Obd2ConnectionState.permissionDenied:
-        return l?.obd2StatusPermissionDeniedBody ??
-            'Grant Bluetooth permission in system settings to reconnect automatically.';
+        return l.obd2StatusPermissionDeniedBody;
       case Obd2ConnectionState.idle:
         return '';
     }

--- a/lib/features/payment/presentation/scan_payment_dispatcher.dart
+++ b/lib/features/payment/presentation/scan_payment_dispatcher.dart
@@ -106,9 +106,7 @@ class ScanPaymentDispatcher {
   static Future<ScanPaymentOutcome> _tryLaunch(Uri uri) async {
     try {
       final ok = await launcher(uri, mode: LaunchMode.externalApplication);
-      return ok
-          ? ScanPaymentOutcome.launched
-          : ScanPaymentOutcome.launchFailed;
+      return ok ? ScanPaymentOutcome.launched : ScanPaymentOutcome.launchFailed;
     } on Exception catch (e, st) {
       debugPrint('ScanPaymentDispatcher launch failed: $e\n$st');
       return ScanPaymentOutcome.launchFailed;
@@ -139,11 +137,17 @@ class ScanPaymentDispatcher {
     };
 
     for (final scheme in const ['sepa', 'iban']) {
-      final uri = Uri(scheme: scheme, host: 'transfer', queryParameters: params);
+      final uri = Uri(
+        scheme: scheme,
+        host: 'transfer',
+        queryParameters: params,
+      );
       try {
         if (await probe(uri)) {
-          final launched = await launcher(uri,
-              mode: LaunchMode.externalApplication);
+          final launched = await launcher(
+            uri,
+            mode: LaunchMode.externalApplication,
+          );
           if (launched) return EpcLaunchOutcome.launched;
         }
       } on Exception catch (e, st) {
@@ -175,38 +179,36 @@ class ScanPaymentDispatcher {
       if (epc.beneficiary != null && epc.beneficiary!.isNotEmpty)
         ListTile(
           dense: true,
-          title: Text(l10n?.qrPaymentBeneficiary ?? 'Beneficiary'),
+          title: Text(l10n.qrPaymentBeneficiary),
           subtitle: Text(epc.beneficiary!),
         ),
       if (epc.iban != null && epc.iban!.isNotEmpty)
         ListTile(
           dense: true,
-          title: const Text('IBAN'), // i18n-ignore: standardised banking acronym (language-neutral)
+          title: const Text('IBAN'), // i18n-ignore: banking acronym
           subtitle: Text(epc.iban!),
         ),
       if (epc.amountEur != null)
         ListTile(
           dense: true,
-          title: Text(l10n?.qrPaymentAmount ?? 'Amount'),
+          title: Text(l10n.qrPaymentAmount),
           subtitle: Text('${epc.amountEur!.toStringAsFixed(2)} €'),
         ),
     ];
     return AlertDialog(
-      title: Text(l10n?.qrPaymentEpcTitle ?? 'SEPA payment'),
+      title: Text(l10n.qrPaymentEpcTitle),
       content: Column(
         mainAxisSize: MainAxisSize.min,
-        children: items.isEmpty
-            ? [Text(l10n?.qrPaymentEpcEmpty ?? 'No fields decoded')]
-            : items,
+        children: items.isEmpty ? [Text(l10n.qrPaymentEpcEmpty)] : items,
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: Text(l10n?.cancel ?? 'Cancel'),
+          child: Text(l10n.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(true),
-          child: Text(l10n?.qrPaymentOpenInBank ?? 'Open in bank app'),
+          child: Text(l10n.qrPaymentOpenInBank),
         ),
       ],
     );

--- a/lib/features/payment/presentation/widgets/unknown_qr_dialog.dart
+++ b/lib/features/payment/presentation/widgets/unknown_qr_dialog.dart
@@ -40,12 +40,10 @@ class UnknownQrDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return AlertDialog(
-      title: Text(l10n?.qrPaymentUnknownTitle ?? 'Unrecognised code'),
+      title: Text(l10n.qrPaymentUnknownTitle),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxHeight: 240),
-        child: SingleChildScrollView(
-          child: SelectableText(raw),
-        ),
+        child: SingleChildScrollView(child: SelectableText(raw)),
       ),
       actions: [
         TextButton.icon(
@@ -54,13 +52,10 @@ class UnknownQrDialog extends StatelessWidget {
             await _writeClipboard(raw);
             if (!context.mounted) return;
             Navigator.of(context).pop();
-            SnackBarHelper.showSuccess(
-              context,
-              l10n?.qrPaymentCopiedRaw ?? 'Copied to clipboard',
-            );
+            SnackBarHelper.showSuccess(context, l10n.qrPaymentCopiedRaw);
           },
           icon: const Icon(Icons.copy),
-          label: Text(l10n?.qrPaymentCopyRaw ?? 'Copy raw text'),
+          label: Text(l10n.qrPaymentCopyRaw),
         ),
         TextButton.icon(
           key: const Key('unknownQrReport'),
@@ -73,11 +68,11 @@ class UnknownQrDialog extends StatelessWidget {
             }
           },
           icon: const Icon(Icons.flag_outlined),
-          label: Text(l10n?.qrPaymentReport ?? 'Report this scan'),
+          label: Text(l10n.qrPaymentReport),
         ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n?.cancel ?? 'Cancel'),
+          child: Text(l10n.cancel),
         ),
       ],
     );

--- a/lib/features/price_history/presentation/screens/price_history_screen.dart
+++ b/lib/features/price_history/presentation/screens/price_history_screen.dart
@@ -28,15 +28,15 @@ class PriceHistoryScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
 
     return PageScaffold(
-      title: l10n?.priceHistory ?? 'Price History',
+      title: l10n.priceHistory,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
         onPressed: () => context.pop(),
       ),
       bodyPadding: EdgeInsets.zero,
       body: history.isEmpty
-          ? Center(child: Text(l10n?.noPriceHistory ?? 'No price history yet'))
+          ? Center(child: Text(l10n.noPriceHistory))
           : ListView(
               padding: const EdgeInsets.all(16),
               children: [
@@ -92,9 +92,9 @@ class _FuelTypeSection extends ConsumerWidget {
           children: [
             Text(
               fuelType.displayName,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
             PriceChart(records: List.from(records), fuelType: fuelType),

--- a/lib/features/price_history/presentation/widgets/fill_up_guidance_card.dart
+++ b/lib/features/price_history/presentation/widgets/fill_up_guidance_card.dart
@@ -29,8 +29,7 @@ class FillUpGuidanceCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final guidance =
-        ref.watch(fillUpGuidanceProvider(stationId, fuelType));
+    final guidance = ref.watch(fillUpGuidanceProvider(stationId, fuelType));
     if (guidance == null) return const SizedBox.shrink();
 
     final l = AppLocalizations.of(context);
@@ -55,7 +54,7 @@ class FillUpGuidanceCard extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    l?.fillUpGuidanceTitle ?? 'Best time to fill up',
+                    l.fillUpGuidanceTitle,
                     style: theme.textTheme.labelLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: accent,
@@ -75,8 +74,7 @@ class FillUpGuidanceCard extends ConsumerWidget {
                   ],
                   const SizedBox(height: 2),
                   Text(
-                    l?.fillUpGuidanceSampleNote(guidance.sampleCount) ??
-                        'Based on ${guidance.sampleCount} readings',
+                    l.fillUpGuidanceSampleNote(guidance.sampleCount),
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
@@ -93,50 +91,42 @@ class FillUpGuidanceCard extends ConsumerWidget {
   (IconData, Color) _iconFor(BuildContext context, FillUpGuidanceKind kind) {
     return switch (kind) {
       FillUpGuidanceKind.goodTimeNow => (
-          Icons.local_gas_station,
-          DarkModeColors.success(context),
-        ),
+        Icons.local_gas_station,
+        DarkModeColors.success(context),
+      ),
       FillUpGuidanceKind.waitCheaperWindow => (
-          Icons.schedule,
-          DarkModeColors.warning(context),
-        ),
+        Icons.schedule,
+        DarkModeColors.warning(context),
+      ),
       FillUpGuidanceKind.fillSoonRising => (
-          Icons.trending_up,
-          DarkModeColors.error(context),
-        ),
-      FillUpGuidanceKind.neutral ||
-      FillUpGuidanceKind.insufficientData =>
-        (
-          Icons.info_outline,
-          Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
+        Icons.trending_up,
+        DarkModeColors.error(context),
+      ),
+      FillUpGuidanceKind.neutral || FillUpGuidanceKind.insufficientData => (
+        Icons.info_outline,
+        Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
     };
   }
 
-  String _message(AppLocalizations? l, FillUpGuidance g) {
+  String _message(AppLocalizations l, FillUpGuidance g) {
     switch (g.kind) {
       case FillUpGuidanceKind.goodTimeNow:
-        return l?.fillUpGuidanceGoodTimeNow(g.windowDays) ??
-            'The current price is in the cheapest part of the last '
-                '${g.windowDays} days — a good time to fill up.';
+        return l.fillUpGuidanceGoodTimeNow(g.windowDays);
       case FillUpGuidanceKind.waitCheaperWindow:
         final window = _windowPhrase(l, g);
-        return l?.fillUpGuidanceWaitCheaper(g.windowDays, window) ??
-            'Prices are near their ${g.windowDays}-day high. They are '
-                'typically cheaper $window — consider waiting.';
+        return l.fillUpGuidanceWaitCheaper(g.windowDays, window);
       case FillUpGuidanceKind.fillSoonRising:
-        return l?.fillUpGuidanceFillSoon ??
-            'Prices are trending up — consider filling up soon.';
+        return l.fillUpGuidanceFillSoon;
       case FillUpGuidanceKind.neutral:
       case FillUpGuidanceKind.insufficientData:
-        return l?.fillUpGuidanceNeutral(g.windowDays) ??
-            "Today's price is around the ${g.windowDays}-day average.";
+        return l.fillUpGuidanceNeutral(g.windowDays);
     }
   }
 
   /// Builds the localized "when it's cheaper" phrase from whichever
   /// of day-of-week / day-part the heuristic surfaced.
-  String _windowPhrase(AppLocalizations? l, FillUpGuidance g) {
+  String _windowPhrase(AppLocalizations l, FillUpGuidance g) {
     final day = g.cheapestDayOfWeek == null
         ? null
         : _weekdayName(l, g.cheapestDayOfWeek!);
@@ -145,26 +135,25 @@ class FillUpGuidanceCard extends ConsumerWidget {
         : _dayPartName(l, g.cheapestDayPart!);
 
     if (day != null && part != null) {
-      return l?.fillUpGuidanceWindowDayAndPart(day, part) ?? '$day $part';
+      return l.fillUpGuidanceWindowDayAndPart(day, part);
     }
     if (day != null) {
-      return l?.fillUpGuidanceWindowDayOnly(day) ?? 'on $day';
+      return l.fillUpGuidanceWindowDayOnly(day);
     }
     if (part != null) {
-      return l?.fillUpGuidanceWindowPartOnly(part) ?? 'in the $part';
+      return l.fillUpGuidanceWindowPartOnly(part);
     }
-    return l?.fillUpGuidanceWindowGeneric ?? 'at other times';
+    return l.fillUpGuidanceWindowGeneric;
   }
 
-  String? _savingLine(AppLocalizations? l, FillUpGuidance g) {
+  String? _savingLine(AppLocalizations l, FillUpGuidance g) {
     final saving = g.potentialSavingPerLitre;
     if (saving == null) return null;
     final amount = PriceFormatter.formatPrice(saving);
-    return l?.fillUpGuidanceSaving(amount) ?? 'Could save about $amount/L';
+    return l.fillUpGuidanceSaving(amount);
   }
 
-  String _weekdayName(AppLocalizations? l, int weekday) {
-    if (l == null) return _fallbackWeekday(weekday);
+  String _weekdayName(AppLocalizations l, int weekday) {
     return switch (weekday) {
       1 => l.fillUpGuidanceWeekday1,
       2 => l.fillUpGuidanceWeekday2,
@@ -176,8 +165,7 @@ class FillUpGuidanceCard extends ConsumerWidget {
     };
   }
 
-  String _dayPartName(AppLocalizations? l, DayPart part) {
-    if (l == null) return part.name;
+  String _dayPartName(AppLocalizations l, DayPart part) {
     return switch (part) {
       DayPart.earlyMorning => l.fillUpGuidancePartEarlyMorning,
       DayPart.morning => l.fillUpGuidancePartMorning,
@@ -186,14 +174,4 @@ class FillUpGuidanceCard extends ConsumerWidget {
       DayPart.night => l.fillUpGuidancePartNight,
     };
   }
-
-  String _fallbackWeekday(int weekday) => const {
-        1: 'Monday',
-        2: 'Tuesday',
-        3: 'Wednesday',
-        4: 'Thursday',
-        5: 'Friday',
-        6: 'Saturday',
-        7: 'Sunday',
-      }[weekday]!;
 }

--- a/lib/features/price_history/presentation/widgets/price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/price_chart.dart
@@ -41,11 +41,9 @@ class PriceChart extends StatefulWidget {
     for (int i = 0; i < reversed.length; i++) {
       final price = priceForFuelType(reversed[i], fuelType);
       if (price != null) {
-        points.add(ChartPoint(
-          index: i,
-          price: price,
-          date: reversed[i].recordedAt,
-        ));
+        points.add(
+          ChartPoint(index: i, price: price, date: reversed[i].recordedAt),
+        );
       }
     }
     return points;
@@ -82,7 +80,7 @@ class _PriceChartState extends State<PriceChart> {
       final l = AppLocalizations.of(context);
       return SizedBox(
         height: _chartHeight,
-        child: Center(child: Text(l?.noPriceHistory ?? 'No price history yet')),
+        child: Center(child: Text(l.noPriceHistory)),
       );
     }
 
@@ -92,8 +90,9 @@ class _PriceChartState extends State<PriceChart> {
     final locale = Localizations.localeOf(context).toString();
     final dateFormat = DateFormat.Md(locale);
 
-    final selected =
-        (_selected != null && _selected! < points.length) ? _selected : null;
+    final selected = (_selected != null && _selected! < points.length)
+        ? _selected
+        : null;
 
     return SizedBox(
       height: _chartHeight,
@@ -195,11 +194,7 @@ class _PriceChartPainter extends CustomPainter {
       final dotPaint = Paint()
         ..color = color
         ..style = PaintingStyle.fill;
-      canvas.drawCircle(
-        Offset(size.width / 2, size.height / 2),
-        4,
-        dotPaint,
-      );
+      canvas.drawCircle(Offset(size.width / 2, size.height / 2), 4, dotPaint);
       return;
     }
 
@@ -242,11 +237,15 @@ class _PriceChartPainter extends CustomPainter {
       ..strokeJoin = StrokeJoin.round;
 
     final path = Path();
-    path.moveTo(layout.xForIndex(points.first.index),
-        layout.yForPrice(points.first.price));
+    path.moveTo(
+      layout.xForIndex(points.first.index),
+      layout.yForPrice(points.first.price),
+    );
     for (int i = 1; i < points.length; i++) {
       path.lineTo(
-          layout.xForIndex(points[i].index), layout.yForPrice(points[i].price));
+        layout.xForIndex(points[i].index),
+        layout.yForPrice(points[i].price),
+      );
     }
     canvas.drawPath(path, linePaint);
 
@@ -278,8 +277,10 @@ class _PriceChartPainter extends CustomPainter {
     // Highlight the selected point with a ring.
     if (selectedIndex != null && selectedIndex! < points.length) {
       final sel = points[selectedIndex!];
-      final center =
-          Offset(layout.xForIndex(sel.index), layout.yForPrice(sel.price));
+      final center = Offset(
+        layout.xForIndex(sel.index),
+        layout.yForPrice(sel.price),
+      );
       canvas.drawCircle(center, 5, dotPaint);
       canvas.drawCircle(
         center,

--- a/lib/features/price_history/presentation/widgets/price_stats_card.dart
+++ b/lib/features/price_history/presentation/widgets/price_stats_card.dart
@@ -13,10 +13,7 @@ import '../../domain/entities/price_stats.dart';
 class PriceStatsCard extends StatelessWidget {
   final PriceStats stats;
 
-  const PriceStatsCard({
-    super.key,
-    required this.stats,
-  });
+  const PriceStatsCard({super.key, required this.stats});
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +23,7 @@ class PriceStatsCard extends StatelessWidget {
       final l = AppLocalizations.of(context);
       return Padding(
         padding: const EdgeInsets.all(16),
-        child: Text(l?.noStatistics ?? 'No statistics available'),
+        child: Text(l.noStatistics),
       );
     }
 
@@ -84,16 +81,16 @@ class _StatItem extends StatelessWidget {
         Text(
           label,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: 2),
         Text(
           value,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w600,
-              ),
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ],
     );
@@ -111,17 +108,20 @@ class _CurrentWithTrend extends StatelessWidget {
     final (icon, color) = switch (trend) {
       PriceTrend.up => (Icons.trending_up, DarkModeColors.error(context)),
       PriceTrend.down => (Icons.trending_down, DarkModeColors.success(context)),
-      PriceTrend.stable => (Icons.trending_flat, Theme.of(context).colorScheme.onSurfaceVariant),
+      PriceTrend.stable => (
+        Icons.trending_flat,
+        Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
     };
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          AppLocalizations.of(context)?.priceStatsCurrent ?? 'Current',
+          AppLocalizations.of(context).priceStatsCurrent,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: 2),
         Row(
@@ -129,9 +129,9 @@ class _CurrentWithTrend extends StatelessWidget {
           children: [
             Text(
               value,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
             ),
             const SizedBox(width: 4),
             Icon(icon, size: 18, color: color),

--- a/lib/features/profile/presentation/screens/developer_tools/developer_tools_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/developer_tools_screen.dart
@@ -58,25 +58,24 @@ class DeveloperToolsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final debugOn =
-        ref.watch(enabledFeaturesProvider).contains(Feature.debugMode);
+    final debugOn = ref
+        .watch(enabledFeaturesProvider)
+        .contains(Feature.debugMode);
 
     if (!debugOn) {
       // Defensive: a stale deep-link must never expose dev tools.
       return PageScaffold(
-        title: l?.developerToolsSectionTitle ?? 'Developer tools',
+        title: l.developerToolsSectionTitle,
         body: const SizedBox.shrink(),
       );
     }
 
     return PageScaffold(
-      title: l?.developerToolsSectionTitle ?? 'Developer tools',
+      title: l.developerToolsSectionTitle,
       body: ListView(
         children: [
           Text(
-            l?.developerToolsSubtitle ??
-                'Diagnostics and tools for debugging — only visible in '
-                    'Developer / Debug mode.',
+            l.developerToolsSubtitle,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -86,7 +85,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // --- Error log -------------------------------------------------
           SectionHeader(
             leadingIcon: Icons.bug_report_outlined,
-            title: l?.developerToolsErrorLogGroupTitle ?? 'Error log',
+            title: l.developerToolsErrorLogGroupTitle,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
@@ -98,8 +97,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // --- Alerts & notifications ------------------------------------
           SectionHeader(
             leadingIcon: Icons.notifications_active_outlined,
-            title: l?.developerToolsAlertsGroupTitle ??
-                'Alerts & notifications',
+            title: l.developerToolsAlertsGroupTitle,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
@@ -107,26 +105,21 @@ class DeveloperToolsScreen extends ConsumerWidget {
             key: const ValueKey('debug-fire-test-notification'),
             onPressed: () => _fireTestNotification(context, ref),
             icon: const Icon(Icons.notifications_outlined),
-            label: Text(
-              l?.developerToolsFireTestNotification ??
-                  'Fire test notification',
-            ),
+            label: Text(l.developerToolsFireTestNotification),
           ),
           const SizedBox(height: 8),
           OutlinedButton.icon(
             key: const ValueKey('debug-run-test-alert'),
             onPressed: () => _runTestAlert(context, ref),
             icon: const Icon(Icons.crisis_alert_outlined),
-            label: Text(
-              l?.developerToolsRunTestAlert ?? 'Run test alert pipeline',
-            ),
+            label: Text(l.developerToolsRunTestAlert),
           ),
           const SizedBox(height: 16),
 
           // --- Diagnostics ----------------------------------------------
           SectionHeader(
             leadingIcon: Icons.analytics_outlined,
-            title: l?.developerToolsDiagnosticsGroupTitle ?? 'Diagnostics',
+            title: l.developerToolsDiagnosticsGroupTitle,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
@@ -134,9 +127,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
             key: const ValueKey('debug-feature-flag-dump'),
             onPressed: () => context.push(RoutePaths.developerToolsFlags),
             icon: const Icon(Icons.flag_outlined),
-            label: Text(
-              l?.developerToolsFeatureFlagDump ?? 'Feature flag inspector',
-            ),
+            label: Text(l.developerToolsFeatureFlagDump),
           ),
           const SizedBox(height: 8),
           // #2471 — OBD2 communication-health diagnostics (Epic #2463).
@@ -144,9 +135,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
             key: const ValueKey('debug-obd2-health'),
             onPressed: () => context.push(RoutePaths.developerToolsObd2Health),
             icon: const Icon(Icons.bluetooth_searching_outlined),
-            label: Text(
-              l?.obd2HealthNavLabel ?? 'OBD2 communication health',
-            ),
+            label: Text(l.obd2HealthNavLabel),
           ),
           const SizedBox(height: 8),
           // #2518 — in-app OCR tester (Epic #2516 Child 2).
@@ -154,23 +143,21 @@ class DeveloperToolsScreen extends ConsumerWidget {
             key: const ValueKey('debug-ocr-tester'),
             onPressed: () => context.push(RoutePaths.developerToolsOcrTester),
             icon: const Icon(Icons.document_scanner_outlined),
-            label: Text(l?.ocrTesterNavLabel ?? 'OCR tester'),
+            label: Text(l.ocrTesterNavLabel),
           ),
           const SizedBox(height: 8),
           OutlinedButton.icon(
             key: const ValueKey('debug-clear-caches'),
             onPressed: () => _clearCaches(context, ref),
             icon: const Icon(Icons.cached_outlined),
-            label: Text(l?.developerToolsClearCaches ?? 'Clear caches'),
+            label: Text(l.developerToolsClearCaches),
           ),
           const SizedBox(height: 8),
           OutlinedButton.icon(
             key: const ValueKey('debug-copy-diagnostics'),
             onPressed: () => _copyDiagnostics(context, ref),
             icon: const Icon(Icons.copy_all_outlined),
-            label: Text(
-              l?.developerToolsCopyDiagnostics ?? 'Copy diagnostics',
-            ),
+            label: Text(l.developerToolsCopyDiagnostics),
           ),
           const SizedBox(height: 8),
           // #2824 — export the recorded network-vs-cache data-access trace so
@@ -180,9 +167,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
             key: const ValueKey('debug-data-access-tracer'),
             onPressed: () => _exportDataAccessTrace(context, ref),
             icon: const Icon(Icons.network_check_outlined),
-            label: Text(
-              l?.dataAccessTracerExport ?? 'Export data-access trace',
-            ),
+            label: Text(l.dataAccessTracerExport),
           ),
           const SizedBox(height: 16),
 
@@ -192,7 +177,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // control, so it belongs with the rest of the dev diagnostics.
           SectionHeader(
             leadingIcon: Icons.local_gas_station_outlined,
-            title: l?.approachOverlaySection ?? 'Approach-station overlay',
+            title: l.approachOverlaySection,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
@@ -202,7 +187,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
           // --- Build info -----------------------------------------------
           SectionHeader(
             leadingIcon: Icons.info_outline,
-            title: l?.developerToolsBuildInfoGroupTitle ?? 'Build info',
+            title: l.developerToolsBuildInfoGroupTitle,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 8),
@@ -224,23 +209,17 @@ class DeveloperToolsScreen extends ConsumerWidget {
     if (!granted) {
       SnackBarHelper.showError(
         context,
-        l?.developerToolsTestNotificationBlocked ??
-            'Notifications are blocked — enable them in system settings, '
-                'then retry.',
+        l.developerToolsTestNotificationBlocked,
       );
       return;
     }
     await notifier.showPriceAlert(
       id: 'debug:test-notification'.hashCode,
-      title: l?.developerToolsTestNotificationTitle ?? 'Test notification',
-      body: l?.developerToolsTestNotificationBody ??
-          'If you can read this, notifications are working.',
+      title: l.developerToolsTestNotificationTitle,
+      body: l.developerToolsTestNotificationBody,
     );
     if (!context.mounted) return;
-    SnackBarHelper.showSuccess(
-      context,
-      l?.developerToolsTestNotificationSent ?? 'Test notification sent.',
-    );
+    SnackBarHelper.showSuccess(context, l.developerToolsTestNotificationSent);
   }
 
   Future<void> _runTestAlert(BuildContext context, WidgetRef ref) async {
@@ -251,33 +230,22 @@ class DeveloperToolsScreen extends ConsumerWidget {
     // fire a stuck synthetic deep-link and tell the user to search first.
     final station = _firstSearchStation(ref);
     if (station == null) {
-      SnackBarHelper.show(
-        context,
-        l?.developerToolsTestAlertNoStation ??
-            'Search for stations first, then run the test alert so the '
-                'notification can open a real station.',
-      );
+      SnackBarHelper.show(context, l.developerToolsTestAlertNoStation);
       return;
     }
     final sample = StationPriceSample.fromStation(station).firstOrNull;
     if (sample == null) {
       // The station reports no priced fuel — nothing the evaluator can
       // match, so the same "search first" guidance applies.
-      SnackBarHelper.show(
-        context,
-        l?.developerToolsTestAlertNoStation ??
-            'Search for stations first, then run the test alert so the '
-                'notification can open a real station.',
-      );
+      SnackBarHelper.show(context, l.developerToolsTestAlertNoStation);
       return;
     }
     final runner = TestAlertRunner(
       notifier: ref.read(notificationServiceProvider),
     );
     final count = await runner.run(
-      title: l?.developerToolsTestAlertTitle ?? 'Test price alert',
-      body: l?.developerToolsTestAlertBody(station.displayName) ??
-          'Synthetic match: ${station.displayName} is below your target.',
+      title: l.developerToolsTestAlertTitle,
+      body: l.developerToolsTestAlertBody(station.displayName),
       station: sample,
       country: (Countries.countryCodeForStationId(station.id) ?? 'de')
           .toLowerCase(),
@@ -286,17 +254,11 @@ class DeveloperToolsScreen extends ConsumerWidget {
     if (count == 0) {
       SnackBarHelper.showError(
         context,
-        l?.developerToolsTestNotificationBlocked ??
-            'Notifications are blocked — enable them in system settings, '
-                'then retry.',
+        l.developerToolsTestNotificationBlocked,
       );
       return;
     }
-    SnackBarHelper.showSuccess(
-      context,
-      l?.developerToolsTestAlertFired(count) ??
-          'Test alert fired — pipeline delivered $count notification(s).',
-    );
+    SnackBarHelper.showSuccess(context, l.developerToolsTestAlertFired(count));
   }
 
   Future<void> _clearCaches(BuildContext context, WidgetRef ref) async {
@@ -305,10 +267,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
     await storageMgmt.clearCache();
     await storageMgmt.clearPriceHistory();
     if (!context.mounted) return;
-    SnackBarHelper.showSuccess(
-      context,
-      l?.developerToolsCachesCleared ?? 'Caches cleared.',
-    );
+    SnackBarHelper.showSuccess(context, l.developerToolsCachesCleared);
   }
 
   Future<void> _copyDiagnostics(BuildContext context, WidgetRef ref) async {
@@ -320,11 +279,7 @@ class DeveloperToolsScreen extends ConsumerWidget {
     );
     await Clipboard.setData(ClipboardData(text: blob));
     if (!context.mounted) return;
-    SnackBarHelper.showSuccess(
-      context,
-      l?.developerToolsDiagnosticsCopied ??
-          'Diagnostics copied to clipboard.',
-    );
+    SnackBarHelper.showSuccess(context, l.developerToolsDiagnosticsCopied);
   }
 
   /// #2824 — build a [DataAccessTrace] from the recorded events and write it to
@@ -337,28 +292,15 @@ class DeveloperToolsScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final recorder = ref.read(dataAccessRecorderProvider);
     if (recorder == null || recorder.events.isEmpty) {
-      SnackBarHelper.show(
-        context,
-        l?.dataAccessTracerEmpty ??
-            'No data-access events recorded yet — search or open stations '
-                'first, then export.',
-      );
+      SnackBarHelper.show(context, l.dataAccessTracerEmpty);
       return;
     }
     final ok = await DataAccessTraceExport.export(recorder.build());
     if (!context.mounted) return;
     if (ok) {
-      SnackBarHelper.showSuccess(
-        context,
-        l?.dataAccessTracerExportSuccess ??
-            'Data-access trace saved to Downloads.',
-      );
+      SnackBarHelper.showSuccess(context, l.dataAccessTracerExportSuccess);
     } else {
-      SnackBarHelper.showError(
-        context,
-        l?.dataAccessTracerExportFailure ??
-            "Couldn't export the data-access trace.",
-      );
+      SnackBarHelper.showError(context, l.dataAccessTracerExportFailure);
     }
   }
 }
@@ -388,13 +330,13 @@ class _BuildInfoRows extends StatelessWidget {
         ListTile(
           dense: true,
           contentPadding: EdgeInsets.zero,
-          title: Text(l?.developerToolsBuildVersion ?? 'App version'),
+          title: Text(l.developerToolsBuildVersion),
           trailing: Text(AppConstants.appVersion),
         ),
         ListTile(
           dense: true,
           contentPadding: EdgeInsets.zero,
-          title: Text(l?.developerToolsBuildChannel ?? 'Build channel'),
+          title: Text(l.developerToolsBuildChannel),
           trailing: Text(channel.name),
         ),
       ],

--- a/lib/features/profile/presentation/screens/developer_tools/error_log_viewer_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/error_log_viewer_screen.dart
@@ -27,13 +27,12 @@ class ErrorLogViewerScreen extends ConsumerWidget {
     final traces = ref.watch(traceStorageProvider).getAll();
 
     return PageScaffold(
-      title: l?.developerToolsViewErrorLog ?? 'View error log',
+      title: l.developerToolsViewErrorLog,
       bodyPadding: EdgeInsets.zero,
       body: traces.isEmpty
           ? Center(
               child: Text(
-                l?.developerToolsErrorLogEmpty ??
-                    'No error traces recorded.',
+                l.developerToolsErrorLogEmpty,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -42,10 +41,8 @@ class ErrorLogViewerScreen extends ConsumerWidget {
           : ListView.separated(
               padding: const EdgeInsets.symmetric(vertical: 8),
               itemCount: traces.length,
-              separatorBuilder: (context, index) =>
-                  const Divider(height: 1),
-              itemBuilder: (context, index) =>
-                  _TraceTile(trace: traces[index]),
+              separatorBuilder: (context, index) => const Divider(height: 1),
+              itemBuilder: (context, index) => _TraceTile(trace: traces[index]),
             ),
     );
   }
@@ -65,8 +62,9 @@ class _TraceTile extends StatelessWidget {
       leading: const Icon(Icons.error_outline, size: 20),
       title: Text(
         trace.errorType,
-        style: theme.textTheme.bodyMedium
-            ?.copyWith(fontWeight: FontWeight.bold),
+        style: theme.textTheme.bodyMedium?.copyWith(
+          fontWeight: FontWeight.bold,
+        ),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),

--- a/lib/features/profile/presentation/screens/developer_tools/feature_flag_dump_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/feature_flag_dump_screen.dart
@@ -23,14 +23,14 @@ class FeatureFlagDumpScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final enabled = ref.watch(enabledFeaturesProvider);
-    final on = l?.developerToolsFlagOn ?? 'On';
-    final off = l?.developerToolsFlagOff ?? 'Off';
+    final on = l.developerToolsFlagOn;
+    final off = l.developerToolsFlagOff;
 
     final features = Feature.values.toList()
       ..sort((a, b) => a.name.compareTo(b.name));
 
     return PageScaffold(
-      title: l?.developerToolsFeatureFlagDump ?? 'Feature flag inspector',
+      title: l.developerToolsFeatureFlagDump,
       bodyPadding: EdgeInsets.zero,
       body: ListView.separated(
         padding: const EdgeInsets.symmetric(vertical: 8),
@@ -51,8 +51,7 @@ class FeatureFlagDumpScreen extends ConsumerWidget {
             trailing: Text(
               isOn ? on : off,
               style: theme.textTheme.labelMedium?.copyWith(
-                color:
-                    isOn ? theme.colorScheme.primary : theme.disabledColor,
+                color: isOn ? theme.colorScheme.primary : theme.disabledColor,
               ),
             ),
           );

--- a/lib/features/profile/presentation/screens/developer_tools/obd2_health_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/obd2_health_screen.dart
@@ -49,10 +49,11 @@ class Obd2HealthScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final debugOn =
-        ref.watch(enabledFeaturesProvider).contains(Feature.debugMode);
+    final debugOn = ref
+        .watch(enabledFeaturesProvider)
+        .contains(Feature.debugMode);
 
-    final title = l?.obd2HealthScreenTitle ?? 'OBD2 communication health';
+    final title = l.obd2HealthScreenTitle;
 
     if (!debugOn) {
       // Defensive: a stale deep-link must never expose dev tools.
@@ -83,9 +84,7 @@ class Obd2HealthScreen extends ConsumerWidget {
       body: ListView(
         children: [
           Text(
-            l?.obd2DiagnosticsExplain ??
-                'Captured while recording to debug the dongle↔app '
-                    'communication — only collected in Developer mode.',
+            l.obd2DiagnosticsExplain,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -103,16 +102,14 @@ class Obd2HealthScreen extends ConsumerWidget {
           SectionHeader(
             key: const Key('obd2_health_connect_attempts_section'),
             leadingIcon: Icons.cable_outlined,
-            title: l?.obd2HealthConnectAttemptsSection ??
-                'Recent connect attempts',
+            title: l.obd2HealthConnectAttemptsSection,
             padding: EdgeInsets.zero,
           ),
           if (connectTraces.isEmpty)
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
               child: Text(
-                l?.obd2HealthConnectAttemptsEmpty ??
-                    'No connect attempts recorded yet.',
+                l.obd2HealthConnectAttemptsEmpty,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -133,8 +130,7 @@ class Obd2HealthScreen extends ConsumerWidget {
                     onPressed: () =>
                         _downloadConnectTrace(context, l, connectTraces[i]),
                     icon: const Icon(Icons.download_outlined, size: 18),
-                    label: Text(l?.obd2HealthDownloadConnectTrace ??
-                        'Download connect trace'),
+                    label: Text(l.obd2HealthDownloadConnectTrace),
                   ),
                 ),
               ),
@@ -147,9 +143,11 @@ class Obd2HealthScreen extends ConsumerWidget {
                   key: const Key('obd2_health_download_all_connect_traces'),
                   onPressed: () =>
                       _downloadAllConnectTraces(context, l, connectTraces),
-                  icon: const Icon(Icons.download_for_offline_outlined, size: 18),
-                  label: Text(l?.obd2HealthDownloadAllConnectTraces ??
-                      'Download all connect traces'),
+                  icon: const Icon(
+                    Icons.download_for_offline_outlined,
+                    size: 18,
+                  ),
+                  label: Text(l.obd2HealthDownloadAllConnectTraces),
                 ),
               ),
             ),
@@ -159,7 +157,7 @@ class Obd2HealthScreen extends ConsumerWidget {
           // --- Live session ---------------------------------------------
           SectionHeader(
             leadingIcon: Icons.sensors_outlined,
-            title: l?.obd2HealthLiveSection ?? 'Live session',
+            title: l.obd2HealthLiveSection,
             padding: EdgeInsets.zero,
           ),
           Obd2DiagnosticsCard(
@@ -168,13 +166,17 @@ class Obd2HealthScreen extends ConsumerWidget {
             enabled: enabled,
           ),
           _downloadJsonButton(
-              context, l, live, const Key('obd2_health_copy_live')),
+            context,
+            l,
+            live,
+            const Key('obd2_health_copy_live'),
+          ),
           const SizedBox(height: 16),
 
           // --- Recent finished sessions ---------------------------------
           SectionHeader(
             leadingIcon: Icons.history_outlined,
-            title: l?.obd2HealthHistorySection ?? 'Recent sessions',
+            title: l.obd2HealthHistorySection,
             padding: EdgeInsets.zero,
           ),
           for (var i = 0; i < finished.length; i++) ...[
@@ -198,7 +200,7 @@ class Obd2HealthScreen extends ConsumerWidget {
 
   Widget _downloadJsonButton(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     Obd2SessionDiagnostic session,
     Key key,
   ) {
@@ -220,16 +222,13 @@ class Obd2HealthScreen extends ConsumerWidget {
                 key: Key('${keyValue}_init'),
                 onPressed: () => _downloadInitTranscript(context, l, session),
                 icon: const Icon(Icons.terminal_outlined, size: 18),
-                label: Text(
-                  l?.obd2HealthDownloadInitTranscript ??
-                      'Download init transcript only',
-                ),
+                label: Text(l.obd2HealthDownloadInitTranscript),
               ),
             TextButton.icon(
               key: key,
               onPressed: () => _downloadAsJson(context, l, session),
               icon: const Icon(Icons.download_outlined, size: 18),
-              label: Text(l?.obd2HealthDownloadJson ?? 'Download as JSON'),
+              label: Text(l.obd2HealthDownloadJson),
             ),
           ],
         ),
@@ -242,7 +241,7 @@ class Obd2HealthScreen extends ConsumerWidget {
   /// trace that is non-empty on a FAILED connect.
   Future<void> _downloadConnectTrace(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     Obd2ConnectTrace trace,
   ) async {
     final json = const JsonEncoder.withIndent('  ').convert(trace.toJson());
@@ -253,11 +252,12 @@ class Obd2HealthScreen extends ConsumerWidget {
   /// Downloads folder (#2969).
   Future<void> _downloadAllConnectTraces(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     List<Obd2ConnectTrace> traces,
   ) async {
-    final json = const JsonEncoder.withIndent('  ')
-        .convert([for (final t in traces) t.toJson()]);
+    final json = const JsonEncoder.withIndent(
+      '  ',
+    ).convert([for (final t in traces) t.toJson()]);
     await _saveJsonToDownloads(context, l, json, 'connect-traces');
   }
 
@@ -267,7 +267,7 @@ class Obd2HealthScreen extends ConsumerWidget {
   /// file manager.
   Future<void> _downloadAsJson(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     Obd2SessionDiagnostic session,
   ) async {
     final json = const JsonEncoder.withIndent('  ').convert(session.toJson());
@@ -280,7 +280,7 @@ class Obd2HealthScreen extends ConsumerWidget {
   /// for attaching a handshake to a bug report.
   Future<void> _downloadInitTranscript(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     Obd2SessionDiagnostic session,
   ) async {
     final payload = <String, dynamic>{
@@ -307,7 +307,7 @@ class Obd2HealthScreen extends ConsumerWidget {
   /// handled defensively (the #2933 background-isolate degrade pattern).
   Future<void> _saveJsonToDownloads(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     String json,
     String kind,
   ) async {
@@ -315,8 +315,10 @@ class Obd2HealthScreen extends ConsumerWidget {
     // context is touched after the await (lint: use_build_context_synchronously).
     final messenger = ScaffoldMessenger.maybeOf(context);
     final scheme = Theme.of(context).colorScheme;
-    final stamp =
-        DateTime.now().toIso8601String().replaceAll(RegExp(r'[:.]'), '-');
+    final stamp = DateTime.now().toIso8601String().replaceAll(
+      RegExp(r'[:.]'),
+      '-',
+    );
     // i18n-ignore: language-neutral filename mask (brand + kind tag + stamp).
     final fileName = 'tankstellen-obd2-$kind-$stamp.json';
     try {
@@ -326,34 +328,41 @@ class Obd2HealthScreen extends ConsumerWidget {
         mimeType: 'application/json',
       );
       messenger?.showSnackBar(
-        SnackBarHelper.successSnackBar(
-          scheme,
-          l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
-        ),
+        SnackBarHelper.successSnackBar(scheme, l.savedToDownloadsFolder),
       );
     } on MissingPluginException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'Obd2HealthScreen download: public_files channel unavailable',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where':
+                'Obd2HealthScreen download: public_files channel unavailable',
+          },
+        ),
+      );
       _showDownloadError(scheme, l, messenger);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'Obd2HealthScreen download: json write',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'Obd2HealthScreen download: json write'},
+        ),
+      );
       _showDownloadError(scheme, l, messenger);
     }
   }
 
   void _showDownloadError(
     ColorScheme scheme,
-    AppLocalizations? l,
+    AppLocalizations l,
     ScaffoldMessengerState? messenger,
   ) {
     messenger?.showSnackBar(
-      SnackBarHelper.errorSnackBar(
-        scheme,
-        l?.obd2HealthDownloadError ?? "Couldn't save the diagnostics file",
-      ),
+      SnackBarHelper.errorSnackBar(scheme, l.obd2HealthDownloadError),
     );
   }
 }

--- a/lib/features/profile/presentation/screens/developer_tools/obd2_self_test_adapter_choice.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/obd2_self_test_adapter_choice.dart
@@ -87,7 +87,7 @@ class Obd2SelfTestAdapterChoice extends StatelessWidget {
       // No paired adapter to choose — the run falls back to the blind scan.
       return const SizedBox.shrink();
     }
-    final scanLabel = l?.obd2TestAdapterScanOption ?? 'Scan for adapter';
+    final scanLabel = l.obd2TestAdapterScanOption;
     return Padding(
       key: const ValueKey('obd2-self-test-adapter-choice'),
       padding: const EdgeInsets.only(top: 4),
@@ -95,7 +95,7 @@ class Obd2SelfTestAdapterChoice extends StatelessWidget {
         key: const ValueKey('obd2-self-test-adapter-dropdown'),
         initialValue: selectedMac ?? _scanSentinel,
         decoration: InputDecoration(
-          labelText: l?.obd2TestAdapterLabel ?? 'Adapter to test',
+          labelText: l.obd2TestAdapterLabel,
           prefixIcon: const Icon(Icons.bluetooth),
         ),
         items: [
@@ -116,8 +116,7 @@ class Obd2SelfTestAdapterChoice extends StatelessWidget {
           ),
         ],
         onChanged: enabled
-            ? (value) =>
-                onChanged(value == _scanSentinel ? null : value)
+            ? (value) => onChanged(value == _scanSentinel ? null : value)
             : null,
       ),
     );
@@ -125,15 +124,16 @@ class Obd2SelfTestAdapterChoice extends StatelessWidget {
 
   /// Localised transport tag shown next to each paired adapter (#2969).
   static String _transportLabel(
-      AppLocalizations? l, BluetoothTransport? transport) {
+    AppLocalizations l,
+    BluetoothTransport? transport,
+  ) {
     switch (transport) {
       case BluetoothTransport.classic:
-        return l?.obd2TestAdapterTransportClassic ?? 'Classic (SPP)';
+        return l.obd2TestAdapterTransportClassic;
       case BluetoothTransport.ble:
-        return l?.obd2TestAdapterTransportBle ?? 'Bluetooth LE';
+        return l.obd2TestAdapterTransportBle;
       case null:
-        return l?.obd2TestAdapterTransportUnknown ??
-            'unknown — defaulting to BLE';
+        return l.obd2TestAdapterTransportUnknown;
     }
   }
 }

--- a/lib/features/profile/presentation/screens/developer_tools/obd2_self_test_panel.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/obd2_self_test_panel.dart
@@ -43,8 +43,9 @@ class Obd2SelfTestPanel extends ConsumerWidget {
 
     final adapters = _pairedAdapters(ref);
     final defaultMac = _defaultMac(ref, adapters);
-    final selectedMac =
-        ref.watch(obd2SelfTestSelectedAdapterProvider(defaultMac));
+    final selectedMac = ref.watch(
+      obd2SelfTestSelectedAdapterProvider(defaultMac),
+    );
     final selectedName = _nameForMac(adapters, selectedMac);
     // #2969 — route the run over the inferred transport of the chosen adapter.
     final selectedTransport = _transportHintForMac(adapters, selectedMac);
@@ -54,7 +55,7 @@ class Obd2SelfTestPanel extends ConsumerWidget {
       children: [
         SectionHeader(
           leadingIcon: Icons.play_circle_outline,
-          title: l?.obd2TestRunTitle ?? 'Run adapter test',
+          title: l.obd2TestRunTitle,
           padding: EdgeInsets.zero,
         ),
         Obd2SelfTestAdapterChoice(
@@ -73,14 +74,15 @@ class Obd2SelfTestPanel extends ConsumerWidget {
             onPressed: running
                 ? null
                 : () => ref
-                    .read(obd2SelfTestControllerProvider.notifier)
-                    .run(
+                      .read(obd2SelfTestControllerProvider.notifier)
+                      .run(
                         targetMac: selectedMac,
                         transportHint: selectedTransport,
                         // #3014 — name the trace headline with the chosen
                         // adapter's human name (already resolved for the row
                         // relabel), not just the redacted MAC.
-                        adapterName: selectedName),
+                        adapterName: selectedName,
+                      ),
             icon: running
                 ? const SizedBox(
                     width: 16,
@@ -88,18 +90,17 @@ class Obd2SelfTestPanel extends ConsumerWidget {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Icon(Icons.play_arrow_outlined, size: 18),
-            label: Text(l?.obd2TestRunButton ?? 'Run adapter test'),
+            label: Text(l.obd2TestRunButton),
           ),
         ),
         if (test.phase == Obd2SelfTestPhase.blockedByRecording)
           Padding(
             padding: const EdgeInsets.only(top: 8),
             child: Text(
-              l?.obd2TestRunCannotWhileRecording ??
-                  'Stop the active recording before running the adapter test.',
+              l.obd2TestRunCannotWhileRecording,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
+                color: Theme.of(context).colorScheme.error,
+              ),
             ),
           ),
         if (test.phase == Obd2SelfTestPhase.running ||
@@ -154,7 +155,9 @@ class Obd2SelfTestPanel extends ConsumerWidget {
   /// no paired adapter selected / no name match → the run defaults to BLE and
   /// records `no-hint-defaulted-ble`.
   Obd2ConnectTransport? _transportHintForMac(
-      List<Obd2PairedAdapter> adapters, String? mac) {
+    List<Obd2PairedAdapter> adapters,
+    String? mac,
+  ) {
     if (mac == null) return null;
     for (final a in adapters) {
       if (a.mac != mac) continue;
@@ -196,11 +199,7 @@ class Obd2SelfTestPanel extends ConsumerWidget {
 /// One row of the live step list: a status icon (with a11y semanticLabel),
 /// the localised step name, and the trailing latency in ms.
 class _StepRow extends StatelessWidget {
-  const _StepRow({
-    super.key,
-    required this.step,
-    this.connectAdapterName,
-  });
+  const _StepRow({super.key, required this.step, this.connectAdapterName});
 
   final Obd2SelfTestStep step;
 
@@ -219,10 +218,7 @@ class _StepRow extends StatelessWidget {
           _statusIcon(context, l),
           const SizedBox(width: 10),
           Expanded(
-            child: Text(
-              _stepLabel(l),
-              style: theme.textTheme.bodyMedium,
-            ),
+            child: Text(_stepLabel(l), style: theme.textTheme.bodyMedium),
           ),
           if (step.latencyMs != null)
             Text(
@@ -236,7 +232,7 @@ class _StepRow extends StatelessWidget {
     );
   }
 
-  Widget _statusIcon(BuildContext context, AppLocalizations? l) {
+  Widget _statusIcon(BuildContext context, AppLocalizations l) {
     final cs = Theme.of(context).colorScheme;
     if (step.running) {
       return const SizedBox(
@@ -247,47 +243,66 @@ class _StepRow extends StatelessWidget {
     }
     switch (step.status) {
       case Obd2SelfTestStepStatus.ok:
-        return Icon(Icons.check_circle, size: 18, color: cs.primary,
-            semanticLabel: l?.obd2TestStatusOk ?? 'OK');
+        return Icon(
+          Icons.check_circle,
+          size: 18,
+          color: cs.primary,
+          semanticLabel: l.obd2TestStatusOk,
+        );
       case Obd2SelfTestStepStatus.timeout:
-        return Icon(Icons.timer_off, size: 18, color: cs.error,
-            semanticLabel: l?.obd2TestStatusTimeout ?? 'Timed out');
+        return Icon(
+          Icons.timer_off,
+          size: 18,
+          color: cs.error,
+          semanticLabel: l.obd2TestStatusTimeout,
+        );
       case Obd2SelfTestStepStatus.garbage:
-        return Icon(Icons.help_outline, size: 18, color: cs.error,
-            semanticLabel: l?.obd2TestStatusGarbage ?? 'Unreadable reply');
+        return Icon(
+          Icons.help_outline,
+          size: 18,
+          color: cs.error,
+          semanticLabel: l.obd2TestStatusGarbage,
+        );
       case Obd2SelfTestStepStatus.noResponse:
-        return Icon(Icons.do_not_disturb_on_outlined, size: 18,
-            color: cs.onSurfaceVariant,
-            semanticLabel: l?.obd2TestStatusNoResponse ?? 'No response');
+        return Icon(
+          Icons.do_not_disturb_on_outlined,
+          size: 18,
+          color: cs.onSurfaceVariant,
+          semanticLabel: l.obd2TestStatusNoResponse,
+        );
       case Obd2SelfTestStepStatus.fail:
       case Obd2SelfTestStepStatus.skipped:
-        return Icon(Icons.error, size: 18, color: cs.error,
-            semanticLabel: l?.obd2TestStatusFail ?? 'Failed');
+        return Icon(
+          Icons.error,
+          size: 18,
+          color: cs.error,
+          semanticLabel: l.obd2TestStatusFail,
+        );
     }
   }
 
-  String _stepLabel(AppLocalizations? l) {
+  String _stepLabel(AppLocalizations l) {
     switch (step.id) {
       case Obd2SelfTestStepId.scan:
         // #2938 — when the run connected by MAC, the first step is a direct
         // connect, not a scan; relabel it so the trace matches what ran.
         final name = connectAdapterName;
         if (name != null) {
-          return l?.obd2TestStepConnectTo(name) ?? 'Connect to $name';
+          return l.obd2TestStepConnectTo(name);
         }
-        return l?.obd2TestStepScan ?? 'Scan for adapter';
+        return l.obd2TestStepScan;
       case Obd2SelfTestStepId.connect:
-        return l?.obd2TestStepConnect ?? 'Connect & init';
+        return l.obd2TestStepConnect;
       case Obd2SelfTestStepId.info:
-        return l?.obd2TestStepInfo ?? 'Adapter info';
+        return l.obd2TestStepInfo;
       case Obd2SelfTestStepId.supportedPids:
-        return l?.obd2TestStepSupportedPids ?? 'Supported PIDs';
+        return l.obd2TestStepSupportedPids;
       case Obd2SelfTestStepId.sampleReads:
-        return l?.obd2TestStepSampleReads ?? 'Sample reads';
+        return l.obd2TestStepSampleReads;
       case Obd2SelfTestStepId.reconnect:
-        return l?.obd2TestStepReconnect ?? 'Reconnect test';
+        return l.obd2TestStepReconnect;
       case Obd2SelfTestStepId.disconnect:
-        return l?.obd2TestStepDisconnect ?? 'Disconnect';
+        return l.obd2TestStepDisconnect;
     }
   }
 }
@@ -313,32 +328,28 @@ class _SummaryBanner extends StatelessWidget {
     final cs = theme.colorScheme;
     final (bg, fg, icon, headline) = switch (state.verdict) {
       Obd2SelfTestVerdict.passed => (
-          cs.primaryContainer,
-          cs.onPrimaryContainer,
-          Icons.check_circle,
-          l?.obd2TestRunPassed ?? 'Adapter test passed',
-        ),
+        cs.primaryContainer,
+        cs.onPrimaryContainer,
+        Icons.check_circle,
+        l.obd2TestRunPassed,
+      ),
       Obd2SelfTestVerdict.engineOff => (
-          DarkModeColors.warningSurface(context),
-          DarkModeColors.warning(context),
-          Icons.info_outline,
-          l?.obd2TestRunEngineOff ??
-              'Adapter OK — engine off; start the engine to read live data',
-        ),
+        DarkModeColors.warningSurface(context),
+        DarkModeColors.warning(context),
+        Icons.info_outline,
+        l.obd2TestRunEngineOff,
+      ),
       Obd2SelfTestVerdict.failed => (
-          cs.errorContainer,
-          cs.onErrorContainer,
-          Icons.error,
-          l?.obd2TestRunFailed ?? 'Adapter test failed',
-        ),
+        cs.errorContainer,
+        cs.onErrorContainer,
+        Icons.error,
+        l.obd2TestRunFailed,
+      ),
     };
     return Container(
       margin: const EdgeInsets.only(top: 12),
       padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: AppRadius.lg,
-      ),
+      decoration: BoxDecoration(color: bg, borderRadius: AppRadius.lg),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -356,13 +367,11 @@ class _SummaryBanner extends StatelessWidget {
           ),
           const SizedBox(height: 4),
           Text(
-            l?.obd2TestRunSummary(
-                  state.passCount,
-                  state.steps.length,
-                  state.elapsedMs ?? 0,
-                ) ??
-                '${state.passCount} of ${state.steps.length} steps OK · '
-                    '${state.elapsedMs ?? 0} ms',
+            l.obd2TestRunSummary(
+              state.passCount,
+              state.steps.length,
+              state.elapsedMs ?? 0,
+            ),
             style: theme.textTheme.bodySmall?.copyWith(color: fg),
           ),
         ],

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen.dart
@@ -99,9 +99,10 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final debugOn =
-        ref.watch(enabledFeaturesProvider).contains(Feature.debugMode);
-    final title = l?.ocrTesterTitle ?? 'OCR tester';
+    final debugOn = ref
+        .watch(enabledFeaturesProvider)
+        .contains(Feature.debugMode);
+    final title = l.ocrTesterTitle;
 
     if (!debugOn) {
       // Defensive: a stale deep-link must never expose dev tools.
@@ -114,11 +115,10 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
       body: ListView(
         children: [
           Text(
-            l?.ocrTesterExplain ??
-                'Run the pump / receipt OCR pipeline on a chosen photo and '
-                    'inspect every step — only available in Developer mode.',
-            style: theme.textTheme.bodySmall
-                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            l.ocrTesterExplain,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 12),
           _modeToggle(l),
@@ -130,32 +130,29 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
           _runButton(l),
           const SizedBox(height: 16),
           if (_running)
-            _RunningRow(label: l?.ocrTesterRunning ?? 'Running OCR…')
+            _RunningRow(label: l.ocrTesterRunning)
           else if (_package != null)
             ..._results(context, l, _package!)
           else
-            Text(
-              l?.ocrTesterNoImage ?? 'Pick or capture an image, then Run.',
-              style: theme.textTheme.bodyMedium,
-            ),
+            Text(l.ocrTesterNoImage, style: theme.textTheme.bodyMedium),
           SizedBox(height: MediaQuery.of(context).viewPadding.bottom + 16),
         ],
       ),
     );
   }
 
-  Widget _modeToggle(AppLocalizations? l) {
+  Widget _modeToggle(AppLocalizations l) {
     return SegmentedButton<_OcrTesterMode>(
       key: const Key('ocr_tester_mode'),
       segments: [
         ButtonSegment(
           value: _OcrTesterMode.pump,
-          label: Text(l?.ocrTesterModePump ?? 'Pump'),
+          label: Text(l.ocrTesterModePump),
           icon: const Icon(Icons.local_gas_station_outlined),
         ),
         ButtonSegment(
           value: _OcrTesterMode.receipt,
-          label: Text(l?.ocrTesterModeReceipt ?? 'Receipt'),
+          label: Text(l.ocrTesterModeReceipt),
           icon: const Icon(Icons.receipt_long_outlined),
         ),
       ],
@@ -169,19 +166,19 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
     );
   }
 
-  Widget _countryDropdown(AppLocalizations? l) {
+  Widget _countryDropdown(AppLocalizations l) {
     return DropdownButtonFormField<String?>(
       key: const Key('ocr_tester_country'),
       initialValue: _country,
       decoration: InputDecoration(
-        labelText: l?.ocrTesterCountry ?? 'Country',
+        labelText: l.ocrTesterCountry,
         border: const OutlineInputBorder(),
         isDense: true,
       ),
       items: [
         DropdownMenuItem<String?>(
           value: null,
-          child: Text(l?.ocrTesterCountryNone ?? 'Default (no profile)'),
+          child: Text(l.ocrTesterCountryNone),
         ),
         for (final c in Countries.all)
           DropdownMenuItem<String?>(
@@ -194,7 +191,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
     );
   }
 
-  Widget _sourceRow(AppLocalizations? l) {
+  Widget _sourceRow(AppLocalizations l) {
     return Row(
       children: [
         Expanded(
@@ -202,7 +199,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
             key: const Key('ocr_tester_capture'),
             onPressed: _running ? null : _capture,
             icon: const Icon(Icons.photo_camera_outlined),
-            label: Text(l?.ocrTesterCapture ?? 'Capture'),
+            label: Text(l.ocrTesterCapture),
           ),
         ),
         const SizedBox(width: 8),
@@ -211,31 +208,31 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
             key: const Key('ocr_tester_pick'),
             onPressed: _running ? null : _pickImage,
             icon: const Icon(Icons.image_outlined),
-            label: Text(l?.ocrTesterPickImage ?? 'Pick image'),
+            label: Text(l.ocrTesterPickImage),
           ),
         ),
       ],
     );
   }
 
-  Widget _runButton(AppLocalizations? l) {
+  Widget _runButton(AppLocalizations l) {
     return FilledButton.icon(
       key: const Key('ocr_tester_run'),
       onPressed: (_running || _imagePath == null) ? null : _run,
       icon: const Icon(Icons.play_arrow_outlined),
-      label: Text(l?.ocrTesterRun ?? 'Run'),
+      label: Text(l.ocrTesterRun),
     );
   }
 
   List<Widget> _results(
     BuildContext context,
-    AppLocalizations? l,
+    AppLocalizations l,
     OcrTracePackage package,
   ) {
     return [
       SectionHeader(
         leadingIcon: Icons.grid_on_outlined,
-        title: l?.ocrTesterOverlaySection ?? 'Block overlay',
+        title: l.ocrTesterOverlaySection,
         padding: EdgeInsets.zero,
       ),
       const SizedBox(height: 8),
@@ -251,7 +248,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
       const SizedBox(height: 16),
       SectionHeader(
         leadingIcon: Icons.list_alt_outlined,
-        title: l?.ocrTesterStepsSection ?? 'Pipeline steps',
+        title: l.ocrTesterStepsSection,
         padding: EdgeInsets.zero,
       ),
       const SizedBox(height: 8),
@@ -263,7 +260,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
     ];
   }
 
-  Widget _exportRow(AppLocalizations? l, OcrTracePackage package) {
+  Widget _exportRow(AppLocalizations l, OcrTracePackage package) {
     return Row(
       children: [
         Expanded(
@@ -271,7 +268,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
             key: const Key('ocr_tester_copy_json'),
             onPressed: () => _copyAsJson(package),
             icon: const Icon(Icons.copy_all_outlined),
-            label: Text(l?.ocrTesterCopyJson ?? 'Copy as JSON'),
+            label: Text(l.ocrTesterCopyJson),
           ),
         ),
         const SizedBox(width: 8),
@@ -280,7 +277,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
             key: const Key('ocr_tester_export'),
             onPressed: () => _exportPackage(package),
             icon: const Icon(Icons.ios_share_outlined),
-            label: Text(l?.ocrTesterExportPackage ?? 'Export package'),
+            label: Text(l.ocrTesterExportPackage),
           ),
         ),
       ],
@@ -291,7 +288,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
   /// regression fixture (#2519): the source image + a `.ocrpkg.json` with
   /// `expected` seeded from the read. Only pump-mode reads with a captured
   /// image can promote (the replay harness drives the pump path).
-  Widget _saveFixtureButton(AppLocalizations? l, OcrTracePackage package) {
+  Widget _saveFixtureButton(AppLocalizations l, OcrTracePackage package) {
     final promotable =
         package.kind == OcrTraceKind.pump && package.image != null;
     return SizedBox(
@@ -300,7 +297,7 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
         key: const Key('ocr_tester_save_fixture'),
         onPressed: promotable ? () => _saveAsFixture(package) : null,
         icon: const Icon(Icons.bookmark_add_outlined),
-        label: Text(l?.ocrTesterSaveFixture ?? 'Save as fixture'),
+        label: Text(l.ocrTesterSaveFixture),
       ),
     );
   }

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
@@ -61,8 +61,7 @@ class _OverlayView extends StatelessWidget {
           aspectRatio: aspect <= 0 ? 1.0 : aspect,
           child: LayoutBuilder(
             builder: (context, constraints) {
-              final size =
-                  Size(constraints.maxWidth, constraints.maxHeight);
+              final size = Size(constraints.maxWidth, constraints.maxHeight);
               final painter = OcrBlockOverlayPainter(
                 package: package,
                 imageSize: imageSize,
@@ -112,17 +111,21 @@ class _OverlayLegend extends StatelessWidget {
         runSpacing: 4,
         children: [
           _LegendChip(
-              color: OcrBlockOverlayColors.label,
-              label: l?.ocrTesterLegendLabel ?? 'Label'),
+            color: OcrBlockOverlayColors.label,
+            label: l.ocrTesterLegendLabel,
+          ),
           _LegendChip(
-              color: OcrBlockOverlayColors.numeric,
-              label: l?.ocrTesterLegendNumeric ?? 'Numeric'),
+            color: OcrBlockOverlayColors.numeric,
+            label: l.ocrTesterLegendNumeric,
+          ),
           _LegendChip(
-              color: OcrBlockOverlayColors.noise,
-              label: l?.ocrTesterLegendNoise ?? 'Noise'),
+            color: OcrBlockOverlayColors.noise,
+            label: l.ocrTesterLegendNoise,
+          ),
           _LegendChip(
-              color: OcrBlockOverlayColors.derived,
-              label: l?.ocrTesterLegendDerived ?? 'Derived'),
+            color: OcrBlockOverlayColors.derived,
+            label: l.ocrTesterLegendDerived,
+          ),
         ],
       ),
     );
@@ -274,11 +277,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
   /// wired. Uses [ReceiptScanService.parseReceiptImage] so no camera is
   /// reopened (the tester owns the source image).
   Future<void> _runReceipt(String path, OcrTraceRecorder trace) async {
-    await _service.parseReceiptImage(
-      path,
-      country: _country,
-      trace: trace,
-    );
+    await _service.parseReceiptImage(path, country: _country, trace: trace);
   }
 
   /// Reads [path]'s bytes and attaches them base64 to [trace] for export.
@@ -307,10 +306,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       final frame = await codec.getNextFrame();
       return (
         bytes: baked,
-        size: Size(
-          frame.image.width.toDouble(),
-          frame.image.height.toDouble(),
-        ),
+        size: Size(frame.image.width.toDouble(), frame.image.height.toDouble()),
       );
     } catch (_) {
       return null;
@@ -329,31 +325,20 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       await _exportPackage(package);
       return;
     }
-    SnackBarHelper.showSuccess(
-      context,
-      l?.ocrTesterCopied ?? 'OCR trace copied to clipboard.',
-    );
+    SnackBarHelper.showSuccess(context, l.ocrTesterCopied);
   }
 
   Future<void> _exportPackage(OcrTracePackage package) async {
     await OcrTesterExport.exportPackage(package);
     if (!mounted) return;
     final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.ocrTesterExported ?? 'OCR package saved to your Downloads folder.',
-    );
+    SnackBarHelper.showSuccess(context, l.ocrTesterExported);
   }
 
   Future<void> _saveAsFixture(OcrTracePackage package) async {
     await OcrTesterExport.saveAsFixture(package);
     if (!mounted) return;
     final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.ocrTesterFixtureSaved ??
-          'Fixture saved to your Downloads folder. Move it under '
-              'test/fixtures and run tool/promote_ocr_fixture.dart.',
-    );
+    SnackBarHelper.showSuccess(context, l.ocrTesterFixtureSaved);
   }
 }

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -77,7 +77,7 @@ class _PrivacyDashboardScreenState
     final errorLogCount = ref.watch(traceStorageProvider).count;
 
     return PageScaffold(
-      title: l?.privacyDashboardTitle ?? 'Privacy Dashboard',
+      title: l.privacyDashboardTitle,
       bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: const EdgeInsets.all(16),
@@ -111,8 +111,7 @@ class _PrivacyDashboardScreenState
                     // #2145 — label reflects the dominant behaviour
                     // (save to Downloads); clipboard/share fallbacks
                     // happen automatically based on payload size.
-                    l?.privacySaveErrorLog(errorLogCount) ??
-                        'Save error log ($errorLogCount)',
+                    l.privacySaveErrorLog(errorLogCount),
                   ),
                 ),
               ),
@@ -121,7 +120,7 @@ class _PrivacyDashboardScreenState
                 key: const ValueKey('privacy-clear-error-log-button'),
                 onPressed: errorLogCount == 0 ? null : _clearErrorLog,
                 icon: const Icon(Icons.delete_outline),
-                tooltip: l?.privacyClearErrorLog ?? 'Clear error log',
+                tooltip: l.privacyClearErrorLog,
               ),
             ],
           ),
@@ -145,7 +144,7 @@ class _PrivacyDashboardScreenState
     await _saveExportToDownloads(
       text: json,
       fileName: 'tankstellen-data.json',
-      copySnackbar: l?.privacyExportSuccess ?? 'Data exported to clipboard',
+      copySnackbar: l.privacyExportSuccess,
     );
   }
 
@@ -168,18 +167,21 @@ class _PrivacyDashboardScreenState
         // Share-sheet wiring failed; fall back to clipboard so the bug
         // report isn't blocked on a platform-channel hiccup. #2146 —
         // also surface on the exportable log.
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-          'where': 'PrivacyDashboard._exportErrorLog: share fallback',
-        }));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {
+              'where': 'PrivacyDashboard._exportErrorLog: share fallback',
+            },
+          ),
+        );
         await Clipboard.setData(ClipboardData(text: json));
         if (!mounted) return;
         SnackBarHelper.showSuccess(
           context,
-          _formatCopySnackbar(
-            parsed: parsed,
-            unparsed: unparsed,
-            kb: kb,
-          ),
+          _formatCopySnackbar(parsed: parsed, unparsed: unparsed, kb: kb),
         );
         return;
       }
@@ -233,10 +235,7 @@ class _PrivacyDashboardScreenState
     // box, so invalidate it to force `build`'s `count` read to re-run.
     ref.invalidate(traceStorageProvider);
     final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.privacyErrorLogCleared ?? 'Error log cleared',
-    );
+    SnackBarHelper.showSuccess(context, l.privacyErrorLogCleared);
   }
 
   /// Routes the large error-log payload to the widget-test share seam
@@ -284,8 +283,7 @@ class _PrivacyDashboardScreenState
     await _saveExportToDownloads(
       text: csvText,
       fileName: 'tankstellen-data.csv',
-      copySnackbar:
-          l?.privacyExportCsvSuccess ?? 'CSV data exported to clipboard',
+      copySnackbar: l.privacyExportCsvSuccess,
     );
   }
 
@@ -308,16 +306,20 @@ class _PrivacyDashboardScreenState
         mimeType: fileName.endsWith('.csv') ? 'text/csv' : 'application/json',
       );
       if (!mounted) return;
-      SnackBarHelper.showSuccess(
-        context,
-        l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
-      );
+      SnackBarHelper.showSuccess(context, l.savedToDownloadsFolder);
     } on Object catch (e, st) {
       // #2146 — surface on the user-exportable log.
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
-        'where': 'PrivacyDashboard._saveExportToDownloads',
-        'fileName': fileName,
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.storage,
+          e,
+          st,
+          context: {
+            'where': 'PrivacyDashboard._saveExportToDownloads',
+            'fileName': fileName,
+          },
+        ),
+      );
       if (!mounted) return;
       SnackBarHelper.showSuccess(context, copySnackbar);
     }
@@ -351,33 +353,19 @@ class _PrivacyDashboardScreenState
           color: theme.colorScheme.error,
           size: 48,
         ),
-        title: Text(l?.privacyDeleteTitle ?? 'Delete all data?'),
-        content: Text(
-          l?.privacyDeleteBody ??
-              'This will permanently delete:\n\n'
-                  '- All favorites and station data\n'
-                  '- All search profiles\n'
-                  '- All price alerts\n'
-                  '- All price history\n'
-                  '- All cached data\n'
-                  '- Your API key\n'
-                  '- All app settings\n\n'
-                  'The app will reset to its initial state. '
-                  'This action cannot be undone.',
-        ),
+        title: Text(l.privacyDeleteTitle),
+        content: Text(l.privacyDeleteBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: theme.colorScheme.error,
             ),
             onPressed: () => Navigator.pop(context, true),
-            child: Text(
-              l?.privacyDeleteConfirm ?? 'Delete everything',
-            ),
+            child: Text(l.privacyDeleteConfirm),
           ),
         ],
       ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -74,7 +74,7 @@ class ProfileScreen extends ConsumerWidget {
     final debugOn = enabledFlags.contains(Feature.debugMode);
 
     return PageScaffold(
-      title: l?.settings ?? 'Settings',
+      title: l.settings,
       // #3061 — Settings is a shell branch (no back-stack) → explicit back arrow.
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
@@ -97,7 +97,7 @@ class ProfileScreen extends ConsumerWidget {
           // with the consumption-tier-dependent toggles it gates.
           SectionHeader(
             leadingIcon: Icons.person,
-            title: l?.sectionProfile ?? 'Profile',
+            title: l.sectionProfile,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 4),
@@ -107,15 +107,12 @@ class ProfileScreen extends ConsumerWidget {
           // ── 2. Setup & data sources — what a fresh install must
           // configure first. API Key gates fuel search working at all
           // (#2521 promotes it from #5); Location follows.
-          _groupHeader(
-            icon: Icons.tune,
-            title: l?.sectionSetupDataSources ?? 'Setup & data sources',
-          ),
+          _groupHeader(icon: Icons.tune, title: l.sectionSetupDataSources),
           const SizedBox(height: 4),
           // API Key — closed by default (unchanged).
           _FoldableSection(
             icon: Icons.key,
-            title: l?.apiKeySetup ?? 'API Key',
+            title: l.apiKeySetup,
             child: const ApiKeySection(),
           ),
           const SizedBox(height: 8),
@@ -124,7 +121,7 @@ class ProfileScreen extends ConsumerWidget {
           // after the initial setup.
           _FoldableSection(
             icon: Icons.my_location,
-            title: l?.sectionLocation ?? 'Location',
+            title: l.sectionLocation,
             child: const LocationSectionWidget(),
           ),
           const SizedBox(height: 16),
@@ -142,7 +139,7 @@ class ProfileScreen extends ConsumerWidget {
           // detail CTA, deep links).
           _groupHeader(
             icon: Icons.dashboard_customize_outlined,
-            title: l?.sectionFeaturesUsage ?? 'Features & usage',
+            title: l.sectionFeaturesUsage,
           ),
           const SizedBox(height: 4),
           // #1373 phase 2 — central feature-management toggles.
@@ -152,7 +149,7 @@ class ProfileScreen extends ConsumerWidget {
           // chooser at the same time as the toggles it gates.
           _FoldableSection(
             icon: Icons.tune,
-            title: l?.featureManagementSectionTitle ?? 'Feature management',
+            title: l.featureManagementSectionTitle,
             child: const Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -172,7 +169,7 @@ class ProfileScreen extends ConsumerWidget {
           if (consumptionOn) ...[
             _FoldableSection(
               icon: Icons.local_gas_station_outlined,
-              title: l?.navConsumption ?? 'Consumption',
+              title: l.navConsumption,
               child: const DrivingSettingsSection(),
             ),
             const SizedBox(height: 8),
@@ -189,7 +186,7 @@ class ProfileScreen extends ConsumerWidget {
           if (tankSyncOn) ...[
             _groupHeader(
               icon: Icons.cloud_outlined,
-              title: l?.sectionAccountSync ?? 'Account & sync',
+              title: l.sectionAccountSync,
             ),
             const SizedBox(height: 4),
             _FoldableSection(
@@ -197,8 +194,7 @@ class ProfileScreen extends ConsumerWidget {
               title: 'TankSync', // i18n-ignore: brand name
               // #1696 — a localized descriptive subtitle so the
               // brand-named section isn't an unexplained label.
-              subtitle: l?.tankSyncSectionSubtitle ??
-                  'Cloud sync across your devices',
+              subtitle: l.tankSyncSectionSubtitle,
               child: const TankSyncSection(),
             ),
             const SizedBox(height: 16),
@@ -207,7 +203,7 @@ class ProfileScreen extends ConsumerWidget {
           // ── 5. Appearance & widgets — Theme + Home-screen widget.
           _groupHeader(
             icon: Icons.palette_outlined,
-            title: l?.sectionAppearanceWidgets ?? 'Appearance & widgets',
+            title: l.sectionAppearanceWidgets,
           ),
           const SizedBox(height: 4),
           // Theme — light / dark / follow system (#752, #897).
@@ -217,7 +213,7 @@ class ProfileScreen extends ConsumerWidget {
           // instead of opening a modal bottom sheet inline.
           SettingsMenuTile(
             icon: Icons.palette_outlined,
-            title: l?.themeCardTitle ?? 'Theme',
+            title: l.themeCardTitle,
             subtitle: _themeSubtitle(ref, l),
             onTap: () => context.push(RoutePaths.themeSettings),
           ),
@@ -228,7 +224,7 @@ class ProfileScreen extends ConsumerWidget {
           // in-app discoverable surface for it.
           _FoldableSection(
             icon: Icons.widgets_outlined,
-            title: l?.widgetHelpSectionTitle ?? 'Home-screen widget',
+            title: l.widgetHelpSectionTitle,
             child: const WidgetHelpSection(),
           ),
           const SizedBox(height: 16),
@@ -238,29 +234,28 @@ class ProfileScreen extends ConsumerWidget {
           // and Storage & cache.
           _groupHeader(
             icon: Icons.privacy_tip_outlined,
-            title: l?.sectionPrivacyData ?? 'Privacy & data',
+            title: l.sectionPrivacyData,
           ),
           const SizedBox(height: 4),
           // Privacy & Consent
           _FoldableSection(
             icon: Icons.privacy_tip_outlined,
-            title: l?.gdprTitle ?? 'Privacy',
+            title: l.gdprTitle,
             child: const ConsentSettingsSection(),
           ),
           const SizedBox(height: 8),
           // Privacy Dashboard
           SettingsMenuTile(
             icon: Icons.privacy_tip,
-            title: l?.privacyDashboardTitle ?? 'Privacy Dashboard',
-            subtitle: l?.privacyDashboardSubtitle ??
-                'View, export, or delete your data',
+            title: l.privacyDashboardTitle,
+            subtitle: l.privacyDashboardSubtitle,
             onTap: () => context.push(RoutePaths.privacyDashboard),
           ),
           const SizedBox(height: 8),
           // Storage & Cache
           _FoldableSection(
             icon: Icons.storage,
-            title: l?.storageAndCache ?? 'Storage & cache',
+            title: l.storageAndCache,
             child: const StorageSection(),
           ),
           const SizedBox(height: 16),
@@ -271,7 +266,7 @@ class ProfileScreen extends ConsumerWidget {
           if (patOn || debugOn) ...[
             _groupHeader(
               icon: Icons.developer_mode,
-              title: l?.sectionAdvancedDeveloper ?? 'Advanced & developer',
+              title: l.sectionAdvancedDeveloper,
             ),
             const SizedBox(height: 4),
             // #952 phase 3 + #2116-6 — bad-scan reporter PAT entry,
@@ -281,8 +276,7 @@ class ProfileScreen extends ConsumerWidget {
             if (patOn) ...[
               _FoldableSection(
                 icon: Icons.bug_report_outlined,
-                title: l?.feedbackTokenSectionTitle ??
-                    'Bad-scan feedback (GitHub)',
+                title: l.feedbackTokenSectionTitle,
                 child: const FeedbackTokenSection(),
               ),
               const SizedBox(height: 8),
@@ -293,9 +287,8 @@ class ProfileScreen extends ConsumerWidget {
             if (debugOn) ...[
               SettingsMenuTile(
                 icon: Icons.developer_mode,
-                title: l?.developerToolsSectionTitle ?? 'Developer tools',
-                subtitle: l?.developerToolsMenuSubtitle ??
-                    'Error log, test alerts, diagnostics',
+                title: l.developerToolsSectionTitle,
+                subtitle: l.developerToolsMenuSubtitle,
                 onTap: () => context.push(RoutePaths.developerTools),
               ),
               const SizedBox(height: 8),
@@ -306,7 +299,7 @@ class ProfileScreen extends ConsumerWidget {
           // ── 8. About — kept last (#534).
           SectionHeader(
             leadingIcon: Icons.info_outline,
-            title: l?.about ?? 'About',
+            title: l.about,
             padding: EdgeInsets.zero,
           ),
           const SizedBox(height: 4),
@@ -322,15 +315,8 @@ class ProfileScreen extends ConsumerWidget {
 /// [SectionHeader] that pins the forest-green primary-tinted leading
 /// icon + zero outer padding shared by the new group rows, so the
 /// `build` method reads as a flat list of groups.
-SectionHeader _groupHeader({
-  required IconData icon,
-  required String title,
-}) =>
-    SectionHeader(
-      leadingIcon: icon,
-      title: title,
-      padding: EdgeInsets.zero,
-    );
+SectionHeader _groupHeader({required IconData icon, required String title}) =>
+    SectionHeader(leadingIcon: icon, title: title, padding: EdgeInsets.zero);
 
 // ---------------------------------------------------------------------------
 // Shared layout helpers (kept private to this file)
@@ -365,9 +351,12 @@ class _FoldableSection extends StatelessWidget {
       margin: EdgeInsets.zero,
       child: ExpansionTile(
         leading: Icon(icon, size: 20),
-        title: Text(title,
-            style: theme.textTheme.titleSmall
-                ?.copyWith(fontWeight: FontWeight.bold)),
+        title: Text(
+          title,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
         subtitle: subtitleText == null
             ? null
             : Text(
@@ -387,17 +376,16 @@ class _FoldableSection extends StatelessWidget {
 }
 
 /// Active-mode subtitle on the Theme `SettingsMenuTile` (#897).
-String _themeSubtitle(WidgetRef ref, AppLocalizations? l) {
+String _themeSubtitle(WidgetRef ref, AppLocalizations l) {
   final choice = ref.watch(themeModeSettingProvider);
   switch (choice) {
     case AppThemeChoice.light:
-      return l?.themeCardSubtitleLight ?? 'Light';
+      return l.themeCardSubtitleLight;
     case AppThemeChoice.dark:
-      return l?.themeCardSubtitleDark ?? 'Dark';
+      return l.themeCardSubtitleDark;
     case AppThemeChoice.eco:
-      return l?.themeSettingsEcoLabel ?? 'Eco';
+      return l.themeSettingsEcoLabel;
     case AppThemeChoice.system:
-      return l?.themeCardSubtitleSystem ?? 'System';
+      return l.themeCardSubtitleSystem;
   }
 }
-

--- a/lib/features/profile/presentation/screens/theme_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/theme_settings_screen.dart
@@ -24,7 +24,7 @@ class ThemeSettingsScreen extends ConsumerWidget {
     final choice = ref.watch(themeModeSettingProvider);
 
     return PageScaffold(
-      title: l?.themeSettingsScreenTitle ?? 'Theme',
+      title: l.themeSettingsScreenTitle,
       bodyPadding: EdgeInsets.zero,
       body: RadioGroup<AppThemeChoice>(
         groupValue: choice,
@@ -35,9 +35,8 @@ class ThemeSettingsScreen extends ConsumerWidget {
             _ThemeChoiceOption(
               choice: AppThemeChoice.system,
               icon: Icons.smartphone,
-              label: l?.themeSettingsSystemLabel ?? 'Follow system',
-              description: l?.themeSettingsSystemDescription ??
-                  'Match the current device appearance.',
+              label: l.themeSettingsSystemLabel,
+              description: l.themeSettingsSystemDescription,
               selected: choice == AppThemeChoice.system,
               onTap: () => _select(ref, AppThemeChoice.system),
               keyValue: 'themeSettingsOptionSystem',
@@ -46,9 +45,8 @@ class ThemeSettingsScreen extends ConsumerWidget {
             _ThemeChoiceOption(
               choice: AppThemeChoice.light,
               icon: Icons.light_mode,
-              label: l?.themeSettingsLightLabel ?? 'Light',
-              description: l?.themeSettingsLightDescription ??
-                  'Bright backgrounds — best for daytime use.',
+              label: l.themeSettingsLightLabel,
+              description: l.themeSettingsLightDescription,
               selected: choice == AppThemeChoice.light,
               onTap: () => _select(ref, AppThemeChoice.light),
               keyValue: 'themeSettingsOptionLight',
@@ -57,10 +55,8 @@ class ThemeSettingsScreen extends ConsumerWidget {
             _ThemeChoiceOption(
               choice: AppThemeChoice.dark,
               icon: Icons.dark_mode,
-              label: l?.themeSettingsDarkLabel ?? 'Dark',
-              description: l?.themeSettingsDarkDescription ??
-                  'Dark backgrounds — easier on the eyes at night and '
-                      'saves battery on OLED screens.',
+              label: l.themeSettingsDarkLabel,
+              description: l.themeSettingsDarkDescription,
               selected: choice == AppThemeChoice.dark,
               onTap: () => _select(ref, AppThemeChoice.dark),
               keyValue: 'themeSettingsOptionDark',
@@ -69,10 +65,8 @@ class ThemeSettingsScreen extends ConsumerWidget {
             _ThemeChoiceOption(
               choice: AppThemeChoice.eco,
               icon: Icons.energy_savings_leaf,
-              label: l?.themeSettingsEcoLabel ?? 'Eco',
-              description: l?.themeSettingsEcoDescription ??
-                  "The app's signature green look — bright and easy "
-                      'to read, with softly green-tinted backgrounds.',
+              label: l.themeSettingsEcoLabel,
+              description: l.themeSettingsEcoDescription,
               selected: choice == AppThemeChoice.eco,
               onTap: () => _select(ref, AppThemeChoice.eco),
               keyValue: 'themeSettingsOptionEco',
@@ -137,15 +131,13 @@ class _ThemeChoiceOption extends StatelessWidget {
                     Text(
                       label,
                       style: theme.textTheme.titleSmall?.copyWith(
-                        fontWeight:
-                            selected ? FontWeight.bold : FontWeight.w500,
+                        fontWeight: selected
+                            ? FontWeight.bold
+                            : FontWeight.w500,
                       ),
                     ),
                     const SizedBox(height: 4),
-                    Text(
-                      description,
-                      style: theme.textTheme.bodySmall,
-                    ),
+                    Text(description, style: theme.textTheme.bodySmall),
                   ],
                 ),
               ),

--- a/lib/features/profile/presentation/widgets/about_section.dart
+++ b/lib/features/profile/presentation/widgets/about_section.dart
@@ -27,21 +27,14 @@ class AboutSection extends StatelessWidget {
             leading: const Icon(Icons.person),
             title: const Text(AppConstants.developerName),
             subtitle: const Text(AppConstants.developerEmail),
-            onTap: () => launchUrl(
-              Uri.parse('mailto:${AppConstants.developerEmail}'),
-            ),
+            onTap: () =>
+                launchUrl(Uri.parse('mailto:${AppConstants.developerEmail}')),
           ),
           const Divider(height: 1),
           ListTile(
             leading: const Icon(Icons.code),
-            title: Text(
-              AppLocalizations.of(context)?.openSource ??
-                  'Open Source (MIT License)',
-            ),
-            subtitle: Text(
-              AppLocalizations.of(context)?.sourceCode ??
-                  'Source code on GitHub',
-            ),
+            title: Text(AppLocalizations.of(context).openSource),
+            subtitle: Text(AppLocalizations.of(context).sourceCode),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.developerWebsite),
               mode: LaunchMode.externalApplication,
@@ -49,10 +42,7 @@ class AboutSection extends StatelessWidget {
           ),
           ListTile(
             leading: const Icon(Icons.privacy_tip),
-            title: Text(
-              AppLocalizations.of(context)?.privacyPolicy ??
-                  'Privacy Policy',
-            ),
+            title: Text(AppLocalizations.of(context).privacyPolicy),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.privacyPolicyUrl),
               mode: LaunchMode.externalApplication,
@@ -70,8 +60,7 @@ class AboutSection extends StatelessWidget {
           ),
           ListTile(
             leading: const Icon(Icons.bug_report),
-            title: Text(AppLocalizations.of(context)?.aboutReportBug ??
-                'Report a bug / Suggest a feature'),
+            title: Text(AppLocalizations.of(context).aboutReportBug),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.githubIssuesUrl),
               mode: LaunchMode.externalApplication,
@@ -82,8 +71,7 @@ class AboutSection extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
             child: Text(
-              AppLocalizations.of(context)?.aboutSupportProject ??
-                  'Support this project',
+              AppLocalizations.of(context).aboutSupportProject,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -92,9 +80,7 @@ class AboutSection extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
-              AppLocalizations.of(context)?.aboutSupportDescription ??
-                  'This app is free, open source, and has no ads. '
-                      'If you find it useful, consider supporting the developer.',
+              AppLocalizations.of(context).aboutSupportDescription,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -102,8 +88,7 @@ class AboutSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           ListTile(
-            leading:
-                const Icon(Icons.payment, color: Color(0xFF003087)),
+            leading: const Icon(Icons.payment, color: Color(0xFF003087)),
             title: const Text('PayPal'), // i18n-ignore: brand / proper noun
             subtitle: const Text('paypal.me/FlorianDITTGEN'),
             onTap: () => launchUrl(
@@ -112,8 +97,10 @@ class AboutSection extends StatelessWidget {
             ),
           ),
           ListTile(
-            leading: const Icon(Icons.account_balance_wallet,
-                color: Color(0xFF0075EB)),
+            leading: const Icon(
+              Icons.account_balance_wallet,
+              color: Color(0xFF0075EB),
+            ),
             title: const Text('Revolut'), // i18n-ignore: brand / proper noun
             subtitle: const Text('revolut.me/floriamcep'),
             onTap: () => launchUrl(

--- a/lib/features/profile/presentation/widgets/api_key_section.dart
+++ b/lib/features/profile/presentation/widgets/api_key_section.dart
@@ -20,7 +20,8 @@ class ApiKeySection extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final country = ref.watch(activeCountryProvider);
-    final tankerkoenigUrl = country.apiKeyRegistrationUrl ??
+    final tankerkoenigUrl =
+        country.apiKeyRegistrationUrl ??
         AppConstants.tankerkoenigRegistrationUrl;
 
     return Card(
@@ -33,10 +34,10 @@ class ApiKeySection extends ConsumerWidget {
               context: context,
               theme: theme,
               icon: Icons.local_gas_station,
-              title: l?.fuelPricesTankerkoenig ?? 'Fuel prices (Tankerkoenig)',
+              title: l.fuelPricesTankerkoenig,
               subtitle: storage.hasApiKey()
-                  ? (l?.configured ?? 'Configured')
-                  : (l?.notConfigured ?? 'Not configured'),
+                  ? (l.configured)
+                  : (l.notConfigured),
               isConfigured: storage.hasApiKey(),
               onEdit: () => _editApiKey(context, ref, storage),
             ),
@@ -45,7 +46,7 @@ class ApiKeySection extends ConsumerWidget {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  l?.requiredForFuelSearch ?? 'Required for fuel price search in Germany',
+                  l.requiredForFuelSearch,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -62,7 +63,7 @@ class ApiKeySection extends ConsumerWidget {
                     mode: LaunchMode.externalApplication,
                   ),
                   child: Text(
-                    l?.register ?? 'Register free \u2192',
+                    l.register,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.primary,
                       decoration: TextDecoration.underline,
@@ -79,10 +80,10 @@ class ApiKeySection extends ConsumerWidget {
               context: context,
               theme: theme,
               icon: Icons.ev_station,
-              title: l?.evChargingOpenChargeMap ?? 'EV Charging (OpenChargeMap)',
+              title: l.evChargingOpenChargeMap,
               subtitle: storage.hasCustomEvApiKey()
-                  ? (l?.customKey ?? 'Custom key')
-                  : (l?.appDefaultKey ?? 'App default key'),
+                  ? (l.customKey)
+                  : (l.appDefaultKey),
               isConfigured: true,
               onEdit: () => _editEvApiKey(context, ref, storage),
             ),
@@ -91,7 +92,7 @@ class ApiKeySection extends ConsumerWidget {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  l?.optionalOverrideKey ?? 'Optional: override the built-in app key with your own',
+                  l.optionalOverrideKey,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -104,11 +105,13 @@ class ApiKeySection extends ConsumerWidget {
                 alignment: Alignment.centerLeft,
                 child: InkWell(
                   onTap: () => launchUrl(
-                    Uri.parse('https://openchargemap.org/site/profile/register'),
+                    Uri.parse(
+                      'https://openchargemap.org/site/profile/register',
+                    ),
                     mode: LaunchMode.externalApplication,
                   ),
                   child: Text(
-                    l?.register ?? 'Register free \u2192',
+                    l.register,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.primary,
                       decoration: TextDecoration.underline,
@@ -151,37 +154,37 @@ class ApiKeySection extends ConsumerWidget {
       trailing: IconButton(
         icon: const Icon(Icons.edit, size: 20),
         onPressed: onEdit,
-        tooltip: AppLocalizations.of(context)?.edit ?? 'Edit',
+        tooltip: AppLocalizations.of(context).edit,
       ),
     );
   }
 
   Future<void> _editApiKey(
-      BuildContext context, WidgetRef ref, ApiKeyStorage storage) async {
-    final controller = TextEditingController(
-      text: storage.getApiKey() ?? '',
-    );
+    BuildContext context,
+    WidgetRef ref,
+    ApiKeyStorage storage,
+  ) async {
+    final controller = TextEditingController(text: storage.getApiKey() ?? '');
 
     final result = await showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)?.fuelPricesApiKey ?? 'Fuel prices API Key'),
+        title: Text(AppLocalizations.of(context).fuelPricesApiKey),
         content: TextField(
           controller: controller,
           decoration: InputDecoration(
-            labelText: AppLocalizations.of(context)?.tankerkoenigApiKeyLabel ??
-                'Tankerkoenig API Key',
+            labelText: AppLocalizations.of(context).tankerkoenigApiKeyLabel,
             border: const OutlineInputBorder(),
           ),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, controller.text),
-            child: Text(AppLocalizations.of(context)?.save ?? 'Save'),
+            child: Text(AppLocalizations.of(context).save),
           ),
         ],
       ),
@@ -198,31 +201,31 @@ class ApiKeySection extends ConsumerWidget {
   }
 
   Future<void> _editEvApiKey(
-      BuildContext context, WidgetRef ref, ApiKeyStorage storage) async {
-    final controller = TextEditingController(
-      text: storage.getEvApiKey() ?? '',
-    );
+    BuildContext context,
+    WidgetRef ref,
+    ApiKeyStorage storage,
+  ) async {
+    final controller = TextEditingController(text: storage.getEvApiKey() ?? '');
 
     final result = await showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)?.evChargingApiKey ?? 'EV Charging API Key'),
+        title: Text(AppLocalizations.of(context).evChargingApiKey),
         content: TextField(
           controller: controller,
           decoration: InputDecoration(
-            labelText: AppLocalizations.of(context)?.openChargeMapApiKeyLabel ??
-                'OpenChargeMap API Key',
+            labelText: AppLocalizations.of(context).openChargeMapApiKeyLabel,
             border: const OutlineInputBorder(),
           ),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, controller.text),
-            child: Text(AppLocalizations.of(context)?.save ?? 'Save'),
+            child: Text(AppLocalizations.of(context).save),
           ),
         ],
       ),

--- a/lib/features/profile/presentation/widgets/config_verification_widget.dart
+++ b/lib/features/profile/presentation/widgets/config_verification_widget.dart
@@ -36,82 +36,79 @@ class ConfigVerificationWidget extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _sectionTitle(theme, l?.configProfileSection ?? 'Profile'),
+            _sectionTitle(theme, l.configProfileSection),
             const SizedBox(height: 8),
             _ConfigRow(
               icon: Icons.person,
-              label: l?.configActiveProfile ?? 'Active profile',
-              value: profile?.name ?? (l?.configNone ?? 'None'),
+              label: l.configActiveProfile,
+              value: profile?.name ?? (l.configNone),
               status: profile != null ? _Status.ok : _Status.warning,
             ),
             _ConfigRow(
               icon: Icons.local_gas_station,
-              label: l?.configPreferredFuel ?? 'Preferred fuel',
+              label: l.configPreferredFuel,
               value: profile?.preferredFuelType.displayName ?? '\u2014',
               status: _Status.ok,
             ),
             _ConfigRow(
               icon: Icons.language,
-              label: l?.configCountry ?? 'Country',
+              label: l.configCountry,
               value: profile?.countryCode?.toUpperCase() ?? 'Auto',
               status: _Status.ok,
             ),
             _ConfigRow(
               icon: Icons.route,
-              label: l?.configRouteSegment ?? 'Route segment',
+              label: l.configRouteSegment,
               value: '${profile?.routeSegmentKm.round() ?? 50} km',
               status: _Status.ok,
             ),
 
             const Divider(height: 24),
-            _sectionTitle(theme, l?.configApiKeysSection ?? 'API keys'),
+            _sectionTitle(theme, l.configApiKeysSection),
             const SizedBox(height: 8),
             _ConfigRow(
               icon: Icons.key,
-              label: l?.configTankerkoenigKey ?? 'Tankerkoenig API key',
+              label: l.configTankerkoenigKey,
               // #521 — never render "Not set (demo mode)": the bundled
               // community key means the app always has a working key.
               // The row now distinguishes user-set (Configurée / green)
               // from the community default (same status — real data,
               // just not the user's own key).
               value: hasCustomApiKey
-                  ? (l?.configApiKeyConfigured ?? 'Configured')
-                  : (l?.configApiKeyCommunity ?? 'Default (community key)'),
+                  ? (l.configApiKeyConfigured)
+                  : (l.configApiKeyCommunity),
               status: _Status.ok,
             ),
             _ConfigRow(
               icon: Icons.ev_station,
-              label: l?.configEvKey ?? 'EV charging API key',
+              label: l.configEvKey,
               value: apiKeys.hasCustomEvApiKey()
-                  ? (l?.configEvKeyCustom ?? 'Custom key')
-                  : (l?.configEvKeyShared ?? 'Default (shared)'),
+                  ? (l.configEvKeyCustom)
+                  : (l.configEvKeyShared),
               status: _Status.ok,
             ),
 
             const Divider(height: 24),
-            _sectionTitle(theme, l?.configCloudSyncSection ?? 'Cloud Sync'),
+            _sectionTitle(theme, l.configCloudSyncSection),
             const SizedBox(height: 8),
             _ConfigRow(
               icon: Icons.cloud,
               label: 'TankSync',
               value: syncConfig.isConfigured
-                  ? (l?.configTankSyncConnected ?? 'Connected')
-                  : (l?.configTankSyncDisabled ?? 'Disabled'),
-              status:
-                  syncConfig.isConfigured ? _Status.ok : _Status.neutral,
+                  ? (l.configTankSyncConnected)
+                  : (l.configTankSyncDisabled),
+              status: syncConfig.isConfigured ? _Status.ok : _Status.neutral,
             ),
             if (syncConfig.isConfigured) ...[
               _ConfigRow(
                 icon: Icons.security,
-                label: l?.configAuthMode ?? 'Auth mode',
-                value: isEmail
-                    ? (l?.configAuthEmail ?? 'Email (persistent)')
-                    : (l?.configAuthAnonymous ?? 'Anonymous (device-only)'),
+                label: l.configAuthMode,
+                value: isEmail ? (l.configAuthEmail) : (l.configAuthAnonymous),
                 status: isEmail ? _Status.ok : _Status.warning,
               ),
               _ConfigRow(
                 icon: Icons.dns,
-                label: l?.configDatabase ?? 'Database',
+                label: l.configDatabase,
                 value: syncConfig.supabaseUrl ?? '\u2014',
                 status: _Status.ok,
                 // A Supabase URL is long enough to wrap "Database" onto two
@@ -130,9 +127,10 @@ class ConfigVerificationWidget extends ConsumerWidget {
   }
 
   Widget _sectionTitle(ThemeData theme, String title) {
-    return Text(title,
-        style: theme.textTheme.titleSmall
-            ?.copyWith(fontWeight: FontWeight.bold));
+    return Text(
+      title,
+      style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+    );
   }
 
   Widget _buildPrivacySummary(
@@ -143,20 +141,11 @@ class ConfigVerificationWidget extends ConsumerWidget {
   ) {
     final l = AppLocalizations.of(context);
     final authNote = isEmail
-        ? (l?.configAuthNoteEmail ??
-            'Email account enables cross-device access')
-        : (l?.configAuthNoteAnonymous ??
-            'Anonymous account — data tied to this device');
+        ? (l.configAuthNoteEmail)
+        : (l.configAuthNoteAnonymous);
     final summaryBody = syncConfig.isConfigured as bool
-        ? (l?.configPrivacySummarySynced(authNote) ??
-            '• Favorites, alerts, and ignored stations are synced to your '
-                'private database\n'
-                '• GPS position and API keys never leave your device\n'
-                '• $authNote')
-        : (l?.configPrivacySummaryLocal ??
-            '• All data is stored locally on this device only\n'
-                '• No data is sent to any server\n'
-                '• API keys encrypted in device secure storage');
+        ? (l.configPrivacySummarySynced(authNote))
+        : (l.configPrivacySummaryLocal);
 
     return Container(
       padding: const EdgeInsets.all(12),
@@ -172,7 +161,7 @@ class ConfigVerificationWidget extends ConsumerWidget {
               Icon(Icons.shield, size: 16, color: theme.colorScheme.primary),
               const SizedBox(width: 8),
               Text(
-                l?.configPrivacySummary ?? 'Privacy summary',
+                l.configPrivacySummary,
                 style: theme.textTheme.titleSmall?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: theme.colorScheme.primary,
@@ -244,9 +233,7 @@ class _ConfigRow extends StatelessWidget {
               children: [
                 Icon(icon, size: 14, color: statusColor),
                 const SizedBox(width: 8),
-                Expanded(
-                  child: Text(label, style: theme.textTheme.bodySmall),
-                ),
+                Expanded(child: Text(label, style: theme.textTheme.bodySmall)),
               ],
             ),
             Padding(

--- a/lib/features/profile/presentation/widgets/country_change_dialog.dart
+++ b/lib/features/profile/presentation/widgets/country_change_dialog.dart
@@ -24,16 +24,16 @@ Future<bool> showCountryChangeDialog(
     context: context,
     builder: (ctx) {
       return AlertDialog(
-        title: Text(l10n?.countryChangeTitle ?? 'Switch country?'),
+        title: Text(l10n.countryChangeTitle),
         content: _DialogBody(from: from, to: to, l10n: l10n),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l10n?.cancel ?? 'Cancel'),
+            child: Text(l10n.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l10n?.countryChangeConfirm ?? 'Switch'),
+            child: Text(l10n.countryChangeConfirm),
           ),
         ],
       );
@@ -58,13 +58,9 @@ bool countriesDifferInUnits(CountryConfig from, CountryConfig to) {
 class _DialogBody extends StatelessWidget {
   final CountryConfig from;
   final CountryConfig to;
-  final AppLocalizations? l10n;
+  final AppLocalizations l10n;
 
-  const _DialogBody({
-    required this.from,
-    required this.to,
-    required this.l10n,
-  });
+  const _DialogBody({required this.from, required this.to, required this.l10n});
 
   @override
   Widget build(BuildContext context) {
@@ -73,44 +69,39 @@ class _DialogBody extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          l10n?.countryChangeBody(to.name) ??
-              'Switching to ${to.name} will change:',
-        ),
+        Text(l10n.countryChangeBody(to.name)),
         const SizedBox(height: 12),
         if (from.currencySymbol != to.currencySymbol)
           _UnitRow(
-            label: l10n?.countryChangeCurrency ?? 'Currency',
+            label: l10n.countryChangeCurrency,
             fromValue: from.currencySymbol,
             toValue: to.currencySymbol,
             theme: theme,
           ),
         if (from.distanceUnit != to.distanceUnit)
           _UnitRow(
-            label: l10n?.countryChangeDistance ?? 'Distance',
+            label: l10n.countryChangeDistance,
             fromValue: from.distanceUnit,
             toValue: to.distanceUnit,
             theme: theme,
           ),
         if (from.volumeUnit != to.volumeUnit)
           _UnitRow(
-            label: l10n?.countryChangeVolume ?? 'Volume',
+            label: l10n.countryChangeVolume,
             fromValue: from.volumeUnit,
             toValue: to.volumeUnit,
             theme: theme,
           ),
         if (from.pricePerUnitSuffix != to.pricePerUnitSuffix)
           _UnitRow(
-            label: l10n?.countryChangePricePerUnit ?? 'Price format',
+            label: l10n.countryChangePricePerUnit,
             fromValue: from.pricePerUnitSuffix,
             toValue: to.pricePerUnitSuffix,
             theme: theme,
           ),
         const SizedBox(height: 12),
         Text(
-          l10n?.countryChangeNote ??
-              'Existing favorites and fill-up logs are not rewritten; '
-                  'only new entries use the new units.',
+          l10n.countryChangeNote,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/lib/features/profile/presentation/widgets/error_log_export_row.dart
+++ b/lib/features/profile/presentation/widgets/error_log_export_row.dart
@@ -80,10 +80,7 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
                 key: const ValueKey('error-log-export-button'),
                 onPressed: _exportErrorLog,
                 icon: const Icon(Icons.bug_report_outlined),
-                label: Text(
-                  l?.developerToolsExportErrorLog(errorLogCount) ??
-                      'Save error log ($errorLogCount)',
-                ),
+                label: Text(l.developerToolsExportErrorLog(errorLogCount)),
               ),
             ),
             const SizedBox(width: 8),
@@ -91,7 +88,7 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
               key: const ValueKey('error-log-clear-button'),
               onPressed: errorLogCount == 0 ? null : _clearErrorLog,
               icon: const Icon(Icons.delete_outline),
-              tooltip: l?.developerToolsClearErrorLog ?? 'Clear error log',
+              tooltip: l.developerToolsClearErrorLog,
             ),
           ],
         ),
@@ -101,7 +98,7 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
             key: const ValueKey('error-log-view-button'),
             onPressed: widget.onView,
             icon: const Icon(Icons.list_alt_outlined),
-            label: Text(l?.developerToolsViewErrorLog ?? 'View error log'),
+            label: Text(l.developerToolsViewErrorLog),
           ),
         ],
       ],
@@ -123,9 +120,16 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
       try {
         await _shareErrorLogAsFile(json);
       } on Object catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-          'where': 'ErrorLogExportRow._exportErrorLog: share fallback',
-        }));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {
+              'where': 'ErrorLogExportRow._exportErrorLog: share fallback',
+            },
+          ),
+        );
         await Clipboard.setData(ClipboardData(text: json));
         if (!mounted) return;
         SnackBarHelper.showSuccess(
@@ -147,8 +151,11 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
     await Clipboard.setData(ClipboardData(text: json));
     await _saveExportToDownloads(
       text: json,
-      copySnackbar:
-          _formatCopySnackbar(parsed: parsed, unparsed: unparsed, kb: kb),
+      copySnackbar: _formatCopySnackbar(
+        parsed: parsed,
+        unparsed: unparsed,
+        kb: kb,
+      ),
     );
   }
 
@@ -169,10 +176,7 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
     if (!mounted) return;
     ref.invalidate(traceStorageProvider);
     final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.privacyErrorLogCleared ?? 'Error log cleared',
-    );
+    SnackBarHelper.showSuccess(context, l.privacyErrorLogCleared);
   }
 
   /// Routes the large payload to the widget-test share seam only. The
@@ -207,15 +211,19 @@ class _ErrorLogExportRowState extends ConsumerState<ErrorLogExportRow> {
         mimeType: 'application/json',
       );
       if (!mounted) return;
-      SnackBarHelper.showSuccess(
-        context,
-        l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
-      );
+      SnackBarHelper.showSuccess(context, l.savedToDownloadsFolder);
     } on Object catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'ErrorLogExportRow._saveExportToDownloads',
-        'fileName': 'tankstellen-error-log.json',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.storage,
+          e,
+          st,
+          context: const {
+            'where': 'ErrorLogExportRow._saveExportToDownloads',
+            'fileName': 'tankstellen-error-log.json',
+          },
+        ),
+      );
       if (!mounted) return;
       SnackBarHelper.showSuccess(context, copySnackbar);
     }

--- a/lib/features/profile/presentation/widgets/feature_management/conso_feature_card.dart
+++ b/lib/features/profile/presentation/widgets/feature_management/conso_feature_card.dart
@@ -65,15 +65,15 @@ class ConsoFeatureCard extends ConsumerWidget {
               segments: <ButtonSegment<ConsoMode>>[
                 ButtonSegment<ConsoMode>(
                   value: ConsoMode.off,
-                  label: Text(l?.consoModeOff ?? 'Off'),
+                  label: Text(l.consoModeOff),
                 ),
                 ButtonSegment<ConsoMode>(
                   value: ConsoMode.fuel,
-                  label: Text(l?.consoModeFuel ?? 'Fuel'),
+                  label: Text(l.consoModeFuel),
                 ),
                 ButtonSegment<ConsoMode>(
                   value: ConsoMode.fuelAndTrips,
-                  label: Text(l?.consoModeFuelAndTrips ?? 'Fuel + Trips'),
+                  label: Text(l.consoModeFuelAndTrips),
                 ),
               ],
               selected: <ConsoMode>{mode},
@@ -125,17 +125,14 @@ class ConsoFeatureCard extends ConsumerWidget {
     );
   }
 
-  String _modeDescription(AppLocalizations? l, ConsoMode m) {
+  String _modeDescription(AppLocalizations l, ConsoMode m) {
     switch (m) {
       case ConsoMode.off:
-        return l?.consoModeOffDescription ??
-            'No Conso tab and no Conso settings section.';
+        return l.consoModeOffDescription;
       case ConsoMode.fuel:
-        return l?.consoModeFuelDescription ??
-            'Manual fill-ups only. Useful without an OBD2 adapter.';
+        return l.consoModeFuelDescription;
       case ConsoMode.fuelAndTrips:
-        return l?.consoModeFuelAndTripsDescription ??
-            'Adds automatic OBD2 trip recording. Requires a paired adapter.';
+        return l.consoModeFuelAndTripsDescription;
     }
   }
 

--- a/lib/features/profile/presentation/widgets/feature_management/feature_localization.dart
+++ b/lib/features/profile/presentation/widgets/feature_management/feature_localization.dart
@@ -20,41 +20,41 @@ import '../../../../feature_management/domain/feature_manifest.dart';
 // Extracted from feature_management_section.dart for #2681 (file-length).
 // ---------------------------------------------------------------------------
 
-String featureLabel(AppLocalizations? l, Feature f) {
+String featureLabel(AppLocalizations l, Feature f) {
   final m = FeatureManifest.defaultManifest.entryFor(f);
   switch (f) {
     case Feature.obd2TripRecording:
-      return l?.featureLabel_obd2TripRecording ?? m.displayName;
+      return l.featureLabel_obd2TripRecording;
     case Feature.gamification:
-      return l?.featureLabel_gamification ?? m.displayName;
+      return l.featureLabel_gamification;
     case Feature.hapticEcoCoach:
-      return l?.featureLabel_hapticEcoCoach ?? m.displayName;
+      return l.featureLabel_hapticEcoCoach;
     case Feature.tankSync:
-      return l?.featureLabel_tankSync ?? m.displayName;
+      return l.featureLabel_tankSync;
     case Feature.consumptionAnalytics:
-      return l?.featureLabel_consumptionAnalytics ?? m.displayName;
+      return l.featureLabel_consumptionAnalytics;
     case Feature.baselineSync:
-      return l?.featureLabel_baselineSync ?? m.displayName;
+      return l.featureLabel_baselineSync;
     case Feature.priceAlerts:
-      return l?.featureLabel_priceAlerts ?? m.displayName;
+      return l.featureLabel_priceAlerts;
     case Feature.priceHistory:
-      return l?.featureLabel_priceHistory ?? m.displayName;
+      return l.featureLabel_priceHistory;
     case Feature.routePlanning:
-      return l?.featureLabel_routePlanning ?? m.displayName;
+      return l.featureLabel_routePlanning;
     case Feature.evCharging:
-      return l?.featureLabel_evCharging ?? m.displayName;
+      return l.featureLabel_evCharging;
     case Feature.glideCoach:
-      return l?.featureLabel_glideCoach ?? m.displayName;
+      return l.featureLabel_glideCoach;
     case Feature.gpsTripPath:
-      return l?.featureLabel_gpsTripPath ?? m.displayName;
+      return l.featureLabel_gpsTripPath;
     case Feature.autoRecord:
-      return l?.featureLabel_autoRecord ?? m.displayName;
+      return l.featureLabel_autoRecord;
     case Feature.showFuel:
-      return l?.featureLabel_showFuel ?? m.displayName;
+      return l.featureLabel_showFuel;
     case Feature.showElectric:
-      return l?.featureLabel_showElectric ?? m.displayName;
+      return l.featureLabel_showElectric;
     case Feature.showConsumptionTab:
-      return l?.featureLabel_showConsumptionTab ?? m.displayName;
+      return l.featureLabel_showConsumptionTab;
     case Feature.manualConsumption:
       // #1517: ARB strings to follow in a localisation pass; English-only
       // fallback from the manifest SSoT (#2189) so the toggle is readable.
@@ -64,73 +64,73 @@ String featureLabel(AppLocalizations? l, Feature f) {
       // fallback from the manifest SSoT (#2189) so the toggle is readable.
       return m.displayName;
     case Feature.tflitePricePrediction:
-      return l?.featureLabel_tflitePricePrediction ?? m.displayName;
+      return l.featureLabel_tflitePricePrediction;
     case Feature.fuelCalculator:
-      return l?.featureLabel_fuelCalculator ?? m.displayName;
+      return l.featureLabel_fuelCalculator;
     case Feature.carbonDashboard:
-      return l?.featureLabel_carbonDashboard ?? m.displayName;
+      return l.featureLabel_carbonDashboard;
     case Feature.experimentalOemPids:
-      return l?.featureLabel_experimentalOemPids ?? m.displayName;
+      return l.featureLabel_experimentalOemPids;
     case Feature.paymentQrScan:
-      return l?.featureLabel_paymentQrScan ?? m.displayName;
+      return l.featureLabel_paymentQrScan;
     case Feature.communityPriceReports:
-      return l?.featureLabel_communityPriceReports ?? m.displayName;
+      return l.featureLabel_communityPriceReports;
     case Feature.obd2Optional:
-      return l?.featureLabel_obd2Optional ?? m.displayName;
+      return l.featureLabel_obd2Optional;
     case Feature.addFillUpOcrReceipt:
-      return l?.featureLabel_addFillUpOcrReceipt ?? m.displayName;
+      return l.featureLabel_addFillUpOcrReceipt;
     case Feature.addFillUpOcrPump:
-      return l?.featureLabel_addFillUpOcrPump ?? m.displayName;
+      return l.featureLabel_addFillUpOcrPump;
     case Feature.addFillUpShareIntentReceipt:
-      return l?.featureLabel_addFillUpShareIntentReceipt ?? m.displayName;
+      return l.featureLabel_addFillUpShareIntentReceipt;
     case Feature.developerPatToken:
-      return l?.featureLabel_developerPatToken ?? m.displayName;
+      return l.featureLabel_developerPatToken;
     case Feature.debugMode:
-      return l?.featureLabel_debugMode ?? m.displayName;
+      return l.featureLabel_debugMode;
     case Feature.approachOverlay:
       // #2681 — renamed to "Fuel Station Radar"; the manifest displayName
       // fallback was renamed in lock-step so this stays the SSoT.
-      return l?.featureLabel_approachOverlay ?? m.displayName;
+      return l.featureLabel_approachOverlay;
     case Feature.voiceAnnouncements:
-      return l?.featureLabel_voiceAnnouncements ?? m.displayName;
+      return l.featureLabel_voiceAnnouncements;
   }
 }
 
-String featureDescription(AppLocalizations? l, Feature f) {
+String featureDescription(AppLocalizations l, Feature f) {
   final m = FeatureManifest.defaultManifest.entryFor(f);
   switch (f) {
     case Feature.obd2TripRecording:
-      return l?.featureDescription_obd2TripRecording ?? m.description;
+      return l.featureDescription_obd2TripRecording;
     case Feature.gamification:
-      return l?.featureDescription_gamification ?? m.description;
+      return l.featureDescription_gamification;
     case Feature.hapticEcoCoach:
-      return l?.featureDescription_hapticEcoCoach ?? m.description;
+      return l.featureDescription_hapticEcoCoach;
     case Feature.tankSync:
-      return l?.featureDescription_tankSync ?? m.description;
+      return l.featureDescription_tankSync;
     case Feature.consumptionAnalytics:
-      return l?.featureDescription_consumptionAnalytics ?? m.description;
+      return l.featureDescription_consumptionAnalytics;
     case Feature.baselineSync:
-      return l?.featureDescription_baselineSync ?? m.description;
+      return l.featureDescription_baselineSync;
     case Feature.priceAlerts:
-      return l?.featureDescription_priceAlerts ?? m.description;
+      return l.featureDescription_priceAlerts;
     case Feature.priceHistory:
-      return l?.featureDescription_priceHistory ?? m.description;
+      return l.featureDescription_priceHistory;
     case Feature.routePlanning:
-      return l?.featureDescription_routePlanning ?? m.description;
+      return l.featureDescription_routePlanning;
     case Feature.evCharging:
-      return l?.featureDescription_evCharging ?? m.description;
+      return l.featureDescription_evCharging;
     case Feature.glideCoach:
-      return l?.featureDescription_glideCoach ?? m.description;
+      return l.featureDescription_glideCoach;
     case Feature.gpsTripPath:
-      return l?.featureDescription_gpsTripPath ?? m.description;
+      return l.featureDescription_gpsTripPath;
     case Feature.autoRecord:
-      return l?.featureDescription_autoRecord ?? m.description;
+      return l.featureDescription_autoRecord;
     case Feature.showFuel:
-      return l?.featureDescription_showFuel ?? m.description;
+      return l.featureDescription_showFuel;
     case Feature.showElectric:
-      return l?.featureDescription_showElectric ?? m.description;
+      return l.featureDescription_showElectric;
     case Feature.showConsumptionTab:
-      return l?.featureDescription_showConsumptionTab ?? m.description;
+      return l.featureDescription_showConsumptionTab;
     case Feature.manualConsumption:
       // #1517: ARB strings to follow in a localisation pass; English-only
       // fallback from the manifest SSoT (#2189).
@@ -140,86 +140,70 @@ String featureDescription(AppLocalizations? l, Feature f) {
       // fallback from the manifest SSoT (#2189).
       return m.description;
     case Feature.tflitePricePrediction:
-      return l?.featureDescription_tflitePricePrediction ?? m.description;
+      return l.featureDescription_tflitePricePrediction;
     case Feature.fuelCalculator:
-      return l?.featureDescription_fuelCalculator ?? m.description;
+      return l.featureDescription_fuelCalculator;
     case Feature.carbonDashboard:
-      return l?.featureDescription_carbonDashboard ?? m.description;
+      return l.featureDescription_carbonDashboard;
     case Feature.experimentalOemPids:
-      return l?.featureDescription_experimentalOemPids ?? m.description;
+      return l.featureDescription_experimentalOemPids;
     case Feature.paymentQrScan:
-      return l?.featureDescription_paymentQrScan ?? m.description;
+      return l.featureDescription_paymentQrScan;
     case Feature.communityPriceReports:
-      return l?.featureDescription_communityPriceReports ?? m.description;
+      return l.featureDescription_communityPriceReports;
     case Feature.obd2Optional:
       // note: manifest differs — the manifest description carries an extra
       // "Calibration drops to confidence tier A…" sentence the toggle
       // subtitle intentionally omits, so keep the local literal here to
       // preserve the existing user-facing text (#2189).
-      return l?.featureDescription_obd2Optional ??
-          'When off, the app records GPS-only trajets without needing an '
-              'OBD2 adapter. Coaching is reduced — no instant L/100 km, '
-              'fewer engine-derived signals.';
+      return l.featureDescription_obd2Optional;
     case Feature.addFillUpOcrReceipt:
-      return l?.featureDescription_addFillUpOcrReceipt ?? m.description;
+      return l.featureDescription_addFillUpOcrReceipt;
     case Feature.addFillUpOcrPump:
-      return l?.featureDescription_addFillUpOcrPump ?? m.description;
+      return l.featureDescription_addFillUpOcrPump;
     case Feature.addFillUpShareIntentReceipt:
-      return l?.featureDescription_addFillUpShareIntentReceipt ?? m.description;
+      return l.featureDescription_addFillUpShareIntentReceipt;
     case Feature.developerPatToken:
       // note: manifest differs — this subtitle adds a "Power-user /
       // contributor feature." sentence absent from the manifest
       // description, so keep the local literal to preserve the existing
       // user-facing text (#2189).
-      return l?.featureDescription_developerPatToken ??
-          'Enable the bad-scan feedback panel that auto-files GitHub '
-              'issues with a Personal Access Token. Power-user / '
-              'contributor feature.';
+      return l.featureDescription_developerPatToken;
     case Feature.debugMode:
-      return l?.featureDescription_debugMode ?? m.description;
+      return l.featureDescription_debugMode;
     case Feature.approachOverlay:
-      return l?.featureDescription_approachOverlay ?? m.description;
+      return l.featureDescription_approachOverlay;
     case Feature.voiceAnnouncements:
-      return l?.featureDescription_voiceAnnouncements ?? m.description;
+      return l.featureDescription_voiceAnnouncements;
   }
 }
 
-String blockedEnableMessage(AppLocalizations? l, Feature f) {
+String blockedEnableMessage(AppLocalizations l, Feature f) {
   switch (f) {
     case Feature.gamification:
-      return l?.featureBlockedEnable_gamification ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_gamification;
     case Feature.hapticEcoCoach:
-      return l?.featureBlockedEnable_hapticEcoCoach ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_hapticEcoCoach;
     case Feature.consumptionAnalytics:
-      return l?.featureBlockedEnable_consumptionAnalytics ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_consumptionAnalytics;
     case Feature.baselineSync:
-      return l?.featureBlockedEnable_baselineSync ?? 'Enable TankSync first';
+      return l.featureBlockedEnable_baselineSync;
     case Feature.glideCoach:
-      return l?.featureBlockedEnable_glideCoach ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_glideCoach;
     case Feature.gpsTripPath:
-      return l?.featureBlockedEnable_gpsTripPath ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_gpsTripPath;
     case Feature.autoRecord:
-      return l?.featureBlockedEnable_autoRecord ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_autoRecord;
     case Feature.showConsumptionTab:
-      return l?.featureBlockedEnable_showConsumptionTab ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_showConsumptionTab;
     case Feature.experimentalOemPids:
-      return l?.featureBlockedEnable_experimentalOemPids ??
-          'Enable OBD2 trip recording first';
+      return l.featureBlockedEnable_experimentalOemPids;
     case Feature.tflitePricePrediction:
-      return l?.featureBlockedEnable_tflitePricePrediction ??
-          'Enable price history first';
+      return l.featureBlockedEnable_tflitePricePrediction;
     case Feature.voiceAnnouncements:
       // #2681 — renamed prerequisite from "approach overlay" to "Fuel
       // Station Radar" to match the renamed parent toggle.
-      return l?.featureBlockedEnable_voiceAnnouncements ??
-          'Enable the Fuel Station Radar first';
+      return l.featureBlockedEnable_voiceAnnouncements;
     // Features without prerequisites can never reach this branch — the
     // dependency-graph helpers short-circuit. Return a generic fallback
     // so the function is total in case the manifest changes.

--- a/lib/features/profile/presentation/widgets/feature_management/feature_section_header.dart
+++ b/lib/features/profile/presentation/widgets/feature_management/feature_section_header.dart
@@ -47,51 +47,43 @@ class FeatureSectionHeader extends StatelessWidget {
     );
   }
 
-  String _title(AppLocalizations? l, FeatureCategory c) {
+  String _title(AppLocalizations l, FeatureCategory c) {
     switch (c) {
       case FeatureCategory.finding:
-        return l?.featureGroupTitle_finding ?? 'Finding & map';
+        return l.featureGroupTitle_finding;
       case FeatureCategory.prices:
-        return l?.featureGroupTitle_prices ?? 'Prices & alerts';
+        return l.featureGroupTitle_prices;
       case FeatureCategory.radar:
-        return l?.featureGroupTitle_radar ?? 'Fuel Station Radar';
+        return l.featureGroupTitle_radar;
       case FeatureCategory.consumption:
         // The consumption section reuses the renamed Conso group title.
-        return l?.consoFeatureGroupTitle ?? 'Consumption';
+        return l.consoFeatureGroupTitle;
       case FeatureCategory.sync:
-        return l?.featureGroupTitle_sync ?? 'Sync & backup';
+        return l.featureGroupTitle_sync;
       case FeatureCategory.input:
-        return l?.featureGroupTitle_input ?? 'Input & scanning';
+        return l.featureGroupTitle_input;
       case FeatureCategory.developer:
-        return l?.featureGroupTitle_developer ?? 'Developer & experimental';
+        return l.featureGroupTitle_developer;
     }
   }
 
-  String _subtitle(AppLocalizations? l, FeatureCategory c) {
+  String _subtitle(AppLocalizations l, FeatureCategory c) {
     switch (c) {
       case FeatureCategory.finding:
-        return l?.featureGroupDescription_finding ??
-            'Where to fuel up or charge — search, map, routing.';
+        return l.featureGroupDescription_finding;
       case FeatureCategory.prices:
-        return l?.featureGroupDescription_prices ??
-            'Price drops, history, and reporting.';
+        return l.featureGroupDescription_prices;
       case FeatureCategory.radar:
-        return l?.featureGroupDescription_radar ??
-            'Live price nudges as you drive.';
+        return l.featureGroupDescription_radar;
       case FeatureCategory.consumption:
         // The consumption section reuses the renamed Conso group subtitle.
-        return l?.consoFeatureGroupDescription ??
-            'Track your consumption — manual fill-ups, or '
-                'automatic OBD2 trip recording.';
+        return l.consoFeatureGroupDescription;
       case FeatureCategory.sync:
-        return l?.featureGroupDescription_sync ??
-            'Keep your data across devices.';
+        return l.featureGroupDescription_sync;
       case FeatureCategory.input:
-        return l?.featureGroupDescription_input ??
-            'Helpers for logging fill-ups.';
+        return l.featureGroupDescription_input;
       case FeatureCategory.developer:
-        return l?.featureGroupDescription_developer ??
-            'Power-user and contributor tools.';
+        return l.featureGroupDescription_developer;
     }
   }
 }

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -127,16 +127,18 @@ class FeatureManagementSection extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
             child: Text(
-              l?.featureManagementSectionSubtitle ??
-                  'Turn individual features on or off. Some features '
-                      'depend on others — switches are disabled until '
-                      'prerequisites are met.',
+              l.featureManagementSectionSubtitle,
               style: theme.textTheme.bodySmall,
             ),
           ),
           for (final category in categoryOrder)
-            ..._buildSection(category, byCategory[category] ?? [], consoCard,
-                manifest, enabled),
+            ..._buildSection(
+              category,
+              byCategory[category] ?? [],
+              consoCard,
+              manifest,
+              enabled,
+            ),
         ],
       ),
     );

--- a/lib/features/profile/presentation/widgets/feedback_token_section.dart
+++ b/lib/features/profile/presentation/widgets/feedback_token_section.dart
@@ -61,9 +61,16 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
     } catch (e, st) {
       // #2146 — route to errorLogger so secure-storage failures land
       // in the user-exportable log alongside other catches.
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'FeedbackTokenSection._refresh: secure-storage read',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.storage,
+          e,
+          st,
+          context: const {
+            'where': 'FeedbackTokenSection._refresh: secure-storage read',
+          },
+        ),
+      );
       if (!mounted) return;
       setState(() {
         _hasToken = false;
@@ -82,10 +89,7 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text(
-            l?.feedbackTokenDescription ??
-                'To automatically open a GitHub ticket from a failed scan, '
-                    'paste a GitHub PAT (`public_repo` scope on the tankstellen '
-                    'repository). Otherwise manual sharing remains available.',
+            l.feedbackTokenDescription,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -105,19 +109,19 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
                 _loading
                     ? '…'
                     : _hasToken
-                        ? (l?.feedbackTokenStatusSet ?? 'Token configured')
-                        : (l?.feedbackTokenStatusUnset ?? 'No token'),
+                    ? (l.feedbackTokenStatusSet)
+                    : (l.feedbackTokenStatusUnset),
                 style: theme.textTheme.bodySmall,
               ),
               const Spacer(),
               if (_hasToken)
                 TextButton(
                   onPressed: _loading ? null : _clearToken,
-                  child: Text(l?.feedbackTokenClear ?? 'Clear'),
+                  child: Text(l.feedbackTokenClear),
                 ),
               FilledButton(
                 onPressed: _loading ? null : _setToken,
-                child: Text(l?.feedbackTokenSet ?? 'Set'),
+                child: Text(l.feedbackTokenSet),
               ),
             ],
           ),
@@ -137,15 +141,19 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
     if (scrubbed.isEmpty) return;
 
     try {
-      await _storage.write(
-        key: kGithubFeedbackTokenKey,
-        value: scrubbed,
-      );
+      await _storage.write(key: kGithubFeedbackTokenKey, value: scrubbed);
     } catch (e, st) {
       // #2146 — same routing rationale as the read catch above.
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'FeedbackTokenSection._setToken: secure-storage write',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.storage,
+          e,
+          st,
+          context: const {
+            'where': 'FeedbackTokenSection._setToken: secure-storage write',
+          },
+        ),
+      );
       return;
     }
 
@@ -164,9 +172,16 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
       await _storage.delete(key: kGithubFeedbackTokenKey);
     } catch (e, st) {
       // #2146 — same routing rationale as the read/write catches above.
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'FeedbackTokenSection._clearToken: secure-storage delete',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.storage,
+          e,
+          st,
+          context: const {
+            'where': 'FeedbackTokenSection._clearToken: secure-storage delete',
+          },
+        ),
+      );
     }
     if (!mounted) return; // #3159 — see _setToken.
     ref.invalidate(githubIssueReporterProvider);
@@ -199,24 +214,24 @@ class _TokenInputDialogState extends State<_TokenInputDialog> {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      title: Text(l?.feedbackTokenDialogTitle ?? 'GitHub PAT'),
+      title: Text(l.feedbackTokenDialogTitle),
       content: TextField(
         controller: _controller,
         autofocus: true,
         obscureText: true,
         decoration: InputDecoration(
-          labelText: l?.feedbackTokenFieldLabel ?? 'Personal Access Token',
+          labelText: l.feedbackTokenFieldLabel,
           border: const OutlineInputBorder(),
         ),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
-          child: Text(l?.cancel ?? 'Cancel'),
+          child: Text(l.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.pop(context, _controller.text),
-          child: Text(l?.save ?? 'Save'),
+          child: Text(l.save),
         ),
       ],
     );

--- a/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
+++ b/lib/features/profile/presentation/widgets/gamification_settings_tile.dart
@@ -40,13 +40,9 @@ class GamificationSettingsTile extends ConsumerWidget {
     return SwitchListTile(
       key: const Key('gamificationToggle'),
       value: enabled,
-      title: Text(
-        l?.profileGamificationToggleTitle ?? 'Show achievements & scores',
-      ),
+      title: Text(l.profileGamificationToggleTitle),
       subtitle: Text(
-        l?.profileGamificationToggleSubtitle ??
-            'When off, badges, scores and trophy icons are hidden across '
-                'the app.',
+        l.profileGamificationToggleSubtitle,
         style: theme.textTheme.bodySmall,
       ),
       onChanged: (v) {

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -43,8 +43,12 @@ class LocationSectionWidget extends ConsumerWidget {
     );
   }
 
-  Widget _buildGpsStatus(BuildContext context, WidgetRef ref, ThemeData theme,
-      AppLocalizations? l) {
+  Widget _buildGpsStatus(
+    BuildContext context,
+    WidgetRef ref,
+    ThemeData theme,
+    AppLocalizations l,
+  ) {
     final userPos = ref.watch(userPositionProvider);
 
     if (userPos != null) {
@@ -52,21 +56,23 @@ class LocationSectionWidget extends ConsumerWidget {
       final age = diff.inMinutes < 60
           ? '${diff.inMinutes} min'
           : diff.inHours < 24
-              ? '${diff.inHours} h'
-              : '${diff.inDays} d';
+          ? '${diff.inHours} h'
+          : '${diff.inDays} d';
 
       return Row(
         children: [
           Icon(Icons.check_circle, size: 16, color: theme.colorScheme.primary),
           const SizedBox(width: 8),
           Expanded(
-            child: Text('${userPos.source} ($age)',
-                style: theme.textTheme.bodyMedium),
+            child: Text(
+              '${userPos.source} ($age)',
+              style: theme.textTheme.bodyMedium,
+            ),
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline, size: 20),
             onPressed: () => _confirmClearGps(context, ref, l),
-            tooltip: l?.delete ?? 'Clear',
+            tooltip: l.delete,
           ),
         ],
       );
@@ -82,11 +88,14 @@ class LocationSectionWidget extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Row(
               children: [
-                Icon(Icons.my_location,
-                    size: 16, color: theme.colorScheme.primary),
+                Icon(
+                  Icons.my_location,
+                  size: 16,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: 8),
                 Text(
-                  l?.tapToUpdateGpsPosition ?? 'Tap to update GPS position',
+                  l.tapToUpdateGpsPosition,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.primary,
                   ),
@@ -107,16 +116,17 @@ class LocationSectionWidget extends ConsumerWidget {
     );
   }
 
-  Widget _buildAutoUpdateToggle(WidgetRef ref, ThemeData theme,
-      UserProfile? activeProfile, AppLocalizations? l) {
+  Widget _buildAutoUpdateToggle(
+    WidgetRef ref,
+    ThemeData theme,
+    UserProfile? activeProfile,
+    AppLocalizations l,
+  ) {
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
-      title: Text(
-        l?.autoUpdatePosition ?? 'Auto-update position',
-        style: theme.textTheme.bodyMedium,
-      ),
+      title: Text(l.autoUpdatePosition, style: theme.textTheme.bodyMedium),
       subtitle: Text(
-        l?.autoUpdateDescription ?? 'Refresh GPS position before each search',
+        l.autoUpdateDescription,
         style: theme.textTheme.bodySmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,
         ),
@@ -124,8 +134,7 @@ class LocationSectionWidget extends ConsumerWidget {
       value: activeProfile?.autoUpdatePosition ?? false,
       onChanged: (value) {
         if (activeProfile != null) {
-          final updated =
-              activeProfile.copyWith(autoUpdatePosition: value);
+          final updated = activeProfile.copyWith(autoUpdatePosition: value);
           unawaited(ref.read(profileRepositoryProvider).updateProfile(updated));
           ref.invalidate(allProfilesProvider);
           ref.invalidate(activeProfileProvider);
@@ -135,18 +144,17 @@ class LocationSectionWidget extends ConsumerWidget {
   }
 
   Widget _buildAutoSwitchToggle(
-      WidgetRef ref, ThemeData theme, AppLocalizations? l) {
+    WidgetRef ref,
+    ThemeData theme,
+    AppLocalizations l,
+  ) {
     final autoSwitch = ref.watch(autoSwitchProfileProvider);
 
     return SwitchListTile(
       contentPadding: EdgeInsets.zero,
-      title: Text(
-        l?.autoSwitchProfile ?? 'Auto-switch profile',
-        style: theme.textTheme.bodyMedium,
-      ),
+      title: Text(l.autoSwitchProfile, style: theme.textTheme.bodyMedium),
       subtitle: Text(
-        l?.autoSwitchDescription ??
-            'Automatically switch profile when crossing borders',
+        l.autoSwitchDescription,
         style: theme.textTheme.bodySmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,
         ),
@@ -159,11 +167,14 @@ class LocationSectionWidget extends ConsumerWidget {
   }
 
   Future<void> _confirmClearGps(
-      BuildContext context, WidgetRef ref, AppLocalizations? l) async {
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+  ) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(l?.delete ?? 'Clear GPS position'),
+        title: Text(l.delete),
         content: const Text(
           'Clear the stored GPS position? '
           'You can update it again at any time.',
@@ -171,11 +182,11 @@ class LocationSectionWidget extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l?.delete ?? 'Clear'),
+            child: Text(l.delete),
           ),
         ],
       ),
@@ -194,13 +205,19 @@ class LocationSectionWidget extends ConsumerWidget {
     } catch (e, st) {
       // #2146 — record the GPS failure on the exportable log so a user
       // bug report has the stack trace instead of just a snackbar.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'LocationSection._updateGps: userPosition.updateFromGps',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'LocationSection._updateGps: userPosition.updateFromGps',
+          },
+        ),
+      );
       if (context.mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showError(
-            context, '${l10n?.gpsError ?? "GPS error"}: $e');
+        SnackBarHelper.showError(context, '${l10n.gpsError}: $e');
       }
     }
   }

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/local_data_card.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/local_data_card.dart
@@ -38,62 +38,62 @@ class _LocalDataCardState extends State<LocalDataCard> {
     final entries = <_RowEntry>[
       _RowEntry(
         icon: Icons.favorite,
-        label: l?.favorites ?? 'Favorites',
+        label: l.favorites,
         value: '${s.favoritesCount}',
         isEmpty: s.favoritesCount == 0,
       ),
       _RowEntry(
         icon: Icons.visibility_off,
-        label: l?.privacyIgnoredStations ?? 'Ignored stations',
+        label: l.privacyIgnoredStations,
         value: '${s.ignoredCount}',
         isEmpty: s.ignoredCount == 0,
       ),
       _RowEntry(
         icon: Icons.star,
-        label: l?.privacyRatings ?? 'Station ratings',
+        label: l.privacyRatings,
         value: '${s.ratingsCount}',
         isEmpty: s.ratingsCount == 0,
       ),
       _RowEntry(
         icon: Icons.notifications,
-        label: l?.priceAlerts ?? 'Price alerts',
+        label: l.priceAlerts,
         value: '${s.alertsCount}',
         isEmpty: s.alertsCount == 0,
       ),
       _RowEntry(
         icon: Icons.show_chart,
-        label: l?.privacyPriceHistory ?? 'Price history stations',
+        label: l.privacyPriceHistory,
         value: '${s.priceHistoryStationCount}',
         isEmpty: s.priceHistoryStationCount == 0,
       ),
       _RowEntry(
         icon: Icons.person,
-        label: l?.privacyProfiles ?? 'Search profiles',
+        label: l.privacyProfiles,
         value: '${s.profileCount}',
         isEmpty: s.profileCount == 0,
       ),
       _RowEntry(
         icon: Icons.route,
-        label: l?.privacyItineraries ?? 'Saved routes',
+        label: l.privacyItineraries,
         value: '${s.itineraryCount}',
         isEmpty: s.itineraryCount == 0,
       ),
       _RowEntry(
         icon: Icons.cached,
-        label: l?.privacyCacheEntries ?? 'Cache entries',
+        label: l.privacyCacheEntries,
         value: '${s.cacheEntryCount}',
         isEmpty: s.cacheEntryCount == 0,
       ),
       _RowEntry(
         icon: Icons.key,
-        label: l?.privacyApiKey ?? 'API key stored',
-        value: s.hasApiKey ? (l?.yes ?? 'Yes') : (l?.no ?? 'No'),
+        label: l.privacyApiKey,
+        value: s.hasApiKey ? (l.yes) : (l.no),
         isEmpty: !s.hasApiKey,
       ),
       _RowEntry(
         icon: Icons.ev_station,
-        label: l?.privacyEvApiKey ?? 'EV API key stored',
-        value: s.hasEvApiKey ? (l?.yes ?? 'Yes') : (l?.no ?? 'No'),
+        label: l.privacyEvApiKey,
+        value: s.hasEvApiKey ? (l.yes) : (l.no),
         isEmpty: !s.hasEvApiKey,
       ),
     ];
@@ -111,11 +111,14 @@ class _LocalDataCardState extends State<LocalDataCard> {
           children: [
             Row(
               children: [
-                Icon(Icons.phone_android,
-                    size: 20, color: theme.colorScheme.primary),
+                Icon(
+                  Icons.phone_android,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: 8),
                 Text(
-                  l?.privacyLocalData ?? 'Data on this device',
+                  l.privacyLocalData,
                   style: theme.textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -130,9 +133,7 @@ class _LocalDataCardState extends State<LocalDataCard> {
               Padding(
                 padding: const EdgeInsets.only(bottom: 8),
                 child: Text(
-                  l?.privacyLocalDataEmpty ??
-                      'Nothing stored yet. Add a favorite or set a price '
-                          'alert to see entries here.',
+                  l.privacyLocalDataEmpty,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -140,11 +141,7 @@ class _LocalDataCardState extends State<LocalDataCard> {
               )
             else
               for (final e in visible)
-                PrivacyDataRow(
-                  icon: e.icon,
-                  label: e.label,
-                  value: e.value,
-                ),
+                PrivacyDataRow(icon: e.icon, label: e.label, value: e.value),
             if (hiddenCount > 0)
               Padding(
                 padding: const EdgeInsets.only(top: 4),
@@ -157,13 +154,14 @@ class _LocalDataCardState extends State<LocalDataCard> {
                   ),
                   label: Text(
                     _showAll
-                        ? (l?.privacyHideEmptyRows ?? 'Hide empty rows')
-                        : (l?.privacyShowEmptyRows(hiddenCount) ??
-                            'Show $hiddenCount empty row${hiddenCount == 1 ? '' : 's'}'),
+                        ? (l.privacyHideEmptyRows)
+                        : (l.privacyShowEmptyRows(hiddenCount)),
                   ),
                   style: TextButton.styleFrom(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
                     minimumSize: Size.zero,
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
@@ -174,7 +172,7 @@ class _LocalDataCardState extends State<LocalDataCard> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  l?.privacyEstimatedSize ?? 'Estimated storage',
+                  l.privacyEstimatedSize,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/privacy_action_buttons.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/privacy_action_buttons.dart
@@ -19,7 +19,7 @@ class PrivacyExportJsonButton extends StatelessWidget {
       child: OutlinedButton.icon(
         onPressed: onPressed,
         icon: const Icon(Icons.download),
-        label: Text(l?.privacyExportButton ?? 'Export all data as JSON'),
+        label: Text(l.privacyExportButton),
       ),
     );
   }
@@ -39,7 +39,7 @@ class PrivacyExportCsvButton extends StatelessWidget {
       child: OutlinedButton.icon(
         onPressed: onPressed,
         icon: const Icon(Icons.table_chart),
-        label: Text(l?.privacyExportCsvButton ?? 'Export all data as CSV'),
+        label: Text(l.privacyExportCsvButton),
       ),
     );
   }
@@ -64,7 +64,7 @@ class PrivacyDeleteAllButton extends StatelessWidget {
           side: BorderSide(color: theme.colorScheme.error),
         ),
         icon: const Icon(Icons.delete_forever),
-        label: Text(l?.privacyDeleteButton ?? 'Delete all data'),
+        label: Text(l.privacyDeleteButton),
       ),
     );
   }

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/privacy_banner.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/privacy_banner.dart
@@ -26,8 +26,7 @@ class PrivacyBanner extends StatelessWidget {
           const SizedBox(width: 16),
           Expanded(
             child: Text(
-              l?.privacyDashboardBanner ??
-                  'Your data belongs to you. Here you can see everything this app stores, export it, or delete it.',
+              l.privacyDashboardBanner,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.primary,
                 fontWeight: FontWeight.w500,

--- a/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
+++ b/lib/features/profile/presentation/widgets/privacy_dashboard/synced_data_card.dart
@@ -29,11 +29,14 @@ class SyncedDataCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                Icon(Icons.cloud_outlined,
-                    size: 20, color: theme.colorScheme.secondary),
+                Icon(
+                  Icons.cloud_outlined,
+                  size: 20,
+                  color: theme.colorScheme.secondary,
+                ),
                 const SizedBox(width: 8),
                 Text(
-                  l?.privacySyncedData ?? 'Cloud sync (TankSync)',
+                  l.privacySyncedData,
                   style: theme.textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -54,7 +57,7 @@ class SyncedDataCard extends StatelessWidget {
 
 class _SyncDisabledBanner extends StatelessWidget {
   final ThemeData theme;
-  final AppLocalizations? l;
+  final AppLocalizations l;
 
   const _SyncDisabledBanner({required this.theme, required this.l});
 
@@ -68,13 +71,15 @@ class _SyncDisabledBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.cloud_off,
-              size: 20, color: theme.colorScheme.onSurfaceVariant),
+          Icon(
+            Icons.cloud_off,
+            size: 20,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              l?.privacySyncDisabled ??
-                  'Cloud sync is disabled. All data stays on this device only.',
+              l.privacySyncDisabled,
               style: theme.textTheme.bodySmall,
             ),
           ),
@@ -86,7 +91,7 @@ class _SyncDisabledBanner extends StatelessWidget {
 
 class _SyncEnabledBody extends ConsumerWidget {
   final ThemeData theme;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final PrivacyDataSnapshot snapshot;
 
   const _SyncEnabledBody({
@@ -104,18 +109,17 @@ class _SyncEnabledBody extends ConsumerWidget {
       children: [
         PrivacyDataRow(
           icon: Icons.sync,
-          label: l?.privacySyncMode ?? 'Sync mode',
+          label: l.privacySyncMode,
           value: snapshot.syncMode ?? '-',
         ),
         PrivacyDataRow(
           icon: Icons.perm_identity,
-          label: l?.privacySyncUserId ?? 'User ID',
+          label: l.privacySyncUserId,
           value: userId != null ? '${userId.substring(0, 8)}...' : '-',
         ),
         const SizedBox(height: 8),
         Text(
-          l?.privacySyncDescription ??
-              'When sync is enabled, favorites, alerts, ignored stations, and ratings are also stored on the TankSync server.',
+          l.privacySyncDescription,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -127,12 +131,9 @@ class _SyncEnabledBody extends ConsumerWidget {
         SwitchListTile(
           key: const Key('syncBaselinesToggle'),
           value: baselineSyncOn,
-          title: Text(
-            l?.syncBaselinesToggleTitle ?? 'Share learned vehicle profiles',
-          ),
+          title: Text(l.syncBaselinesToggleTitle),
           subtitle: Text(
-            l?.syncBaselinesToggleSubtitle ??
-                'Upload per-vehicle consumption baselines so a second device can reuse them.',
+            l.syncBaselinesToggleSubtitle,
             style: theme.textTheme.bodySmall,
           ),
           onChanged: (v) async {
@@ -143,7 +144,7 @@ class _SyncEnabledBody extends ConsumerWidget {
         OutlinedButton.icon(
           onPressed: () => context.push(RoutePaths.dataTransparency),
           icon: const Icon(Icons.visibility, size: 18),
-          label: Text(l?.privacyViewServerData ?? 'View server data'),
+          label: Text(l.privacyViewServerData),
         ),
       ],
     );

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -84,22 +84,19 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
           color: Theme.of(context).colorScheme.error,
           size: 48,
         ),
-        title: Text(l10n?.deleteProfileTitle ?? 'Delete profile?'),
-        content: Text(
-          l10n?.deleteProfileBody ??
-              'This profile and its settings will be permanently deleted. This cannot be undone.',
-        ),
+        title: Text(l10n.deleteProfileTitle),
+        content: Text(l10n.deleteProfileBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(l10n?.cancel ?? 'Cancel'),
+            child: Text(l10n.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.error,
             ),
             onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n?.deleteProfileConfirm ?? 'Delete profile'),
+            child: Text(l10n.deleteProfileConfirm),
           ),
         ],
       ),
@@ -114,8 +111,9 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
   @override
   Widget build(BuildContext context) {
     final editState = ref.watch(profileEditControllerProvider(widget.profile));
-    final editCtrl =
-        ref.read(profileEditControllerProvider(widget.profile).notifier);
+    final editCtrl = ref.read(
+      profileEditControllerProvider(widget.profile).notifier,
+    );
 
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
@@ -138,7 +136,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
       // 1 — Identity: name + preferred-fuel (disabled when a vehicle
       // owns the fuel, #695) + the derived-fuel hint.
       SectionCard(
-        title: l10n?.vehicleSectionIdentityTitle ?? 'Identity',
+        title: l10n.vehicleSectionIdentityTitle,
         leadingIcon: Icons.person_outline,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -146,7 +144,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
             TextField(
               controller: _nameController,
               decoration: InputDecoration(
-                labelText: l10n?.profileName ?? 'Profile name',
+                labelText: l10n.profileName,
                 border: const OutlineInputBorder(),
               ),
             ),
@@ -168,9 +166,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
             if (editState.defaultVehicleId != null) ...[
               const SizedBox(height: Spacing.sm),
               Text(
-                l10n?.profileFuelFromVehicleHint ??
-                    'Fuel type is derived from your default vehicle. '
-                        'Clear the vehicle to pick a fuel directly.',
+                l10n.profileFuelFromVehicleHint,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                   fontStyle: FontStyle.italic,
@@ -182,7 +178,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
       ),
       // 2 — Search radius.
       SectionCard(
-        title: l10n?.defaultRadius ?? 'Default radius',
+        title: l10n.defaultRadius,
         leadingIcon: Icons.my_location,
         child: ProfileRadiusSlider(
           value: editState.radius,
@@ -192,26 +188,25 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
       // 3 — Route planning (gated on Feature.routePlanning).
       if (routePlanningOn)
         SectionCard(
-          title: l10n?.routePlanningSection ?? 'Route planning',
+          title: l10n.routePlanningSection,
           leadingIcon: Icons.alt_route,
           child: _RouteSegmentSection(state: editState, ctrl: editCtrl),
         ),
       // 4 — Display & stations toggles.
       SectionCard(
-        title:
-            l10n?.profileSectionDisplayStations ?? 'Display & stations',
+        title: l10n.profileSectionDisplayStations,
         leadingIcon: Icons.tune,
         child: _TogglesSection(state: editState, ctrl: editCtrl),
       ),
       // 5 — Station ratings.
       SectionCard(
-        title: l10n?.privacyRatings ?? 'Station ratings',
+        title: l10n.privacyRatings,
         leadingIcon: Icons.reviews_outlined,
         child: _RatingModeSection(state: editState, ctrl: editCtrl),
       ),
       // 6 — Start screen.
       SectionCard(
-        title: l10n?.landingScreen ?? 'Start screen',
+        title: l10n.landingScreen,
         leadingIcon: Icons.home_outlined,
         child: ProfileLandingScreenDropdown(
           value: editState.landingScreen,
@@ -220,28 +215,25 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
       ),
       // 7 — Approach overlay.
       SectionCard(
-        title: l10n?.approachOverlaySection ?? 'Approach-station overlay',
+        title: l10n.approachOverlaySection,
         leadingIcon: Icons.radar,
         child: _ApproachOverlaySection(state: editState, ctrl: editCtrl),
       ),
       // 8 — Vehicle (only when a vehicle exists).
       if (hasVehicles)
         SectionCard(
-          title: l10n?.fillUpVehicleLabel ?? 'Vehicle',
+          title: l10n.fillUpVehicleLabel,
           leadingIcon: Icons.directions_car_outlined,
           child: _DefaultVehicleSection(state: editState, ctrl: editCtrl),
         ),
       // 9 — Region: country + language under one card.
       SectionCard(
-        title: l10n?.profileSectionRegion ?? 'Region',
+        title: l10n.profileSectionRegion,
         leadingIcon: Icons.public,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              l10n?.profileCountry ?? 'Country',
-              style: theme.textTheme.bodyMedium,
-            ),
+            Text(l10n.profileCountry, style: theme.textTheme.bodyMedium),
             const SizedBox(height: Spacing.md),
             _CountrySection(
               state: editState,
@@ -249,10 +241,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
               profileId: widget.profile.id,
             ),
             const SizedBox(height: Spacing.xl),
-            Text(
-              l10n?.profileLanguage ?? 'Language',
-              style: theme.textTheme.bodyMedium,
-            ),
+            Text(l10n.profileLanguage, style: theme.textTheme.bodyMedium),
             const SizedBox(height: Spacing.md),
             _LanguageSection(state: editState, ctrl: editCtrl),
           ],
@@ -260,17 +249,17 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
       ),
       // 10 — Home postal code.
       SectionCard(
-        title: l10n?.home ?? 'Home',
+        title: l10n.home,
         leadingIcon: Icons.location_on_outlined,
         child: TextField(
           controller: _zipController,
           keyboardType: TextInputType.number,
           maxLength: editState.countryCode != null
               ? (Countries.byCode(editState.countryCode!)?.postalCodeLength ??
-                  5)
+                    5)
               : 5,
           decoration: InputDecoration(
-            labelText: l10n?.homeZip ?? 'Home postal code',
+            labelText: l10n.homeZip,
             border: const OutlineInputBorder(),
             counterText: '',
           ),
@@ -327,10 +316,7 @@ class _ProfileEditSheetState extends ConsumerState<ProfileEditSheet> {
                     ),
                   ),
                 ),
-                Text(
-                  l10n?.editProfile ?? 'Edit profile',
-                  style: theme.textTheme.titleLarge,
-                ),
+                Text(l10n.editProfile, style: theme.textTheme.titleLarge),
                 const SizedBox(height: Spacing.xl),
                 for (final card in cards) ...[
                   card,

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet_parts.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet_parts.dart
@@ -23,7 +23,7 @@ class _RouteSegmentSection extends StatelessWidget {
       children: [
         Row(
           children: [
-            Text('${l10n?.routeSegment ?? "Route segment"}:'),
+            Text('${l10n.routeSegment}:'),
             Expanded(
               child: Slider(
                 value: state.routeSegmentKm,
@@ -38,15 +38,14 @@ class _RouteSegmentSection extends StatelessWidget {
           ],
         ),
         Text(
-          l10n?.showCheapestEveryNKm(state.routeSegmentKm.round()) ??
-              'Show cheapest station every ${state.routeSegmentKm.round()} km along route',
+          l10n.showCheapestEveryNKm(state.routeSegmentKm.round()),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
         ),
         Row(
           children: [
-            Text('${l10n?.routeDetourBudget ?? "Maximum detour"}:'),
+            Text('${l10n.routeDetourBudget}:'),
             Expanded(
               child: Slider(
                 value: state.routeDetourBudgetKm,
@@ -61,9 +60,7 @@ class _RouteSegmentSection extends StatelessWidget {
           ],
         ),
         Text(
-          l10n?.routeDetourBudgetCaption(state.routeDetourBudgetKm.round()) ??
-              'Surface stations up to ${state.routeDetourBudgetKm.round()} '
-                  'km off your direct route',
+          l10n.routeDetourBudgetCaption(state.routeDetourBudgetKm.round()),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -79,19 +76,19 @@ class _RouteSegmentSection extends StatelessWidget {
   Widget _buildMinSavingRow(
     BuildContext context,
     ThemeData theme,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) {
     final saving = state.minRouteSavingPerLiter;
     final off = saving <= 0;
     // i18n-ignore: language-neutral currency-per-litre unit mask.
     final amount = '${saving.toStringAsFixed(2)} €/L';
-    final valueLabel = off ? (l10n?.routeMinSavingOff ?? 'Off') : amount;
+    final valueLabel = off ? (l10n.routeMinSavingOff) : amount;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
           children: [
-            Text('${l10n?.routeMinSaving ?? "Minimum saving"}:'),
+            Text('${l10n.routeMinSaving}:'),
             Expanded(
               child: Slider(
                 value: saving,
@@ -106,10 +103,8 @@ class _RouteSegmentSection extends StatelessWidget {
         ),
         Text(
           off
-              ? (l10n?.routeMinSavingOffCaption ??
-                  'Showing every station found along the route')
-              : (l10n?.routeMinSavingCaption(amount) ??
-                  "Only stations within $amount of the route's cheapest"),
+              ? (l10n.routeMinSavingOffCaption)
+              : (l10n.routeMinSavingCaption(amount)),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -145,33 +140,26 @@ class _TogglesSection extends ConsumerWidget {
         SwitchListTile(
           value: state.avoidHighways,
           onChanged: ctrl.setAvoidHighways,
-          title: Text(l10n?.avoidHighways ?? 'Avoid highways'),
-          subtitle: Text(l10n?.avoidHighwaysDesc ??
-              'Route calculation avoids toll roads and highways'),
+          title: Text(l10n.avoidHighways),
+          subtitle: Text(l10n.avoidHighwaysDesc),
           dense: true,
         ),
         SwitchListTile(
           value: showFuel,
           onChanged: (v) {
-            unawaited(
-              ref.read(showFuelEnabledProvider.notifier).set(v),
-            );
+            unawaited(ref.read(showFuelEnabledProvider.notifier).set(v));
           },
-          title: Text(l10n?.showFuelStations ?? 'Show fuel stations'),
-          subtitle: Text(l10n?.showFuelStationsDesc ??
-              'Include gas, diesel, LPG, CNG stations'),
+          title: Text(l10n.showFuelStations),
+          subtitle: Text(l10n.showFuelStationsDesc),
           dense: true,
         ),
         SwitchListTile(
           value: showElectric,
           onChanged: (v) {
-            unawaited(
-              ref.read(showElectricEnabledProvider.notifier).set(v),
-            );
+            unawaited(ref.read(showElectricEnabledProvider.notifier).set(v));
           },
-          title: Text(l10n?.showEvStations ?? 'Show EV charging stations'),
-          subtitle: Text(l10n?.showEvStationsDesc ??
-              'Include electric charging stations in search results'),
+          title: Text(l10n.showEvStations),
+          subtitle: Text(l10n.showEvStationsDesc),
           dense: true,
         ),
       ],
@@ -196,17 +184,20 @@ class _RatingModeSection extends StatelessWidget {
         SegmentedButton<String>(
           segments: [
             ButtonSegment(
-                value: 'local',
-                label: Text(l10n?.ratingModeLocal ?? 'Local'),
-                icon: const Icon(Icons.phone_android, size: 16)),
+              value: 'local',
+              label: Text(l10n.ratingModeLocal),
+              icon: const Icon(Icons.phone_android, size: 16),
+            ),
             ButtonSegment(
-                value: 'private',
-                label: Text(l10n?.ratingModePrivate ?? 'Private'),
-                icon: const Icon(Icons.lock, size: 16)),
+              value: 'private',
+              label: Text(l10n.ratingModePrivate),
+              icon: const Icon(Icons.lock, size: 16),
+            ),
             ButtonSegment(
-                value: 'shared',
-                label: Text(l10n?.ratingModeShared ?? 'Shared'),
-                icon: const Icon(Icons.people, size: 16)),
+              value: 'shared',
+              label: Text(l10n.ratingModeShared),
+              icon: const Icon(Icons.people, size: 16),
+            ),
           ],
           selected: {state.ratingMode},
           onSelectionChanged: (s) => ctrl.setRatingMode(s.first),
@@ -214,12 +205,10 @@ class _RatingModeSection extends StatelessWidget {
         const SizedBox(height: Spacing.sm),
         Text(
           state.ratingMode == 'local'
-              ? (l10n?.ratingDescLocal ?? 'Ratings saved on this device only')
+              ? (l10n.ratingDescLocal)
               : state.ratingMode == 'private'
-                  ? (l10n?.ratingDescPrivate ??
-                      'Synced with your database (not visible to others)')
-                  : (l10n?.ratingDescShared ??
-                      'Visible to all users of your database'),
+              ? (l10n.ratingDescPrivate)
+              : (l10n.ratingDescShared),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -247,25 +236,20 @@ class _DefaultVehicleSection extends ConsumerWidget {
       return const SizedBox.shrink();
     }
     return DropdownButtonFormField<String?>(
-      initialValue:
-          vehicles.any((v) => v.id == state.defaultVehicleId)
-              ? state.defaultVehicleId
-              : null,
+      initialValue: vehicles.any((v) => v.id == state.defaultVehicleId)
+          ? state.defaultVehicleId
+          : null,
       decoration: InputDecoration(
-        labelText:
-            l10n?.profileDefaultVehicleLabel ?? 'Default vehicle (optional)',
+        labelText: l10n.profileDefaultVehicleLabel,
         prefixIcon: const Icon(Icons.directions_car_outlined),
       ),
       items: [
         DropdownMenuItem<String?>(
           value: null,
-          child: Text(l10n?.profileDefaultVehicleNone ?? 'No default'),
+          child: Text(l10n.profileDefaultVehicleNone),
         ),
         ...vehicles.map(
-          (v) => DropdownMenuItem<String?>(
-            value: v.id,
-            child: Text(v.name),
-          ),
+          (v) => DropdownMenuItem<String?>(value: v.id, child: Text(v.name)),
         ),
       ],
       onChanged: (v) {
@@ -353,7 +337,7 @@ class _SaveDeleteActions extends StatelessWidget {
               await onSave(updated);
               if (context.mounted) Navigator.pop(context);
             },
-            child: Text(l10n?.save ?? 'Save'),
+            child: Text(l10n.save),
           ),
         ),
         if (onDelete != null) ...[
@@ -363,7 +347,7 @@ class _SaveDeleteActions extends StatelessWidget {
             style: OutlinedButton.styleFrom(
               foregroundColor: DarkModeColors.error(context),
             ),
-            child: Text(l10n?.delete ?? 'Delete'),
+            child: Text(l10n.delete),
           ),
         ],
       ],

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet_parts2.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet_parts2.dart
@@ -28,8 +28,7 @@ class _CountrySection extends ConsumerWidget {
       children: Countries.verified.map((c) {
         // A country owned by another profile is taken — the profile being
         // edited may keep its own current country.
-        final taken =
-            repo.isCountryTaken(c.code, excludeProfileId: profileId);
+        final taken = repo.isCountryTaken(c.code, excludeProfileId: profileId);
         return ChoiceChip(
           label: Text('${c.flag} ${c.name}'),
           selected: c.code == state.countryCode,
@@ -47,11 +46,7 @@ class _CountrySection extends ConsumerWidget {
 
   void _explainTaken(BuildContext context, CountryConfig c) {
     final l10n = AppLocalizations.of(context);
-    SnackBarHelper.show(
-      context,
-      l10n?.profileCountryTaken(c.name) ??
-          'A profile for ${c.name} already exists — edit it instead.',
-    );
+    SnackBarHelper.show(context, l10n.profileCountryTaken(c.name));
   }
 
   Future<void> _selectCountry(BuildContext context, CountryConfig c) async {
@@ -107,7 +102,7 @@ class _ApproachOverlaySection extends StatelessWidget {
       children: [
         Row(
           children: [
-            Text('${l10n?.approachRadiusLabel ?? "Radius"}:'),
+            Text('${l10n.approachRadiusLabel}:'),
             Expanded(
               child: Slider(
                 value: state.approachRadiusKm,
@@ -122,39 +117,30 @@ class _ApproachOverlaySection extends StatelessWidget {
           ],
         ),
         Text(
-          l10n?.approachRadiusCaption(
-                  state.approachRadiusKm.toStringAsFixed(1)) ??
-              'Overlay grows + shows the price when within '
-                  '${state.approachRadiusKm.toStringAsFixed(1)} km '
-                  'of a fuel station',
+          l10n.approachRadiusCaption(state.approachRadiusKm.toStringAsFixed(1)),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
         ),
         const SizedBox(height: Spacing.md),
-        Text(
-          l10n?.approachPriceModeLabel ?? 'Show price for',
-          style: theme.textTheme.bodyMedium,
-        ),
+        Text(l10n.approachPriceModeLabel, style: theme.textTheme.bodyMedium),
         const SizedBox(height: Spacing.sm),
         Wrap(
           spacing: 6,
           children: [
             ChoiceChip(
-              label: Text(l10n?.approachPriceModeNearest ?? 'Nearest station'),
-              selected:
-                  state.approachPriceMode == ApproachPriceMode.nearest,
+              label: Text(l10n.approachPriceModeNearest),
+              selected: state.approachPriceMode == ApproachPriceMode.nearest,
               onSelected: (_) =>
                   ctrl.setApproachPriceMode(ApproachPriceMode.nearest),
               visualDensity: VisualDensity.compact,
             ),
             ChoiceChip(
-              label: Text(l10n?.approachPriceModeCheapestInRadius ??
-                  'Cheapest in radius'),
-              selected: state.approachPriceMode ==
-                  ApproachPriceMode.cheapestInRadius,
-              onSelected: (_) => ctrl
-                  .setApproachPriceMode(ApproachPriceMode.cheapestInRadius),
+              label: Text(l10n.approachPriceModeCheapestInRadius),
+              selected:
+                  state.approachPriceMode == ApproachPriceMode.cheapestInRadius,
+              onSelected: (_) =>
+                  ctrl.setApproachPriceMode(ApproachPriceMode.cheapestInRadius),
               visualDensity: VisualDensity.compact,
             ),
           ],
@@ -162,7 +148,7 @@ class _ApproachOverlaySection extends StatelessWidget {
         const SizedBox(height: Spacing.md),
         Row(
           children: [
-            Text('${l10n?.approachMinPollLabel ?? "Min refresh"}:'),
+            Text('${l10n.approachMinPollLabel}:'),
             Expanded(
               child: Slider(
                 value: state.approachMinPollSeconds.toDouble(),
@@ -170,18 +156,14 @@ class _ApproachOverlaySection extends StatelessWidget {
                 max: 10,
                 divisions: 9,
                 label: '${state.approachMinPollSeconds} s',
-                onChanged: (v) =>
-                    ctrl.setApproachMinPollSeconds(v.round()),
+                onChanged: (v) => ctrl.setApproachMinPollSeconds(v.round()),
               ),
             ),
             Text('${state.approachMinPollSeconds} s'),
           ],
         ),
         Text(
-          l10n?.approachMinPollCaption(state.approachMinPollSeconds) ??
-              'Floor on how often the overlay refreshes the nearest '
-                  'station (faster at speed, never tighter than '
-                  '${state.approachMinPollSeconds} s)',
+          l10n.approachMinPollCaption(state.approachMinPollSeconds),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/lib/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart
+++ b/lib/features/profile/presentation/widgets/profile_landing_screen_dropdown.dart
@@ -31,15 +31,17 @@ class ProfileLandingScreenDropdown extends StatelessWidget {
     return DropdownButtonFormField<LandingScreen>(
       initialValue: value,
       decoration: InputDecoration(
-        labelText: l10n?.landingScreen ?? 'Start screen',
+        labelText: l10n.landingScreen,
         border: const OutlineInputBorder(),
       ),
       items: LandingScreen.values
           .where((s) => s != LandingScreen.map)
-          .map((s) => DropdownMenuItem(
-                value: s,
-                child: Text(s.localizedName(languageCode)),
-              ))
+          .map(
+            (s) => DropdownMenuItem(
+              value: s,
+              child: Text(s.localizedName(languageCode)),
+            ),
+          )
           .toList(),
       onChanged: (v) {
         if (v != null) onChanged(v);

--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -38,9 +38,7 @@ class ProfileListSection extends ConsumerWidget {
               // theme default.
               textColor: isActive ? cs.onPrimaryContainer : null,
               iconColor: isActive ? cs.onPrimaryContainer : null,
-              leading: Icon(
-                isActive ? Icons.person : Icons.person_outline,
-              ),
+              leading: Icon(isActive ? Icons.person : Icons.person_outline),
               title: Text(profile.name),
               subtitle: Text(
                 '${profile.countryCode != null ? (Countries.byCode(profile.countryCode!)?.flag ?? "") : ""} '
@@ -54,12 +52,11 @@ class ProfileListSection extends ConsumerWidget {
                   if (!isActive)
                     TextButton(
                       onPressed: () => _activateProfile(context, ref, profile),
-                      child: Text(AppLocalizations.of(context)?.activate ?? 'Activate'),
+                      child: Text(AppLocalizations.of(context).activate),
                     ),
                   IconButton(
                     icon: const Icon(Icons.edit),
-                    tooltip: AppLocalizations.of(context)?.editProfile ??
-                        'Edit profile',
+                    tooltip: AppLocalizations.of(context).editProfile,
                     onPressed: () => _editProfile(context, ref, profile),
                   ),
                 ],
@@ -71,8 +68,7 @@ class ProfileListSection extends ConsumerWidget {
         OutlinedButton.icon(
           onPressed: () => _createProfile(context, ref),
           icon: const Icon(Icons.add),
-          label: Text(
-              AppLocalizations.of(context)?.newProfile ?? 'New profile'),
+          label: Text(AppLocalizations.of(context).newProfile),
         ),
       ],
     );
@@ -84,7 +80,10 @@ class ProfileListSection extends ConsumerWidget {
   /// once that mutation has completed, so we await it, then refresh the
   /// active provider and invalidate the list before surfacing feedback.
   Future<void> _activateProfile(
-      BuildContext context, WidgetRef ref, UserProfile profile) async {
+    BuildContext context,
+    WidgetRef ref,
+    UserProfile profile,
+  ) async {
     // #3159 — capture the notifier BEFORE the await: Riverpod 3 throws a
     // StateError when a WidgetRef is used after the element unmounted, and
     // the user can leave the screen while switchProfile persists.
@@ -94,11 +93,7 @@ class ProfileListSection extends ConsumerWidget {
     if (!context.mounted) return;
     ref.invalidate(allProfilesProvider);
     final l10n = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l10n?.profileSwitchedTo(profile.name) ??
-          'Switched to ${profile.name}',
-    );
+    SnackBarHelper.showSuccess(context, l10n.profileSwitchedTo(profile.name));
   }
 
   Future<void> _createProfile(BuildContext context, WidgetRef ref) async {
@@ -111,7 +106,7 @@ class ProfileListSection extends ConsumerWidget {
 
     final name = await _showNameDialog(
       context,
-      AppLocalizations.of(context)?.newProfile ?? 'New profile',
+      AppLocalizations.of(context).newProfile,
       '',
     );
     if (name == null || name.isEmpty) return;
@@ -135,14 +130,14 @@ class ProfileListSection extends ConsumerWidget {
     if (!context.mounted) return;
     ref.invalidate(allProfilesProvider);
     final l10n = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l10n?.profileCreatedNamed(name) ?? 'Profile $name created',
-    );
+    SnackBarHelper.showSuccess(context, l10n.profileCreatedNamed(name));
   }
 
   Future<void> _editProfile(
-      BuildContext context, WidgetRef ref, UserProfile profile) async {
+    BuildContext context,
+    WidgetRef ref,
+    UserProfile profile,
+  ) async {
     // Check how many profiles exist — the last one cannot be deleted
     final allProfiles = ref.read(allProfilesProvider);
     final canDelete = allProfiles.length > 1;
@@ -168,17 +163,22 @@ class ProfileListSection extends ConsumerWidget {
           if (context.mounted) ref.invalidate(allProfilesProvider);
         },
         // Default profile (last remaining) cannot be deleted
-        onDelete: canDelete ? () async {
-          await repo.deleteProfile(profile.id);
-          profileNotifier.refresh();
-          if (context.mounted) ref.invalidate(allProfilesProvider);
-        } : null,
+        onDelete: canDelete
+            ? () async {
+                await repo.deleteProfile(profile.id);
+                profileNotifier.refresh();
+                if (context.mounted) ref.invalidate(allProfilesProvider);
+              }
+            : null,
       ),
     );
   }
 
   Future<String?> _showNameDialog(
-      BuildContext context, String title, String initial) async {
+    BuildContext context,
+    String title,
+    String initial,
+  ) async {
     final controller = TextEditingController(text: initial);
     final result = await showDialog<String>(
       context: context,
@@ -188,18 +188,18 @@ class ProfileListSection extends ConsumerWidget {
           controller: controller,
           autofocus: true,
           decoration: InputDecoration(
-            labelText: AppLocalizations.of(context)?.nameLabel ?? 'Name',
+            labelText: AppLocalizations.of(context).nameLabel,
             border: const OutlineInputBorder(),
           ),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, controller.text),
-            child: Text(AppLocalizations.of(context)?.save ?? 'Save'),
+            child: Text(AppLocalizations.of(context).save),
           ),
         ],
       ),

--- a/lib/features/profile/presentation/widgets/profile_radius_slider.dart
+++ b/lib/features/profile/presentation/widgets/profile_radius_slider.dart
@@ -29,7 +29,7 @@ class ProfileRadiusSlider extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return LabeledValueSlider(
-      label: '${l10n?.defaultRadius ?? "Radius"}:',
+      label: '${l10n.defaultRadius}:',
       valueLabel: '${value.round()} km',
       value: value,
       min: 1,

--- a/lib/features/profile/presentation/widgets/storage_bar.dart
+++ b/lib/features/profile/presentation/widgets/storage_bar.dart
@@ -53,8 +53,7 @@ class StorageBar extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
         ),
         child: Center(
-          child: Text(l10n?.noStorageUsed ?? 'No storage used',
-              style: const TextStyle(fontSize: 11)),
+          child: Text(l10n.noStorageUsed, style: const TextStyle(fontSize: 11)),
         ),
       );
     }
@@ -172,10 +171,12 @@ class StorageDetailRow extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(label,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    )),
+                Text(
+                  label,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
                 Text(
                   detail,
                   style: theme.textTheme.bodySmall?.copyWith(
@@ -212,20 +213,17 @@ class CacheTtlInfo extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _ttlGroupHeader(l?.cacheTtlGroupNetwork ?? 'Network'),
-        _ttlRow(l?.stationSearch ?? 'Station search', l?.minutes(5) ?? '5 min'),
-        _ttlRow(l?.stationDetails ?? 'Station details',
-            l?.minutes(15) ?? '15 min'),
-        _ttlRow(l?.priceQuery ?? 'Price query', l?.minutes(5) ?? '5 min'),
+        _ttlGroupHeader(l.cacheTtlGroupNetwork),
+        _ttlRow(l.stationSearch, l.minutes(5)),
+        _ttlRow(l.stationDetails, l.minutes(15)),
+        _ttlRow(l.priceQuery, l.minutes(5)),
         const SizedBox(height: 4),
-        _ttlGroupHeader(l?.cacheTtlGroupData ?? 'Data'),
-        _ttlRow(l?.favoritesDataCache ?? 'Favorites data',
-            l?.minutes(30) ?? '30 min'),
-        _ttlRow(l?.citySearchCache ?? 'City search',
-            l?.minutes(30) ?? '30 min'),
+        _ttlGroupHeader(l.cacheTtlGroupData),
+        _ttlRow(l.favoritesDataCache, l.minutes(30)),
+        _ttlRow(l.citySearchCache, l.minutes(30)),
         const SizedBox(height: 4),
-        _ttlGroupHeader(l?.cacheTtlGroupGeocoding ?? 'Geocoding'),
-        _ttlRow(l?.zipGeocoding ?? 'ZIP geocoding', l?.hours(24) ?? '24 h'),
+        _ttlGroupHeader(l.cacheTtlGroupGeocoding),
+        _ttlRow(l.zipGeocoding, l.hours(24)),
       ],
     );
   }
@@ -250,8 +248,11 @@ class CacheTtlInfo extends StatelessWidget {
       child: Row(
         children: [
           const SizedBox(width: 8),
-          Icon(Icons.timer,
-              size: 14, color: theme.colorScheme.onSurfaceVariant),
+          Icon(
+            Icons.timer,
+            size: 14,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           const SizedBox(width: 8),
           Text(label, style: theme.textTheme.bodySmall),
           const Spacer(),

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -29,7 +29,7 @@ class StorageSection extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l?.storageUsage ?? 'Storage',
+              l.storageUsage,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -38,23 +38,23 @@ class StorageSection extends ConsumerWidget {
             StorageBar(
               segments: [
                 StorageSegment(
-                  l?.settingsLabel ?? 'Settings',
+                  l.settingsLabel,
                   stats.settings,
                   theme.colorScheme.primary,
                 ),
                 StorageSegment(
-                  '${l?.profile ?? "Profile"} (${storageMgmt.profileCount})',
+                  '${l.profile} (${storageMgmt.profileCount})',
                   stats.profiles,
                   theme.colorScheme.secondary,
                 ),
                 StorageSegment(
-                  '${l?.favorites ?? "Favorites"} (${storageMgmt.favoriteCount})',
+                  '${l.favorites} (${storageMgmt.favoriteCount})',
                   stats.favorites,
                   theme.colorScheme.tertiary,
                 ),
                 StorageSegment(
                   // i18n-ignore: "Cache" is a brand-neutral technical term.
-                  'Cache (${storageMgmt.cacheEntryCount} ${l?.entries ?? "entries"})',
+                  'Cache (${storageMgmt.cacheEntryCount} ${l.entries})',
                   stats.cache,
                   // #2490 — cache is benign data, not data-loss. It maps to
                   // a NEUTRAL categorical tone rather than error-red (which
@@ -63,7 +63,7 @@ class StorageSection extends ConsumerWidget {
                   theme.colorScheme.surfaceContainerHighest,
                 ),
                 StorageSegment(
-                  '${l?.priceHistory ?? "Price History"} '
+                  '${l.priceHistory} '
                   '(${storageMgmt.priceHistoryEntryCount})',
                   stats.priceHistory,
                   // #2490 — neutral categorical tone, not warning-orange.
@@ -75,22 +75,20 @@ class StorageSection extends ConsumerWidget {
             ),
             const SizedBox(height: 16),
             StorageDetailRow(
-              label: l?.settingsLabel ?? 'Settings',
-              detail: l?.settingsStorageDetail ?? 'API key, active profile',
+              label: l.settingsLabel,
+              detail: l.settingsStorageDetail,
               bytes: stats.settings,
               color: theme.colorScheme.primary,
             ),
             StorageDetailRow(
-              label: l?.profile ?? 'Profile',
-              detail:
-                  '${storageMgmt.profileCount} ${l?.profilesStored ?? 'profiles'}',
+              label: l.profile,
+              detail: '${storageMgmt.profileCount} ${l.profilesStored}',
               bytes: stats.profiles,
               color: theme.colorScheme.secondary,
             ),
             StorageDetailRow(
-              label: l?.favorites ?? 'Favorites',
-              detail:
-                  '${storageMgmt.favoriteCount} ${l?.stationsMarked ?? 'stations'}',
+              label: l.favorites,
+              detail: '${storageMgmt.favoriteCount} ${l.stationsMarked}',
               bytes: stats.favorites,
               color: theme.colorScheme.tertiary,
             ),
@@ -98,44 +96,40 @@ class StorageSection extends ConsumerWidget {
               // i18n-ignore: "Cache" is a brand-neutral technical term
               // commonly left untranslated across European locales.
               label: 'Cache',
-              detail:
-                  '${storageMgmt.cacheEntryCount} ${l?.cachedResponses ?? 'cached'}',
+              detail: '${storageMgmt.cacheEntryCount} ${l.cachedResponses}',
               bytes: stats.cache,
               // #2490 — neutral categorical tone (matches the bar segment),
               // not error-red; cache is benign data, not data-loss.
               color: theme.colorScheme.surfaceContainerHighest,
             ),
             StorageDetailRow(
-              label: l?.priceHistory ?? 'Price History',
-              detail: l?.priceHistoryStationsTracked(
-                      storageMgmt.priceHistoryEntryCount) ??
-                  '${storageMgmt.priceHistoryEntryCount} stations tracked',
+              label: l.priceHistory,
+              detail: l.priceHistoryStationsTracked(
+                storageMgmt.priceHistoryEntryCount,
+              ),
               bytes: stats.priceHistory,
               // #2490 — neutral categorical tone, not warning-orange.
               color: theme.colorScheme.secondaryContainer,
             ),
             StorageDetailRow(
-              label: l?.priceAlerts ?? 'Alerts',
-              detail: l?.alertsConfiguredCount(storageMgmt.alertCount) ??
-                  '${storageMgmt.alertCount} configured',
+              label: l.priceAlerts,
+              detail: l.alertsConfiguredCount(storageMgmt.alertCount),
               bytes: stats.alerts,
               // #2490 — neutral categorical tone, not warning-orange.
               color: theme.colorScheme.tertiaryContainer,
             ),
             StorageDetailRow(
-              label: l?.ignoredStationsLabel ?? 'Ignored',
-              detail: l?.ignoredStationsHidden(
-                      storageMgmt.getIgnoredIds().length) ??
-                  '${storageMgmt.getIgnoredIds().length} stations hidden',
+              label: l.ignoredStationsLabel,
+              detail: l.ignoredStationsHidden(
+                storageMgmt.getIgnoredIds().length,
+              ),
               bytes: storageMgmt.getIgnoredIds().length * 64,
               // #2490 — theme outline token instead of a hard-coded grey.
               color: theme.colorScheme.outlineVariant,
             ),
             StorageDetailRow(
-              label: l?.ratingsLabel ?? 'Ratings',
-              detail: l?.ratingsStationsRated(
-                      storageMgmt.getRatings().length) ??
-                  '${storageMgmt.getRatings().length} stations rated',
+              label: l.ratingsLabel,
+              detail: l.ratingsStationsRated(storageMgmt.getRatings().length),
               bytes: storageMgmt.getRatings().length * 64,
               // #2490 — neutral categorical tone instead of hard-coded amber.
               color: theme.colorScheme.tertiary,
@@ -145,7 +139,7 @@ class StorageSection extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  l?.total ?? 'Total',
+                  l.total,
                   style: theme.textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -160,17 +154,13 @@ class StorageSection extends ConsumerWidget {
             ),
             const SizedBox(height: 24),
             Text(
-              l?.cacheManagement ?? 'Cache management',
+              l.cacheManagement,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
             ),
             const SizedBox(height: 8),
-            Text(
-              l?.cacheDescription ??
-                  'The cache stores API responses for faster loading and offline access.',
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(l.cacheDescription, style: theme.textTheme.bodySmall),
             const SizedBox(height: 4),
             CacheTtlInfo(theme: theme),
             const SizedBox(height: 16),
@@ -184,8 +174,8 @@ class StorageSection extends ConsumerWidget {
                     icon: const Icon(Icons.delete_sweep),
                     label: Text(
                       storageMgmt.cacheEntryCount > 0
-                          ? '${l?.clearCacheButton ?? "Clear cache"} (${storageMgmt.cacheEntryCount} ${l?.entries ?? "entries"})'
-                          : l?.cacheEmpty ?? 'Cache is empty',
+                          ? '${l.clearCacheButton} (${storageMgmt.cacheEntryCount} ${l.entries})'
+                          : l.cacheEmpty,
                     ),
                   ),
                 ),
@@ -201,7 +191,7 @@ class StorageSection extends ConsumerWidget {
                       foregroundColor: theme.colorScheme.error,
                     ),
                     icon: const Icon(Icons.delete_forever),
-                    label: Text(l?.deleteAllButton ?? 'Delete all'),
+                    label: Text(l.deleteAllButton),
                   ),
                 ),
               ],
@@ -216,22 +206,16 @@ class StorageSection extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: ctx,
       builder: (context) => AlertDialog(
-        title: Text(
-            AppLocalizations.of(context)?.clearCacheTitle ?? 'Clear cache?'),
-        content: Text(
-          AppLocalizations.of(context)?.clearCacheBody ??
-              'Cached data will be deleted. Settings preserved.',
-        ),
+        title: Text(AppLocalizations.of(context).clearCacheTitle),
+        content: Text(AppLocalizations.of(context).clearCacheBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child:
-                Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(AppLocalizations.of(context)?.clearCacheButton ??
-                'Clear cache'),
+            child: Text(AppLocalizations.of(context).clearCacheButton),
           ),
         ],
       ),
@@ -251,8 +235,7 @@ class StorageSection extends ConsumerWidget {
       if (!ctx.mounted) return;
       ref.invalidate(storageManagementProvider);
       if (ctx.mounted) {
-        SnackBarHelper.show(
-            ctx, AppLocalizations.of(ctx)?.cacheCleared ?? 'Cache cleared.');
+        SnackBarHelper.show(ctx, AppLocalizations.of(ctx).cacheCleared);
       }
     }
   }
@@ -266,25 +249,19 @@ class StorageSection extends ConsumerWidget {
           color: Theme.of(context).colorScheme.error,
           size: 48,
         ),
-        title: Text(AppLocalizations.of(context)?.deleteAllTitle ??
-            'Delete all data?'),
-        content: Text(
-          AppLocalizations.of(context)?.deleteAllBody ??
-              'Permanently deletes all data. App will reset.',
-        ),
+        title: Text(AppLocalizations.of(context).deleteAllTitle),
+        content: Text(AppLocalizations.of(context).deleteAllBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child:
-                Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.error,
             ),
             onPressed: () => Navigator.pop(context, true),
-            child: Text(AppLocalizations.of(context)?.deleteAllButton ??
-                'Delete all'),
+            child: Text(AppLocalizations.of(context).deleteAllButton),
           ),
         ],
       ),

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -62,15 +62,15 @@ class TankSyncSection extends ConsumerWidget {
       if (!syncConfig.hasEmail)
         ListTile(
           leading: const Icon(Icons.email_outlined),
-          title: Text(l?.switchToEmail ?? 'Switch to email'),
-          subtitle: Text(l?.switchToEmailSubtitle ?? 'Keep data, add sign-in from other devices'),
+          title: Text(l.switchToEmail),
+          subtitle: Text(l.switchToEmailSubtitle),
           onTap: () => context.push(RoutePaths.auth),
         )
       else
         ListTile(
           leading: const Icon(Icons.person_outline),
-          title: Text(l?.switchToAnonymousAction ?? 'Switch to anonymous'),
-          subtitle: Text(l?.switchToAnonymousSubtitle ?? 'Keep local data, use new anonymous session'),
+          title: Text(l.switchToAnonymousAction),
+          subtitle: Text(l.switchToAnonymousSubtitle),
           onTap: () => _confirmSwitchToAnonymous(context, ref),
         ),
       const Divider(indent: 16, endIndent: 16),
@@ -81,79 +81,77 @@ class TankSyncSection extends ConsumerWidget {
       SwitchListTile(
         key: const Key('tripsSyncToggle'),
         secondary: const Icon(Icons.route_outlined),
-        title: Text(l?.consentSyncTripsTitle ?? 'Sync trip recordings'),
+        title: Text(l.consentSyncTripsTitle),
         subtitle: Text(
           !consent.cloudSync
-              ? (l?.consentSyncTripsDisabledHint ??
-                  'Enable Cloud Sync to back up trips.')
+              ? (l.consentSyncTripsDisabledHint)
               : !syncConfig.hasEmail
-                  ? (l?.consentSyncTripsNeedsEmailHint ??
-                      'Sign in with an email account to sync trips '
-                          'across devices.')
-                  : (l?.consentSyncTripsSubtitle ??
-                      'Back up OBD2 + GPS trips to TankSync. '
-                          'Cross-device, opt-in.'),
+              ? (l.consentSyncTripsNeedsEmailHint)
+              : (l.consentSyncTripsSubtitle),
         ),
         value: consent.syncTrips,
         onChanged: (consent.cloudSync && syncConfig.hasEmail)
-            ? (v) => ref.read(gdprConsentProvider.notifier).save(
-                  location: consent.location,
-                  errorReporting: consent.errorReporting,
-                  cloudSync: consent.cloudSync,
-                  vinOnlineDecode: consent.vinOnlineDecode,
-                  syncTrips: v,
-                )
+            ? (v) => ref
+                  .read(gdprConsentProvider.notifier)
+                  .save(
+                    location: consent.location,
+                    errorReporting: consent.errorReporting,
+                    cloudSync: consent.cloudSync,
+                    vinOnlineDecode: consent.vinOnlineDecode,
+                    syncTrips: v,
+                  )
             : null,
       ),
       const Divider(indent: 16, endIndent: 16),
       ListTile(
         leading: const Icon(Icons.visibility_outlined),
-        title: Text(l?.viewMyData ?? 'View my data'),
+        title: Text(l.viewMyData),
         onTap: () => context.push(RoutePaths.dataTransparency),
       ),
       ListTile(
         leading: const Icon(Icons.link),
-        title: Text(l?.linkDevice ?? 'Link device'),
+        title: Text(l.linkDevice),
         onTap: () => context.push(RoutePaths.linkDevice),
       ),
       if (syncConfig.mode != SyncMode.community)
         ListTile(
           leading: const Icon(Icons.qr_code),
-          title: Text(l?.shareDatabase ?? 'Share database'),
+          title: Text(l.shareDatabase),
           onTap: () => _showQrShare(context),
         ),
       const Divider(indent: 16, endIndent: 16),
       ListTile(
         leading: const Icon(Icons.logout),
-        title: Text(l?.disconnectAction ?? 'Disconnect'),
-        subtitle: Text(l?.disconnectSubtitle ?? 'Stop syncing (local data kept)'),
+        title: Text(l.disconnectAction),
+        subtitle: Text(l.disconnectSubtitle),
         onTap: () => _confirmDisconnect(context, ref),
       ),
       if (syncConfig.mode != SyncMode.community)
         ListTile(
           leading: Icon(Icons.delete_forever, color: theme.colorScheme.error),
-          title: Text(l?.deleteAccountAction ?? 'Delete account',
-              style: TextStyle(color: theme.colorScheme.error)),
-          subtitle: Text(l?.deleteAccountSubtitle ?? 'Remove all server data permanently'),
+          title: Text(
+            l.deleteAccountAction,
+            style: TextStyle(color: theme.colorScheme.error),
+          ),
+          subtitle: Text(l.deleteAccountSubtitle),
           onTap: () => _confirmDeleteAccount(context, ref),
         ),
     ];
   }
 
-  List<Widget> _buildDisconnected(BuildContext context, AppLocalizations? l) {
+  List<Widget> _buildDisconnected(BuildContext context, AppLocalizations l) {
     return [
       ListTile(
         leading: const Icon(Icons.cloud_off),
-        title: Text(l?.localOnly ?? 'Local only'),
-        subtitle: Text(l?.localOnlySubtitle ??
-            'Optional: sync favorites, alerts, and ratings across devices'),
+        title: Text(l.localOnly),
+        subtitle: Text(l.localOnlySubtitle),
       ),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: FilledButton.icon(
           onPressed: () => context.push(RoutePaths.syncSetup),
           icon: const Icon(Icons.cloud_upload),
-          label: Text(l?.setupCloudSync ?? 'Set up cloud sync'),
+          label: Text(l.setupCloudSync),
         ),
       ),
     ];
@@ -164,21 +162,20 @@ class TankSyncSection extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        icon: Icon(Icons.warning_amber,
-            color: Theme.of(ctx).colorScheme.error),
-        title: Text(l?.disconnectTitle ?? 'Disconnect TankSync?'),
-        content: Text(l?.disconnectBody ??
-          'Cloud sync will be disabled. Your local data (favorites, alerts, history) '
-          'is preserved on this device. Server data is not deleted.'),
+        icon: Icon(Icons.warning_amber, color: Theme.of(ctx).colorScheme.error),
+        title: Text(l.disconnectTitle),
+        content: Text(l.disconnectBody),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: Text(l?.cancel ?? 'Cancel')),
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l.cancel),
+          ),
           FilledButton(
             style: FilledButton.styleFrom(
-                backgroundColor: Theme.of(ctx).colorScheme.error),
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
             onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l?.disconnectAction ?? 'Disconnect'),
+            child: Text(l.disconnectAction),
           ),
         ],
       ),
@@ -193,28 +190,31 @@ class TankSyncSection extends ConsumerWidget {
   }
 
   Future<void> _confirmDeleteAccount(
-      BuildContext context, WidgetRef ref) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final l = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        icon: Icon(Icons.warning_amber,
-            color: Theme.of(ctx).colorScheme.error, size: 48),
-        title: Text(l?.deleteAccountTitle ?? 'Delete account?'),
-        content: Text(l?.deleteAccountBody ??
-          'This permanently deletes all your data from the server '
-          '(favorites, alerts, ratings, routes). '
-          'Local data on this device is preserved.\n\n'
-          'This cannot be undone.'),
+        icon: Icon(
+          Icons.warning_amber,
+          color: Theme.of(ctx).colorScheme.error,
+          size: 48,
+        ),
+        title: Text(l.deleteAccountTitle),
+        content: Text(l.deleteAccountBody),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: Text(l?.cancel ?? 'Cancel')),
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l.cancel),
+          ),
           FilledButton(
             style: FilledButton.styleFrom(
-                backgroundColor: Theme.of(ctx).colorScheme.error),
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
             onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l?.deleteEverything ?? 'Delete everything'),
+            child: Text(l.deleteEverything),
           ),
         ],
       ),
@@ -222,32 +222,33 @@ class TankSyncSection extends ConsumerWidget {
     if (confirmed == true && context.mounted) {
       await ref.read(syncStateProvider.notifier).deleteAccount();
       if (context.mounted) {
-        SnackBarHelper.show(context, AppLocalizations.of(context)?.accountDeleted ?? 'Account deleted. Local data preserved.');
+        SnackBarHelper.show(
+          context,
+          AppLocalizations.of(context).accountDeleted,
+        );
       }
     }
   }
 
   Future<void> _confirmSwitchToAnonymous(
-      BuildContext context, WidgetRef ref) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final l = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         icon: const Icon(Icons.swap_horiz, size: 48),
-        title: Text(l?.switchToAnonymousTitle ?? 'Switch to anonymous?'),
-        content: Text(l?.switchToAnonymousBody ??
-          'You will be signed out of your email account and continue '
-          'with a new anonymous session.\n\n'
-          'Your local data (favorites, alerts) is kept on this device '
-          'and will be synced to the new anonymous account.'),
+        title: Text(l.switchToAnonymousTitle),
+        content: Text(l.switchToAnonymousBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l?.switchAction ?? 'Switch'),
+            child: Text(l.switchAction),
           ),
         ],
       ),
@@ -257,40 +258,53 @@ class TankSyncSection extends ConsumerWidget {
       try {
         await ref.read(syncStateProvider.notifier).switchToAnonymous();
         if (context.mounted) {
-          SnackBarHelper.show(context, AppLocalizations.of(context)?.switchedToAnonymous ?? 'Switched to anonymous session');
+          SnackBarHelper.show(
+            context,
+            AppLocalizations.of(context).switchedToAnonymous,
+          );
         }
       } catch (e, st) {
         // #2146 — route to errorLogger so the failure lands on the
         // exportable log (the snackbar is transient).
-        unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-          'where': 'TankSyncSection: switchToAnonymous',
-        }));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.sync,
+            e,
+            st,
+            context: const {'where': 'TankSyncSection: switchToAnonymous'},
+          ),
+        );
         if (context.mounted) {
-          SnackBarHelper.showError(context, AppLocalizations.of(context)?.failedToSwitch(e.toString()) ?? 'Failed to switch: $e');
+          SnackBarHelper.showError(
+            context,
+            AppLocalizations.of(context).failedToSwitch(e.toString()),
+          );
         }
       }
     }
   }
 
   void _showQrShare(BuildContext context) {
-    unawaited(showDialog<void>(
-      context: context,
-      builder: (ctx) => Dialog(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const QrShareWidget(),
-              const SizedBox(height: 8),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx),
-                child: Text(AppLocalizations.of(ctx)?.close ?? 'Close'),
-              ),
-            ],
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (ctx) => Dialog(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const QrShareWidget(),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx),
+                  child: Text(AppLocalizations.of(ctx).close),
+                ),
+              ],
+            ),
           ),
         ),
       ),
-    ));
+    );
   }
 }

--- a/lib/features/profile/presentation/widgets/use_mode_section.dart
+++ b/lib/features/profile/presentation/widgets/use_mode_section.dart
@@ -40,10 +40,7 @@ class UseModeSection extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.only(left: 4, right: 4, bottom: 8),
             child: Text(
-              l?.useModeSectionHint ??
-                  'Right-size the app to how you actually use it. '
-                      'Picking a preset enables the matching set of '
-                      'features.',
+              l.useModeSectionHint,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -52,10 +49,8 @@ class UseModeSection extends ConsumerWidget {
           _PresetCard(
             profile: AppProfile.basic,
             icon: Icons.local_gas_station_outlined,
-            title: l?.wizardProfileBasicName ?? 'Basic',
-            description: l?.wizardProfileBasicDescription ??
-                'Cheapest fuel and EV charging prices nearby. '
-                    'Favorites and price alerts.',
+            title: l.wizardProfileBasicName,
+            description: l.wizardProfileBasicDescription,
             isActive: activeProfile == AppProfile.basic,
             onTap: () => _select(context, ref, AppProfile.basic, l),
           ),
@@ -63,10 +58,8 @@ class UseModeSection extends ConsumerWidget {
           _PresetCard(
             profile: AppProfile.medium,
             icon: Icons.analytics_outlined,
-            title: l?.wizardProfileMediumName ?? 'Medium',
-            description: l?.wizardProfileMediumDescription ??
-                'Everything in Basic, plus track your fuel fill-ups '
-                    'and EV charging by hand.',
+            title: l.wizardProfileMediumName,
+            description: l.wizardProfileMediumDescription,
             isActive: activeProfile == AppProfile.medium,
             onTap: () => _select(context, ref, AppProfile.medium, l),
           ),
@@ -74,10 +67,8 @@ class UseModeSection extends ConsumerWidget {
           _PresetCard(
             profile: AppProfile.full,
             icon: Icons.directions_car_filled,
-            title: l?.wizardProfileFullName ?? 'Full',
-            description: l?.wizardProfileFullDescription ??
-                'Everything in Medium, plus automatic OBD2 trip '
-                    'recording, driving scores, and loyalty cards.',
+            title: l.wizardProfileFullName,
+            description: l.wizardProfileFullDescription,
             isActive: activeProfile == AppProfile.full,
             onTap: () => _select(context, ref, AppProfile.full, l),
           ),
@@ -86,11 +77,8 @@ class UseModeSection extends ConsumerWidget {
             _PresetCard(
               profile: AppProfile.custom,
               icon: Icons.tune_outlined,
-              title: l?.wizardProfileCustomName ?? 'Custom',
-              description: l?.useModeCustomSettingsDescription ??
-                  "Your feature mix doesn't match any preset. Pick "
-                      'one above to overwrite, or keep customising '
-                      'individual features in the section below.',
+              title: l.wizardProfileCustomName,
+              description: l.useModeCustomSettingsDescription,
               isActive: true,
               onTap: null,
             ),
@@ -104,29 +92,26 @@ class UseModeSection extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     AppProfile profile,
-    AppLocalizations? l,
+    AppLocalizations l,
   ) async {
     final messenger = ScaffoldMessenger.maybeOf(context);
     await ref.read(activeAppProfileProvider.notifier).select(profile);
     if (messenger != null && context.mounted) {
       final name = _localizedName(profile, l);
-      SnackBarHelper.showSuccess(
-        context,
-        l?.useModeSwitchedSnack(name) ?? 'Use mode set to $name.',
-      );
+      SnackBarHelper.showSuccess(context, l.useModeSwitchedSnack(name));
     }
   }
 
-  String _localizedName(AppProfile profile, AppLocalizations? l) {
+  String _localizedName(AppProfile profile, AppLocalizations l) {
     switch (profile) {
       case AppProfile.basic:
-        return l?.wizardProfileBasicName ?? 'Basic';
+        return l.wizardProfileBasicName;
       case AppProfile.medium:
-        return l?.wizardProfileMediumName ?? 'Medium';
+        return l.wizardProfileMediumName;
       case AppProfile.full:
-        return l?.wizardProfileFullName ?? 'Full';
+        return l.wizardProfileFullName;
       case AppProfile.custom:
-        return l?.wizardProfileCustomName ?? 'Custom';
+        return l.wizardProfileCustomName;
     }
   }
 }
@@ -207,11 +192,7 @@ class _PresetCard extends StatelessWidget {
                         ),
                         if (isActive) ...[
                           const SizedBox(width: 6),
-                          Icon(
-                            Icons.check_circle,
-                            color: activeOn,
-                            size: 16,
-                          ),
+                          Icon(Icons.check_circle, color: activeOn, size: 16),
                         ],
                       ],
                     ),

--- a/lib/features/report/domain/entities/report_type.dart
+++ b/lib/features/report/domain/entities/report_type.dart
@@ -125,28 +125,28 @@ enum ReportType {
   }
 
   /// Localized display name for this report type.
-  String displayName(AppLocalizations? l10n) {
+  String displayName(AppLocalizations l10n) {
     switch (this) {
       case wrongE5:
-        return l10n?.wrongE5Price ?? 'Prix Super E5 incorrect';
+        return l10n.wrongE5Price;
       case wrongE10:
-        return l10n?.wrongE10Price ?? 'Prix Super E10 incorrect';
+        return l10n.wrongE10Price;
       case wrongDiesel:
-        return l10n?.wrongDieselPrice ?? 'Prix Diesel incorrect';
+        return l10n.wrongDieselPrice;
       case wrongE85:
-        return l10n?.wrongE85Price ?? 'Wrong E85 price';
+        return l10n.wrongE85Price;
       case wrongE98:
-        return l10n?.wrongE98Price ?? 'Wrong Super 98 price';
+        return l10n.wrongE98Price;
       case wrongLpg:
-        return l10n?.wrongLpgPrice ?? 'Wrong LPG price';
+        return l10n.wrongLpgPrice;
       case wrongStatusOpen:
-        return l10n?.wrongStatusOpen ?? 'Shown as open, but closed';
+        return l10n.wrongStatusOpen;
       case wrongStatusClosed:
-        return l10n?.wrongStatusClosed ?? 'Shown as closed, but open';
+        return l10n.wrongStatusClosed;
       case wrongName:
-        return l10n?.wrongStationName ?? 'Wrong station name';
+        return l10n.wrongStationName;
       case wrongAddress:
-        return l10n?.wrongStationAddress ?? 'Wrong address';
+        return l10n.wrongStationAddress;
     }
   }
 }

--- a/lib/features/report/presentation/screens/report_screen.dart
+++ b/lib/features/report/presentation/screens/report_screen.dart
@@ -28,11 +28,7 @@ class ReportScreen extends ConsumerStatefulWidget {
   /// user confirms the consent dialog. Tests inject a fake.
   final ErrorReporter? reporter;
 
-  const ReportScreen({
-    super.key,
-    required this.stationId,
-    this.reporter,
-  });
+  const ReportScreen({super.key, required this.stationId, this.reporter});
 
   @override
   ConsumerState<ReportScreen> createState() => _ReportScreenState();
@@ -96,11 +92,11 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
     // add metadata-only report types. Generic "Report a problem"
     // matches the actual scope.
     return PageScaffold(
-      title: l10n?.reportIssueTitle ?? 'Report a problem',
+      title: l10n.reportIssueTitle,
       bodyPadding: EdgeInsets.zero,
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
         onPressed: () => context.pop(),
       ),
       // RadioGroup sits OUTSIDE the ListView so every lazy-built
@@ -114,11 +110,11 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            if (!backends.hasAnyBackend && !backends.allVisibleRouteToGitHub)
-              ...[
-                const NoBackendBanner(),
-                const SizedBox(height: 16),
-              ],
+            if (!backends.hasAnyBackend &&
+                !backends.allVisibleRouteToGitHub) ...[
+              const NoBackendBanner(),
+              const SizedBox(height: 16),
+            ],
             ...buildReportTypeList(
               context,
               ref,
@@ -132,7 +128,8 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
             ),
             const SizedBox(height: 24),
             FilledButton(
-              onPressed: selectedType != null &&
+              onPressed:
+                  selectedType != null &&
                       !form.isSubmitting &&
                       _hasRequiredInput(selectedType) &&
                       (backends.selectedIsGitHubRouted(selectedType) ||
@@ -145,7 +142,7 @@ class _ReportScreenState extends ConsumerState<ReportScreen> {
                       width: 20,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : Text(l10n?.sendReport ?? 'Send report'),
+                  : Text(l10n.sendReport),
             ),
           ],
         ),

--- a/lib/features/report/presentation/screens/report_submit_handler.dart
+++ b/lib/features/report/presentation/screens/report_submit_handler.dart
@@ -51,17 +51,11 @@ class ReportSubmitHandler {
     final selectedType = form.selectedType;
     if (selectedType == null) return;
     if (selectedType.needsPrice && priceController.text.isEmpty) {
-      SnackBarHelper.showError(
-        context,
-        l10n?.enterValidPrice ?? 'Please enter a valid price',
-      );
+      SnackBarHelper.showError(context, l10n.enterValidPrice);
       return;
     }
     if (selectedType.needsText && textController.text.trim().isEmpty) {
-      SnackBarHelper.showError(
-        context,
-        l10n?.enterCorrection ?? 'Please enter the correction',
-      );
+      SnackBarHelper.showError(context, l10n.enterCorrection);
       return;
     }
 
@@ -80,8 +74,9 @@ class ReportSubmitHandler {
       final price = selectedType.needsPrice
           ? double.tryParse(priceController.text.replaceAll(',', '.'))
           : null;
-      final correctionText =
-          selectedType.needsText ? textController.text.trim() : null;
+      final correctionText = selectedType.needsText
+          ? textController.text.trim()
+          : null;
 
       // #484 — resolve the reporting backends for the current country
       // and config. Before this fix the screen always hit the
@@ -99,22 +94,17 @@ class ReportSubmitHandler {
       // #484 — Tankerkoenig only accepts the 5 original report types.
       // Metadata and extended-fuel types (wrongE85, wrongName, etc.)
       // route to TankSync only, even in Germany with a key set.
-      final canSubmitTankerkoenig = country.code == 'DE' &&
+      final canSubmitTankerkoenig =
+          country.code == 'DE' &&
           apiKey != null &&
           apiKey.isNotEmpty &&
           selectedType.isTankerkoenigSupported;
-      final canSubmitTankSync = TankSyncClient.isConnected &&
-          syncConfig.userId != null;
+      final canSubmitTankSync =
+          TankSyncClient.isConnected && syncConfig.userId != null;
 
       if (!canSubmitTankerkoenig && !canSubmitTankSync) {
         if (context.mounted) {
-          SnackBarHelper.showError(
-            context,
-            l10n?.reportNoBackendAvailable ??
-                'The report could not be sent: no reporting service is '
-                    'configured for this country. Enable TankSync in Settings '
-                    'to send community reports.',
-          );
+          SnackBarHelper.showError(context, l10n.reportNoBackendAvailable);
         }
         return;
       }
@@ -134,8 +124,7 @@ class ReportSubmitHandler {
         // reports carry neither (they don't hit TankSync — the row
         // would fail the check constraint, so we skip).
         final hasPricePayload = selectedType.needsPrice && price != null;
-        final hasTextPayload =
-            selectedType.needsText && correctionText != null;
+        final hasTextPayload = selectedType.needsText && correctionText != null;
         if (hasPricePayload || hasTextPayload) {
           await CommunityReportService.submitReport(
             stationId: stationId,
@@ -152,21 +141,22 @@ class ReportSubmitHandler {
       }
 
       if (context.mounted) {
-        SnackBarHelper.showSuccess(
-          context,
-          l10n?.reportSent ?? 'Report sent. Thank you!',
-        );
+        SnackBarHelper.showSuccess(context, l10n.reportSent);
         context.pop();
       }
     } on ApiException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'ReportSubmitHandler.submit: report submission failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'ReportSubmitHandler.submit: report submission failed',
+          },
+        ),
+      );
       if (context.mounted) {
-        SnackBarHelper.showError(
-          context,
-          '${l10n?.retry ?? "Error"}: ${e.message}',
-        );
+        SnackBarHelper.showError(context, '${l10n.retry}: ${e.message}');
       }
     } finally {
       if (context.mounted) {
@@ -177,7 +167,7 @@ class ReportSubmitHandler {
 
   Future<void> _routeToGitHub(
     ReportType selectedType,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) async {
     final country = ref.read(activeCountryProvider);
     final correction = textController.text.trim();
@@ -185,7 +175,7 @@ class ReportSubmitHandler {
       errorType: 'WrongMetadataReport',
       errorMessage:
           '${selectedType.fuelTypeColumnValue} reported wrong for '
-              'station $stationId: "$correction"',
+          'station $stationId: "$correction"',
       sourceLabel: country.apiProvider ?? country.name,
       countryCode: country.code,
       appVersion: ErrorReporterContext.currentAppVersion(),
@@ -193,13 +183,12 @@ class ReportSubmitHandler {
       locale: ErrorReporterContext.currentLocale(context),
       capturedAt: DateTime.now(),
     );
-    final launched =
-        await (reporter ?? const ErrorReporter()).reportError(context, payload);
+    final launched = await (reporter ?? const ErrorReporter()).reportError(
+      context,
+      payload,
+    );
     if (context.mounted && launched) {
-      SnackBarHelper.showSuccess(
-        context,
-        l10n?.reportSent ?? 'Report sent. Thank you!',
-      );
+      SnackBarHelper.showSuccess(context, l10n.reportSent);
       // Use Navigator.maybePop so the path works both under the
       // real GoRouter shell and under the plain MaterialApp that
       // widget tests use — context.pop() would throw

--- a/lib/features/report/presentation/widgets/report_input_section.dart
+++ b/lib/features/report/presentation/widgets/report_input_section.dart
@@ -31,10 +31,9 @@ class ReportInputSection extends StatelessWidget {
         padding: const EdgeInsets.only(top: 16),
         child: TextField(
           controller: priceController,
-          keyboardType:
-              const TextInputType.numberWithOptions(decimal: true),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
           decoration: InputDecoration(
-            labelText: l10n?.correctPrice ?? 'Correct price (e.g. 1.459)',
+            labelText: l10n.correctPrice,
             prefixText: '\u20ac ',
             border: const OutlineInputBorder(),
           ),
@@ -51,8 +50,8 @@ class ReportInputSection extends StatelessWidget {
           textCapitalization: TextCapitalization.sentences,
           decoration: InputDecoration(
             labelText: type == ReportType.wrongName
-                ? (l10n?.correctName ?? 'Correct station name')
-                : (l10n?.correctAddress ?? 'Correct address'),
+                ? (l10n.correctName)
+                : (l10n.correctAddress),
             border: const OutlineInputBorder(),
           ),
         ),

--- a/lib/features/report/presentation/widgets/report_type_list.dart
+++ b/lib/features/report/presentation/widgets/report_type_list.dart
@@ -38,10 +38,7 @@ List<Widget> buildReportTypeList(
   ref.watch(reportFormControllerProvider);
 
   return [
-    Text(
-      l10n?.whatsWrong ?? "What's wrong?",
-      style: theme.textTheme.titleMedium,
-    ),
+    Text(l10n.whatsWrong, style: theme.textTheme.titleMedium),
     const SizedBox(height: 12),
     for (final type in visibleTypes)
       RadioListTile<ReportType>(

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -110,16 +110,20 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       final coords = LatLng(position.latitude, position.longitude);
       ref.read(routeInputControllerProvider.notifier).setStartCoords(coords);
       final l10n = AppLocalizations.of(context);
-      _startController.text = l10n?.currentLocation ?? 'Current location';
+      _startController.text = l10n.currentLocation;
     } catch (e, st) {
       // #2146 — route to the exportable log; the snackbar is transient.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'RouteInput._useGpsForStart',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'RouteInput._useGpsForStart'},
+        ),
+      );
       if (mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showError(
-            context, '${l10n?.gpsError ?? "GPS error"}: $e');
+        SnackBarHelper.showError(context, '${l10n.gpsError}: $e');
       }
     }
   }
@@ -174,8 +178,7 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
 
       // Resolve start if needed
       if (startCoords == null && _startController.text.isNotEmpty) {
-        final results =
-            await searchService.searchCities(_startController.text);
+        final results = await searchService.searchCities(_startController.text);
         if (results.isNotEmpty) {
           startCoords = LatLng(results.first.lat, results.first.lng);
           notifier.setStartCoords(startCoords);
@@ -196,8 +199,9 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
         if (i < stopCoords.length &&
             stopCoords[i] == null &&
             _stopControllers[i].text.isNotEmpty) {
-          final results =
-              await searchService.searchCities(_stopControllers[i].text);
+          final results = await searchService.searchCities(
+            _stopControllers[i].text,
+          );
           if (results.isNotEmpty) {
             stopCoords[i] = LatLng(results.first.lat, results.first.lng);
             notifier.setStopCoord(i, stopCoords[i]);
@@ -216,9 +220,9 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
           !isUsableCoord(endCoords.latitude, endCoords.longitude)) {
         if (mounted) {
           SnackBarHelper.showError(
-              context,
-              AppLocalizations.of(context)?.couldNotResolve ??
-                  'Could not resolve start or destination');
+            context,
+            AppLocalizations.of(context).couldNotResolve,
+          );
         }
         return;
       }
@@ -251,12 +255,19 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       widget.onSearch(waypoints);
     } catch (e, st) {
       // #2146 — route to the exportable log; the snackbar is transient.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'RouteInput.resolveAndSearch',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'RouteInput.resolveAndSearch'},
+        ),
+      );
       if (mounted) {
-        SnackBarHelper.showError(context,
-            '${AppLocalizations.of(context)?.errorUnknown ?? "Error"}: $e');
+        SnackBarHelper.showError(
+          context,
+          '${AppLocalizations.of(context).errorUnknown}: $e',
+        );
       }
     } finally {
       // #2139 — always reset isSearching, even if the widget unmounted
@@ -284,17 +295,18 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
         CityAutocompleteField(
           controller: _startController,
           searchService: searchService,
-          label: l10n?.start ?? 'Start',
-          hint: l10n?.cityAddressOrGps ?? 'City, address, or GPS',
+          label: l10n.start,
+          hint: l10n.cityAddressOrGps,
           prefixIcon: Icons.trip_origin,
           suffixWidget: IconButton(
             icon: const Icon(Icons.my_location, size: 18),
             onPressed: _useGpsForStart,
-            tooltip: l10n?.useGps ?? 'Use GPS',
+            tooltip: l10n.useGps,
           ),
           onCitySelected: _onStartCitySelected,
-          onTextChanged: () =>
-              ref.read(routeInputControllerProvider.notifier).setStartCoords(null),
+          onTextChanged: () => ref
+              .read(routeInputControllerProvider.notifier)
+              .setStartCoords(null),
         ),
         const SizedBox(height: 6),
 
@@ -305,12 +317,12 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
             child: CityAutocompleteField(
               controller: _stopControllers[i],
               searchService: searchService,
-              label: '${l10n?.stop ?? "Stop"} ${i + 1}',
-              hint: l10n?.cityOrAddress ?? 'City or address',
+              label: '${l10n.stop} ${i + 1}',
+              hint: l10n.cityOrAddress,
               prefixIcon: Icons.more_vert,
               suffixWidget: IconButton(
                 icon: const Icon(Icons.close, size: 16),
-                tooltip: l10n?.remove ?? 'Remove',
+                tooltip: l10n.remove,
                 onPressed: () => _removeStop(i),
               ),
               onCitySelected: (city) => _onStopCitySelected(i, city),
@@ -327,8 +339,7 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
             child: TextButton.icon(
               onPressed: _addStop,
               icon: const Icon(Icons.add, size: 16),
-              label: Text(l10n?.addStop ?? 'Add stop',
-                  style: theme.textTheme.bodySmall),
+              label: Text(l10n.addStop, style: theme.textTheme.bodySmall),
               style: TextButton.styleFrom(
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 minimumSize: const Size(0, 32),
@@ -340,12 +351,13 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
         CityAutocompleteField(
           controller: _endController,
           searchService: searchService,
-          label: l10n?.destination ?? 'Destination',
-          hint: l10n?.cityOrAddress ?? 'City or address',
+          label: l10n.destination,
+          hint: l10n.cityOrAddress,
           prefixIcon: Icons.place,
           onCitySelected: _onEndCitySelected,
-          onTextChanged: () =>
-              ref.read(routeInputControllerProvider.notifier).setEndCoords(null),
+          onTextChanged: () => ref
+              .read(routeInputControllerProvider.notifier)
+              .setEndCoords(null),
         ),
         // #2131 — the inline "Search along route" submit button moved
         // to the central FAB. RouteInput now owns inputs only;

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -32,7 +32,8 @@ class EVStationDetailScreen extends ConsumerStatefulWidget {
   const EVStationDetailScreen({super.key, required this.station});
 
   @override
-  ConsumerState<EVStationDetailScreen> createState() => _EVStationDetailScreenState();
+  ConsumerState<EVStationDetailScreen> createState() =>
+      _EVStationDetailScreenState();
 }
 
 class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
@@ -63,9 +64,14 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
       final enriched = (await enricher.enrich([widget.station])).first;
       if (mounted) setState(() => _station = enriched);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'EVStationDetailScreen: enrich on open',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'EVStationDetailScreen: enrich on open'},
+        ),
+      );
     }
   }
 
@@ -86,29 +92,42 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
         maxResults: 10,
       );
       final ocmId = _station.id.replaceFirst('ocm-', '');
-      final refreshed = result.data.where((s) => s.id == _station.id || s.id == 'ocm-$ocmId').firstOrNull;
+      final refreshed = result.data
+          .where((s) => s.id == _station.id || s.id == 'ocm-$ocmId')
+          .firstOrNull;
       if (refreshed != null && mounted) {
         // Re-apply the same country-authoritative enrich the open path uses
         // (#2632). The raw OCM re-fetch carries null UsageType / no IRVE
         // flag, so a plain `_station = refreshed` here STRIPPED the badge
         // a search-list open had shown. Inside the try/catch, so an IRVE
         // outage degrades to the raw refreshed station rather than blanking.
-        final enriched =
-            (await ref.read(evPriceEnricherProvider).enrich([refreshed])).first;
+        final enriched = (await ref.read(evPriceEnricherProvider).enrich([
+          refreshed,
+        ])).first;
         if (!mounted) return;
         setState(() => _station = enriched);
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showSuccess(context, l10n?.evStatusUpdated ?? 'Status updated');
+        SnackBarHelper.showSuccess(context, l10n.evStatusUpdated);
       } else if (mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showError(context, l10n?.evStationNotFound ?? 'Could not refresh — station not found nearby');
+        SnackBarHelper.showError(context, l10n.evStationNotFound);
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-        'where': 'EVStationDetailScreen._refreshStation: refresh failed',
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'EVStationDetailScreen._refreshStation: refresh failed',
+          },
+        ),
+      );
       if (mounted) {
-        SnackBarHelper.showError(context, AppLocalizations.of(context)?.refreshFailed ?? 'Refresh failed. Please try again.');
+        SnackBarHelper.showError(
+          context,
+          AppLocalizations.of(context).refreshFailed,
+        );
       }
     } finally {
       if (mounted) setState(() => _isRefreshing = false);
@@ -116,8 +135,13 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   }
 
   void _navigateToStation() {
-    unawaited(NavigationUtils.openInMaps(_station.lat, _station.lng,
-        label: _station.name));
+    unawaited(
+      NavigationUtils.openInMaps(
+        _station.lat,
+        _station.lng,
+        label: _station.name,
+      ),
+    );
   }
 
   /// Open the add-charging-log form pre-filled with this station
@@ -150,57 +174,65 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
       title: operatorName.isNotEmpty ? operatorName : station.name,
       bodyPadding: EdgeInsets.zero,
       actions: [
-        Consumer(builder: (context, ref, _) {
-          final isFav = ref.watch(isFavoriteProvider(station.id));
-          return IconButton(
-            icon: Icon(
-              isFav ? Icons.star : Icons.star_outline,
-              color: isFav ? Colors.amber : Colors.white70,
-              size: 26,
-            ),
-            tooltip: isFav ? (l10n?.removeFavorite ?? 'Remove from favorites') : (l10n?.addFavorite ?? 'Add to favorites'),
-            onPressed: () async {
-              // Await the toggle so the snackbar fires AFTER persistence
-              // and the isFavoriteProvider has flipped. Otherwise a quick
-              // back-navigation can cancel the in-flight Hive write and
-              // leave the favorite half-persisted (#566).
-              // Persist the ALREADY-ENRICHED `_station` (not the raw
-              // `widget.station`) so a later rehydrate of the favorite keeps
-              // the IRVE free/paid signal that initState enriched in (#2632).
-              await ref.read(favoritesProvider.notifier).toggle(
-                    station.id,
-                    rawJson: _station.toJson(),
-                  );
-              if (!context.mounted) return;
-              // Temporary diagnostic: surface live storage counts in the
-              // snackbar so a user on an APK without logcat can verify
-              // the favorite actually persisted.
-              final storage = ref.read(storageRepositoryProvider);
-              final evIds = storage.getEvFavoriteIds();
-              final savedCount = evIds
-                  .where((id) => storage.getEvFavoriteStationData(id) != null)
-                  .length;
-              final base = isFav
-                  ? (l10n?.removedFromFavorites ?? 'Removed from favorites')
-                  : (l10n?.addedToFavorites ?? 'Added to favorites');
-              SnackBarHelper.show(
-                context,
-                '$base (EV: ${evIds.length} ids / $savedCount saved)',
-                duration: const Duration(seconds: 3),
-              );
-            },
-          );
-        }),
+        Consumer(
+          builder: (context, ref, _) {
+            final isFav = ref.watch(isFavoriteProvider(station.id));
+            return IconButton(
+              icon: Icon(
+                isFav ? Icons.star : Icons.star_outline,
+                color: isFav ? Colors.amber : Colors.white70,
+                size: 26,
+              ),
+              tooltip: isFav ? (l10n.removeFavorite) : (l10n.addFavorite),
+              onPressed: () async {
+                // Await the toggle so the snackbar fires AFTER persistence
+                // and the isFavoriteProvider has flipped. Otherwise a quick
+                // back-navigation can cancel the in-flight Hive write and
+                // leave the favorite half-persisted (#566).
+                // Persist the ALREADY-ENRICHED `_station` (not the raw
+                // `widget.station`) so a later rehydrate of the favorite keeps
+                // the IRVE free/paid signal that initState enriched in (#2632).
+                await ref
+                    .read(favoritesProvider.notifier)
+                    .toggle(station.id, rawJson: _station.toJson());
+                if (!context.mounted) return;
+                // Temporary diagnostic: surface live storage counts in the
+                // snackbar so a user on an APK without logcat can verify
+                // the favorite actually persisted.
+                final storage = ref.read(storageRepositoryProvider);
+                final evIds = storage.getEvFavoriteIds();
+                final savedCount = evIds
+                    .where((id) => storage.getEvFavoriteStationData(id) != null)
+                    .length;
+                final base = isFav
+                    ? (l10n.removedFromFavorites)
+                    : (l10n.addedToFavorites);
+                SnackBarHelper.show(
+                  context,
+                  '$base (EV: ${evIds.length} ids / $savedCount saved)',
+                  duration: const Duration(seconds: 3),
+                );
+              },
+            );
+          },
+        ),
         IconButton(
           icon: _isRefreshing
-              ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70))
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white70,
+                  ),
+                )
               : const Icon(Icons.refresh),
-          tooltip: l10n?.evRefreshStatus ?? 'Refresh status',
+          tooltip: l10n.evRefreshStatus,
           onPressed: _isRefreshing ? null : _refreshStation,
         ),
         IconButton(
           icon: const Icon(Icons.navigation),
-          tooltip: l10n?.navigate ?? 'Navigate',
+          tooltip: l10n.navigate,
           onPressed: _navigateToStation,
         ),
       ],
@@ -218,13 +250,17 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   Widget _compactBody(
     BuildContext context,
     ThemeData theme,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     ChargingStation station,
     Color evColor,
   ) {
     return ListView(
       padding: EdgeInsets.fromLTRB(
-          16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom + 24),
+        16,
+        16,
+        16,
+        16 + MediaQuery.of(context).viewPadding.bottom + 24,
+      ),
       children: [
         ..._headerSections(station, evColor),
         const SizedBox(height: 8),
@@ -240,7 +276,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   Widget _wideBody(
     BuildContext context,
     ThemeData theme,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     ChargingStation station,
     Color evColor,
   ) {
@@ -259,8 +295,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
         Expanded(
           flex: 3,
           child: ListView(
-            padding:
-                EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
             children: _detailSections(context, theme, l10n, station, evColor),
           ),
         ),
@@ -283,7 +318,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
   List<Widget> _detailSections(
     BuildContext context,
     ThemeData theme,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     ChargingStation station,
     Color evColor,
   ) {
@@ -302,28 +337,31 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(l10n?.yourRating ?? 'Your rating',
-                  style: theme.textTheme.titleMedium),
+              Text(l10n.yourRating, style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
-              Consumer(builder: (context, ref, _) {
-                final rating = ref.watch(stationRatingProvider(station.id));
-                return Row(
-                  children: [
-                    StarRating(
-                      rating: rating,
-                      onRatingChanged: (stars) {
-                        unawaited(ref
-                            .read(stationRatingsProvider.notifier)
-                            .rate(station.id, stars));
-                      },
-                    ),
-                    if (rating != null) ...[
-                      const SizedBox(width: 12),
-                      Text('$rating/5', style: theme.textTheme.bodyMedium),
+              Consumer(
+                builder: (context, ref, _) {
+                  final rating = ref.watch(stationRatingProvider(station.id));
+                  return Row(
+                    children: [
+                      StarRating(
+                        rating: rating,
+                        onRatingChanged: (stars) {
+                          unawaited(
+                            ref
+                                .read(stationRatingsProvider.notifier)
+                                .rate(station.id, stars),
+                          );
+                        },
+                      ),
+                      if (rating != null) ...[
+                        const SizedBox(width: 12),
+                        Text('$rating/5', style: theme.textTheme.bodyMedium),
+                      ],
                     ],
-                  ],
-                );
-              }),
+                  );
+                },
+              ),
             ],
           ),
         ),
@@ -335,7 +373,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
         key: const Key('ev_log_charging_button'),
         onPressed: _logCharging,
         icon: const Icon(Icons.ev_station),
-        label: Text(l10n?.chargingLogButtonLabel ?? 'Log charging'),
+        label: Text(l10n.chargingLogButtonLabel),
         style: FilledButton.styleFrom(
           minimumSize: const Size.fromHeight(48),
           backgroundColor: evColor,
@@ -347,7 +385,7 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
       FilledButton.icon(
         onPressed: _navigateToStation,
         icon: const Icon(Icons.navigation),
-        label: Text(l10n?.evNavigateToStation ?? 'Navigate to station'),
+        label: Text(l10n.evNavigateToStation),
         style: FilledButton.styleFrom(
           minimumSize: const Size.fromHeight(48),
           backgroundColor: evColor.withValues(alpha: 0.85),

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -91,13 +91,15 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       // #2139 — microtask fires before any frame; addPostFrameCallback
       // can be skipped if no frame is scheduled, leaving a stale
       // action that makes the FAB look enabled but no-op.
-      unawaited(Future.microtask(() {
-        try {
-          notifier.clearFor(this); // #2553 — clear by owner, not action.
-        } catch (_) {
-          // ignore: silent_catch — ProviderContainer torn down (e.g. test teardown) — no-op.
-        }
-      }));
+      unawaited(
+        Future.microtask(() {
+          try {
+            notifier.clearFor(this); // #2553 — clear by owner, not action.
+          } catch (_) {
+            // ignore: silent_catch — ProviderContainer torn down (e.g. test teardown) — no-op.
+          }
+        }),
+      );
     }
     super.dispose();
   }
@@ -134,7 +136,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
 
     final action = SearchFabAction(
       icon: Icons.search,
-      tooltip: l10n?.fabRunSearch ?? 'Run search',
+      tooltip: l10n.fabRunSearch,
       enabled: enabled,
       onTap: onTap,
     );
@@ -179,8 +181,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
         if (mounted) {
           SnackBarHelper.show(
             context,
-            AppLocalizations.of(context)?.locationDenied ??
-                'Location permission denied.',
+            AppLocalizations.of(context).locationDenied,
           );
         }
         return;
@@ -190,8 +191,11 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     if (_searchFired || !mounted) return;
     _searchFired = true;
     // SearchState dispatches to EV or fuel service based on fuelType.
-    unawaited(ref.read(searchStateProvider.notifier).searchByGps(
-        fuelType: fuelType, radiusKm: radius));
+    unawaited(
+      ref
+          .read(searchStateProvider.notifier)
+          .searchByGps(fuelType: fuelType, radiusKm: radius),
+    );
     Navigator.of(context).pop();
   }
 
@@ -200,11 +204,11 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    unawaited(ref.read(searchStateProvider.notifier).searchByZipCode(
-          zipCode: zip,
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
+    unawaited(
+      ref
+          .read(searchStateProvider.notifier)
+          .searchByZipCode(zipCode: zip, fuelType: fuelType, radiusKm: radius),
+    );
     Navigator.of(context).pop();
   }
 
@@ -213,14 +217,18 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    unawaited(ref.read(searchStateProvider.notifier).searchByCoordinates(
-          lat: city.lat,
-          lng: city.lng,
-          postalCode: city.postcode,
-          locationName: city.name,
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
+    unawaited(
+      ref
+          .read(searchStateProvider.notifier)
+          .searchByCoordinates(
+            lat: city.lat,
+            lng: city.lng,
+            postalCode: city.postcode,
+            locationName: city.name,
+            fuelType: fuelType,
+            radiusKm: radius,
+          ),
+    );
     Navigator.of(context).pop();
   }
 
@@ -235,13 +243,17 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final segmentKm = ref.read(routeSegmentSearchParamProvider);
     final minSaving = ref.read(minRouteSavingSearchParamProvider);
     ref.read(activeSearchModeProvider.notifier).set(SearchMode.route);
-    unawaited(ref.read(routeSearchStateProvider.notifier).searchAlongRoute(
-          waypoints: waypoints,
-          fuelType: fuelType,
-          searchRadiusKm: detourBudgetKm,
-          segmentKm: segmentKm,
-          minSavingPerLiter: minSaving,
-        ));
+    unawaited(
+      ref
+          .read(routeSearchStateProvider.notifier)
+          .searchAlongRoute(
+            waypoints: waypoints,
+            fuelType: fuelType,
+            searchRadiusKm: detourBudgetKm,
+            segmentKm: segmentKm,
+            minSavingPerLiter: minSaving,
+          ),
+    );
     Navigator.of(context).pop();
   }
 
@@ -271,8 +283,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     // the *whole* default set round-trips, not just the profile
     // subset. This runs regardless of whether a profile is active.
     await storage.putSetting(StorageKeys.defaultOpenOnly, openOnly);
-    await storage.putSetting(
-        StorageKeys.defaultExcludeHighway, excludeHighway);
+    await storage.putSetting(StorageKeys.defaultExcludeHighway, excludeHighway);
     await storage.putSetting(
       StorageKeys.defaultAmenities,
       amenities.map((a) => a.name).toList(),
@@ -285,27 +296,22 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     // per-search overrides become the new profile defaults.
     if (profile != null) {
       await profileNotifier.updateProfile(
-            profile.copyWith(
-              preferredFuelType: fuelType,
-              defaultSearchRadius: radius,
-              routeSegmentKm: inRoute
-                  ? routeSegmentKm
-                  : profile.routeSegmentKm,
-              routeDetourBudgetKm: inRoute
-                  ? routeDetourBudgetKm
-                  : profile.routeDetourBudgetKm,
-              minRouteSavingPerLiter: inRoute
-                  ? minRouteSavingPerLiter
-                  : profile.minRouteSavingPerLiter,
-            ),
-          );
+        profile.copyWith(
+          preferredFuelType: fuelType,
+          defaultSearchRadius: radius,
+          routeSegmentKm: inRoute ? routeSegmentKm : profile.routeSegmentKm,
+          routeDetourBudgetKm: inRoute
+              ? routeDetourBudgetKm
+              : profile.routeDetourBudgetKm,
+          minRouteSavingPerLiter: inRoute
+              ? minRouteSavingPerLiter
+              : profile.minRouteSavingPerLiter,
+        ),
+      );
     }
 
     if (!mounted) return;
-    SnackBarHelper.show(
-      context,
-      l10n?.criteriaSavedToProfile ?? 'Saved as defaults',
-    );
+    SnackBarHelper.show(context, l10n.criteriaSavedToProfile);
   }
 
   @override
@@ -314,7 +320,10 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final storedMode = ref.watch(activeSearchModeProvider);
 
     // #2131 — re-register the FAB when mode or canSearch flip.
-    ref.listen<SearchMode>(activeSearchModeProvider, (_, _) => _updateFabAction());
+    ref.listen<SearchMode>(
+      activeSearchModeProvider,
+      (_, _) => _updateFabAction(),
+    );
     ref.listen<RouteInputState>(routeInputControllerProvider, (p, n) {
       if (p?.canSearch != n.canSearch) _updateFabAction();
     });
@@ -331,10 +340,10 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final mode = routePlanningOn ? storedMode : SearchMode.nearby;
 
     return PageScaffold(
-      title: l10n?.searchCriteriaTitle ?? 'Search criteria',
+      title: l10n.searchCriteriaTitle,
       leading: IconButton(
         icon: const Icon(Icons.close),
-        tooltip: AppLocalizations.of(context)?.tooltipClose ?? 'Close',
+        tooltip: AppLocalizations.of(context).tooltipClose,
         onPressed: () => Navigator.of(context).pop(),
       ),
       bodyPadding: EdgeInsets.zero,
@@ -357,4 +366,3 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     );
   }
 }
-

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -118,9 +118,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       if (!consented) {
         if (mounted) {
           SnackBarHelper.show(
-              context,
-              AppLocalizations.of(context)?.locationDenied ??
-                  'Location permission denied. You can search by postal code.');
+            context,
+            AppLocalizations.of(context).locationDenied,
+          );
         }
         return;
       }
@@ -128,20 +128,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     }
 
     // SearchState dispatches to EV or fuel service internally based on fuelType.
-    unawaited(searchNotifier.searchByGps(
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
+    unawaited(searchNotifier.searchByGps(fuelType: fuelType, radiusKm: radius));
   }
 
   void _performZipSearch(String zip) {
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
-    unawaited(ref.read(searchStateProvider.notifier).searchByZipCode(
-          zipCode: zip,
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
+    unawaited(
+      ref
+          .read(searchStateProvider.notifier)
+          .searchByZipCode(zipCode: zip, fuelType: fuelType, radiusKm: radius),
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -176,9 +173,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     // before the re-search lands.
     ref.listen<FuelType>(selectedFuelTypeProvider, (prev, next) {
       if (prev != next) {
-        unawaited(
-          ref.read(searchStateProvider.notifier).repeatLastSearch(),
-        );
+        unawaited(ref.read(searchStateProvider.notifier).repeatLastSearch());
       }
     });
 
@@ -216,7 +211,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     }
 
     return PageScaffold(
-      title: l10n?.appTitle ?? 'Sparkilo', // i18n-ignore: brand name
+      title: l10n.appTitle, // i18n-ignore: brand name
       toolbarHeight: isLandscape ? 40 : null,
       actions: [
         IconButton(
@@ -226,7 +221,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               ref.read(searchStateProvider.notifier).repeatLastSearch(),
             );
           },
-          tooltip: l10n?.refreshPrices ?? 'Refresh prices',
+          tooltip: l10n.refreshPrices,
         ),
         if (radarActive) ...[
           // Pin — wake lock + immersive bars (copied from the trip screen).
@@ -235,8 +230,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             button: true,
             toggled: pinned,
             label: pinned
-                ? (l10n?.tripRecordingPinSemanticOn ?? 'Unpin recording form')
-                : (l10n?.tripRecordingPinSemanticOff ?? 'Pin recording form'),
+                ? (l10n.tripRecordingPinSemanticOn)
+                : (l10n.tripRecordingPinSemanticOff),
             // #2785 — long-press opens the pin-help sheet (what pinning does
             // + the "always pin when the radar starts" toggle).
             child: GestureDetector(
@@ -248,8 +243,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
                   pinned ? Icons.push_pin : Icons.push_pin_outlined,
                   color: pinned ? Theme.of(context).colorScheme.primary : null,
                 ),
-                tooltip: l10n?.tripRecordingPinTooltip ??
-                    'Pinning keeps the screen on — uses more battery',
+                tooltip: l10n.tripRecordingPinTooltip,
                 isSelected: pinned,
                 onPressed: togglePin,
               ),
@@ -260,8 +254,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             IconButton(
               key: const Key('radarMinimiseButton'),
               icon: const Icon(Icons.picture_in_picture_alt),
-              tooltip: l10n?.tripRecordingMinimiseTooltip ??
-                  'Minimise to a floating tile',
+              tooltip: l10n.tripRecordingMinimiseTooltip,
               onPressed: () => _pip.enterPip(),
             ),
         ],
@@ -303,8 +296,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       detail: (!radarActive && selectedId != null)
           ? StationDetailInline(
               stationId: selectedId,
-              onClose: () =>
-                  ref.read(selectedStationProvider.notifier).clear(),
+              onClose: () => ref.read(selectedStationProvider.notifier).clear(),
             )
           : null,
       detailPlaceholder: const InlineMap(),
@@ -325,10 +317,12 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     final isRoute = ref.watch(activeSearchModeProvider) == SearchMode.route;
     final corridorCodes = isRoute
         ? (ref
-                .watch(routeSearchStateProvider)
-                .value
-                ?.contributingCountryCodes(ref.watch(selectedFuelTypeProvider)) ??
-            const <String>{})
+                  .watch(routeSearchStateProvider)
+                  .value
+                  ?.contributingCountryCodes(
+                    ref.watch(selectedFuelTypeProvider),
+                  ) ??
+              const <String>{})
         : const <String>{};
 
     return Column(
@@ -360,14 +354,20 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               // user; show a localized, actionable message instead.
               // #2146 — route to the exportable log so the cause is
               // recoverable from a bug report.
-              unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
-                'where': 'SearchScreen: userPosition.updateFromGps',
-              }));
+              unawaited(
+                errorLogger.log(
+                  ErrorLayer.ui,
+                  e,
+                  st,
+                  context: const {
+                    'where': 'SearchScreen: userPosition.updateFromGps',
+                  },
+                ),
+              );
               if (!context.mounted) return;
               SnackBarHelper.showError(
                 context,
-                AppLocalizations.of(context)?.searchFailedSnackbar ??
-                    'Search failed — please try again',
+                AppLocalizations.of(context).searchFailedSnackbar,
               );
             }
           },
@@ -375,7 +375,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
         // Results dominate the remaining vertical space.
         Expanded(
           child: Semantics(
-            label: l10n?.searchResultsSemanticLabel ?? 'Search results',
+            label: l10n.searchResultsSemanticLabel,
             child: SearchResultsContent(onGpsRetry: _performGpsSearch),
           ),
         ),

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -57,10 +57,10 @@ class AllPricesStationCard extends StatelessWidget {
   /// #3198 — tri-state status colour: green when known-open, red when
   /// known-closed, neutral muted when the source gave no signal.
   Color _statusColor(BuildContext context) => switch (station.isOpen) {
-        true => DarkModeColors.success(context),
-        false => DarkModeColors.error(context),
-        null => DarkModeColors.mutedText(context),
-      };
+    true => DarkModeColors.success(context),
+    false => DarkModeColors.error(context),
+    null => DarkModeColors.mutedText(context),
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -115,9 +115,9 @@ class AllPricesStationCard extends StatelessWidget {
                   ),
                   child: Text(
                     switch (station.isOpen) {
-                      true => l10n?.open ?? 'Open',
-                      false => l10n?.closed ?? 'Closed',
-                      null => l10n?.openStateUnknown ?? 'Unknown',
+                      true => l10n.open,
+                      false => l10n.closed,
+                      null => l10n.openStateUnknown,
                     },
                     style: TextStyle(
                       fontSize: 10,
@@ -148,8 +148,8 @@ class AllPricesStationCard extends StatelessWidget {
                             onFavoriteTap!();
                           },
                     tooltip: isFavorite
-                        ? (l10n?.removeFavorite ?? 'Remove from favorites')
-                        : (l10n?.addFavorite ?? 'Add to favorites'),
+                        ? (l10n.removeFavorite)
+                        : (l10n.addFavorite),
                   ),
                 ),
               ],
@@ -203,20 +203,41 @@ class AllPricesStationCard extends StatelessWidget {
 
     final fuelEntries = <(FuelType, double?, String)>[
       (FuelType.e5, station.e5, fuelDisplayLabel(FuelType.e5, countryCode: cc)),
-      (FuelType.e10, station.e10,
-          fuelDisplayLabel(FuelType.e10, countryCode: cc)),
-      (FuelType.e98, station.e98,
-          fuelDisplayLabel(FuelType.e98, countryCode: cc)),
-      (FuelType.diesel, station.diesel,
-          fuelDisplayLabel(FuelType.diesel, countryCode: cc)),
-      (FuelType.dieselPremium, station.dieselPremium,
-          fuelDisplayLabel(FuelType.dieselPremium, countryCode: cc)),
-      (FuelType.e85, station.e85,
-          fuelDisplayLabel(FuelType.e85, countryCode: cc)),
-      (FuelType.lpg, station.lpg,
-          fuelDisplayLabel(FuelType.lpg, countryCode: cc)),
-      (FuelType.cng, station.cng,
-          fuelDisplayLabel(FuelType.cng, countryCode: cc)),
+      (
+        FuelType.e10,
+        station.e10,
+        fuelDisplayLabel(FuelType.e10, countryCode: cc),
+      ),
+      (
+        FuelType.e98,
+        station.e98,
+        fuelDisplayLabel(FuelType.e98, countryCode: cc),
+      ),
+      (
+        FuelType.diesel,
+        station.diesel,
+        fuelDisplayLabel(FuelType.diesel, countryCode: cc),
+      ),
+      (
+        FuelType.dieselPremium,
+        station.dieselPremium,
+        fuelDisplayLabel(FuelType.dieselPremium, countryCode: cc),
+      ),
+      (
+        FuelType.e85,
+        station.e85,
+        fuelDisplayLabel(FuelType.e85, countryCode: cc),
+      ),
+      (
+        FuelType.lpg,
+        station.lpg,
+        fuelDisplayLabel(FuelType.lpg, countryCode: cc),
+      ),
+      (
+        FuelType.cng,
+        station.cng,
+        fuelDisplayLabel(FuelType.cng, countryCode: cc),
+      ),
     ];
 
     for (final (fuelType, price, label) in fuelEntries) {

--- a/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
@@ -39,8 +39,8 @@ class _FuelBadge extends StatelessWidget {
     final bgColor = isChampion
         ? color
         : isHighlighted
-            ? FuelColors.forType(fuelType).withValues(alpha: 0.22)
-            : FuelColors.forTypeLight(fuelType);
+        ? FuelColors.forType(fuelType).withValues(alpha: 0.22)
+        : FuelColors.forTypeLight(fuelType);
 
     final borderWidth = isChampion ? 1.5 : (isHighlighted ? 1.5 : 0.5);
     final labelFontSize = isHighlighted ? 11.0 : 10.0;
@@ -60,9 +60,7 @@ class _FuelBadge extends StatelessWidget {
             : bgColor,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: isUnavailable
-              ? theme.colorScheme.outlineVariant
-              : borderColor,
+          color: isUnavailable ? theme.colorScheme.outlineVariant : borderColor,
           width: borderWidth,
         ),
       ),
@@ -77,8 +75,8 @@ class _FuelBadge extends StatelessWidget {
               color: isUnavailable
                   ? theme.colorScheme.onSurfaceVariant
                   : isChampion
-                      ? Colors.white
-                      : color,
+                  ? Colors.white
+                  : color,
             ),
           ),
           const SizedBox(width: 4),
@@ -92,8 +90,8 @@ class _FuelBadge extends StatelessWidget {
               color: isUnavailable
                   ? theme.colorScheme.onSurfaceVariant
                   : isChampion
-                      ? Colors.white
-                      : color,
+                  ? Colors.white
+                  : color,
             ),
           ),
           const SizedBox(width: 4),
@@ -106,7 +104,7 @@ class _FuelBadge extends StatelessWidget {
             price: isUnavailable ? null : price,
             child: Text(
               isUnavailable
-                  ? (l10n?.outOfStock ?? 'Out of stock')
+                  ? (l10n.outOfStock)
                   : PriceFormatter.formatPriceCompact(price),
               style: TextStyle(
                 fontSize: priceFontSize,
@@ -114,10 +112,10 @@ class _FuelBadge extends StatelessWidget {
                 color: isUnavailable
                     ? theme.colorScheme.onSurfaceVariant
                     : isChampion
-                        ? Colors.white
-                        : isHighlighted
-                            ? color
-                            : theme.colorScheme.onSurface,
+                    ? Colors.white
+                    : isHighlighted
+                    ? color
+                    : theme.colorScheme.onSurface,
               ),
             ),
           ),

--- a/lib/features/search/presentation/widgets/amenity_chips.dart
+++ b/lib/features/search/presentation/widgets/amenity_chips.dart
@@ -17,11 +17,7 @@ class AmenityChips extends StatelessWidget {
   /// Maximum number of chips to display. Extra amenities show a "+N" chip.
   final int maxVisible;
 
-  const AmenityChips({
-    super.key,
-    required this.amenities,
-    this.maxVisible = 4,
-  });
+  const AmenityChips({super.key, required this.amenities, this.maxVisible = 4});
 
   @override
   Widget build(BuildContext context) {
@@ -36,43 +32,43 @@ class AmenityChips extends StatelessWidget {
       spacing: 4,
       runSpacing: 2,
       children: [
-        ...visible.map((a) => AppPill(
-              icon: amenityIcon(a),
-              label: _localizedLabel(a, l10n),
-            )),
+        ...visible.map(
+          (a) => AppPill(icon: amenityIcon(a), label: _localizedLabel(a, l10n)),
+        ),
         // #2622 — make the "+N" overflow pill meaningful: a tooltip +
         // accessibility label spell out the hidden amenities by localized
         // name so the count is no longer opaque.
         if (overflow > 0)
-          Builder(builder: (_) {
-            final hiddenNames = sorted
-                .skip(maxVisible)
-                .map((a) => _localizedLabel(a, l10n))
-                .join(', ');
-            final message =
-                l10n?.amenityMoreTooltip(hiddenNames) ?? 'Also: $hiddenNames';
-            return Tooltip(
-              message: message,
-              child: Semantics(
-                label: message,
-                child: AppPill(label: '+$overflow'),
-              ),
-            );
-          }),
+          Builder(
+            builder: (_) {
+              final hiddenNames = sorted
+                  .skip(maxVisible)
+                  .map((a) => _localizedLabel(a, l10n))
+                  .join(', ');
+              final message = l10n.amenityMoreTooltip(hiddenNames);
+              return Tooltip(
+                message: message,
+                child: Semantics(
+                  label: message,
+                  child: AppPill(label: '+$overflow'),
+                ),
+              );
+            },
+          ),
       ],
     );
   }
 
-  String _localizedLabel(StationAmenity a, AppLocalizations? l10n) {
+  String _localizedLabel(StationAmenity a, AppLocalizations l10n) {
     return switch (a) {
-      StationAmenity.shop => l10n?.amenityShop ?? 'Shop',
-      StationAmenity.carWash => l10n?.amenityCarWash ?? 'Car Wash',
-      StationAmenity.airPump => l10n?.amenityAirPump ?? 'Air',
-      StationAmenity.toilet => l10n?.amenityToilet ?? 'WC',
-      StationAmenity.restaurant => l10n?.amenityRestaurant ?? 'Food',
-      StationAmenity.atm => l10n?.amenityAtm ?? 'ATM',
-      StationAmenity.wifi => l10n?.amenityWifi ?? 'WiFi',
-      StationAmenity.ev => l10n?.amenityEv ?? 'EV',
+      StationAmenity.shop => l10n.amenityShop,
+      StationAmenity.carWash => l10n.amenityCarWash,
+      StationAmenity.airPump => l10n.amenityAirPump,
+      StationAmenity.toilet => l10n.amenityToilet,
+      StationAmenity.restaurant => l10n.amenityRestaurant,
+      StationAmenity.atm => l10n.amenityAtm,
+      StationAmenity.wifi => l10n.amenityWifi,
+      StationAmenity.ev => l10n.amenityEv,
     };
   }
 }

--- a/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
+++ b/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
@@ -49,24 +49,23 @@ class AmenityFilterWrap extends StatelessWidget {
               selected: selected.contains(amenity),
               onSelected: (_) => onToggle(amenity),
             ),
-            if (amenity != StationAmenity.values.last)
-              const SizedBox(width: 8),
+            if (amenity != StationAmenity.values.last) const SizedBox(width: 8),
           ],
         ],
       ),
     );
   }
 
-  String _label(StationAmenity a, AppLocalizations? l10n) {
+  String _label(StationAmenity a, AppLocalizations l10n) {
     return switch (a) {
-      StationAmenity.shop => l10n?.amenityShop ?? 'Shop',
-      StationAmenity.carWash => l10n?.amenityCarWash ?? 'Car Wash',
-      StationAmenity.airPump => l10n?.amenityAirPump ?? 'Air',
-      StationAmenity.toilet => l10n?.amenityToilet ?? 'WC',
-      StationAmenity.restaurant => l10n?.amenityRestaurant ?? 'Food',
-      StationAmenity.atm => l10n?.amenityAtm ?? 'ATM',
-      StationAmenity.wifi => l10n?.amenityWifi ?? 'WiFi',
-      StationAmenity.ev => l10n?.amenityEv ?? 'EV',
+      StationAmenity.shop => l10n.amenityShop,
+      StationAmenity.carWash => l10n.amenityCarWash,
+      StationAmenity.airPump => l10n.amenityAirPump,
+      StationAmenity.toilet => l10n.amenityToilet,
+      StationAmenity.restaurant => l10n.amenityRestaurant,
+      StationAmenity.atm => l10n.amenityAtm,
+      StationAmenity.wifi => l10n.amenityWifi,
+      StationAmenity.ev => l10n.amenityEv,
     };
   }
 }

--- a/lib/features/search/presentation/widgets/brand_filter_chips.dart
+++ b/lib/features/search/presentation/widgets/brand_filter_chips.dart
@@ -47,7 +47,7 @@ class BrandFilterChips extends ConsumerWidget {
             // "All" chip
             ChoiceChip(
               avatar: const Icon(Icons.select_all, size: 16),
-              label: Text(l10n?.brandFilterAll ?? 'All'),
+              label: Text(l10n.brandFilterAll),
               selected: isAllSelected,
               onSelected: (_) =>
                   ref.read(selectedBrandsProvider.notifier).clear(),
@@ -58,11 +58,10 @@ class BrandFilterChips extends ConsumerWidget {
               const SizedBox(width: 6),
               FilterChip(
                 avatar: const Icon(Icons.no_crash, size: 16),
-                label: Text(l10n?.brandFilterNoHighway ?? 'No highway'),
+                label: Text(l10n.brandFilterNoHighway),
                 selected: excludeHighway,
-                onSelected: (_) => ref
-                    .read(excludeHighwayStationsProvider.notifier)
-                    .toggle(),
+                onSelected: (_) =>
+                    ref.read(excludeHighwayStationsProvider.notifier).toggle(),
                 visualDensity: VisualDensity.compact,
               ),
             ],
@@ -70,10 +69,11 @@ class BrandFilterChips extends ConsumerWidget {
             if (hasHighwayStations) ...[
               const SizedBox(width: 6),
               FilterChip(
-                label: Text(l10n?.brandFilterHighway ?? 'Autoroute'),
+                label: Text(l10n.brandFilterHighway),
                 selected: selectedBrands.contains('Autoroute'),
-                onSelected: (_) =>
-                    ref.read(selectedBrandsProvider.notifier).toggle('Autoroute'),
+                onSelected: (_) => ref
+                    .read(selectedBrandsProvider.notifier)
+                    .toggle('Autoroute'),
                 visualDensity: VisualDensity.compact,
               ),
             ],

--- a/lib/features/search/presentation/widgets/cross_border_banner.dart
+++ b/lib/features/search/presentation/widgets/cross_border_banner.dart
@@ -62,15 +62,13 @@ class _CrossBorderSuggestionCard extends ConsumerWidget {
     final priceLabel = suggestion.priceDeltaPerLiter.toStringAsFixed(2);
     final distanceLabel = suggestion.distanceKm.toStringAsFixed(0);
 
-    final headline = l10n?.crossBorderCheaper(
-          suggestion.neighborName,
-          distanceLabel,
-          priceLabel,
-        ) ??
-        '${suggestion.neighborName} stations $distanceLabel km away '
-            '— €$priceLabel/L cheaper';
+    final headline = l10n.crossBorderCheaper(
+      suggestion.neighborName,
+      distanceLabel,
+      priceLabel,
+    );
 
-    final hint = l10n?.crossBorderTapToSwitch ?? 'Tap to switch country';
+    final hint = l10n.crossBorderTapToSwitch;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -79,9 +77,7 @@ class _CrossBorderSuggestionCard extends ConsumerWidget {
         color: colorScheme.tertiaryContainer.withValues(alpha: 0.4),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
-          side: BorderSide(
-            color: colorScheme.tertiary.withValues(alpha: 0.3),
-          ),
+          side: BorderSide(color: colorScheme.tertiary.withValues(alpha: 0.3)),
         ),
         child: InkWell(
           onTap: () => _onTap(ref),
@@ -125,7 +121,7 @@ class _CrossBorderSuggestionCard extends ConsumerWidget {
                   icon: const Icon(Icons.close),
                   iconSize: 20,
                   visualDensity: VisualDensity.compact,
-                  tooltip: l10n?.crossBorderDismissTooltip ?? 'Dismiss',
+                  tooltip: l10n.crossBorderDismissTooltip,
                   onPressed: () => ref
                       .read(crossBorderBannerDismissedProvider.notifier)
                       .dismiss(suggestion.neighborCountryCode),
@@ -158,8 +154,8 @@ class _CrossBorderSuggestionCard extends ConsumerWidget {
     // location-permission prompt — we already have the position.
     if (position == null) return;
     await searchNotifier.searchByCoordinates(
-          lat: position.lat,
-          lng: position.lng,
-        );
+      lat: position.lat,
+      lng: position.lng,
+    );
   }
 }

--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -59,13 +59,13 @@ class DemoModeBanner extends ConsumerWidget {
         forceActionsBelow: true,
         content: Text(
           '${country.flag} ${country.name} — '
-          '${l10n?.demoModeBanner ?? 'Demo mode — showing sample prices.'}',
+          '${l10n.demoModeBanner}',
         ),
         leading: const Icon(Icons.science_outlined),
         actions: [
           TextButton(
             onPressed: () => context.go(RoutePaths.profile),
-            child: Text(l10n?.demoModeBannerAction ?? 'Get live prices'),
+            child: Text(l10n.demoModeBannerAction),
           ),
         ],
       );
@@ -141,9 +141,7 @@ class _CountryServiceHeader extends StatelessWidget {
           children: [
             flag,
             const SizedBox(width: 6),
-            Expanded(
-              child: Text(labelText, style: theme.textTheme.labelSmall),
-            ),
+            Expanded(child: Text(labelText, style: theme.textTheme.labelSmall)),
           ],
         ),
       );
@@ -154,8 +152,7 @@ class _CountryServiceHeader extends StatelessWidget {
     // screen-reader users still get the full open-data credit (#2373).
     final source = attribution ?? providerLabel ?? country.name;
     final lic = license ?? '';
-    final semanticLabel = l10n?.dataSourceLinkSemantic(source, lic) ??
-        'Open the $source data source ($lic) in your browser.';
+    final semanticLabel = l10n.dataSourceLinkSemantic(source, lic);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
@@ -244,7 +241,7 @@ class _MultiSourceHeader extends StatelessWidget {
     if (segments.isEmpty) return const SizedBox.shrink();
 
     final joined = segments.join(' · ');
-    final labelText = l10n?.routeDataSourceMulti(joined) ?? joined;
+    final labelText = l10n.routeDataSourceMulti(joined);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
@@ -253,9 +250,7 @@ class _MultiSourceHeader extends StatelessWidget {
         children: [
           Text(flags.join(' '), style: const TextStyle(fontSize: 14)),
           const SizedBox(width: 6),
-          Expanded(
-            child: Text(labelText, style: theme.textTheme.labelSmall),
-          ),
+          Expanded(child: Text(labelText, style: theme.textTheme.labelSmall)),
         ],
       ),
     );

--- a/lib/features/search/presentation/widgets/ev_connector_chips.dart
+++ b/lib/features/search/presentation/widgets/ev_connector_chips.dart
@@ -46,9 +46,14 @@ class EvConnectorChips extends StatelessWidget {
   /// AA, preserving per-connector identity. Callers that omit [brightness]
   /// keep the canonical light identity hue (the value the chip-colour API
   /// and its tests document).
-  static Color colorFor(String type, {Brightness brightness = Brightness.light}) {
+  static Color colorFor(
+    String type, {
+    Brightness brightness = Brightness.light,
+  }) {
     final dark = brightness == Brightness.dark;
-    if (type.contains('CCS')) return FuelColors.evAccent; // Crystal-blue (already light)
+    if (type.contains('CCS')) {
+      return FuelColors.evAccent; // Crystal-blue (already light)
+    }
     if (type.contains('Type 2')) {
       return dark ? const Color(0xFF81C784) : const Color(0xFF4CAF50); // Green
     }
@@ -68,8 +73,8 @@ class EvConnectorChips extends StatelessWidget {
     final brightness = Theme.of(context).brightness;
     final isDark = brightness == Brightness.dark;
     final semanticLabel = visible.isEmpty
-        ? (l10n?.evConnectorsNone ?? 'No connector information')
-        : '${l10n?.evConnectorsLabel ?? "Available connectors"}: '
+        ? (l10n.evConnectorsNone)
+        : '${l10n.evConnectorsLabel}: '
               '${visible.join(", ")}';
 
     return Semantics(

--- a/lib/features/search/presentation/widgets/ev_station_card.dart
+++ b/lib/features/search/presentation/widgets/ev_station_card.dart
@@ -43,8 +43,8 @@ class EVStationCard extends StatelessWidget {
     final evPrice = EvPrice.parse(station.usageCost);
     final priceLabel =
         evPrice.label(
-          perKwhUnit: l10n?.refuelUnitPerKwh ?? '/kWh',
-          perSessionUnit: l10n?.refuelUnitPerSession ?? '/session',
+          perKwhUnit: l10n.refuelUnitPerKwh,
+          perSessionUnit: l10n.refuelUnitPerSession,
         ) ??
         station.usageCost;
 
@@ -165,7 +165,7 @@ class EVStationCard extends StatelessWidget {
               IconButton(
                 icon: Icon(isFavorite ? Icons.star : Icons.star_border),
                 color: isFavorite ? DarkModeColors.warning(context) : null,
-                tooltip: l10n?.favorites ?? 'Favorites',
+                tooltip: l10n.favorites,
                 visualDensity: VisualDensity.compact,
                 onPressed: onFavoriteTap,
               ),

--- a/lib/features/search/presentation/widgets/ev_station_header_card.dart
+++ b/lib/features/search/presentation/widgets/ev_station_header_card.dart
@@ -45,8 +45,8 @@ class EVStationHeaderCard extends StatelessWidget {
                 const SizedBox(width: 8),
                 Text(
                   station.isOperational == true
-                      ? (l10n?.evOperational ?? 'Operational')
-                      : (l10n?.evStatusUnknown ?? 'Status unknown'),
+                      ? (l10n.evOperational)
+                      : (l10n.evStatusUnknown),
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: station.isOperational == true
                         ? DarkModeColors.success(context)
@@ -61,10 +61,15 @@ class EVStationHeaderCard extends StatelessWidget {
             const SizedBox(height: 12),
             Text(
               station.name,
-              style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
             if (operatorName.isNotEmpty && operatorName != station.name)
-              Text(operatorName, style: theme.textTheme.titleMedium?.copyWith(color: evColor)),
+              Text(
+                operatorName,
+                style: theme.textTheme.titleMedium?.copyWith(color: evColor),
+              ),
           ],
         ),
       ),

--- a/lib/features/search/presentation/widgets/ev_station_info_cards.dart
+++ b/lib/features/search/presentation/widgets/ev_station_info_cards.dart
@@ -32,7 +32,12 @@ class EVAddressCard extends StatelessWidget {
               children: [
                 const Icon(Icons.place, size: 20),
                 const SizedBox(width: 8),
-                Expanded(child: Text(station.address ?? '', style: theme.textTheme.bodyLarge)),
+                Expanded(
+                  child: Text(
+                    station.address ?? '',
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                ),
               ],
             ),
             if (postCode.isNotEmpty || place.isNotEmpty)
@@ -40,13 +45,18 @@ class EVAddressCard extends StatelessWidget {
                 padding: const EdgeInsets.only(left: 28),
                 child: Text(
                   '$postCode $place'.trim(),
-                  style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
             const SizedBox(height: 8),
             Padding(
               padding: const EdgeInsets.only(left: 28),
-              child: Text(PriceFormatter.formatDistance(station.dist), style: theme.textTheme.bodySmall),
+              child: Text(
+                PriceFormatter.formatDistance(station.dist),
+                style: theme.textTheme.bodySmall,
+              ),
             ),
           ],
         ),
@@ -60,7 +70,11 @@ class EVConnectorsCard extends StatelessWidget {
   final ChargingStation station;
   final Color evColor;
 
-  const EVConnectorsCard({super.key, required this.station, required this.evColor});
+  const EVConnectorsCard({
+    super.key,
+    required this.station,
+    required this.evColor,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -77,16 +91,22 @@ class EVConnectorsCard extends StatelessWidget {
                 Icon(Icons.electrical_services, color: evColor, size: 20),
                 const SizedBox(width: 8),
                 Text(
-                  l10n?.evConnectors(station.totalPoints) ?? 'Connectors (${station.totalPoints} points)',
-                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                  l10n.evConnectors(station.totalPoints),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 12),
             ...station.connectors.map((c) => EVConnectorTile(connector: c)),
             if (station.connectors.isEmpty)
-              Text(l10n?.evNoConnectors ?? 'No connector details available',
-                  style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+              Text(
+                l10n.evNoConnectors,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
           ],
         ),
       ),
@@ -99,7 +119,11 @@ class EVPricingCard extends StatelessWidget {
   final ChargingStation station;
   final Color evColor;
 
-  const EVPricingCard({super.key, required this.station, required this.evColor});
+  const EVPricingCard({
+    super.key,
+    required this.station,
+    required this.evColor,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -116,8 +140,8 @@ class EVPricingCard extends StatelessWidget {
     // existing neutral raw-text rendering below.
     final evPrice = EvPrice.parse(usageCost);
     final priceLabel = evPrice.label(
-      perKwhUnit: l10n?.refuelUnitPerKwh ?? '/kWh',
-      perSessionUnit: l10n?.refuelUnitPerSession ?? '/session',
+      perKwhUnit: l10n.refuelUnitPerKwh,
+      perSessionUnit: l10n.refuelUnitPerSession,
     );
 
     // Honest-UX (#2618): the structured free/paid/membership chip is the
@@ -137,9 +161,10 @@ class EVPricingCard extends StatelessWidget {
                   Icon(Icons.payments, color: evColor, size: 20),
                   const SizedBox(width: 8),
                   Text(
-                    l10n?.evUsageCost ?? 'Usage cost',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    l10n.evUsageCost,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ],
               ),
@@ -156,7 +181,7 @@ class EVPricingCard extends StatelessWidget {
                 if (priceLabel != null) ...[
                   const SizedBox(height: 12),
                   Text(
-                    '${l10n?.evPriceIndicative ?? 'Indicative price'}: '
+                    '${l10n.evPriceIndicative}: '
                     '$priceLabel',
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
@@ -167,14 +192,13 @@ class EVPricingCard extends StatelessWidget {
                 const SizedBox(height: 12),
                 Text(
                   usageCost,
-                  style: theme.textTheme.bodyMedium
-                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  l10n?.evPriceDeclaredByOperator ??
-                      'Indicative price declared by the operator '
-                          '— verify on site',
+                  l10n.evPriceDeclaredByOperator,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                     fontStyle: FontStyle.italic,
@@ -187,9 +211,7 @@ class EVPricingCard extends StatelessWidget {
                 if (!station.isFranceIrveEnriched) ...[
                   const SizedBox(height: 4),
                   Text(
-                    l10n?.evPriceBestEffortOcm ??
-                        'Best-effort pricing from OpenChargeMap '
-                            '— sparse and may be incomplete.',
+                    l10n.evPriceBestEffortOcm,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                       fontStyle: FontStyle.italic,
@@ -200,9 +222,7 @@ class EVPricingCard extends StatelessWidget {
               if (station.isFranceIrveEnriched) ...[
                 const SizedBox(height: 8),
                 Text(
-                  l10n?.evPriceFranceAttribution ??
-                      'Pricing: Base nationale des IRVE '
-                          '— Licence Ouverte / data.gouv.fr / ODRÉ',
+                  l10n.evPriceFranceAttribution,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                     fontStyle: FontStyle.italic,
@@ -218,11 +238,12 @@ class EVPricingCard extends StatelessWidget {
     return Card(
       child: ListTile(
         leading: Icon(Icons.payments, color: theme.colorScheme.outline),
-        title: Text(l10n?.evUsageCost ?? 'Usage cost'),
+        title: Text(l10n.evUsageCost),
         subtitle: Text(
-          l10n?.evPricingUnavailable ?? 'Pricing not available from provider',
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          l10n.evPricingUnavailable,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         ),
       ),
     );
@@ -246,31 +267,31 @@ class _EvPriceBadge extends StatelessWidget {
 
     final (IconData icon, String label, Color fg, Color bg) = switch (kind) {
       EvAccessCostKind.free => (
-          Icons.money_off,
-          l10n?.evPriceFree ?? 'Free',
-          // Eco / green — reuse the tertiary "positive" surface.
-          scheme.onTertiaryContainer,
-          scheme.tertiaryContainer,
-        ),
+        Icons.money_off,
+        l10n.evPriceFree,
+        // Eco / green — reuse the tertiary "positive" surface.
+        scheme.onTertiaryContainer,
+        scheme.tertiaryContainer,
+      ),
       EvAccessCostKind.paid => (
-          Icons.payments,
-          l10n?.evPricePayAtLocation ?? 'Pay at location',
-          scheme.onErrorContainer,
-          scheme.errorContainer,
-        ),
+        Icons.payments,
+        l10n.evPricePayAtLocation,
+        scheme.onErrorContainer,
+        scheme.errorContainer,
+      ),
       EvAccessCostKind.membership => (
-          Icons.card_membership,
-          l10n?.evPriceMembership ?? 'Membership required',
-          scheme.onSecondaryContainer,
-          scheme.secondaryContainer,
-        ),
+        Icons.card_membership,
+        l10n.evPriceMembership,
+        scheme.onSecondaryContainer,
+        scheme.secondaryContainer,
+      ),
       // Never rendered — the caller gates on `cost.isKnown`.
       EvAccessCostKind.unknown => (
-          Icons.help_outline,
-          '',
-          scheme.onSurfaceVariant,
-          scheme.surfaceContainerHighest,
-        ),
+        Icons.help_outline,
+        '',
+        scheme.onSurfaceVariant,
+        scheme.surfaceContainerHighest,
+      ),
     };
 
     return Container(
@@ -283,8 +304,10 @@ class _EvPriceBadge extends StatelessWidget {
           const SizedBox(width: 6),
           Text(
             label,
-            style: theme.textTheme.labelLarge
-                ?.copyWith(color: fg, fontWeight: FontWeight.w600),
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: fg,
+              fontWeight: FontWeight.w600,
+            ),
           ),
         ],
       ),
@@ -313,17 +336,19 @@ class EVLastUpdatedCard extends StatelessWidget {
               children: [
                 const Icon(Icons.update, size: 20),
                 const SizedBox(width: 8),
-                Text(l10n?.evLastUpdated ?? 'Last updated'),
+                Text(l10n.evLastUpdated),
                 const Spacer(),
                 Text(
-                  station.updatedAt ?? (l10n?.evUnknown ?? 'Unknown'),
-                  style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                  station.updatedAt ?? (l10n.evUnknown),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 8),
             Text(
-              l10n?.evDataAttribution ?? 'Data from OpenChargeMap (community-sourced)',
+              l10n.evDataAttribution,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
@@ -331,9 +356,10 @@ class EVLastUpdatedCard extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              l10n?.evStatusDisclaimer ?? 'Status may not reflect real-time availability. '
-              'Tap refresh to get the latest data from OpenChargeMap.',
-              style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              l10n.evStatusDisclaimer,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),

--- a/lib/features/search/presentation/widgets/fuel_type_selector.dart
+++ b/lib/features/search/presentation/widgets/fuel_type_selector.dart
@@ -47,9 +47,11 @@ class FuelTypeSelector extends ConsumerWidget {
 
     // If selected type isn't available in this country, reset to 'all'
     if (!types.contains(selected)) {
-      unawaited(Future.microtask(() {
-        ref.read(selectedFuelTypeProvider.notifier).select(FuelType.all);
-      }));
+      unawaited(
+        Future.microtask(() {
+          ref.read(selectedFuelTypeProvider.notifier).select(FuelType.all);
+        }),
+      );
     }
 
     return SingleChildScrollView(
@@ -58,14 +60,14 @@ class FuelTypeSelector extends ConsumerWidget {
         children: types.map((type) {
           // Localize "All" for display — other types use their canonical names
           final label = type == FuelType.all
-              ? (AppLocalizations.of(context)?.allFuels ?? 'All')
+              ? (AppLocalizations.of(context).allFuels)
               : type.displayName;
           return Padding(
             padding: const EdgeInsets.only(right: 6),
             child: Semantics(
-              label: AppLocalizations.of(context)
-                      ?.fuelTypeSemantic(label, '${selected == type}') ??
-                  'Fuel type $label',
+              label: AppLocalizations.of(
+                context,
+              ).fuelTypeSemantic(label, '${selected == type}'),
               child: ChoiceChip(
                 avatar: selected == type
                     ? null

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -112,9 +112,10 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
           final l10n = AppLocalizations.of(context);
           SnackBarHelper.showError(
             context,
-            l10n?.invalidPostalCode(
-                    country.postalCodeLength.toString(), country.postalCodeLabel) ??
-                'Please enter a valid ${country.postalCodeLength}-digit ${country.postalCodeLabel}',
+            l10n.invalidPostalCode(
+              country.postalCodeLength.toString(),
+              country.postalCodeLabel,
+            ),
           );
         }
       case LocationInputType.city:
@@ -126,17 +127,16 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
   }
 
   IconData _prefixIcon(LocationInputType type) => switch (type) {
-        LocationInputType.gps => Icons.my_location,
-        LocationInputType.zip => Icons.pin_drop,
-        LocationInputType.city => Icons.location_city,
-      };
+    LocationInputType.gps => Icons.my_location,
+    LocationInputType.zip => Icons.pin_drop,
+    LocationInputType.city => Icons.location_city,
+  };
 
   @override
   Widget build(BuildContext context) {
     final uiState = ref.watch(locationInputControllerProvider);
     final l10n = AppLocalizations.of(context);
-    final placeholder = l10n?.searchLocationPlaceholder ??
-        'Address, postal code or city';
+    final placeholder = l10n.searchLocationPlaceholder;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -159,10 +159,14 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
                   floatingLabelBehavior: FloatingLabelBehavior.never,
                   isDense: true,
                   contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 12, vertical: 8),
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                   prefixIcon: Icon(_prefixIcon(uiState.inputType), size: 20),
-                  prefixIconConstraints:
-                      const BoxConstraints(minWidth: 36, minHeight: 36),
+                  prefixIconConstraints: const BoxConstraints(
+                    minWidth: 36,
+                    minHeight: 36,
+                  ),
                   border: const OutlineInputBorder(),
                   suffixIcon: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -173,17 +177,20 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
                           child: SizedBox(
                             width: 16,
                             height: 16,
-                            child:
-                                CircularProgressIndicator(strokeWidth: 2),
+                            child: CircularProgressIndicator(strokeWidth: 2),
                           ),
                         ),
                       if (_controller.text.isNotEmpty)
                         IconButton(
                           icon: const Icon(Icons.clear, size: 18),
-                          tooltip: AppLocalizations.of(context)?.tooltipClearSearch ?? 'Clear search input',
+                          tooltip: AppLocalizations.of(
+                            context,
+                          ).tooltipClearSearch,
                           padding: const EdgeInsets.all(4),
                           constraints: const BoxConstraints(
-                              minWidth: 32, minHeight: 32),
+                            minWidth: 32,
+                            minHeight: 32,
+                          ),
                           onPressed: () {
                             _controller.clear();
                             _onChanged('');
@@ -191,10 +198,12 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
                         ),
                       IconButton(
                         icon: const Icon(Icons.my_location, size: 18),
-                        tooltip: AppLocalizations.of(context)?.tooltipUseGps ?? 'Use GPS location',
+                        tooltip: AppLocalizations.of(context).tooltipUseGps,
                         padding: const EdgeInsets.all(4),
                         constraints: const BoxConstraints(
-                            minWidth: 32, minHeight: 32),
+                          minWidth: 32,
+                          minHeight: 32,
+                        ),
                         onPressed: () {
                           // #2137 — switch the criteria to GPS mode but
                           // don't fire the search; the FAB owns that.
@@ -204,8 +213,10 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
                       ),
                     ],
                   ),
-                  suffixIconConstraints:
-                      const BoxConstraints(minWidth: 36, minHeight: 36),
+                  suffixIconConstraints: const BoxConstraints(
+                    minWidth: 36,
+                    minHeight: 36,
+                  ),
                 ),
                 onChanged: _onChanged,
                 // #2137 — Enter is not a search trigger any more; the
@@ -221,9 +232,7 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
             constraints: const BoxConstraints(maxHeight: 200),
             margin: const EdgeInsets.only(top: 4),
             decoration: BoxDecoration(
-              border: Border.all(
-                color: Theme.of(context).colorScheme.outline,
-              ),
+              border: Border.all(color: Theme.of(context).colorScheme.outline),
               borderRadius: BorderRadius.circular(8),
             ),
             child: ListView.builder(
@@ -237,11 +246,12 @@ class LocationInputWidgetState extends ConsumerState<LocationInput> {
                   dense: true,
                   selected: isSelected,
                   leading: const Icon(Icons.place, size: 18),
-                  title: Text(city.name,
-                      style: const TextStyle(fontSize: 13)),
+                  title: Text(city.name, style: const TextStyle(fontSize: 13)),
                   subtitle: city.postcode != null
-                      ? Text(city.postcode!,
-                          style: const TextStyle(fontSize: 11))
+                      ? Text(
+                          city.postcode!,
+                          style: const TextStyle(fontSize: 11),
+                        )
                       : null,
                   onTap: () {
                     _controller.text = city.name;

--- a/lib/features/search/presentation/widgets/mixed_results_filter_chips.dart
+++ b/lib/features/search/presentation/widgets/mixed_results_filter_chips.dart
@@ -5,8 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../l10n/app_localizations.dart';
-import '../../../../core/domain/vehicle_profile.dart'
-    show ConnectorType;
+import '../../../../core/domain/vehicle_profile.dart' show ConnectorType;
 import '../../../../core/domain/search_result_item.dart';
 import '../../providers/mixed_results_filter_provider.dart';
 import '../../providers/search_provider.dart';
@@ -37,7 +36,8 @@ class MixedResultsFilterChips extends ConsumerWidget {
     // Connector types present across the raw (unfiltered) result set,
     // so the offered chips stay stable as the user toggles filters.
     final rawItems =
-        ref.watch(searchStateProvider).value?.data ?? const <SearchResultItem>[];
+        ref.watch(searchStateProvider).value?.data ??
+        const <SearchResultItem>[];
 
     final availableConnectors = <ConnectorType>{
       for (final item in rawItems)
@@ -57,13 +57,11 @@ class MixedResultsFilterChips extends ConsumerWidget {
           for (final preset in _powerPresets) ...[
             _chip(
               label: preset == 0
-                  ? (l10n?.evPowerAny ?? 'Any')
-                  : (l10n?.evPowerKw(preset.round()) ??
-                      '${preset.round()} kW+'),
+                  ? (l10n.evPowerAny)
+                  : (l10n.evPowerKw(preset.round())),
               selected: minPower == preset,
-              onSelected: () => ref
-                  .read(evMinPowerFilterProvider.notifier)
-                  .set(preset),
+              onSelected: () =>
+                  ref.read(evMinPowerFilterProvider.notifier).set(preset),
             ),
             const SizedBox(width: 6),
           ],
@@ -72,9 +70,8 @@ class MixedResultsFilterChips extends ConsumerWidget {
               _chip(
                 label: _connectorLabel(type, l10n),
                 selected: connectorFilter.contains(type),
-                onSelected: () => ref
-                    .read(evConnectorFilterProvider.notifier)
-                    .toggle(type),
+                onSelected: () =>
+                    ref.read(evConnectorFilterProvider.notifier).toggle(type),
               ),
               const SizedBox(width: 6),
             ],
@@ -97,15 +94,15 @@ class MixedResultsFilterChips extends ConsumerWidget {
     );
   }
 
-  static String _connectorLabel(ConnectorType type, AppLocalizations? l10n) {
+  static String _connectorLabel(ConnectorType type, AppLocalizations l10n) {
     return switch (type) {
-      ConnectorType.type2 => l10n?.connectorType2 ?? 'Type 2',
-      ConnectorType.ccs => l10n?.connectorCcs ?? 'CCS',
-      ConnectorType.chademo => l10n?.connectorChademo ?? 'CHAdeMO',
-      ConnectorType.tesla => l10n?.connectorTesla ?? 'Tesla',
-      ConnectorType.schuko => l10n?.connectorSchuko ?? 'Schuko',
-      ConnectorType.type1 => l10n?.connectorType1 ?? 'Type 1',
-      ConnectorType.threePin => l10n?.connectorThreePin ?? '3-pin',
+      ConnectorType.type2 => l10n.connectorType2,
+      ConnectorType.ccs => l10n.connectorCcs,
+      ConnectorType.chademo => l10n.connectorChademo,
+      ConnectorType.tesla => l10n.connectorTesla,
+      ConnectorType.schuko => l10n.connectorSchuko,
+      ConnectorType.type1 => l10n.connectorType1,
+      ConnectorType.threePin => l10n.connectorThreePin,
     };
   }
 }

--- a/lib/features/search/presentation/widgets/pay_with_app_button.dart
+++ b/lib/features/search/presentation/widgets/pay_with_app_button.dart
@@ -22,11 +22,7 @@ class PayWithAppButton extends StatelessWidget {
   /// Override for tests; production uses [PaymentAppLauncher.open].
   final Future<bool> Function(PaymentApp app)? onLaunch;
 
-  const PayWithAppButton({
-    super.key,
-    required this.brand,
-    this.onLaunch,
-  });
+  const PayWithAppButton({super.key, required this.brand, this.onLaunch});
 
   @override
   Widget build(BuildContext context) {
@@ -34,8 +30,7 @@ class PayWithAppButton extends StatelessWidget {
     if (app == null) return const SizedBox.shrink();
 
     final l10n = AppLocalizations.of(context);
-    final label = l10n?.payWithApp(app.displayName) ??
-        'Pay with ${app.displayName}';
+    final label = l10n.payWithApp(app.displayName);
 
     return Align(
       alignment: Alignment.centerLeft,
@@ -54,10 +49,17 @@ class PayWithAppButton extends StatelessWidget {
     } on Exception catch (e, st) {
       // #2146 — route to the exportable log so a missing deep-link
       // handler is visible from a bug report.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {
-        'where': 'PayWithAppButton._launch',
-        'app': app.displayName,
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {
+            'where': 'PayWithAppButton._launch',
+            'app': app.displayName,
+          },
+        ),
+      );
     }
   }
 }

--- a/lib/features/search/presentation/widgets/payment_method_chips.dart
+++ b/lib/features/search/presentation/widgets/payment_method_chips.dart
@@ -41,7 +41,8 @@ class PaymentMethodChips extends StatelessWidget {
         .toList();
 
     return Semantics(
-      label: '${l10n?.paymentMethods ?? 'Payment methods'}: '
+      label:
+          '${l10n.paymentMethods}: '
           '${labels.join(', ')}',
       container: true,
       child: ExcludeSemantics(
@@ -78,16 +79,15 @@ class PaymentMethodChips extends StatelessWidget {
 
   String _localizedLabel(
     PaymentMethod method,
-    AppLocalizations? l10n, {
+    AppLocalizations l10n, {
     String? appName,
   }) {
     return switch (method) {
-      PaymentMethod.cash => l10n?.paymentMethodCash ?? 'Cash',
-      PaymentMethod.card => l10n?.paymentMethodCard ?? 'Card',
-      PaymentMethod.contactless =>
-        l10n?.paymentMethodContactless ?? 'Contactless',
-      PaymentMethod.fuelCard => l10n?.paymentMethodFuelCard ?? 'Fuel Card',
-      PaymentMethod.app => appName ?? l10n?.paymentMethodApp ?? 'App',
+      PaymentMethod.cash => l10n.paymentMethodCash,
+      PaymentMethod.card => l10n.paymentMethodCard,
+      PaymentMethod.contactless => l10n.paymentMethodContactless,
+      PaymentMethod.fuelCard => l10n.paymentMethodFuelCard,
+      PaymentMethod.app => appName ?? l10n.paymentMethodApp,
     };
   }
 }

--- a/lib/features/search/presentation/widgets/radar_pin_help_sheet.dart
+++ b/lib/features/search/presentation/widgets/radar_pin_help_sheet.dart
@@ -20,73 +20,64 @@ void showRadarPinHelp(
   required Future<void> Function() onEnableNow,
 }) {
   final l = AppLocalizations.of(context);
-  unawaited(showModalBottomSheet<void>(
-    context: context,
-    builder: (ctx) {
-      return SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  const Icon(Icons.push_pin, size: 24),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      l?.radarPinHelpTitle ?? 'About pin',
-                      style: Theme.of(ctx).textTheme.titleLarge,
+  unawaited(
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.push_pin, size: 24),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        l.radarPinHelpTitle,
+                        style: Theme.of(ctx).textTheme.titleLarge,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Text(
-                l?.radarPinHelpBody ??
-                    'Pin keeps the screen on and hides system bars so the '
-                        'closest-station readout stays readable on a dashboard '
-                        'mount. Tap again to release. Auto-releases when the '
-                        'radar stops.',
-              ),
-              const SizedBox(height: 8),
-              // Reactive so the switch reflects the persisted preference.
-              Consumer(
-                builder: (context, ref, _) {
-                  final autoPin = ref.watch(radarAutoPinProvider);
-                  return SwitchListTile(
-                    key: const Key('radarAutoPinToggle'),
-                    contentPadding: EdgeInsets.zero,
-                    value: autoPin,
-                    onChanged: (value) async {
-                      await ref.read(radarAutoPinProvider.notifier).set(value);
-                      if (value) await onEnableNow();
-                    },
-                    title: Text(
-                      l?.radarAutoPinTitle ??
-                          'Always pin when the radar starts',
-                    ),
-                    subtitle: Text(
-                      l?.radarAutoPinSubtitle ??
-                          'Pin the radar automatically every time instead of '
-                              'tapping each time. Uses more battery.',
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(height: 16),
-              Align(
-                alignment: Alignment.centerRight,
-                child: TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  child: Text(l?.tooltipBack ?? 'Close'),
+                  ],
                 ),
-              ),
-            ],
+                const SizedBox(height: 12),
+                Text(l.radarPinHelpBody),
+                const SizedBox(height: 8),
+                // Reactive so the switch reflects the persisted preference.
+                Consumer(
+                  builder: (context, ref, _) {
+                    final autoPin = ref.watch(radarAutoPinProvider);
+                    return SwitchListTile(
+                      key: const Key('radarAutoPinToggle'),
+                      contentPadding: EdgeInsets.zero,
+                      value: autoPin,
+                      onChanged: (value) async {
+                        await ref
+                            .read(radarAutoPinProvider.notifier)
+                            .set(value);
+                        if (value) await onEnableNow();
+                      },
+                      title: Text(l.radarAutoPinTitle),
+                      subtitle: Text(l.radarAutoPinSubtitle),
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(),
+                    child: Text(l.tooltipBack),
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-      );
-    },
-  ));
+        );
+      },
+    ),
+  );
 }

--- a/lib/features/search/presentation/widgets/radar_search_fab.dart
+++ b/lib/features/search/presentation/widgets/radar_search_fab.dart
@@ -32,9 +32,7 @@ class RadarSearchFab extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final active = ref.watch(radarSearchProvider).active;
 
-    final label = active
-        ? (l10n?.stopRadar ?? 'Stop radar')
-        : (l10n?.fuelStationRadarStart ?? 'Start fuel station radar');
+    final label = active ? (l10n.stopRadar) : (l10n.fuelStationRadarStart);
 
     return FloatingActionButton.extended(
       key: const Key('radarSearchButton'),

--- a/lib/features/search/presentation/widgets/route_planning_controls.dart
+++ b/lib/features/search/presentation/widgets/route_planning_controls.dart
@@ -31,7 +31,7 @@ class RoutePlanningControls extends ConsumerWidget {
       children: [
         Row(
           children: [
-            Text('${l10n?.routeSegment ?? "Route segment"}:'),
+            Text('${l10n.routeSegment}:'),
             Expanded(
               child: Slider(
                 value: segment,
@@ -47,15 +47,14 @@ class RoutePlanningControls extends ConsumerWidget {
           ],
         ),
         Text(
-          l10n?.showCheapestEveryNKm(segment.round()) ??
-              'Show cheapest station every ${segment.round()} km along route',
+          l10n.showCheapestEveryNKm(segment.round()),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
         ),
         Row(
           children: [
-            Text('${l10n?.routeDetourBudget ?? "Maximum detour"}:'),
+            Text('${l10n.routeDetourBudget}:'),
             Expanded(
               child: Slider(
                 value: detour,
@@ -71,9 +70,7 @@ class RoutePlanningControls extends ConsumerWidget {
           ],
         ),
         Text(
-          l10n?.routeDetourBudgetCaption(detour.round()) ??
-              'Surface stations up to ${detour.round()} '
-                  'km off your direct route',
+          l10n.routeDetourBudgetCaption(detour.round()),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -90,28 +87,27 @@ class RoutePlanningControls extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     ThemeData theme,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) {
     final saving = ref.watch(minRouteSavingSearchParamProvider);
     final off = saving <= 0;
     // i18n-ignore: language-neutral currency-per-litre unit mask.
     final amount = '${saving.toStringAsFixed(2)} €/L';
-    final valueLabel = off ? (l10n?.routeMinSavingOff ?? 'Off') : amount;
+    final valueLabel = off ? (l10n.routeMinSavingOff) : amount;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
           children: [
-            Text('${l10n?.routeMinSaving ?? "Minimum saving"}:'),
+            Text('${l10n.routeMinSaving}:'),
             Expanded(
               child: Slider(
                 value: saving,
                 max: 0.30,
                 divisions: 30,
                 label: valueLabel,
-                onChanged: (v) => ref
-                    .read(minRouteSavingSearchParamProvider.notifier)
-                    .set(v),
+                onChanged: (v) =>
+                    ref.read(minRouteSavingSearchParamProvider.notifier).set(v),
               ),
             ),
             Text(valueLabel),
@@ -119,10 +115,8 @@ class RoutePlanningControls extends ConsumerWidget {
         ),
         Text(
           off
-              ? (l10n?.routeMinSavingOffCaption ??
-                  'Showing every station found along the route')
-              : (l10n?.routeMinSavingCaption(amount) ??
-                  "Only stations within $amount of the route's cheapest"),
+              ? (l10n.routeMinSavingOffCaption)
+              : (l10n.routeMinSavingCaption(amount)),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -58,7 +58,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
           return SliverFillRemaining(
             child: Center(
               child: Text(
-                l10n?.startSearch ?? 'Enter start and destination to search along route.',
+                l10n.startSearch,
                 style: const TextStyle(fontSize: 16),
                 textAlign: TextAlign.center,
               ),
@@ -69,8 +69,11 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
           return SliverFillRemaining(
             child: Center(
               child: Text(
-                l10n?.noStationsAlongThisRoute ?? 'No stations found along this route.',
-                style: TextStyle(fontSize: 16, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                l10n.noStationsAlongThisRoute,
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
                 textAlign: TextAlign.center,
               ),
             ),
@@ -85,7 +88,9 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
         // Sort stations by position along the route (drive order)
         _sortByRoutePosition(visibleStations, result.route.geometry);
 
-        final allFuelStations = visibleStations.whereType<FuelStationResult>().toList();
+        final allFuelStations = visibleStations
+            .whereType<FuelStationResult>()
+            .toList();
         final displayItems = _resultMode == RouteResultMode.bestStops
             ? _filterBestStops(allFuelStations, result)
             : visibleStations;
@@ -125,7 +130,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
   /// Route info header with distance/duration and all/best-stops toggle.
   Widget _buildHeader(
     BuildContext context,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     RouteSearchResult result,
   ) {
     final theme = Theme.of(context);
@@ -153,7 +158,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
                   Text(
                     '${result.route.distanceKm.round()} km · '
                     '${result.route.durationMinutes.round()} min · '
-                    '${l10n?.routeStationCount(result.stations.length) ?? '${result.stations.length} stations'}',
+                    '${l10n.routeStationCount(result.stations.length)}',
                     style: theme.textTheme.bodySmall?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
@@ -164,19 +169,20 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   SelectablePill(
-                    label: l10n?.allStations ?? 'All stations',
+                    label: l10n.allStations,
                     icon: Icons.local_gas_station,
                     selected: _resultMode == RouteResultMode.allStations,
                     onTap: () => setState(
-                        () => _resultMode = RouteResultMode.allStations),
+                      () => _resultMode = RouteResultMode.allStations,
+                    ),
                   ),
                   const SizedBox(width: 8),
                   SelectablePill(
-                    label: l10n?.bestStops ?? 'Best stops',
+                    label: l10n.bestStops,
                     icon: Icons.star,
                     selected: _resultMode == RouteResultMode.bestStops,
-                    onTap: () => setState(
-                        () => _resultMode = RouteResultMode.bestStops),
+                    onTap: () =>
+                        setState(() => _resultMode = RouteResultMode.bestStops),
                   ),
                 ],
               ),
@@ -190,7 +196,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
   /// A single station card wrapped in a Dismissible for swipe actions.
   Widget _buildDismissibleCard(
     BuildContext context,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     FuelStationResult item,
     FuelType fuelType,
     RouteSearchResult result,
@@ -204,19 +210,22 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
         final ignored = ref.read(ignoredStationsProvider.notifier);
         if (direction == DismissDirection.startToEnd) {
           await NavigationUtils.openInMaps(
-            item.station.lat, item.station.lng,
+            item.station.lat,
+            item.station.lng,
             label: item.station.displayName,
           );
           return false;
         } else {
           await ignored.add(item.id);
           if (context.mounted) {
-            final stationLabel = item.station.brand.isNotEmpty ? item.station.brand : item.station.name;
+            final stationLabel = item.station.brand.isNotEmpty
+                ? item.station.brand
+                : item.station.name;
             final l10n = AppLocalizations.of(context);
             SnackBarHelper.showWithUndo(
               context,
-              l10n?.stationHidden(stationLabel) ?? '$stationLabel hidden',
-              undoLabel: l10n?.undo ?? 'Undo',
+              l10n.stationHidden(stationLabel),
+              undoLabel: l10n.undo,
               onUndo: () => ignored.remove(item.id),
             );
           }
@@ -232,8 +241,13 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
           children: [
             const Icon(Icons.navigation, color: Colors.white, size: 20),
             const SizedBox(width: 8),
-            Text(l10n?.navigate ?? 'Navigate',
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            Text(
+              l10n.navigate,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ],
         ),
       ),
@@ -244,8 +258,13 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(l10n?.swipeHide ?? 'Hide',
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            Text(
+              l10n.swipeHide,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
             const SizedBox(width: 8),
             const Icon(Icons.visibility_off, color: Colors.white, size: 20),
           ],
@@ -290,7 +309,12 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
       double minDist = double.infinity;
       int bestIdx = 0;
       for (int i = 0; i < polyline.length; i += step) {
-        final d = distanceKm(lat, lng, polyline[i].latitude, polyline[i].longitude);
+        final d = distanceKm(
+          lat,
+          lng,
+          polyline[i].latitude,
+          polyline[i].longitude,
+        );
         if (d < minDist) {
           minDist = d;
           bestIdx = i;
@@ -314,11 +338,17 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
     final segmentMap = result.cheapestPerSegment;
     if (segmentMap == null || segmentMap.isEmpty) {
       if (result.cheapestId != null) {
-        return allStations.where((s) => s.id == result.cheapestId).cast<SearchResultItem>().toList();
+        return allStations
+            .where((s) => s.id == result.cheapestId)
+            .cast<SearchResultItem>()
+            .toList();
       }
       return allStations.take(5).cast<SearchResultItem>().toList();
     }
     final bestIds = segmentMap.values.toSet();
-    return allStations.where((s) => bestIds.contains(s.id)).cast<SearchResultItem>().toList();
+    return allStations
+        .where((s) => bestIds.contains(s.id))
+        .cast<SearchResultItem>()
+        .toList();
   }
 }

--- a/lib/features/search/presentation/widgets/search_criteria_form.dart
+++ b/lib/features/search/presentation/widgets/search_criteria_form.dart
@@ -71,8 +71,7 @@ class SearchCriteriaForm extends ConsumerWidget {
           HelpBanner(
             storageKey: StorageKeys.helpBannerCriteria,
             icon: Icons.lightbulb_outline,
-            message: l10n?.helpBannerCriteria ??
-                'Your profile defaults are pre-filled. Adjust criteria below to refine your search.',
+            message: l10n.helpBannerCriteria,
           ),
           if (routePlanningOn) ...[
             SearchModeToggle(
@@ -91,16 +90,10 @@ class SearchCriteriaForm extends ConsumerWidget {
               onCitySearch: onCitySearch,
             ),
           ] else ...[
-            RouteInput(
-              key: routeInputKey,
-              onSearch: onRouteSearch,
-            ),
+            RouteInput(key: routeInputKey, onSearch: onRouteSearch),
           ],
           const SizedBox(height: 8),
-          Text(
-            l10n?.fuelType ?? 'Fuel type',
-            style: theme.textTheme.titleSmall,
-          ),
+          Text(l10n.fuelType, style: theme.textTheme.titleSmall),
           const SizedBox(height: 4),
           const FuelTypeSelector(),
           const SizedBox(height: 8),
@@ -122,14 +115,11 @@ class SearchCriteriaForm extends ConsumerWidget {
             onChanged: (value) {
               ref.read(openOnlyFilterProvider.notifier).set(value);
             },
-            title: Text(l10n?.openOnlyFilter ?? 'Open only'),
+            title: Text(l10n.openOnlyFilter),
             secondary: const Icon(Icons.schedule),
           ),
           const SizedBox(height: 4),
-          Text(
-            l10n?.amenities ?? 'Amenities',
-            style: theme.textTheme.titleSmall,
-          ),
+          Text(l10n.amenities, style: theme.textTheme.titleSmall),
           const SizedBox(height: 4),
           AmenityFilterWrap(
             selected: amenities,
@@ -149,9 +139,7 @@ class SearchCriteriaForm extends ConsumerWidget {
             key: const ValueKey('criteria-save-defaults-button'),
             onPressed: onSaveDefaults,
             icon: const Icon(Icons.bookmark_add),
-            label: Text(
-              l10n?.saveAsDefaults ?? 'Save as my defaults',
-            ),
+            label: Text(l10n.saveAsDefaults),
             style: OutlinedButton.styleFrom(
               minimumSize: const Size.fromHeight(44),
             ),

--- a/lib/features/search/presentation/widgets/search_mode_toggle.dart
+++ b/lib/features/search/presentation/widgets/search_mode_toggle.dart
@@ -27,12 +27,12 @@ class SearchModeToggle extends StatelessWidget {
       segments: [
         ButtonSegment(
           value: SearchMode.nearby,
-          label: Text(l10n?.searchNearby ?? 'Nearby'),
+          label: Text(l10n.searchNearby),
           icon: const Icon(Icons.near_me),
         ),
         ButtonSegment(
           value: SearchMode.route,
-          label: Text(l10n?.searchAlongRoute ?? 'Along route'),
+          label: Text(l10n.searchAlongRoute),
           icon: const Icon(Icons.route),
         ),
       ],

--- a/lib/features/search/presentation/widgets/search_radius_slider.dart
+++ b/lib/features/search/presentation/widgets/search_radius_slider.dart
@@ -32,15 +32,9 @@ class SearchRadiusSlider extends StatelessWidget {
       children: [
         Row(
           children: [
-            Text(
-              '${l10n?.searchRadius ?? "Radius"}:',
-              style: theme.textTheme.titleSmall,
-            ),
+            Text('${l10n.searchRadius}:', style: theme.textTheme.titleSmall),
             const Spacer(),
-            Text(
-              '${radiusKm.round()} km',
-              style: theme.textTheme.titleSmall,
-            ),
+            Text('${radiusKm.round()} km', style: theme.textTheme.titleSmall),
           ],
         ),
         // #1962 — shrink the slider's reaction overlay so the control
@@ -48,8 +42,7 @@ class SearchRadiusSlider extends StatelessWidget {
         // (the default 24 dp overlay inflates the row to ~48 dp).
         SliderTheme(
           data: SliderTheme.of(context).copyWith(
-            overlayShape:
-                const RoundSliderOverlayShape(overlayRadius: 14),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
           ),
           child: Slider(
             value: radiusKm.clamp(minKm, maxKm),

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -40,9 +40,7 @@ class SearchResultsContent extends ConsumerWidget {
     final searchState = ref.watch(searchStateProvider);
 
     if (searchMode == SearchMode.route) {
-      return const CustomScrollView(
-        slivers: [RouteResultsView()],
-      );
+      return const CustomScrollView(slivers: [RouteResultsView()]);
     }
 
     // #2675 — when the on-search Fuel Station Radar is active it OWNS the
@@ -69,8 +67,7 @@ class SearchResultsContent extends ConsumerWidget {
           // still searching (the old bare "0 stations" + blank was ambiguous).
           if (stations.isEmpty) {
             return _RadarEmptyState(
-              onRetry: () =>
-                  ref.read(radarSearchProvider.notifier).runRadar(),
+              onRetry: () => ref.read(radarSearchProvider.notifier).runRadar(),
             );
           }
           final radarResult = ServiceResult<List<SearchResultItem>>(
@@ -80,8 +77,7 @@ class SearchResultsContent extends ConsumerWidget {
           );
           return SearchResultsList(
             result: radarResult,
-            onRefresh: () =>
-                ref.read(radarSearchProvider.notifier).runRadar(),
+            onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
           );
         },
         loading: () => const ShimmerStationList(),
@@ -111,7 +107,7 @@ class SearchResultsContent extends ConsumerWidget {
                   // on this screen, so the empty state is no longer a
                   // dead-end even without an inline button.
                   Text(
-                    l10n?.startSearch ?? 'Search to find fuel stations.',
+                    l10n.startSearch,
                     style: TextStyle(
                       fontSize: 14,
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -125,13 +121,13 @@ class SearchResultsContent extends ConsumerWidget {
         return SearchResultsList(result: result, onRefresh: onGpsRetry);
       },
       loading: () => const ShimmerStationList(),
-      error: (error, stackTrace) =>
-          ServiceChainErrorWidget(
-            error: error,
-            onRetry: onGpsRetry,
-            stackTrace: stackTrace,
-            searchContext: 'Station search (${ref.read(selectedFuelTypeProvider).apiValue})',
-          ),
+      error: (error, stackTrace) => ServiceChainErrorWidget(
+        error: error,
+        onRetry: onGpsRetry,
+        stackTrace: stackTrace,
+        searchContext:
+            'Station search (${ref.read(selectedFuelTypeProvider).apiValue})',
+      ),
     );
   }
 }
@@ -155,17 +151,20 @@ class _RadarEmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.radar, size: 56, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.radar,
+              size: 56,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             const SizedBox(height: 16),
             Text(
-              l10n?.noResults ?? 'No stations found.',
+              l10n.noResults,
               style: theme.textTheme.titleMedium,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
-              l10n?.errorHintNoStations ??
-                  'Try increasing the search radius or search a different location.',
+              l10n.errorHintNoStations,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -175,7 +174,7 @@ class _RadarEmptyState extends StatelessWidget {
             FilledButton.icon(
               onPressed: onRetry,
               icon: const Icon(Icons.refresh),
-              label: Text(l10n?.retry ?? 'Try again'),
+              label: Text(l10n.retry),
             ),
           ],
         ),

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -117,8 +117,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                   return Text(
                     location.isNotEmpty
                         ? '$location · ${result.data.length}'
-                        : l10n?.stationsFound(result.data.length) ??
-                            '${result.data.length} stations',
+                        : l10n.stationsFound(result.data.length),
                     style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
@@ -129,7 +128,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
               _ViewToggleButton(),
               const SizedBox(width: 4),
               Semantics(
-                label: l10n?.showOnMapSemanticLabel ?? 'Show stations on map',
+                label: l10n.showOnMapSemanticLabel,
                 button: true,
                 child: InkWell(
                   onTap: () => context.go(RoutePaths.map),
@@ -155,7 +154,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                   .watch(enabledFeaturesProvider)
                   .contains(Feature.fuelCalculator)) ...[
                 Semantics(
-                  label: l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator',
+                  label: l10n.fuelCostCalculator,
                   button: true,
                   child: InkWell(
                     // #2543 — carry the cheapest visible price for the
@@ -380,8 +379,8 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showWithUndo(
           context,
-          l10n?.stationHidden(station.displayName) ?? '${station.displayName} hidden',
-          undoLabel: l10n?.undo ?? 'Undo',
+          l10n.stationHidden(station.displayName),
+          undoLabel: l10n.undo,
           onUndo: () => ignoredNotifier.remove(station.id),
         );
       },

--- a/lib/features/search/presentation/widgets/search_results_list_parts.dart
+++ b/lib/features/search/presentation/widgets/search_results_list_parts.dart
@@ -67,25 +67,25 @@ class _CollapsibleBrandFilters extends ConsumerWidget {
     final theme = Theme.of(context);
     final selectedBrands = ref.watch(selectedBrandsProvider);
     final excludeHighway = ref.watch(excludeHighwayStationsProvider);
-    final hasActiveFilters =
-        selectedBrands.isNotEmpty || excludeHighway;
+    final hasActiveFilters = selectedBrands.isNotEmpty || excludeHighway;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         InkWell(
-          onTap: () =>
-              ref.read(brandFiltersExpandedProvider.notifier).toggle(),
+          onTap: () => ref.read(brandFiltersExpandedProvider.notifier).toggle(),
           child: Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: Row(
               children: [
-                Icon(Icons.filter_list, size: 16,
-                    color: theme.colorScheme.primary),
+                Icon(
+                  Icons.filter_list,
+                  size: 16,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: 6),
                 Text(
-                  l10n?.brandFilterAll ?? 'Brands',
+                  l10n.brandFilterAll,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.primary,
                   ),
@@ -103,9 +103,7 @@ class _CollapsibleBrandFilters extends ConsumerWidget {
                 ],
                 const Spacer(),
                 Icon(
-                  expanded
-                      ? Icons.expand_less
-                      : Icons.expand_more,
+                  expanded ? Icons.expand_less : Icons.expand_more,
                   size: 18,
                   color: theme.colorScheme.primary,
                 ),
@@ -134,8 +132,8 @@ class _ViewToggleButton extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
 
     final label = allPrices
-        ? (l10n?.switchToCompactView ?? 'Switch to compact view')
-        : (l10n?.switchToAllPricesView ?? 'Switch to all-prices view');
+        ? (l10n.switchToCompactView)
+        : (l10n.switchToAllPricesView);
 
     return Semantics(
       label: label,
@@ -143,9 +141,7 @@ class _ViewToggleButton extends ConsumerWidget {
       child: Tooltip(
         message: label,
         child: InkWell(
-          onTap: () => ref
-              .read(allPricesViewEnabledProvider.notifier)
-              .toggle(),
+          onTap: () => ref.read(allPricesViewEnabledProvider.notifier).toggle(),
           borderRadius: BorderRadius.circular(12),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -45,7 +45,7 @@ class SearchSummaryBar extends ConsumerWidget {
 
   String _fuelLabel(BuildContext context, FuelType type) {
     if (type == FuelType.all) {
-      return AppLocalizations.of(context)?.allFuels ?? 'All';
+      return AppLocalizations.of(context).allFuels;
     }
     return type.displayName;
   }
@@ -57,7 +57,7 @@ class SearchSummaryBar extends ConsumerWidget {
   Widget _secondChip(
     BuildContext context,
     WidgetRef ref,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
     SearchMode mode,
   ) {
     // #2676 — while the on-search Fuel Station Radar owns the results, the
@@ -67,14 +67,14 @@ class SearchSummaryBar extends ConsumerWidget {
     if (ref.watch(radarSearchProvider).active) {
       return _SummaryChip(
         icon: const Icon(Icons.radar, size: 16),
-        label: l10n?.fuelStationRadarResultBadge ?? 'Fuel Station Radar result',
+        label: l10n.fuelStationRadarResultBadge,
       );
     }
     if (mode != SearchMode.route) {
       final kmText = ref.watch(searchRadiusProvider).round().toString();
       return _SummaryChip(
         icon: const Icon(Icons.radar, size: 16),
-        label: l10n?.searchCriteriaRadiusBadge(kmText) ?? 'Within $kmText km',
+        label: l10n.searchCriteriaRadiusBadge(kmText),
       );
     }
     final routeState = ref.watch(routeSearchStateProvider);
@@ -90,15 +90,16 @@ class SearchSummaryBar extends ConsumerWidget {
           height: 14,
           child: CircularProgressIndicator(strokeWidth: 2),
         ),
-        label: l10n?.routeSearchingChip ?? 'Searching the route…',
+        label: l10n.routeSearchingChip,
       );
     }
-    final segmentText =
-        ref.watch(routeSegmentSearchParamProvider).round().toString();
+    final segmentText = ref
+        .watch(routeSegmentSearchParamProvider)
+        .round()
+        .toString();
     return _SummaryChip(
       icon: const Icon(Icons.route, size: 16),
-      label: l10n?.routeSegmentSummaryBadge(segmentText) ??
-          'Every $segmentText km',
+      label: l10n.routeSegmentSummaryBadge(segmentText),
     );
   }
 
@@ -114,16 +115,15 @@ class SearchSummaryBar extends ConsumerWidget {
     final storedMode = ref.watch(activeSearchModeProvider);
     final manifest = ref.watch(featureManifestProvider);
     final enabledFlags = ref.watch(enabledFeaturesProvider);
-    final mode = isEffectivelyEnabled(
-            Feature.routePlanning, manifest, enabledFlags)
+    final mode =
+        isEffectivelyEnabled(Feature.routePlanning, manifest, enabledFlags)
         ? storedMode
         : SearchMode.nearby;
 
     final fuelColor = FuelColors.forType(fuelType);
 
     return Semantics(
-      label: l10n?.searchCriteriaSemanticLabel ??
-          'Search criteria summary. Tap to edit.',
+      label: l10n.searchCriteriaSemanticLabel,
       button: true,
       child: Material(
         color: theme.colorScheme.surfaceContainerHighest,
@@ -141,8 +141,7 @@ class SearchSummaryBar extends ConsumerWidget {
                       children: [
                         // Fuel type chip
                         _SummaryChip(
-                          icon: Icon(fuelType.icon,
-                              size: 16, color: fuelColor),
+                          icon: Icon(fuelType.icon, size: 16, color: fuelColor),
                           label: _fuelLabel(context, fuelType),
                         ),
                         const SizedBox(width: 6),

--- a/lib/features/search/presentation/widgets/sort_selector.dart
+++ b/lib/features/search/presentation/widgets/sort_selector.dart
@@ -26,14 +26,14 @@ class SortSelector extends StatelessWidget {
         child: Row(
           children: [
             _SortChip(
-              label: l10n?.sortDistance ?? 'Distance',
+              label: l10n.sortDistance,
               icon: Icons.near_me,
               selected: selected == SortMode.distance,
               onSelected: () => onChanged(SortMode.distance),
             ),
             const SizedBox(width: 6),
             _SortChip(
-              label: l10n?.price ?? 'Price',
+              label: l10n.price,
               icon: Icons.euro,
               selected: selected == SortMode.price,
               onSelected: () => onChanged(SortMode.price),
@@ -47,21 +47,21 @@ class SortSelector extends StatelessWidget {
             ),
             const SizedBox(width: 6),
             _SortChip(
-              label: l10n?.sortOpen24h ?? '24h',
+              label: l10n.sortOpen24h,
               icon: Icons.schedule,
               selected: selected == SortMode.open24h,
               onSelected: () => onChanged(SortMode.open24h),
             ),
             const SizedBox(width: 6),
             _SortChip(
-              label: l10n?.sortRating ?? 'Rating',
+              label: l10n.sortRating,
               icon: Icons.star,
               selected: selected == SortMode.rating,
               onSelected: () => onChanged(SortMode.rating),
             ),
             const SizedBox(width: 6),
             _SortChip(
-              label: l10n?.sortPriceDistance ?? 'Price/km',
+              label: l10n.sortPriceDistance,
               icon: Icons.balance,
               selected: selected == SortMode.priceDistance,
               onSelected: () => onChanged(SortMode.priceDistance),
@@ -90,7 +90,7 @@ class _SortChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Semantics(
-      label: l10n?.sortBySemantic(label, '$selected') ?? 'Sort by $label',
+      label: l10n.sortBySemantic(label, '$selected'),
       child: ChoiceChip(
         avatar: Icon(icon, size: 16),
         label: Text(label),

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -144,9 +144,9 @@ class StationCard extends StatelessWidget {
     // #3198 — tri-state: an unknown open state is announced as unknown,
     // never as closed (and never as open).
     final semanticStatus = switch (station.isOpen) {
-      true => l10n?.open ?? 'Open',
-      false => l10n?.closed ?? 'Closed',
-      null => l10n?.openStateUnknown ?? 'Unknown',
+      true => l10n.open,
+      false => l10n.closed,
+      null => l10n.openStateUnknown,
     };
     final semanticLabel =
         '${_hasBrand ? station.brand : station.name}, ${station.street}, '

--- a/lib/features/search/presentation/widgets/station_card_price_column.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_column.dart
@@ -63,7 +63,8 @@ class _StationPriceColumn extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final effective = _effectivePrice;
-    final hasDiscount = loyaltyDiscount != null &&
+    final hasDiscount =
+        loyaltyDiscount != null &&
         loyaltyDiscount! > 0 &&
         price != null &&
         effective != null;
@@ -80,10 +81,7 @@ class _StationPriceColumn extends StatelessWidget {
           child: IconButton(
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
-            icon: AnimatedFavoriteStar(
-              isFavorite: isFavorite,
-              size: 22,
-            ),
+            icon: AnimatedFavoriteStar(isFavorite: isFavorite, size: 22),
             // #2974 — a selection tick on the favourite toggle, matching the
             // everyday tap-surface haptics. selectionClick only (never
             // heavyImpact); fires only on the discrete star tap, never scroll.
@@ -93,9 +91,7 @@ class _StationPriceColumn extends StatelessWidget {
                     unawaited(HapticFeedback.selectionClick());
                     onFavoriteTap!();
                   },
-            tooltip: isFavorite
-                ? (l10n?.favoriteRemove ?? 'Remove from favorites')
-                : (l10n?.favoriteAdd ?? 'Add to favorites'),
+            tooltip: isFavorite ? (l10n.favoriteRemove) : (l10n.favoriteAdd),
           ),
         ),
         if (rating != null && rating! >= 1 && rating! <= 5)
@@ -108,16 +104,13 @@ class _StationPriceColumn extends StatelessWidget {
         if (isCheapest)
           Container(
             margin: const EdgeInsets.only(bottom: 2),
-            padding: const EdgeInsets.symmetric(
-              horizontal: 6,
-              vertical: 1,
-            ),
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
             decoration: BoxDecoration(
               color: DarkModeColors.successSurface(context),
               borderRadius: AppRadius.sm,
             ),
             child: Text(
-              l10n?.cheapest ?? 'Cheapest',
+              l10n.cheapest,
               style: TextStyle(
                 fontSize: 10,
                 fontWeight: FontWeight.bold,
@@ -149,10 +142,12 @@ class _StationPriceColumn extends StatelessWidget {
                 // tooltip surfaces the un-discounted raw price so
                 // power users can verify what the operator quoted.
                 message: hasDiscount
-                    ? (l10n?.loyaltyRawPriceTooltip(
-                            PriceFormatter.formatPrice(price,
-                                currencyOverride: currencyOverride)) ??
-                        'Raw: ${PriceFormatter.formatPrice(price, currencyOverride: currencyOverride)}')
+                    ? (l10n.loyaltyRawPriceTooltip(
+                        PriceFormatter.formatPrice(
+                          price,
+                          currencyOverride: currencyOverride,
+                        ),
+                      ))
                     : '',
                 child: RichText(
                   overflow: TextOverflow.ellipsis,
@@ -230,7 +225,7 @@ class _LoyaltyDiscountBadge extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final canonical = BrandRegistry.canonicalize(station.brand) ?? '';
-    final prefix = l?.loyaltyBadgePrefix ?? '−';
+    final prefix = l.loyaltyBadgePrefix;
     final discountStr = PriceFormatter.formatPrice(
       discount,
       currencyOverride: currencyOverride,
@@ -250,8 +245,7 @@ class _LoyaltyDiscountBadge extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            '$prefix$discountStr ${canonical.isEmpty ? '' : canonical}'
-                .trim(),
+            '$prefix$discountStr ${canonical.isEmpty ? '' : canonical}'.trim(),
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.bold,
@@ -264,8 +258,9 @@ class _LoyaltyDiscountBadge extends StatelessWidget {
             rawStr,
             style: TextStyle(
               fontSize: 10,
-              color: theme.colorScheme.onPrimaryContainer
-                  .withValues(alpha: 0.7),
+              color: theme.colorScheme.onPrimaryContainer.withValues(
+                alpha: 0.7,
+              ),
               decoration: TextDecoration.lineThrough,
             ),
             overflow: TextOverflow.ellipsis,

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -81,8 +81,8 @@ class _StationDetails extends StatelessWidget {
     final titleText = hasBrand
         ? station.brand
         : useName
-            ? station.name
-            : (l10n?.stationUnbrandedTitle ?? 'Unbranded station');
+        ? station.name
+        : (l10n.stationUnbrandedTitle);
     // The street is shown on the address line whenever it is NOT the title —
     // i.e. for a branded station (it was already), and now also for the
     // unbranded label case (the street is no longer hoisted to the title).
@@ -135,8 +135,7 @@ class _StationDetails extends StatelessWidget {
                   // "Updated {time}" so it reads as freshness, not a bare
                   // code. (No relative "2h ago": updatedAt is a lossy,
                   // per-country pre-formatted String.)
-                  l10n?.stationUpdatedLabel(station.updatedAt!) ??
-                      'Updated ${station.updatedAt!}',
+                  l10n.stationUpdatedLabel(station.updatedAt!),
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),

--- a/lib/features/search/presentation/widgets/swipeable_station_card.dart
+++ b/lib/features/search/presentation/widgets/swipeable_station_card.dart
@@ -73,8 +73,13 @@ class SwipeableStationCard extends ConsumerWidget {
           children: [
             const Icon(Icons.navigation, color: Colors.white, size: 20),
             const SizedBox(width: 8),
-            Text(l10n?.navigate ?? 'Navigate',
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            Text(
+              l10n.navigate,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ],
         ),
       ),
@@ -86,8 +91,13 @@ class SwipeableStationCard extends ConsumerWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(l10n?.swipeHide ?? 'Hide',
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            Text(
+              l10n.swipeHide,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
             const SizedBox(width: 8),
             const Icon(Icons.visibility_off, color: Colors.white, size: 20),
           ],
@@ -107,9 +117,7 @@ class SwipeableStationCard extends ConsumerWidget {
         // strings so the StationCard widget stays decoupled from the
         // [LoyaltyBrand] enum.
         activeDiscountsByBrand: {
-          for (final entry in ref
-              .watch(activeDiscountByBrandProvider)
-              .entries)
+          for (final entry in ref.watch(activeDiscountByBrandProvider).entries)
             entry.key.canonicalBrand: entry.value,
         },
       ),

--- a/lib/features/search/presentation/widgets/user_position_bar.dart
+++ b/lib/features/search/presentation/widgets/user_position_bar.dart
@@ -10,10 +10,7 @@ import '../../../../l10n/app_localizations.dart';
 class UserPositionBar extends ConsumerWidget {
   final VoidCallback onUpdatePosition;
 
-  const UserPositionBar({
-    super.key,
-    required this.onUpdatePosition,
-  });
+  const UserPositionBar({super.key, required this.onUpdatePosition});
 
   String _formatAge(DateTime updatedAt) {
     final diff = DateTime.now().difference(updatedAt);
@@ -29,10 +26,9 @@ class UserPositionBar extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    final posLabel = l10n?.yourPosition ?? 'Your position';
-    final unknownLabel = l10n?.positionUnknown ?? 'Position unknown';
-    final distFromSearchLabel =
-        l10n?.distancesFromCenter ?? 'Distances from search center';
+    final posLabel = l10n.yourPosition;
+    final unknownLabel = l10n.positionUnknown;
+    final distFromSearchLabel = l10n.distancesFromCenter;
 
     if (userPos != null) {
       return Container(
@@ -40,8 +36,7 @@ class UserPositionBar extends ConsumerWidget {
         color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
         child: Row(
           children: [
-            Icon(Icons.my_location,
-                size: 16, color: theme.colorScheme.primary),
+            Icon(Icons.my_location, size: 16, color: theme.colorScheme.primary),
             const SizedBox(width: 6),
             Expanded(
               child: Text(
@@ -56,10 +51,12 @@ class UserPositionBar extends ConsumerWidget {
               onTap: onUpdatePosition,
               borderRadius: BorderRadius.circular(12),
               child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                child: Icon(Icons.refresh,
-                    size: 18, color: theme.colorScheme.primary),
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                child: Icon(
+                  Icons.refresh,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
               ),
             ),
           ],
@@ -72,8 +69,11 @@ class UserPositionBar extends ConsumerWidget {
       color: theme.colorScheme.errorContainer.withValues(alpha: 0.3),
       child: Row(
         children: [
-          Icon(Icons.location_off,
-              size: 16, color: theme.colorScheme.onErrorContainer),
+          Icon(
+            Icons.location_off,
+            size: 16,
+            color: theme.colorScheme.onErrorContainer,
+          ),
           const SizedBox(width: 6),
           Expanded(
             child: Text(
@@ -86,11 +86,15 @@ class UserPositionBar extends ConsumerWidget {
           ),
           TextButton.icon(
             onPressed: onUpdatePosition,
-            icon: Icon(Icons.my_location,
-                size: 14, color: theme.colorScheme.primary),
-            label: Text('GPS',
-                style:
-                    TextStyle(fontSize: 12, color: theme.colorScheme.primary)),
+            icon: Icon(
+              Icons.my_location,
+              size: 14,
+              color: theme.colorScheme.primary,
+            ),
+            label: Text(
+              'GPS',
+              style: TextStyle(fontSize: 12, color: theme.colorScheme.primary),
+            ),
             style: TextButton.styleFrom(
               padding: const EdgeInsets.symmetric(horizontal: 8),
               minimumSize: Size.zero,

--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -115,11 +115,13 @@ class _OnboardingWizardScreenState
 
   void _goToStep(int step) {
     ref.read(onboardingWizardControllerProvider.notifier).setStep(step);
-    unawaited(_pageController.animateToPage(
-      step,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeInOut,
-    ));
+    unawaited(
+      _pageController.animateToPage(
+        step,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      ),
+    );
   }
 
   void _next(int currentStep) {
@@ -127,12 +129,10 @@ class _OnboardingWizardScreenState
     // once the user taps a card. If they hit the wizard's "Next" button
     // without picking, refuse with a hint — otherwise the wizard would
     // enter the next step with a null `activeAppProfileProvider`.
-    if (currentStep == 0 &&
-        ref.read(activeAppProfileProvider) == null) {
+    if (currentStep == 0 && ref.read(activeAppProfileProvider) == null) {
       SnackBarHelper.showError(
         context,
-        AppLocalizations.of(context)?.onboardingPickUseMode ??
-            'Pick a use mode to continue.',
+        AppLocalizations.of(context).onboardingPickUseMode,
       );
       return;
     }
@@ -183,7 +183,10 @@ class _OnboardingWizardScreenState
       if (!result.isValid) {
         if (mounted) {
           final l10n = AppLocalizations.of(context);
-          SnackBarHelper.showError(context, l10n?.invalidApiKey(result.errorMessage ?? '') ?? 'Invalid API key: ${result.errorMessage}');
+          SnackBarHelper.showError(
+            context,
+            l10n.invalidApiKey(result.errorMessage ?? ''),
+          );
         }
         return false;
       }
@@ -269,8 +272,8 @@ class _OnboardingWizardScreenState
     final profile = ref.watch(activeAppProfileProvider);
     final showVehicle =
         profile == AppProfile.medium ||
-            profile == AppProfile.full ||
-            profile == AppProfile.custom;
+        profile == AppProfile.full ||
+        profile == AppProfile.custom;
     final showObd2 = profile == AppProfile.full || profile == AppProfile.custom;
     // #1542 phase 6 — on iOS, prepend an explainer step before the
     // OBD2 pairing so the user understands the three iOS-only
@@ -280,8 +283,8 @@ class _OnboardingWizardScreenState
     // not setting up. Platform resolution lives in the dedicated
     // dispatch-seam provider (#3163) so this screen stays free of
     // inline `defaultTargetPlatform` branching.
-    final showIosStandby = showObd2 &&
-        ref.watch(onboardingIncludesIosStandbyStepProvider);
+    final showIosStandby =
+        showObd2 && ref.watch(onboardingIncludesIosStandbyStepProvider);
     return [
       ProfileChoiceStep(onProfilePicked: _onProfilePicked),
       const CountryLanguageStep(),

--- a/lib/features/setup/presentation/screens/setup_screen.dart
+++ b/lib/features/setup/presentation/screens/setup_screen.dart
@@ -98,9 +98,9 @@ class _SetupScreenState extends ConsumerState<SetupScreen> {
         if (mounted) {
           final l10n = AppLocalizations.of(context);
           SnackBarHelper.showError(
-              context,
-              l10n?.invalidApiKey(result.errorMessage ?? '') ??
-                  'Invalid API key: ${result.errorMessage}');
+            context,
+            l10n.invalidApiKey(result.errorMessage ?? ''),
+          );
         }
         return;
       }

--- a/lib/features/setup/presentation/widgets/api_key_input_section.dart
+++ b/lib/features/setup/presentation/widgets/api_key_input_section.dart
@@ -18,7 +18,7 @@ class ApiKeyInputSection extends StatelessWidget {
   final CountryConfig country;
   final TextEditingController controller;
   final bool? formatValid;
-  final AppLocalizations? l10n;
+  final AppLocalizations l10n;
 
   const ApiKeyInputSection({
     super.key,
@@ -42,53 +42,38 @@ class ApiKeyInputSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(l10n?.apiKeySetupTitle ?? 'API key setup (optional)',
-            style: theme.textTheme.titleMedium),
+        Text(l10n.apiKeySetupTitle, style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
-        Text(
-          l10n?.apiKeySetupDescription ??
-              'Register for a free API key, or skip to explore '
-                  'the app with demo data.',
-          style: theme.textTheme.bodyMedium,
-        ),
+        Text(l10n.apiKeySetupDescription, style: theme.textTheme.bodyMedium),
         const SizedBox(height: 12),
         if (country.apiKeyRegistrationUrl != null)
           OutlinedButton.icon(
             onPressed: () async {
               final uri = Uri.parse(country.apiKeyRegistrationUrl!);
               if (await canLaunchUrl(uri)) {
-                await launchUrl(
-                  uri,
-                  mode: LaunchMode.externalApplication,
-                );
+                await launchUrl(uri, mode: LaunchMode.externalApplication);
               }
             },
             icon: const Icon(Icons.open_in_new),
             label: Text(
-              l10n?.apiKeyRegistrationButton(country.apiProvider ?? '') ??
-                  '${country.apiProvider} Registration',
+              l10n.apiKeyRegistrationButton(country.apiProvider ?? ''),
             ),
           ),
         const SizedBox(height: 16),
         TextField(
           controller: controller,
           decoration: InputDecoration(
-            labelText: l10n?.apiKeyLabel ?? 'API Key',
+            labelText: l10n.apiKeyLabel,
             hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
             prefixIcon: const Icon(Icons.key),
             border: const OutlineInputBorder(),
             suffixIcon: _buildFormatIndicator(context),
-            errorText: formatValid == false
-                ? (l10n?.apiKeyFormatError ??
-                    'Invalid format — expected UUID (8-4-4-4-12)')
-                : null,
+            errorText: formatValid == false ? (l10n.apiKeyFormatError) : null,
           ),
         ),
         const SizedBox(height: 8),
         Text(
-          l10n?.apiKeyTerms(country.apiProvider ?? '') ??
-              'By entering an API key you accept the terms of '
-                  '${country.apiProvider}. Data redistribution is prohibited.',
+          l10n.apiKeyTerms(country.apiProvider ?? ''),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/lib/features/setup/presentation/widgets/api_key_step.dart
+++ b/lib/features/setup/presentation/widgets/api_key_step.dart
@@ -88,14 +88,10 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const SizedBox(height: 16),
-          Icon(
-            Icons.key,
-            size: 48,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.key, size: 48, color: theme.colorScheme.primary),
           const SizedBox(height: 16),
           Text(
-            l10n?.apiKeySetup ?? 'API key setup',
+            l10n.apiKeySetup,
             style: theme.textTheme.titleLarge?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -103,8 +99,7 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
           ),
           const SizedBox(height: 8),
           Text(
-            l10n?.onboardingApiKeyDescription ??
-                'Register for a free API key, or skip to explore the app with demo data.',
+            l10n.onboardingApiKeyDescription,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -118,10 +113,7 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
                 onPressed: () async {
                   final uri = Uri.parse(country.apiKeyRegistrationUrl!);
                   if (await canLaunchUrl(uri)) {
-                    await launchUrl(
-                      uri,
-                      mode: LaunchMode.externalApplication,
-                    );
+                    await launchUrl(uri, mode: LaunchMode.externalApplication);
                   }
                 },
                 icon: const Icon(Icons.open_in_new),
@@ -131,21 +123,19 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
           TextField(
             controller: widget.apiKeyController,
             decoration: InputDecoration(
-              labelText: l10n?.apiKeyLabel ?? 'API Key',
+              labelText: l10n.apiKeyLabel,
               hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
               prefixIcon: const Icon(Icons.key),
               border: const OutlineInputBorder(),
               suffixIcon: _buildFormatIndicator(context),
               errorText: _isFormatValid == false
-                  ? (l10n?.apiKeyFormatError ??
-                      'Invalid format — expected UUID (8-4-4-4-12)')
+                  ? (l10n.apiKeyFormatError)
                   : null,
             ),
           ),
           const SizedBox(height: 8),
           Text(
-            l10n?.apiKeyNote ??
-                'Free registration. Data from government price transparency agencies.',
+            l10n.apiKeyNote,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -156,8 +146,7 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
           OutlinedButton.icon(
             onPressed: widget.onUseDemoData,
             icon: const Icon(Icons.explore_outlined),
-            label: Text(l10n?.onboardingExploreDemoData ??
-                'Explore with demo data'),
+            label: Text(l10n.onboardingExploreDemoData),
           ),
           const SizedBox(height: 16),
           if (country.attribution != null)

--- a/lib/features/setup/presentation/widgets/completion_step.dart
+++ b/lib/features/setup/presentation/widgets/completion_step.dart
@@ -25,17 +25,14 @@ class CompletionStep extends StatelessWidget {
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: constraints.maxHeight),
             child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 32,
-                vertical: 16,
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   const ShieldIllustration(size: 160),
                   const SizedBox(height: 24),
                   Text(
-                    l10n?.onboardingComplete ?? 'All set!',
+                    l10n.onboardingComplete,
                     style: theme.textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
@@ -43,9 +40,7 @@ class CompletionStep extends StatelessWidget {
                   ),
                   const SizedBox(height: 12),
                   Text(
-                    l10n?.onboardingCompleteHint ??
-                        'You can change these settings anytime in your '
-                            'profile.',
+                    l10n.onboardingCompleteHint,
                     style: theme.textTheme.bodyLarge?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),

--- a/lib/features/setup/presentation/widgets/country_info_card.dart
+++ b/lib/features/setup/presentation/widgets/country_info_card.dart
@@ -22,20 +22,17 @@ class CountryInfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final dataSource =
-        country.apiProvider ?? (l10n?.countryInfoDemoSource ?? 'Demo');
+    final dataSource = country.apiProvider ?? (l10n.countryInfoDemoSource);
     final keyRequirement = country.requiresApiKey
-        ? (l10n?.countryInfoApiKeyRequired ?? 'API key required')
-        : (l10n?.countryInfoNoKeyNeeded ?? 'Free, no key needed');
+        ? (l10n.countryInfoApiKeyRequired)
+        : (l10n.countryInfoNoKeyNeeded);
     final fuelTypesList = country.fuelTypes.join(', ');
-    final semanticLabel = l10n?.countryInfoSemantic(
-          country.name,
-          dataSource,
-          keyRequirement,
-          fuelTypesList,
-        ) ??
-        '${country.name}, data source: $dataSource, $keyRequirement, '
-            'fuel types: $fuelTypesList';
+    final semanticLabel = l10n.countryInfoSemantic(
+      country.name,
+      dataSource,
+      keyRequirement,
+      fuelTypesList,
+    );
     return Semantics(
       label: semanticLabel,
       child: Card(
@@ -65,8 +62,7 @@ class CountryInfoCard extends StatelessWidget {
                             ),
                           ),
                           Text(
-                            l10n?.countryInfoDataSource(dataSource) ??
-                                'Data: $dataSource',
+                            l10n.countryInfoDataSource(dataSource),
                             style: theme.textTheme.bodySmall,
                           ),
                         ],
@@ -79,8 +75,7 @@ class CountryInfoCard extends StatelessWidget {
               const SizedBox(height: 8),
               ExcludeSemantics(
                 child: Text(
-                  l10n?.countryInfoFuelTypes(fuelTypesList) ??
-                      'Fuel types: $fuelTypesList',
+                  l10n.countryInfoFuelTypes(fuelTypesList),
                   style: theme.textTheme.bodySmall,
                 ),
               ),

--- a/lib/features/setup/presentation/widgets/country_language_step.dart
+++ b/lib/features/setup/presentation/widgets/country_language_step.dart
@@ -33,7 +33,7 @@ class CountryLanguageStep extends ConsumerWidget {
           const SizedBox(height: 16),
           // Language selector
           Text(
-            l10n?.language ?? 'Language',
+            l10n.language,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -45,16 +45,17 @@ class CountryLanguageStep extends ConsumerWidget {
             children: AppLanguages.all.map((lang) {
               final isSelected = lang.code == language.code;
               return Semantics(
-                label: l10n?.languageChipSemantic(
-                      lang.nativeName,
-                      '$isSelected',
-                    ) ??
-                    'Language ${lang.nativeName}',
+                label: l10n.languageChipSemantic(
+                  lang.nativeName,
+                  '$isSelected',
+                ),
                 child: ChoiceChip(
                   label: Text(lang.nativeName),
                   selected: isSelected,
                   onSelected: (_) {
-                    unawaited(ref.read(activeLanguageProvider.notifier).select(lang));
+                    unawaited(
+                      ref.read(activeLanguageProvider.notifier).select(lang),
+                    );
                   },
                   visualDensity: VisualDensity.compact,
                 ),
@@ -65,7 +66,7 @@ class CountryLanguageStep extends ConsumerWidget {
 
           // Country selector
           Text(
-            l10n?.country ?? 'Country',
+            l10n.country,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -77,13 +78,14 @@ class CountryLanguageStep extends ConsumerWidget {
             children: Countries.verified.map((c) {
               final isSelected = c.code == country.code;
               return Semantics(
-                label: l10n?.countryChipSemantic(c.name, '$isSelected') ??
-                    'Country ${c.name}',
+                label: l10n.countryChipSemantic(c.name, '$isSelected'),
                 child: ChoiceChip(
                   label: Text('${c.flag} ${c.name}'),
                   selected: isSelected,
                   onSelected: (_) {
-                    unawaited(ref.read(activeCountryProvider.notifier).select(c));
+                    unawaited(
+                      ref.read(activeCountryProvider.notifier).select(c),
+                    );
                   },
                 ),
               );
@@ -100,10 +102,7 @@ class CountryLanguageStep extends ConsumerWidget {
                 children: [
                   Row(
                     children: [
-                      Text(
-                        country.flag,
-                        style: const TextStyle(fontSize: 24),
-                      ),
+                      Text(country.flag, style: const TextStyle(fontSize: 24)),
                       const SizedBox(width: 12),
                       Expanded(
                         child: Column(
@@ -116,11 +115,10 @@ class CountryLanguageStep extends ConsumerWidget {
                               ),
                             ),
                             Text(
-                              l10n?.countryInfoDataSource(
-                                    country.apiProvider ??
-                                        (l10n.countryInfoDemoSource),
-                                  ) ??
-                                  'Data: ${country.apiProvider ?? 'Demo'}',
+                              l10n.countryInfoDataSource(
+                                country.apiProvider ??
+                                    (l10n.countryInfoDemoSource),
+                              ),
                               style: theme.textTheme.bodySmall,
                             ),
                           ],
@@ -139,8 +137,8 @@ class CountryLanguageStep extends ConsumerWidget {
                         ),
                         child: Text(
                           country.requiresApiKey
-                              ? (l10n?.apiKeyRequired ?? 'API key required')
-                              : (l10n?.freeNoKey ?? 'Free — no key needed'),
+                              ? (l10n.apiKeyRequired)
+                              : (l10n.freeNoKey),
                           style: TextStyle(
                             fontSize: 11,
                             fontWeight: FontWeight.w600,

--- a/lib/features/setup/presentation/widgets/country_selector.dart
+++ b/lib/features/setup/presentation/widgets/country_selector.dart
@@ -28,7 +28,7 @@ class CountrySelector extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(l10n?.country ?? 'Country', style: theme.textTheme.titleMedium),
+        Text(l10n.country, style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
         Wrap(
           spacing: 8,
@@ -36,8 +36,7 @@ class CountrySelector extends StatelessWidget {
           children: Countries.verified.map((c) {
             final isSelected = c.code == selected.code;
             return Semantics(
-              label: l10n?.countryChipSemantic(c.name, '$isSelected') ??
-                  'Country ${c.name}',
+              label: l10n.countryChipSemantic(c.name, '$isSelected'),
               child: ChoiceChip(
                 label: Text('${c.flag} ${c.name}'),
                 selected: isSelected,

--- a/lib/features/setup/presentation/widgets/illustrations/fuel_pump_illustration.dart
+++ b/lib/features/setup/presentation/widgets/illustrations/fuel_pump_illustration.dart
@@ -25,7 +25,7 @@ class FuelPumpIllustration extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context);
     return Semantics(
-      label: l10n?.fuelPumpIllustrationSemantic ?? 'Fuel pump with price ticker',
+      label: l10n.fuelPumpIllustrationSemantic,
       image: true,
       child: SizedBox(
         width: size,

--- a/lib/features/setup/presentation/widgets/illustrations/globe_illustration.dart
+++ b/lib/features/setup/presentation/widgets/illustrations/globe_illustration.dart
@@ -28,7 +28,7 @@ class GlobeIllustration extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context);
     return Semantics(
-      label: l10n?.globeIllustrationSemantic ?? 'Globe with fuel station markers',
+      label: l10n.globeIllustrationSemantic,
       image: true,
       child: SizedBox(
         width: size,
@@ -42,20 +42,13 @@ class GlobeIllustration extends StatelessWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 gradient: RadialGradient(
-                  colors: [
-                    scheme.surface,
-                    scheme.surfaceContainerLow,
-                  ],
+                  colors: [scheme.surface, scheme.surfaceContainerLow],
                   stops: const [0.3, 1.0],
                 ),
               ),
             ),
             // Central globe glyph.
-            Icon(
-              Icons.public,
-              size: size * 0.6,
-              color: scheme.primary,
-            ),
+            Icon(Icons.public, size: size * 0.6, color: scheme.primary),
             // Three location markers arranged at 10 / 2 / 6 o'clock around
             // the globe to hint at "multi-country coverage".
             Positioned(
@@ -96,11 +89,7 @@ class _Marker extends StatelessWidget {
         shape: BoxShape.circle,
       ),
       alignment: Alignment.center,
-      child: Icon(
-        Icons.local_gas_station,
-        size: size * 0.65,
-        color: color,
-      ),
+      child: Icon(Icons.local_gas_station, size: size * 0.65, color: color),
     );
   }
 }

--- a/lib/features/setup/presentation/widgets/illustrations/shield_illustration.dart
+++ b/lib/features/setup/presentation/widgets/illustrations/shield_illustration.dart
@@ -23,7 +23,7 @@ class ShieldIllustration extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context);
     return Semantics(
-      label: l10n?.shieldIllustrationSemantic ?? 'Privacy shield with fuel drop',
+      label: l10n.shieldIllustrationSemantic,
       image: true,
       child: SizedBox(
         width: size,
@@ -36,20 +36,13 @@ class ShieldIllustration extends StatelessWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 gradient: RadialGradient(
-                  colors: [
-                    scheme.surface,
-                    scheme.surfaceContainerLow,
-                  ],
+                  colors: [scheme.surface, scheme.surfaceContainerLow],
                   stops: const [0.3, 1.0],
                 ),
               ),
             ),
             // Shield — the privacy pledge.
-            Icon(
-              Icons.verified_user,
-              size: size * 0.72,
-              color: scheme.primary,
-            ),
+            Icon(Icons.verified_user, size: size * 0.72, color: scheme.primary),
             // Fuel drop — nested inside the shield, white so it reads
             // against the primary-tinted shield fill.
             Padding(

--- a/lib/features/setup/presentation/widgets/landing_screen_step.dart
+++ b/lib/features/setup/presentation/widgets/landing_screen_step.dart
@@ -22,11 +22,10 @@ class LandingScreenStep extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 32),
       child: Column(
         children: [
-          Icon(Icons.home_outlined, size: 48,
-              color: theme.colorScheme.primary),
+          Icon(Icons.home_outlined, size: 48, color: theme.colorScheme.primary),
           const SizedBox(height: 16),
           Text(
-            l10n?.onboardingLandingTitle ?? 'Home screen',
+            l10n.onboardingLandingTitle,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -34,8 +33,7 @@ class LandingScreenStep extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            l10n?.onboardingLandingHint ??
-                'Choose which screen opens when you launch the app.',
+            l10n.onboardingLandingHint,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -46,9 +44,9 @@ class LandingScreenStep extends ConsumerWidget {
           // sheet's dropdown (profile_landing_screen_dropdown.dart), so the
           // wizard and the profile agree on the same 3 options. Picking a
           // preference the profile cannot display/edit was confusing.
-          ...LandingScreen.values
-              .where((s) => s != LandingScreen.map)
-              .map((screen) {
+          ...LandingScreen.values.where((s) => s != LandingScreen.map).map((
+            screen,
+          ) {
             final selected = wizardState.landingScreen == screen;
             return Padding(
               padding: const EdgeInsets.only(bottom: 8),
@@ -67,7 +65,7 @@ class LandingScreenStep extends ConsumerWidget {
                   color: selected ? theme.colorScheme.primary : null,
                 ),
                 title: Text(
-                  screen.localizedName(l10n?.localeName ?? 'en'),
+                  screen.localizedName(l10n.localeName),
                   style: TextStyle(
                     fontWeight: selected ? FontWeight.bold : null,
                     color: selected ? theme.colorScheme.primary : null,

--- a/lib/features/setup/presentation/widgets/language_selector.dart
+++ b/lib/features/setup/presentation/widgets/language_selector.dart
@@ -28,7 +28,7 @@ class LanguageSelector extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(l10n?.language ?? 'Language', style: theme.textTheme.titleMedium),
+        Text(l10n.language, style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
         Wrap(
           spacing: 6,
@@ -36,11 +36,7 @@ class LanguageSelector extends StatelessWidget {
           children: AppLanguages.all.map((lang) {
             final isSelected = lang.code == selected.code;
             return Semantics(
-              label: l10n?.languageChipSemantic(
-                    lang.nativeName,
-                    '$isSelected',
-                  ) ??
-                  'Language ${lang.nativeName}',
+              label: l10n.languageChipSemantic(lang.nativeName, '$isSelected'),
               child: ChoiceChip(
                 label: Text(lang.nativeName),
                 selected: isSelected,

--- a/lib/features/setup/presentation/widgets/onboarding_ios_standby_step.dart
+++ b/lib/features/setup/presentation/widgets/onboarding_ios_standby_step.dart
@@ -32,15 +32,10 @@ class OnboardingIosStandbyStep extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Icon(
-            Icons.phone_iphone,
-            size: 48,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.phone_iphone, size: 48, color: theme.colorScheme.primary),
           const SizedBox(height: 16),
           Text(
-            l10n?.iosAutoRecordOnboardingTitle ??
-                "Stay out of the app — but don't quit it.",
+            l10n.iosAutoRecordOnboardingTitle,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -49,32 +44,20 @@ class OnboardingIosStandbyStep extends StatelessWidget {
           const SizedBox(height: 24),
           _Bullet(
             number: 1,
-            title: l10n?.iosAutoRecordOnboardingBullet1Title ??
-                'Open Sparkilo once after each reboot.',
-            body: l10n?.iosAutoRecordOnboardingBullet1Body ??
-                'Apple wakes Sparkilo only after you’ve opened it at '
-                    'least once since the phone restarted. After that, '
-                    'your trips record automatically.',
+            title: l10n.iosAutoRecordOnboardingBullet1Title,
+            body: l10n.iosAutoRecordOnboardingBullet1Body,
           ),
           const SizedBox(height: 16),
           _Bullet(
             number: 2,
-            title: l10n?.iosAutoRecordOnboardingBullet2Title ??
-                'Don’t swipe Sparkilo away in the app switcher.',
-            body: l10n?.iosAutoRecordOnboardingBullet2Body ??
-                '"Force-quit" tells iOS to stop relaunching the app. Your '
-                    'trips will stop recording until you open Sparkilo '
-                    'again.',
+            title: l10n.iosAutoRecordOnboardingBullet2Title,
+            body: l10n.iosAutoRecordOnboardingBullet2Body,
           ),
           const SizedBox(height: 16),
           _Bullet(
             number: 3,
-            title: l10n?.iosAutoRecordOnboardingBullet3Title ??
-                'When iOS asks for "Always" location, please say yes.',
-            body: l10n?.iosAutoRecordOnboardingBullet3Body ??
-                'The fallback that records your trip when the OBD2 '
-                    'adapter is slow needs background location. We never '
-                    'share it.',
+            title: l10n.iosAutoRecordOnboardingBullet3Title,
+            body: l10n.iosAutoRecordOnboardingBullet3Body,
           ),
         ],
       ),

--- a/lib/features/setup/presentation/widgets/onboarding_navigation_buttons.dart
+++ b/lib/features/setup/presentation/widgets/onboarding_navigation_buttons.dart
@@ -60,7 +60,7 @@ class OnboardingNavigationButtons extends StatelessWidget {
             TextButton.icon(
               onPressed: isLoading ? null : onBack,
               icon: const Icon(Icons.arrow_back),
-              label: Text(l10n?.onboardingBack ?? 'Back'),
+              label: Text(l10n.onboardingBack),
             )
           else
             const SizedBox(width: 80),
@@ -70,7 +70,7 @@ class OnboardingNavigationButtons extends StatelessWidget {
               padding: const EdgeInsets.only(right: 8),
               child: TextButton(
                 onPressed: isLoading ? null : onSkip,
-                child: Text(l10n?.onboardingSkip ?? 'Skip'),
+                child: Text(l10n.onboardingSkip),
               ),
             ),
           FilledButton.icon(
@@ -83,9 +83,7 @@ class OnboardingNavigationButtons extends StatelessWidget {
                   )
                 : Icon(isLastStep ? Icons.check : Icons.arrow_forward),
             label: Text(
-              isLastStep
-                  ? (l10n?.onboardingFinish ?? 'Get started')
-                  : (l10n?.onboardingNext ?? 'Next'),
+              isLastStep ? (l10n.onboardingFinish) : (l10n.onboardingNext),
             ),
           ),
         ],

--- a/lib/features/setup/presentation/widgets/onboarding_obd2_step.dart
+++ b/lib/features/setup/presentation/widgets/onboarding_obd2_step.dart
@@ -58,8 +58,7 @@ class OnboardingObd2Step extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<OnboardingObd2Step> createState() =>
-      _OnboardingObd2StepState();
+  ConsumerState<OnboardingObd2Step> createState() => _OnboardingObd2StepState();
 }
 
 enum _Phase { initial, connecting, readingVin }
@@ -97,11 +96,7 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
       // later" button — the skip path is still available below the
       // scaffold body.
       setState(() => _phase = _Phase.initial);
-      SnackBarHelper.show(
-        context,
-        l10n?.onboardingObd2ConnectFailed ??
-            "Couldn't connect to the adapter. You can retry or skip.",
-      );
+      SnackBarHelper.show(context, l10n.onboardingObd2ConnectFailed);
       return;
     }
 
@@ -142,7 +137,14 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
     try {
       decoded = await ref.read(decodedVinProvider(vin).future);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'OnboardingObd2Step: VIN decode failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'OnboardingObd2Step: VIN decode failed'},
+        ),
+      );
       decoded = null;
     }
 
@@ -154,9 +156,9 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
       // anything with it. Fall through to manual entry with the VIN
       // stashed so the following step can still pre-fill the VIN text
       // field if it wants to.
-      ref.read(onboardingWizardControllerProvider.notifier).setObd2VinData(
-            VinData(vin: vin, source: VinDataSource.invalid),
-          );
+      ref
+          .read(onboardingWizardControllerProvider.notifier)
+          .setObd2VinData(VinData(vin: vin, source: VinDataSource.invalid));
       widget.onProceed();
       return;
     }
@@ -185,7 +187,16 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
     try {
       await _saveDecodedProfile(decoded);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'OnboardingObd2Step: save decoded profile failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'OnboardingObd2Step: save decoded profile failed',
+          },
+        ),
+      );
     }
     if (!mounted) return;
     widget.onAutoFillSuccess();
@@ -266,8 +277,7 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
           Semantics(
             header: true,
             child: Text(
-              l10n?.onboardingObd2StepTitle ??
-                  'Connect your OBD2 adapter',
+              l10n.onboardingObd2StepTitle,
               style: theme.textTheme.headlineSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -276,10 +286,7 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
           ),
           const SizedBox(height: 12),
           Text(
-            l10n?.onboardingObd2StepBody ??
-                "Plug your OBD2 adapter into the car's port and turn the "
-                    "ignition on. We'll read the VIN and fill in engine "
-                    'details for you.',
+            l10n.onboardingObd2StepBody,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -293,7 +300,7 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
                 const CircularProgressIndicator(),
                 const SizedBox(height: 12),
                 Text(
-                  l10n?.onboardingObd2ReadingVin ?? 'Reading VIN…',
+                  l10n.onboardingObd2ReadingVin,
                   style: theme.textTheme.bodyMedium,
                 ),
               ],
@@ -313,19 +320,16 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
                         : const Icon(Icons.bluetooth),
-                    label: Text(
-                      l10n?.onboardingObd2ConnectButton ?? 'Connect adapter',
-                    ),
+                    label: Text(l10n.onboardingObd2ConnectButton),
                   ),
                 ),
                 const SizedBox(height: 12),
                 TextButton(
                   key: const Key('onboardingObd2SkipButton'),
-                  onPressed:
-                      _phase == _Phase.connecting ? null : widget.onProceed,
-                  child: Text(
-                    l10n?.onboardingObd2SkipButton ?? 'Maybe later',
-                  ),
+                  onPressed: _phase == _Phase.connecting
+                      ? null
+                      : widget.onProceed,
+                  child: Text(l10n.onboardingObd2SkipButton),
                 ),
               ],
             ),

--- a/lib/features/setup/presentation/widgets/preferences_step.dart
+++ b/lib/features/setup/presentation/widgets/preferences_step.dart
@@ -49,7 +49,7 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
           Icon(Icons.tune, size: 48, color: theme.colorScheme.primary),
           const SizedBox(height: 16),
           Text(
-            l10n?.onboardingPreferencesTitle ?? 'Your preferences',
+            l10n.onboardingPreferencesTitle,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -61,10 +61,9 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
           TextField(
             controller: _zipController,
             decoration: InputDecoration(
-              labelText: l10n?.homeZip ?? 'Home postal code',
-              hintText: l10n?.zipCodeHint ?? 'e.g. 10115',
-              helperText: l10n?.onboardingZipHelper ??
-                  'Used when GPS is unavailable',
+              labelText: l10n.homeZip,
+              hintText: l10n.zipCodeHint,
+              helperText: l10n.onboardingZipHelper,
               prefixIcon: const Icon(Icons.home),
               border: const OutlineInputBorder(),
             ),
@@ -73,13 +72,14 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
             // keyboard.
             keyboardType: TextInputType.number,
             onChanged: (value) => notifier.setHomeZipCode(
-                value.trim().isEmpty ? null : value.trim()),
+              value.trim().isEmpty ? null : value.trim(),
+            ),
           ),
           const SizedBox(height: 24),
 
           // Search radius
           Text(
-            '${l10n?.searchRadius ?? 'Radius'}: ${wizardState.defaultSearchRadius.round()} km',
+            '${l10n.searchRadius}: ${wizardState.defaultSearchRadius.round()} km',
             style: theme.textTheme.titleSmall,
           ),
           Slider(
@@ -91,8 +91,7 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
             onChanged: notifier.setDefaultSearchRadius,
           ),
           Text(
-            l10n?.onboardingRadiusHelper ??
-                'Larger radius = more results',
+            l10n.onboardingRadiusHelper,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -102,75 +101,77 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
           // Fuel type — locked to the default vehicle's fuel if one is
           // configured in the previous wizard step (#710). The chips
           // are disabled so the user can't pick a conflicting value.
-          Builder(builder: (_) {
-            final vehicles = ref.watch(vehicleProfileListProvider);
-            final defaultVehicle =
-                vehicles.isNotEmpty ? vehicles.first : null;
-            final derivedFromVehicle =
-                defaultVehicle != null ? _fuelForVehicle(defaultVehicle) : null;
-            // Sync wizard state to the vehicle's fuel so completion
-            // writes the right value to the profile.
-            if (derivedFromVehicle != null &&
-                wizardState.preferredFuelType.runtimeType !=
-                    derivedFromVehicle.runtimeType) {
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                notifier.setPreferredFuelType(derivedFromVehicle);
-              });
-            }
-            final locked = derivedFromVehicle != null;
-            final activeFuel = derivedFromVehicle ?? wizardState.preferredFuelType;
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  l10n?.preferredFuel ?? 'Preferred fuel',
-                  style: theme.textTheme.titleSmall,
-                ),
-                const SizedBox(height: 8),
-                Opacity(
-                  opacity: locked ? 0.5 : 1.0,
-                  child: IgnorePointer(
-                    ignoring: locked,
-                    child: Wrap(
-                      spacing: 8,
-                      runSpacing: 4,
-                      children: [
-                        FuelType.e5,
-                        FuelType.e10,
-                        FuelType.diesel,
-                        FuelType.e98,
-                        FuelType.lpg,
-                        FuelType.e85,
-                        FuelType.electric,
-                      ].map((fuel) {
-                        final selected =
-                            activeFuel.runtimeType == fuel.runtimeType;
-                        return ChoiceChip(
-                          label: Text(fuel.displayName),
-                          selected: selected,
-                          onSelected: locked
-                              ? null
-                              : (_) => notifier.setPreferredFuelType(fuel),
-                        );
-                      }).toList(),
+          Builder(
+            builder: (_) {
+              final vehicles = ref.watch(vehicleProfileListProvider);
+              final defaultVehicle = vehicles.isNotEmpty
+                  ? vehicles.first
+                  : null;
+              final derivedFromVehicle = defaultVehicle != null
+                  ? _fuelForVehicle(defaultVehicle)
+                  : null;
+              // Sync wizard state to the vehicle's fuel so completion
+              // writes the right value to the profile.
+              if (derivedFromVehicle != null &&
+                  wizardState.preferredFuelType.runtimeType !=
+                      derivedFromVehicle.runtimeType) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  notifier.setPreferredFuelType(derivedFromVehicle);
+                });
+              }
+              final locked = derivedFromVehicle != null;
+              final activeFuel =
+                  derivedFromVehicle ?? wizardState.preferredFuelType;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(l10n.preferredFuel, style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 8),
+                  Opacity(
+                    opacity: locked ? 0.5 : 1.0,
+                    child: IgnorePointer(
+                      ignoring: locked,
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children:
+                            [
+                              FuelType.e5,
+                              FuelType.e10,
+                              FuelType.diesel,
+                              FuelType.e98,
+                              FuelType.lpg,
+                              FuelType.e85,
+                              FuelType.electric,
+                            ].map((fuel) {
+                              final selected =
+                                  activeFuel.runtimeType == fuel.runtimeType;
+                              return ChoiceChip(
+                                label: Text(fuel.displayName),
+                                selected: selected,
+                                onSelected: locked
+                                    ? null
+                                    : (_) =>
+                                          notifier.setPreferredFuelType(fuel),
+                              );
+                            }).toList(),
+                      ),
                     ),
                   ),
-                ),
-                if (locked) ...[
-                  const SizedBox(height: 6),
-                  Text(
-                    l10n?.profileFuelFromVehicleHint ??
-                        'Fuel type is derived from your default vehicle. '
-                            'Clear the vehicle to pick a fuel directly.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                      fontStyle: FontStyle.italic,
+                  if (locked) ...[
+                    const SizedBox(height: 6),
+                    Text(
+                      l10n.profileFuelFromVehicleHint,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontStyle: FontStyle.italic,
+                      ),
                     ),
-                  ),
+                  ],
                 ],
-              ],
-            );
-          }),
+              );
+            },
+          ),
           const SizedBox(height: 24),
 
           // Privacy reassurance
@@ -182,13 +183,11 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
             ),
             child: Row(
               children: [
-                Icon(Icons.shield, size: 20,
-                    color: theme.colorScheme.primary),
+                Icon(Icons.shield, size: 20, color: theme.colorScheme.primary),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
-                    l10n?.onboardingPrivacy ??
-                        'These settings are stored only on your device and never shared.',
+                    l10n.onboardingPrivacy,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onPrimaryContainer,
                     ),

--- a/lib/features/setup/presentation/widgets/profile_choice_step.dart
+++ b/lib/features/setup/presentation/widgets/profile_choice_step.dart
@@ -24,10 +24,7 @@ class ProfileChoiceStep extends ConsumerWidget {
   /// been applied). The wizard moves to the next step.
   final VoidCallback onProfilePicked;
 
-  const ProfileChoiceStep({
-    super.key,
-    required this.onProfilePicked,
-  });
+  const ProfileChoiceStep({super.key, required this.onProfilePicked});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -53,9 +50,7 @@ class ProfileChoiceStep extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            l?.wizardProfileChoiceHint ??
-                'Choose how you want to use the app. You can change '
-                    'this later in Settings.',
+            l.wizardProfileChoiceHint,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -65,10 +60,8 @@ class ProfileChoiceStep extends ConsumerWidget {
           _ProfileCard(
             profile: AppProfile.basic,
             icon: Icons.local_gas_station_outlined,
-            title: l?.wizardProfileBasicName ?? 'Basic',
-            description: l?.wizardProfileBasicDescription ??
-                'Cheapest fuel and EV charging prices nearby. '
-                    'Favorites and price alerts.',
+            title: l.wizardProfileBasicName,
+            description: l.wizardProfileBasicDescription,
             isActive: activeProfile == AppProfile.basic,
             onTap: () => _pick(ref, AppProfile.basic),
           ),
@@ -76,10 +69,8 @@ class ProfileChoiceStep extends ConsumerWidget {
           _ProfileCard(
             profile: AppProfile.medium,
             icon: Icons.analytics_outlined,
-            title: l?.wizardProfileMediumName ?? 'Medium',
-            description: l?.wizardProfileMediumDescription ??
-                'Everything in Basic, plus track your fuel fill-ups '
-                    'and EV charging by hand.',
+            title: l.wizardProfileMediumName,
+            description: l.wizardProfileMediumDescription,
             isActive: activeProfile == AppProfile.medium,
             onTap: () => _pick(ref, AppProfile.medium),
           ),
@@ -87,18 +78,14 @@ class ProfileChoiceStep extends ConsumerWidget {
           _ProfileCard(
             profile: AppProfile.full,
             icon: Icons.directions_car_filled,
-            title: l?.wizardProfileFullName ?? 'Full',
-            description: l?.wizardProfileFullDescription ??
-                'Everything in Medium, plus automatic OBD2 trip '
-                    'recording, driving scores, and loyalty cards.',
+            title: l.wizardProfileFullName,
+            description: l.wizardProfileFullDescription,
             isActive: activeProfile == AppProfile.full,
             onTap: () => _pick(ref, AppProfile.full),
           ),
           const SizedBox(height: 16),
           Text(
-            l?.wizardProfileChoiceFooter ??
-                'You can change your choice any time from Settings '
-                    '→ Use mode.',
+            l.wizardProfileChoiceFooter,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
               fontStyle: FontStyle.italic,
@@ -185,11 +172,7 @@ class _ProfileCard extends StatelessWidget {
                         ),
                         if (isActive) ...[
                           const SizedBox(width: 8),
-                          Icon(
-                            Icons.check_circle,
-                            color: brandGreen,
-                            size: 20,
-                          ),
+                          Icon(Icons.check_circle, color: brandGreen, size: 20),
                         ],
                       ],
                     ),

--- a/lib/features/setup/presentation/widgets/setup_header.dart
+++ b/lib/features/setup/presentation/widgets/setup_header.dart
@@ -30,7 +30,7 @@ class SetupHeader extends StatelessWidget {
         Semantics(
           header: true,
           child: Text(
-            l10n?.welcome ?? 'Sparkilo', // i18n-ignore: brand name
+            l10n.welcome, // i18n-ignore: brand name
             style: theme.textTheme.headlineMedium?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -39,7 +39,7 @@ class SetupHeader extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         Text(
-          l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
+          l10n.welcomeSubtitle,
           style: theme.textTheme.bodyLarge,
           textAlign: TextAlign.center,
         ),

--- a/lib/features/setup/presentation/widgets/vehicles_step.dart
+++ b/lib/features/setup/presentation/widgets/vehicles_step.dart
@@ -35,7 +35,7 @@ class VehiclesStep extends ConsumerWidget {
           Semantics(
             header: true,
             child: Text(
-              l10n?.vehiclesWizardTitle ?? 'My vehicles (optional)',
+              l10n.vehiclesWizardTitle,
               style: theme.textTheme.headlineSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -44,9 +44,7 @@ class VehiclesStep extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            l10n?.vehiclesWizardSubtitle ??
-                'Add your car to pre-fill the consumption log and enable '
-                    'EV connector filters. You can skip this and add vehicles later.',
+            l10n.vehiclesWizardSubtitle,
             style: theme.textTheme.bodyMedium,
             textAlign: TextAlign.center,
           ),
@@ -61,13 +59,15 @@ class VehiclesStep extends ConsumerWidget {
                   children: [
                     Row(
                       children: [
-                        Icon(Icons.info_outline,
-                            color: theme.colorScheme.primary, size: 20),
+                        Icon(
+                          Icons.info_outline,
+                          color: theme.colorScheme.primary,
+                          size: 20,
+                        ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            l10n?.vehiclesWizardNoneYet ??
-                                'No vehicle configured yet.',
+                            l10n.vehiclesWizardNoneYet,
                             style: theme.textTheme.bodyMedium,
                           ),
                         ),
@@ -82,8 +82,7 @@ class VehiclesStep extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  l10n?.vehiclesWizardYoursList(vehicles.length) ??
-                      'You have ${vehicles.length} vehicle(s):',
+                  l10n.vehiclesWizardYoursList(vehicles.length),
                   style: theme.textTheme.titleSmall,
                 ),
                 const SizedBox(height: 8),
@@ -101,7 +100,7 @@ class VehiclesStep extends ConsumerWidget {
                       _typeLabel(l10n, v.isEv, v.isCombustion) +
                           _fuelSuffix(v.preferredFuelType) +
                           (isDefault
-                              ? '  •  ${l10n?.wizardVehicleDefaultBadge ?? 'Default'}'
+                              ? '  •  ${l10n.wizardVehicleDefaultBadge}'
                               : ''),
                     ),
                     trailing: const Icon(Icons.edit_outlined),
@@ -126,13 +125,12 @@ class VehiclesStep extends ConsumerWidget {
                 await const EditVehicleRoute().push<void>(context);
               },
               icon: const Icon(Icons.add),
-              label: Text(l10n?.vehicleAdd ?? 'Add vehicle'),
+              label: Text(l10n.vehicleAdd),
             ),
           ),
           const SizedBox(height: 8),
           Text(
-            l10n?.vehiclesWizardSkipHint ??
-                'Skip to finish setup — you can add vehicles anytime from Settings.',
+            l10n.vehiclesWizardSkipHint,
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
               fontStyle: FontStyle.italic,
@@ -143,10 +141,10 @@ class VehiclesStep extends ConsumerWidget {
     );
   }
 
-  String _typeLabel(AppLocalizations? l10n, bool isEv, bool isCombustion) {
-    if (isEv && isCombustion) return l10n?.vehicleTypeHybrid ?? 'Hybrid';
-    if (isEv) return l10n?.vehicleTypeEv ?? 'Electric';
-    return l10n?.vehicleTypeCombustion ?? 'Combustion';
+  String _typeLabel(AppLocalizations l10n, bool isEv, bool isCombustion) {
+    if (isEv && isCombustion) return l10n.vehicleTypeHybrid;
+    if (isEv) return l10n.vehicleTypeEv;
+    return l10n.vehicleTypeCombustion;
   }
 
   String _fuelSuffix(String? fuel) {

--- a/lib/features/setup/presentation/widgets/welcome_step.dart
+++ b/lib/features/setup/presentation/widgets/welcome_step.dart
@@ -22,7 +22,7 @@ class WelcomeStep extends StatelessWidget {
           const FuelPumpIllustration(size: 160),
           const SizedBox(height: 24),
           Text(
-            l10n?.welcome ?? 'Sparkilo', // i18n-ignore: brand name
+            l10n.welcome, // i18n-ignore: brand name
             style: theme.textTheme.headlineLarge?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -30,7 +30,7 @@ class WelcomeStep extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            l10n?.welcomeSubtitle ?? 'Find the cheapest fuel near you.',
+            l10n.welcomeSubtitle,
             style: theme.textTheme.bodyLarge?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -38,8 +38,7 @@ class WelcomeStep extends StatelessWidget {
           ),
           const SizedBox(height: 32),
           Text(
-            l10n?.onboardingWelcomeHint ??
-                'Set up the app in a few quick steps.',
+            l10n.onboardingWelcomeHint,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -49,9 +49,7 @@ class StationDetailScreen extends ConsumerWidget {
         detail: result.data,
         serviceResult: result,
       ),
-      loading: () => const _StationDetailPlain(
-        body: ShimmerStationDetail(),
-      ),
+      loading: () => const _StationDetailPlain(body: ShimmerStationDetail()),
       error: (error, _) => _StationDetailPlain(
         body: ServiceChainErrorWidget(
           error: error,
@@ -78,7 +76,7 @@ class _StationDetailPlain extends StatelessWidget {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         onPressed: () => context.pop(),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
       ),
       bodyPadding: EdgeInsets.zero,
       body: body,
@@ -137,7 +135,7 @@ class _StationDetailLoaded extends StatelessWidget {
             leading: IconButton(
               icon: const Icon(Icons.arrow_back),
               onPressed: () => context.pop(),
-              tooltip: l10n?.tooltipBack ?? 'Back',
+              tooltip: l10n.tooltipBack,
             ),
             actions: [
               StationDetailAppBarActions(
@@ -176,9 +174,7 @@ class _StationDetailLoaded extends StatelessWidget {
               ),
             ),
           ),
-          SliverToBoxAdapter(
-            child: ServiceStatusBanner(result: serviceResult),
-          ),
+          SliverToBoxAdapter(child: ServiceStatusBanner(result: serviceResult)),
           SliverPadding(
             padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
             sliver: SliverList(
@@ -201,4 +197,3 @@ class _StationDetailLoaded extends StatelessWidget {
     );
   }
 }
-

--- a/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
@@ -67,13 +67,10 @@ class StationDetailWideLayout extends StatelessWidget {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         onPressed: () => context.pop(),
-        tooltip: l10n?.tooltipBack ?? 'Back',
+        tooltip: l10n.tooltipBack,
       ),
       actions: [
-        StationDetailAppBarActions(
-          stationId: stationId,
-          station: station,
-        ),
+        StationDetailAppBarActions(stationId: stationId, station: station),
       ],
       bodyPadding: EdgeInsets.zero,
       body: Row(

--- a/lib/features/station_detail/presentation/widgets/opening_hours_format.dart
+++ b/lib/features/station_detail/presentation/widgets/opening_hours_format.dart
@@ -28,69 +28,69 @@ String formatRange(TimeRange r) =>
 /// The localized full weekday name (e.g. "Monday"), falling back to English
 /// when [l10n] is null. [OpeningDay.publicHoliday] maps to the holidays
 /// label.
-String fullDayName(OpeningDay day, AppLocalizations? l10n) {
+String fullDayName(OpeningDay day, AppLocalizations l10n) {
   switch (day) {
     case OpeningDay.mon:
-      return l10n?.dayMon ?? 'Monday';
+      return l10n.dayMon;
     case OpeningDay.tue:
-      return l10n?.dayTue ?? 'Tuesday';
+      return l10n.dayTue;
     case OpeningDay.wed:
-      return l10n?.dayWed ?? 'Wednesday';
+      return l10n.dayWed;
     case OpeningDay.thu:
-      return l10n?.dayThu ?? 'Thursday';
+      return l10n.dayThu;
     case OpeningDay.fri:
-      return l10n?.dayFri ?? 'Friday';
+      return l10n.dayFri;
     case OpeningDay.sat:
-      return l10n?.daySat ?? 'Saturday';
+      return l10n.daySat;
     case OpeningDay.sun:
-      return l10n?.daySun ?? 'Sunday';
+      return l10n.daySun;
     case OpeningDay.publicHoliday:
-      return l10n?.publicHolidays ?? 'Public holidays';
+      return l10n.publicHolidays;
   }
 }
 
 /// The localized abbreviated weekday name (e.g. "Mon"), falling back to
 /// English when [l10n] is null.
-String shortDayName(OpeningDay day, AppLocalizations? l10n) {
+String shortDayName(OpeningDay day, AppLocalizations l10n) {
   switch (day) {
     case OpeningDay.mon:
-      return l10n?.dayShortMon ?? 'Mon';
+      return l10n.dayShortMon;
     case OpeningDay.tue:
-      return l10n?.dayShortTue ?? 'Tue';
+      return l10n.dayShortTue;
     case OpeningDay.wed:
-      return l10n?.dayShortWed ?? 'Wed';
+      return l10n.dayShortWed;
     case OpeningDay.thu:
-      return l10n?.dayShortThu ?? 'Thu';
+      return l10n.dayShortThu;
     case OpeningDay.fri:
-      return l10n?.dayShortFri ?? 'Fri';
+      return l10n.dayShortFri;
     case OpeningDay.sat:
-      return l10n?.dayShortSat ?? 'Sat';
+      return l10n.dayShortSat;
     case OpeningDay.sun:
-      return l10n?.dayShortSun ?? 'Sun';
+      return l10n.dayShortSun;
     case OpeningDay.publicHoliday:
-      return l10n?.publicHolidays ?? 'Public holidays';
+      return l10n.publicHolidays;
   }
 }
 
 /// One day's hours as a single display string: "Closed" / "Open 24 hours" /
 /// the joined intervals (split-shift days joined with " · "), or "Hours
 /// unknown" for a missing/empty/unknown day.
-String dayValueText(DayHours? day, AppLocalizations? l10n) {
+String dayValueText(DayHours? day, AppLocalizations l10n) {
   if (day == null || day.state == DayState.unknown) {
-    return l10n?.openHoursUnknown ?? 'Hours unknown';
+    return l10n.openHoursUnknown;
   }
   switch (day.state) {
     case DayState.closed:
-      return l10n?.closedLabel ?? 'Closed';
+      return l10n.closedLabel;
     case DayState.open24h:
-      return l10n?.open24Hours ?? 'Open 24 hours';
+      return l10n.open24Hours;
     case DayState.openRanges:
       final usable = day.ranges.where((r) => !r.isDegenerate).toList();
       if (usable.isEmpty) {
-        return l10n?.openHoursUnknown ?? 'Hours unknown';
+        return l10n.openHoursUnknown;
       }
       return usable.map(formatRange).join(' · ');
     case DayState.unknown:
-      return l10n?.openHoursUnknown ?? 'Hours unknown';
+      return l10n.openHoursUnknown;
   }
 }

--- a/lib/features/station_detail/presentation/widgets/opening_hours_status_line.dart
+++ b/lib/features/station_detail/presentation/widgets/opening_hours_status_line.dart
@@ -47,11 +47,10 @@ class OpeningHoursStatusLine extends StatelessWidget {
     final Color colour = closingSoon
         ? DarkModeColors.warning(context)
         : (isOpen
-            ? DarkModeColors.success(context)
-            : DarkModeColors.mutedText(context));
+              ? DarkModeColors.success(context)
+              : DarkModeColors.mutedText(context));
 
-    final headline =
-        isOpen ? (l10n?.openNow ?? 'Open') : (l10n?.openNowClosed ?? 'Closed');
+    final headline = isOpen ? (l10n.openNow) : (l10n.openNowClosed);
     final detail = _detailText(status, l10n);
 
     return Row(
@@ -65,23 +64,27 @@ class OpeningHoursStatusLine extends StatelessWidget {
         const SizedBox(width: Spacing.md),
         Flexible(
           child: Text.rich(
-            TextSpan(children: [
-              TextSpan(
-                text: headline,
-                style: theme.textTheme.titleSmall
-                    ?.copyWith(color: colour, fontWeight: FontWeight.w700),
-              ),
-              if (detail != null)
+            TextSpan(
+              children: [
                 TextSpan(
-                  text: ' · $detail',
-                  style: theme.textTheme.bodyMedium,
+                  text: headline,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: colour,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-            ]),
+                if (detail != null)
+                  TextSpan(
+                    text: ' · $detail',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+              ],
+            ),
           ),
         ),
         if (badge24h) ...[
           const SizedBox(width: Spacing.md),
-          _Badge24h(label: l10n?.badge24h ?? '24h'),
+          _Badge24h(label: l10n.badge24h),
         ],
       ],
     );
@@ -89,21 +92,21 @@ class OpeningHoursStatusLine extends StatelessWidget {
 
   /// The "Closes …" / "Opens …" trailing fragment, or `null` when there is
   /// no determinable next change (a 24/7 station).
-  String? _detailText(OpenNowStatus status, AppLocalizations? l10n) {
+  String? _detailText(OpenNowStatus status, AppLocalizations l10n) {
     if (status.nextChangeDay == null || status.nextChangeMinutes == null) {
       return null;
     }
     final time = formatHhmm(status.nextChangeMinutes!);
     if (status.status == OpenStatus.open) {
-      return l10n?.closesAt(time) ?? 'Closes $time';
+      return l10n.closesAt(time);
     }
     // Closed → opens. Same-day vs other-day phrasing.
     final today = openingDayFromIsoWeekday(now.weekday);
     if (status.nextChangeDay == today) {
-      return l10n?.opensToday(time) ?? 'Opens $time';
+      return l10n.opensToday(time);
     }
     final day = shortDayName(status.nextChangeDay!, l10n);
-    return l10n?.opensAt(day, time) ?? 'Opens $day $time';
+    return l10n.opensAt(day, time);
   }
 
   /// True when an open station closes in under an hour (the amber
@@ -129,7 +132,9 @@ class _Badge24h extends StatelessWidget {
     return Container(
       key: const ValueKey('opening-hours-24h-badge'),
       padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.md, vertical: Spacing.xs),
+        horizontal: Spacing.md,
+        vertical: Spacing.xs,
+      ),
       decoration: BoxDecoration(
         color: DarkModeColors.successSurface(context),
         borderRadius: AppRadius.sm,

--- a/lib/features/station_detail/presentation/widgets/opening_hours_view.dart
+++ b/lib/features/station_detail/presentation/widgets/opening_hours_view.dart
@@ -96,63 +96,67 @@ class _OpeningHoursViewState extends State<OpeningHoursView> {
   }
 
   /// True when every regular weekday is [DayState.open24h].
-  bool _isAllDay24h(WeeklyOpeningHours hours) => kRegularWeekdays
-      .every((d) => hours.dayFor(d)?.state == DayState.open24h);
+  bool _isAllDay24h(WeeklyOpeningHours hours) =>
+      kRegularWeekdays.every((d) => hours.dayFor(d)?.state == DayState.open24h);
 
   /// The collapsed week (consecutive identical days grouped) with an
   /// expand affordance; on expand, the full per-day table.
   List<Widget> _buildWeek(
     WeeklyOpeningHours hours,
     DateTime now,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) {
     final today = openingDayFromIsoWeekday(now.weekday);
     final rows = <Widget>[];
 
     if (_expanded) {
       for (final day in kRegularWeekdays) {
-        rows.add(_DayRow(
-          label: fullDayName(day, l10n),
-          value: dayValueText(hours.dayFor(day), l10n),
-          emphasised: day == today,
-        ));
+        rows.add(
+          _DayRow(
+            label: fullDayName(day, l10n),
+            value: dayValueText(hours.dayFor(day), l10n),
+            emphasised: day == today,
+          ),
+        );
       }
     } else {
       for (final group in _groupWeek(hours)) {
-        rows.add(_DayRow(
-          label: _groupLabel(group, l10n),
-          value: dayValueText(group.sample, l10n),
-          emphasised: group.containsDay(today),
-        ));
+        rows.add(
+          _DayRow(
+            label: _groupLabel(group, l10n),
+            value: dayValueText(group.sample, l10n),
+            emphasised: group.containsDay(today),
+          ),
+        );
       }
     }
 
-    rows.add(Align(
-      alignment: AlignmentDirectional.centerStart,
-      child: TextButton(
-        key: const ValueKey('opening-hours-expand-toggle'),
-        onPressed: () => setState(() => _expanded = !_expanded),
-        child: Text(_expanded
-            ? (l10n?.showLessHours ?? 'Show less')
-            : (l10n?.showAllHours ?? 'Show all hours')),
+    rows.add(
+      Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: TextButton(
+          key: const ValueKey('opening-hours-expand-toggle'),
+          onPressed: () => setState(() => _expanded = !_expanded),
+          child: Text(_expanded ? (l10n.showLessHours) : (l10n.showAllHours)),
+        ),
       ),
-    ));
+    );
     return rows;
   }
 
-  String _groupLabel(_DayGroup group, AppLocalizations? l10n) {
+  String _groupLabel(_DayGroup group, AppLocalizations l10n) {
     if (group.from == group.to) return shortDayName(group.from, l10n);
     final from = shortDayName(group.from, l10n);
     final to = shortDayName(group.to, l10n);
-    return l10n?.dayRange(from, to) ?? '$from – $to';
+    return l10n.dayRange(from, to);
   }
 
-  Widget _buildHolidayRow(WeeklyOpeningHours hours, AppLocalizations? l10n) {
+  Widget _buildHolidayRow(WeeklyOpeningHours hours, AppLocalizations l10n) {
     final ph = hours.dayFor(OpeningDay.publicHoliday);
     if (ph == null) return const SizedBox.shrink();
     return _DayRow(
       key: const ValueKey('opening-hours-holiday-row'),
-      label: l10n?.publicHolidays ?? 'Public holidays',
+      label: l10n.publicHolidays,
       value: dayValueText(ph, l10n),
       emphasised: false,
     );
@@ -213,7 +217,7 @@ class _DayGroup {
 
 /// The muted single-line no-data state.
 class _NoDataLine extends StatelessWidget {
-  final AppLocalizations? l10n;
+  final AppLocalizations l10n;
 
   const _NoDataLine({required this.l10n});
 
@@ -225,14 +229,18 @@ class _NoDataLine extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: Spacing.md),
       child: Row(
         children: [
-          Icon(Icons.schedule,
-              size: 18, color: DarkModeColors.mutedText(context)),
+          Icon(
+            Icons.schedule,
+            size: 18,
+            color: DarkModeColors.mutedText(context),
+          ),
           const SizedBox(width: Spacing.lg),
           Expanded(
             child: Text(
-              l10n?.openingHoursNotAvailable ?? 'Opening hours not available',
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: DarkModeColors.mutedText(context)),
+              l10n.openingHoursNotAvailable,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: DarkModeColors.mutedText(context),
+              ),
             ),
           ),
         ],
@@ -243,7 +251,7 @@ class _NoDataLine extends StatelessWidget {
 
 /// The single "Open 24 hours" row shown for an around-the-clock station.
 class _Open24Row extends StatelessWidget {
-  final AppLocalizations? l10n;
+  final AppLocalizations l10n;
 
   const _Open24Row({super.key, required this.l10n});
 
@@ -254,13 +262,13 @@ class _Open24Row extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: Spacing.sm),
       child: Row(
         children: [
-          Icon(Icons.schedule,
-              size: 18, color: DarkModeColors.success(context)),
-          const SizedBox(width: Spacing.lg),
-          Text(
-            l10n?.open24Hours ?? 'Open 24 hours',
-            style: theme.textTheme.bodyMedium,
+          Icon(
+            Icons.schedule,
+            size: 18,
+            color: DarkModeColors.success(context),
           ),
+          const SizedBox(width: Spacing.lg),
+          Text(l10n.open24Hours, style: theme.textTheme.bodyMedium),
         ],
       ),
     );
@@ -270,7 +278,7 @@ class _Open24Row extends StatelessWidget {
 /// The "24/7 automate" indicator: an unattended pump open round-the-clock
 /// alongside the staffed boutique schedule (FR `Automate : 24/24`, #2742).
 class _Automate24Line extends StatelessWidget {
-  final AppLocalizations? l10n;
+  final AppLocalizations l10n;
 
   const _Automate24Line({required this.l10n});
 
@@ -282,11 +290,14 @@ class _Automate24Line extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: Spacing.xs),
       child: Row(
         children: [
-          Icon(Icons.local_gas_station,
-              size: 18, color: DarkModeColors.success(context)),
+          Icon(
+            Icons.local_gas_station,
+            size: 18,
+            color: DarkModeColors.success(context),
+          ),
           const SizedBox(width: Spacing.lg),
           Text(
-            l10n?.openingHoursAutomate24h ?? '24/7 automate',
+            l10n.openingHoursAutomate24h,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: DarkModeColors.success(context),
               fontWeight: FontWeight.w600,

--- a/lib/features/station_detail/presentation/widgets/price_history_foldable.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_foldable.dart
@@ -31,14 +31,9 @@ class PriceHistoryFoldable extends StatelessWidget {
       margin: EdgeInsets.zero,
       clipBehavior: Clip.antiAlias,
       child: ExpansionTile(
-        title: Text(
-          l10n?.priceHistory ?? 'Price History',
-          style: theme.textTheme.titleMedium,
-        ),
+        title: Text(l10n.priceHistory, style: theme.textTheme.titleMedium),
         childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        children: [
-          PriceHistorySection(stationId: stationId, station: station),
-        ],
+        children: [PriceHistorySection(stationId: stationId, station: station)],
       ),
     );
   }

--- a/lib/features/station_detail/presentation/widgets/price_history_section.dart
+++ b/lib/features/station_detail/presentation/widgets/price_history_section.dart
@@ -25,10 +25,15 @@ class PriceHistorySection extends ConsumerStatefulWidget {
   final String stationId;
   final Station station;
 
-  const PriceHistorySection({super.key, required this.stationId, required this.station});
+  const PriceHistorySection({
+    super.key,
+    required this.stationId,
+    required this.station,
+  });
 
   @override
-  ConsumerState<PriceHistorySection> createState() => _PriceHistorySectionState();
+  ConsumerState<PriceHistorySection> createState() =>
+      _PriceHistorySectionState();
 }
 
 class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
@@ -45,17 +50,19 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
     final repo = ref.read(priceHistoryRepositoryProvider);
     final station = widget.station;
 
-    await repo.recordPrice(PriceRecord(
-      stationId: widget.stationId,
-      recordedAt: DateTime.now(),
-      e5: station.e5,
-      e10: station.e10,
-      e98: station.e98,
-      diesel: station.diesel,
-      e85: station.e85,
-      lpg: station.lpg,
-      cng: station.cng,
-    ));
+    await repo.recordPrice(
+      PriceRecord(
+        stationId: widget.stationId,
+        recordedAt: DateTime.now(),
+        e5: station.e5,
+        e10: station.e10,
+        e98: station.e98,
+        diesel: station.diesel,
+        e85: station.e85,
+        lpg: station.lpg,
+        cng: station.cng,
+      ),
+    );
 
     // Guard before touching ref after the await — leaving the screen during
     // recordPrice disposes the widget and Riverpod 3's WidgetRef throws
@@ -84,17 +91,21 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
       final rows = await PriceHistorySync.fetch(widget.stationId);
       if (rows.isNotEmpty && mounted) {
         final storageMgmt = ref.read(storageManagementProvider);
-        final records = rows.map((r) => {
-          'stationId': r['station_id'],
-          'recordedAt': r['recorded_at'],
-          'e5': r['e5'],
-          'e10': r['e10'],
-          'diesel': r['diesel'],
-          'e98': r['e98'],
-          'e85': r['e85'],
-          'lpg': r['lpg'],
-          'cng': r['cng'],
-        }).toList();
+        final records = rows
+            .map(
+              (r) => {
+                'stationId': r['station_id'],
+                'recordedAt': r['recorded_at'],
+                'e5': r['e5'],
+                'e10': r['e10'],
+                'diesel': r['diesel'],
+                'e98': r['e98'],
+                'e85': r['e85'],
+                'lpg': r['lpg'],
+                'cng': r['cng'],
+              },
+            )
+            .toList();
         await storageMgmt.savePriceRecords(widget.stationId, records);
         // #3159 — same #2298 guard as _recordAndLoad: the save above can
         // outlive the widget, and invalidating a dead WidgetRef throws.
@@ -103,7 +114,14 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
         }
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'PriceHistory DB fetch failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'PriceHistory DB fetch failed'},
+        ),
+      );
     }
     if (mounted) setState(() => _fetchedFromDb = true);
   }
@@ -115,7 +133,13 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
     if (!_recorded && history.isEmpty) {
       return const SizedBox(
         height: 120,
-        child: Center(child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))),
+        child: Center(
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
       );
     }
 
@@ -133,7 +157,7 @@ class _PriceHistorySectionState extends ConsumerState<PriceHistorySection> {
           alignment: Alignment.centerRight,
           child: TextButton(
             onPressed: () => PriceHistoryRoute(widget.stationId).push<void>(context),
-            child: Text(AppLocalizations.of(context)?.showAllFuelTypes ?? 'Show all fuel types'),
+            child: Text(AppLocalizations.of(context).showAllFuelTypes),
           ),
         ),
       ],

--- a/lib/features/station_detail/presentation/widgets/station_brand_header.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_header.dart
@@ -70,7 +70,8 @@ class StationBrandHeader extends StatelessWidget {
                 ),
                 if (headingIsBrandOrName)
                   Text(addressLine, style: theme.textTheme.bodyLarge)
-                else if (addressLine != station.street && addressLine.isNotEmpty)
+                else if (addressLine != station.street &&
+                    addressLine.isNotEmpty)
                   // Heading IS the street — still surface postal code +
                   // place on a second line so the user gets the city.
                   Text(
@@ -81,7 +82,7 @@ class StationBrandHeader extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
                     child: Text(
-                      l10n?.independentStation ?? 'Independent station',
+                      l10n.independentStation,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                         fontStyle: FontStyle.italic,

--- a/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
@@ -56,19 +56,21 @@ class StationDetailAppBarActions extends ConsumerWidget {
           onPressed: () {
             final s = station;
             if (s != null) {
-              unawaited(NavigationUtils.openInMaps(
-                s.lat,
-                s.lng,
-                label: hasRealBrand(s) ? s.brand : s.street,
-              ));
+              unawaited(
+                NavigationUtils.openInMaps(
+                  s.lat,
+                  s.lng,
+                  label: hasRealBrand(s) ? s.brand : s.street,
+                ),
+              );
             }
           },
-          tooltip: l10n?.navigate ?? 'Navigate',
+          tooltip: l10n.navigate,
         ),
         IconButton(
           icon: const Icon(Icons.notifications_outlined),
           onPressed: () => _showCreateAlertDialog(context, ref),
-          tooltip: l10n?.createAlert ?? 'Create price alert',
+          tooltip: l10n.createAlert,
         ),
         // #1638 — the scan-payment-QR action is gated on the central
         // Feature enum so it can be toggled per profile.
@@ -77,7 +79,7 @@ class StationDetailAppBarActions extends ConsumerWidget {
             key: const Key('scan_payment_qr'),
             icon: const Icon(Icons.qr_code_scanner),
             onPressed: () => _startScanPayment(context),
-            tooltip: l10n?.scanPayment ?? 'Scan payment QR',
+            tooltip: l10n.scanPayment,
           ),
         // #1638 — the community price-report action is gated on the
         // central Feature enum so it can be toggled per profile.
@@ -86,14 +88,16 @@ class StationDetailAppBarActions extends ConsumerWidget {
             key: const Key('report_price'),
             icon: const Icon(Icons.flag_outlined),
             onPressed: () => ReportRoute(stationId).push<void>(context),
-            tooltip: l10n?.reportPrice ?? 'Report price',
+            tooltip: l10n.reportPrice,
           ),
         IconButton(
           icon: AnimatedFavoriteStar(isFavorite: isFav),
           onPressed: () {
-            unawaited(ref
-                .read(favoritesProvider.notifier)
-                .toggle(stationId, stationData: station));
+            unawaited(
+              ref
+                  .read(favoritesProvider.notifier)
+                  .toggle(stationId, stationData: station),
+            );
           },
           tooltip: isFav ? 'Remove from favorites' : 'Add to favorites',
         ),
@@ -102,7 +106,9 @@ class StationDetailAppBarActions extends ConsumerWidget {
   }
 
   Future<void> _showCreateAlertDialog(
-      BuildContext context, WidgetRef ref) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final detailAsync = ref.read(stationDetailProvider(stationId));
     final s = detailAsync.value?.data.station;
     final stationName = s != null
@@ -123,8 +129,7 @@ class StationDetailAppBarActions extends ConsumerWidget {
       await ref.read(alertProvider.notifier).addAlert(alert);
       if (context.mounted) {
         final l10n = AppLocalizations.of(context);
-        SnackBarHelper.showSuccess(
-            context, l10n?.alertCreated ?? 'Price alert created');
+        SnackBarHelper.showSuccess(context, l10n.alertCreated);
       }
     }
   }
@@ -133,9 +138,9 @@ class StationDetailAppBarActions extends ConsumerWidget {
   /// dispatches to url_launcher / a confirmation dialog / a fallback
   /// sheet based on the [QrPaymentTarget] classification (#587).
   Future<void> _startScanPayment(BuildContext context) async {
-    final raw = await Navigator.of(context).push<String>(
-      MaterialPageRoute(builder: (_) => const QrScannerScreen()),
-    );
+    final raw = await Navigator.of(
+      context,
+    ).push<String>(MaterialPageRoute(builder: (_) => const QrScannerScreen()));
     if (raw == null || !context.mounted) return;
 
     final target = QrPaymentDecoder.decode(raw);
@@ -147,11 +152,7 @@ class StationDetailAppBarActions extends ConsumerWidget {
       case ScanPaymentOutcome.launched:
         break;
       case ScanPaymentOutcome.launchFailed:
-        SnackBarHelper.showError(
-          context,
-          l10n?.qrPaymentLaunchFailed ??
-              'No app available to open this code',
-        );
+        SnackBarHelper.showError(context, l10n.qrPaymentLaunchFailed);
       case ScanPaymentOutcome.confirmEpc:
         final epc = target as QrPaymentEpc;
         final confirmed = await showDialog<bool>(
@@ -165,17 +166,9 @@ class StationDetailAppBarActions extends ConsumerWidget {
             case EpcLaunchOutcome.launched:
               break;
             case EpcLaunchOutcome.copiedToClipboard:
-              SnackBarHelper.showSuccess(
-                context,
-                l10n?.qrPaymentEpcCopied ??
-                    'Bank details copied — paste into your banking app',
-              );
+              SnackBarHelper.showSuccess(context, l10n.qrPaymentEpcCopied);
             case EpcLaunchOutcome.failed:
-              SnackBarHelper.showError(
-                context,
-                l10n?.qrPaymentLaunchFailed ??
-                    'No app available to open this code',
-              );
+              SnackBarHelper.showError(context, l10n.qrPaymentLaunchFailed);
           }
         }
       case ScanPaymentOutcome.unknown:

--- a/lib/features/station_detail/presentation/widgets/station_detail_inline.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_inline.dart
@@ -20,11 +20,7 @@ class StationDetailInline extends ConsumerWidget {
   final String stationId;
   final VoidCallback? onClose;
 
-  const StationDetailInline({
-    super.key,
-    required this.stationId,
-    this.onClose,
-  });
+  const StationDetailInline({super.key, required this.stationId, this.onClose});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -46,7 +42,7 @@ class StationDetailInline extends ConsumerWidget {
                 IconButton(
                   icon: const Icon(Icons.close, size: 20),
                   onPressed: onClose,
-                  tooltip: l10n?.tooltipClose ?? 'Close',
+                  tooltip: l10n.tooltipClose,
                 ),
               Expanded(
                 child: Text(
@@ -68,10 +64,7 @@ class StationDetailInline extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    StationInfoSection(
-                      station: detail.station,
-                      detail: detail,
-                    ),
+                    StationInfoSection(station: detail.station, detail: detail),
                     const SizedBox(height: 16),
                     PriceHistorySection(
                       stationId: stationId,

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -69,10 +69,7 @@ class StationInfoSection extends StatelessWidget {
       children: [
         // Opening times — section + content fully elided when empty.
         if (hasOpeningInfo) ...[
-          SectionHeader(
-            title: l10n?.openingHours ?? 'Opening hours',
-            padding: EdgeInsets.zero,
-          ),
+          SectionHeader(title: l10n.openingHours, padding: EdgeInsets.zero),
           const SizedBox(height: 8),
           // #3198 — evaluate "open now" on the STATION's wall clock, not
           // the device's: weekly hours are local to the pump, so browsing
@@ -80,41 +77,40 @@ class StationInfoSection extends StatelessWidget {
           // status by the timezone gap. Unknown country → device clock.
           OpeningHoursView(
             hours: hours,
-            now: nowInCountry(Countries.countryForStation(
-              id: station.id,
-              lat: station.lat,
-              lng: station.lng,
-            )?.code),
+            now: nowInCountry(
+              Countries.countryForStation(
+                id: station.id,
+                lat: station.lat,
+                lng: station.lng,
+              )?.code,
+            ),
           ),
           const SizedBox(height: 12),
         ],
 
         // Location info
         if (station.department != null || station.region != null) ...[
-          SectionHeader(
-            title: l10n?.zone ?? 'Zone',
-            padding: EdgeInsets.zero,
-          ),
+          SectionHeader(title: l10n.zone, padding: EdgeInsets.zero),
           const SizedBox(height: 8),
           ListTile(
             dense: true,
             leading: const Icon(Icons.map),
-            title: Text([station.department, station.region]
-                .whereType<String>()
-                .join(', ')),
+            title: Text(
+              [
+                station.department,
+                station.region,
+              ].whereType<String>().join(', '),
+            ),
             subtitle: station.stationType == 'A'
-                ? Text(l10n?.highway ?? 'Highway')
-                : Text(l10n?.localStation ?? 'Local station'),
+                ? Text(l10n.highway)
+                : Text(l10n.localStation),
           ),
           const SizedBox(height: 12),
         ],
 
         // Amenities (icon chips) — at the bottom
         if (station.amenities.isNotEmpty) ...[
-          SectionHeader(
-            title: l10n?.amenities ?? 'Amenities',
-            padding: EdgeInsets.zero,
-          ),
+          SectionHeader(title: l10n.amenities, padding: EdgeInsets.zero),
           const SizedBox(height: 8),
           AmenityChips(amenities: station.amenities, maxVisible: 8),
           const SizedBox(height: 12),
@@ -122,10 +118,7 @@ class StationInfoSection extends StatelessWidget {
 
         // Payment methods (inferred from brand — no API data available)
         if (station.brand.trim().isNotEmpty) ...[
-          SectionHeader(
-            title: l10n?.paymentMethods ?? 'Payment methods',
-            padding: EdgeInsets.zero,
-          ),
+          SectionHeader(title: l10n.paymentMethods, padding: EdgeInsets.zero),
           const SizedBox(height: 8),
           PaymentMethodChips(brand: station.brand, maxVisible: 8),
           const SizedBox(height: 8),
@@ -152,7 +145,7 @@ class StationInfoSection extends StatelessWidget {
               title: Semantics(
                 header: true,
                 child: Text(
-                  '${l10n?.services ?? "Services"} '
+                  '${l10n.services} '
                   '(${station.services.length})',
                   style: theme.textTheme.titleMedium,
                 ),
@@ -161,11 +154,18 @@ class StationInfoSection extends StatelessWidget {
                 Wrap(
                   spacing: 6,
                   runSpacing: 4,
-                  children: station.services.map((s) => Chip(
-                        avatar: const Icon(Icons.check_circle_outline, size: 16),
-                        label: Text(s, style: const TextStyle(fontSize: 11)),
-                        visualDensity: VisualDensity.compact,
-                      )).toList(),
+                  children: station.services
+                      .map(
+                        (s) => Chip(
+                          avatar: const Icon(
+                            Icons.check_circle_outline,
+                            size: 16,
+                          ),
+                          label: Text(s, style: const TextStyle(fontSize: 11)),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                      )
+                      .toList(),
                 ),
               ],
             ),

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -44,7 +44,7 @@ class StationPricesSection extends StatelessWidget {
     final isMx = cc == 'MX';
 
     return SectionCard(
-      title: l10n?.prices ?? 'Prices',
+      title: l10n.prices,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -55,8 +55,16 @@ class StationPricesSection extends StatelessWidget {
             price: station.e5,
             fuelType: FuelType.e5,
           ),
-          PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
-          PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
+          PriceTile(
+            label: 'Super E10',
+            price: station.e10,
+            fuelType: FuelType.e10,
+          ),
+          PriceTile(
+            label: 'Diesel',
+            price: station.diesel,
+            fuelType: FuelType.diesel,
+          ),
           if (station.e98 != null)
             PriceTile(
               label: isMx
@@ -95,13 +103,15 @@ class LogFillUpButton extends ConsumerWidget {
     // Fall back to any fuel the station reports if the profile fuel isn't
     // available at this station (e.g. diesel-preferring user at a petrol-only
     // bio station).
-    final pricedFuel = preferredFuel != null &&
-            station.priceFor(preferredFuel) != null
+    final pricedFuel =
+        preferredFuel != null && station.priceFor(preferredFuel) != null
         ? preferredFuel
         : _firstAvailableFuel(station);
-    final pricePerLiter =
-        pricedFuel != null ? station.priceFor(pricedFuel) : null;
-    final stationName = station.brand.isNotEmpty &&
+    final pricePerLiter = pricedFuel != null
+        ? station.priceFor(pricedFuel)
+        : null;
+    final stationName =
+        station.brand.isNotEmpty &&
             station.brand != 'Station' &&
             station.brand != BrandRegistry.independentLabel
         ? station.brand
@@ -119,9 +129,7 @@ class LogFillUpButton extends ConsumerWidget {
         ).push<void>(context));
       },
       icon: const Icon(Icons.local_gas_station_outlined),
-      label: Text(
-        AppLocalizations.of(context)?.addFillUp ?? 'Log fill-up here',
-      ),
+      label: Text(AppLocalizations.of(context).addFillUp),
     );
   }
 

--- a/lib/features/station_detail/presentation/widgets/station_rating_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_rating_section.dart
@@ -27,24 +27,30 @@ class StationRatingSection extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     return SectionCard(
-      title: l10n?.yourRating ?? 'Your rating',
-      child: Consumer(builder: (context, ref, _) {
-        final rating = ref.watch(stationRatingProvider(stationId));
-        return Row(
-          children: [
-            StarRating(
-              rating: rating,
-              onRatingChanged: (stars) {
-                unawaited(ref.read(stationRatingsProvider.notifier).rate(stationId, stars));
-              },
-            ),
-            if (rating != null) ...[
-              const SizedBox(width: 12),
-              Text('$rating/5', style: theme.textTheme.bodyMedium),
+      title: l10n.yourRating,
+      child: Consumer(
+        builder: (context, ref, _) {
+          final rating = ref.watch(stationRatingProvider(stationId));
+          return Row(
+            children: [
+              StarRating(
+                rating: rating,
+                onRatingChanged: (stars) {
+                  unawaited(
+                    ref
+                        .read(stationRatingsProvider.notifier)
+                        .rate(stationId, stars),
+                  );
+                },
+              ),
+              if (rating != null) ...[
+                const SizedBox(width: 12),
+                Text('$rating/5', style: theme.textTheme.bodyMedium),
+              ],
             ],
-          ],
-        );
-      }),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/station_detail/presentation/widgets/station_status_row.dart
+++ b/lib/features/station_detail/presentation/widgets/station_status_row.dart
@@ -47,13 +47,7 @@ class StationStatusRow extends ConsumerWidget {
       null => DarkModeColors.mutedText(context),
     };
 
-    final statusSemantic =
-        l10n?.stationOpenStateSemantic('${station.isOpen}') ??
-            switch (station.isOpen) {
-              true => 'Station is open',
-              false => 'Station is closed',
-              null => 'Open state unknown',
-            };
+    final statusSemantic = l10n.stationOpenStateSemantic('${station.isOpen}');
 
     return Row(
       children: [
@@ -116,14 +110,14 @@ class StationStatusRow extends ConsumerWidget {
   static String _buildStatusText(
     Station station,
     ServiceResult<dynamic> result,
-    AppLocalizations? l10n,
+    AppLocalizations l10n,
   ) {
     final status = switch (station.isOpen) {
-      true => l10n?.open ?? 'Open',
-      false => l10n?.closed ?? 'Closed',
-      null => l10n?.openStateUnknown ?? 'Unknown',
+      true => l10n.open,
+      false => l10n.closed,
+      null => l10n.openStateUnknown,
     };
-    final agoSuffix = l10n?.freshnessAgo ?? 'ago';
+    final agoSuffix = l10n.freshnessAgo;
     final freshness = result.freshnessLabel;
     return '$status — $freshness $agoSuffix';
   }

--- a/lib/features/sync/data/auth_error_mapper.dart
+++ b/lib/features/sync/data/auth_error_mapper.dart
@@ -12,7 +12,7 @@ import '../../../l10n/app_localizations.dart';
 /// Pure function — no Riverpod, no I/O. The full exception is still
 /// expected to be logged by the caller via `errorLogger.log` for
 /// diagnostics; only the user-facing string is sanitized here.
-String friendlyAuthError(Object error, AppLocalizations? l) {
+String friendlyAuthError(Object error, AppLocalizations l) {
   final raw = error.toString();
 
   // Network family: DNS NXDOMAIN, dropped sockets, retryable fetch.
@@ -26,24 +26,20 @@ String friendlyAuthError(Object error, AppLocalizations? l) {
       raw.contains('errno = 7') ||
       raw.contains('Network is unreachable') ||
       raw.contains('Connection refused')) {
-    return l?.authErrorNoNetwork ??
-        'No network connection. Try again later.';
+    return l.authErrorNoNetwork;
   }
 
   // Supabase auth-specific error codes surfaced through AuthException.
   if (raw.contains('invalid_credentials')) {
-    return l?.authErrorInvalidCredentials ??
-        'Invalid email or password. Check your credentials.';
+    return l.authErrorInvalidCredentials;
   }
   if (raw.contains('user_already_exists') ||
       raw.contains('already registered')) {
-    return l?.authErrorUserAlreadyExists ??
-        'This email is already registered. Try signing in instead.';
+    return l.authErrorUserAlreadyExists;
   }
   if (raw.contains('email_not_confirmed')) {
-    return l?.authErrorEmailNotConfirmed ??
-        'Please check your email and confirm your account first.';
+    return l.authErrorEmailNotConfirmed;
   }
 
-  return l?.authErrorGeneric ?? 'Sign-in failed. Please try again.';
+  return l.authErrorGeneric;
 }

--- a/lib/features/sync/presentation/screens/auth_screen.dart
+++ b/lib/features/sync/presentation/screens/auth_screen.dart
@@ -82,18 +82,24 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         if (!mounted) return;
         ref.invalidate(syncStateProvider);
         SnackBarHelper.showSuccess(
-            context,
-            AppLocalizations.of(context)?.connectedAsGuest ??
-                'Connected as guest');
+          context,
+          AppLocalizations.of(context).connectedAsGuest,
+        );
         context.pop();
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-        'where': 'AuthScreen._continueAsGuest: guest sign-in failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.sync,
+          e,
+          st,
+          context: const {
+            'where': 'AuthScreen._continueAsGuest: guest sign-in failed',
+          },
+        ),
+      );
       if (mounted) {
-        form.setError(
-            friendlyAuthError(e, AppLocalizations.of(context)));
+        form.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
     } finally {
       if (mounted) form.setLoading(false);
@@ -117,8 +123,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     }
     if (isSignUp && !PasswordValidator.isValid(password)) {
       final l10n = AppLocalizations.of(context);
-      form.setError(
-          l10n?.passwordTooWeak ?? 'Password does not meet all requirements');
+      form.setError(l10n.passwordTooWeak);
       return;
     }
     if (isSignUp && password != _confirmController.text) {
@@ -128,10 +133,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
 
     form.setLoading(true);
     try {
-      final result = await ref.read(syncStateProvider.notifier).signInWithEmail(
-            email, password,
-            isSignUp: isSignUp,
-          );
+      final result = await ref
+          .read(syncStateProvider.notifier)
+          .signInWithEmail(email, password, isSignUp: isSignUp);
 
       if (mounted) {
         final l10n = AppLocalizations.of(context);
@@ -139,28 +143,28 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
           // Anonymous account upgraded in place but the server requires a
           // confirmation click. The UUID + data are already safe — surface
           // the pending state instead of treating it as success/failure.
-          SnackBarHelper.show(
-              context,
-              l10n?.authConfirmationPending ??
-                  'Almost there — check your email and click the link to '
-                      'finish linking it. Your data is already saved on '
-                      'this account.');
+          SnackBarHelper.show(context, l10n.authConfirmationPending);
         } else {
           SnackBarHelper.showSuccess(
-              context,
-              isSignUp
-                  ? (l10n?.accountCreated ?? 'Account created!')
-                  : (l10n?.signedIn ?? 'Signed in!'));
+            context,
+            isSignUp ? (l10n.accountCreated) : (l10n.signedIn),
+          );
         }
         context.pop();
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-        'where': 'AuthScreen._submitEmail: email auth failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.sync,
+          e,
+          st,
+          context: const {
+            'where': 'AuthScreen._submitEmail: email auth failed',
+          },
+        ),
+      );
       if (mounted) {
-        form.setError(
-            friendlyAuthError(e, AppLocalizations.of(context)));
+        form.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
     } finally {
       if (mounted) form.setLoading(false);
@@ -175,18 +179,24 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
       await ref.read(syncStateProvider.notifier).switchToAnonymous();
       if (mounted) {
         SnackBarHelper.show(
-            context,
-            AppLocalizations.of(context)?.switchedToAnonymous ??
-                'Switched to anonymous session');
+          context,
+          AppLocalizations.of(context).switchedToAnonymous,
+        );
         context.pop();
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-        'where': 'AuthScreen._switchToAnonymous: switch failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.sync,
+          e,
+          st,
+          context: const {
+            'where': 'AuthScreen._switchToAnonymous: switch failed',
+          },
+        ),
+      );
       if (mounted) {
-        form.setError(
-            friendlyAuthError(e, AppLocalizations.of(context)));
+        form.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
     } finally {
       if (mounted) form.setLoading(false);
@@ -202,11 +212,15 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final isEmailUser = syncConfig.hasEmail;
 
     return PageScaffold(
-      title: l10n?.account ?? 'Account',
+      title: l10n.account,
       bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: EdgeInsets.fromLTRB(
-            16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom),
+          16,
+          16,
+          16,
+          16 + MediaQuery.of(context).viewPadding.bottom,
+        ),
         children: [
           if (isEmailUser)
             EmailUserStatusCard(
@@ -253,13 +267,21 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 padding: const EdgeInsets.all(12),
                 child: Row(
                   children: [
-                    Icon(Icons.error_outline,
-                        size: 16, color: theme.colorScheme.error),
+                    Icon(
+                      Icons.error_outline,
+                      size: 16,
+                      color: theme.colorScheme.error,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
-                        child: Text(form.error!,
-                            style: TextStyle(
-                                color: theme.colorScheme.error, fontSize: 12))),
+                      child: Text(
+                        form.error!,
+                        style: TextStyle(
+                          color: theme.colorScheme.error,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -32,7 +32,7 @@ class DataTransparencyScreen extends ConsumerWidget {
     await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)?.rawDataJson ?? 'Raw data (JSON)'),
+        title: Text(AppLocalizations.of(context).rawDataJson),
         content: SizedBox(
           width: double.maxFinite,
           child: SingleChildScrollView(
@@ -45,7 +45,7 @@ class DataTransparencyScreen extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)?.close ?? 'Close'),
+            child: Text(AppLocalizations.of(context).close),
           ),
         ],
       ),
@@ -58,19 +58,17 @@ class DataTransparencyScreen extends ConsumerWidget {
   ) async {
     await Clipboard.setData(ClipboardData(text: _prettyJson(data)));
     if (!context.mounted) return;
-    SnackBarHelper.show(
-      context,
-      AppLocalizations.of(context)?.jsonCopied ?? 'JSON copied to clipboard',
-    );
+    SnackBarHelper.show(context, AppLocalizations.of(context).jsonCopied);
   }
 
   Future<void> _forceSyncAndReload(BuildContext context, WidgetRef ref) async {
-    await ref.read(dataTransparencyControllerProvider.notifier).forceSyncAndReload();
+    await ref
+        .read(dataTransparencyControllerProvider.notifier)
+        .forceSyncAndReload();
     if (!context.mounted) return;
     SnackBarHelper.showSuccess(
       context,
-      AppLocalizations.of(context)?.syncCompleted ??
-          'Sync completed — data refreshed',
+      AppLocalizations.of(context).syncCompleted,
     );
   }
 
@@ -78,22 +76,19 @@ class DataTransparencyScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)?.deleteServerDataConfirm ?? 'Delete all server data?'),
-        content: Text(AppLocalizations.of(context)?.deleteAccountBody ??
-          'This will permanently remove all your favorites, alerts, push '
-          'tokens, and price reports from the server. Your local data will '
-          'not be affected.\n\nThis action cannot be undone.'),
+        title: Text(AppLocalizations.of(context).deleteServerDataConfirm),
+        content: Text(AppLocalizations.of(context).deleteAccountBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: DarkModeColors.error(context),
             ),
             onPressed: () => Navigator.pop(context, true),
-            child: Text(AppLocalizations.of(context)?.deleteEverything ?? 'Delete everything'),
+            child: Text(AppLocalizations.of(context).deleteEverything),
           ),
         ],
       ),
@@ -105,7 +100,7 @@ class DataTransparencyScreen extends ConsumerWidget {
     if (!context.mounted) return;
     SnackBarHelper.showSuccess(
       context,
-      AppLocalizations.of(context)?.allDataDeleted ?? 'All server data deleted',
+      AppLocalizations.of(context).allDataDeleted,
     );
   }
 
@@ -114,19 +109,12 @@ class DataTransparencyScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(
-          l?.forgetAllSyncedTripsConfirmTitle ?? 'Forget all synced trips?',
-        ),
-        content: Text(
-          l?.forgetAllSyncedTripsConfirmBody ??
-              'Every trip summary and detail blob will be removed from the '
-                  "server. Your local trip history on this device won't be "
-                  'affected.\n\nThis action cannot be undone.',
-        ),
+        title: Text(l.forgetAllSyncedTripsConfirmTitle),
+        content: Text(l.forgetAllSyncedTripsConfirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             key: const Key('forget_all_synced_trips_confirm'),
@@ -134,9 +122,7 @@ class DataTransparencyScreen extends ConsumerWidget {
               backgroundColor: DarkModeColors.error(context),
             ),
             onPressed: () => Navigator.pop(context, true),
-            child: Text(
-              l?.forgetAllSyncedTripsConfirmAction ?? 'Forget all',
-            ),
+            child: Text(l.forgetAllSyncedTripsConfirmAction),
           ),
         ],
       ),
@@ -151,28 +137,23 @@ class DataTransparencyScreen extends ConsumerWidget {
         .read(dataTransparencyControllerProvider.notifier)
         .forceSyncAndReload();
     if (!context.mounted) return;
-    SnackBarHelper.showSuccess(
-      context,
-      l?.forgetAllSyncedTripsSuccess ?? 'All synced trips removed from server',
-    );
+    SnackBarHelper.showSuccess(context, l.forgetAllSyncedTripsSuccess);
   }
 
   Future<void> _disconnect(BuildContext context, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)?.disconnectTitle ?? 'Disconnect TankSync?'),
-        content: Text(AppLocalizations.of(context)?.disconnectBody ??
-          'You will be signed out from cloud sync. Your local data remains '
-          'intact. You can reconnect at any time.'),
+        title: Text(AppLocalizations.of(context).disconnectTitle),
+        content: Text(AppLocalizations.of(context).disconnectBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(AppLocalizations.of(context)?.disconnectAction ?? 'Disconnect'),
+            child: Text(AppLocalizations.of(context).disconnectAction),
           ),
         ],
       ),
@@ -191,42 +172,41 @@ class DataTransparencyScreen extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return PageScaffold(
-      title: AppLocalizations.of(context)?.myServerData ?? 'My server data',
+      title: AppLocalizations.of(context).myServerData,
       bodyPadding: EdgeInsets.zero,
       body: uiState.loading
           ? const Center(child: CircularProgressIndicator())
           : uiState.error != null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Text(
-                      uiState.error!,
-                      style: TextStyle(color: theme.colorScheme.error),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                )
-              : ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    AccountInfoCard(syncConfig: syncConfig),
-                    const SizedBox(height: 12),
-                    if (uiState.data != null) ...[
-                      SyncedDataCard(data: uiState.data!),
-                      const SizedBox(height: 16),
-                      DataActionButtons(
-                        loading: uiState.loading,
-                        onSync: () => _forceSyncAndReload(context, ref),
-                        onViewRawJson: () =>
-                            _showRawJson(context, uiState.data!),
-                        onExportJson: () => _exportJson(context, uiState.data!),
-                        onDeleteAll: () => _deleteAllData(context, ref),
-                        onForgetAllTrips: () => _forgetAllTrips(context, ref),
-                        onDisconnect: () => _disconnect(context, ref),
-                      ),
-                    ],
-                  ],
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  uiState.error!,
+                  style: TextStyle(color: theme.colorScheme.error),
+                  textAlign: TextAlign.center,
                 ),
+              ),
+            )
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                AccountInfoCard(syncConfig: syncConfig),
+                const SizedBox(height: 12),
+                if (uiState.data != null) ...[
+                  SyncedDataCard(data: uiState.data!),
+                  const SizedBox(height: 16),
+                  DataActionButtons(
+                    loading: uiState.loading,
+                    onSync: () => _forceSyncAndReload(context, ref),
+                    onViewRawJson: () => _showRawJson(context, uiState.data!),
+                    onExportJson: () => _exportJson(context, uiState.data!),
+                    onDeleteAll: () => _deleteAllData(context, ref),
+                    onForgetAllTrips: () => _forgetAllTrips(context, ref),
+                    onDisconnect: () => _disconnect(context, ref),
+                  ),
+                ],
+              ],
+            ),
     );
   }
 }

--- a/lib/features/sync/presentation/screens/link_device_screen.dart
+++ b/lib/features/sync/presentation/screens/link_device_screen.dart
@@ -36,7 +36,7 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
     final l10n = AppLocalizations.of(context);
 
     return PageScaffold(
-      title: l10n?.linkDeviceScreenTitle ?? 'Link Device',
+      title: l10n.linkDeviceScreenTitle,
       bodyPadding: EdgeInsets.zero,
       body: ListView(
         padding: const EdgeInsets.all(16),
@@ -51,6 +51,3 @@ class _LinkDeviceScreenState extends ConsumerState<LinkDeviceScreen> {
     );
   }
 }
-
-
-

--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -57,13 +57,14 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
   String _titleFor(SyncSetupStep step, SyncMode mode) {
     final l10n = AppLocalizations.of(context);
     return switch (step) {
-      SyncSetupStep.mode => l10n?.syncWizardTitleConnect ?? 'Connect TankSync',
-      SyncSetupStep.credentials => mode == SyncMode.private
-          ? (l10n?.syncSetupTitleYourDatabase ?? 'Your database')
-          : (l10n?.syncSetupTitleJoinGroup ?? 'Join a group'),
-      SyncSetupStep.auth => l10n?.syncSetupTitleAccount ?? 'Your account',
-      SyncSetupStep.adopt => l10n?.syncSetupTitleAccount ?? 'Your account',
-      SyncSetupStep.done => l10n?.syncSuccessTitle ?? 'Successfully connected!',
+      SyncSetupStep.mode => l10n.syncWizardTitleConnect,
+      SyncSetupStep.credentials =>
+        mode == SyncMode.private
+            ? (l10n.syncSetupTitleYourDatabase)
+            : (l10n.syncSetupTitleJoinGroup),
+      SyncSetupStep.auth => l10n.syncSetupTitleAccount,
+      SyncSetupStep.adopt => l10n.syncSetupTitleAccount,
+      SyncSetupStep.done => l10n.syncSuccessTitle,
     };
   }
 
@@ -123,9 +124,16 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-        'where': 'SyncSetupScreen._onAuthSubmit: connect/sign-in failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.sync,
+          e,
+          st,
+          context: const {
+            'where': 'SyncSetupScreen._onAuthSubmit: connect/sign-in failed',
+          },
+        ),
+      );
       if (mounted) {
         ctrl.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
@@ -164,9 +172,16 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       await Future<void>.delayed(const Duration(milliseconds: 1500));
       if (mounted) Navigator.pop(context);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
-        'where': 'SyncSetupScreen._onAdopt: adopt connect/sign-in failed'
-      }));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.sync,
+          e,
+          st,
+          context: const {
+            'where': 'SyncSetupScreen._onAdopt: adopt connect/sign-in failed',
+          },
+        ),
+      );
       if (mounted) {
         ctrl.setError(friendlyAuthError(e, AppLocalizations.of(context)));
       }
@@ -192,9 +207,19 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
           ref.read(syncSetupControllerProvider.notifier).startAdoption(email);
         }
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'QR code parse failed'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.ui,
+            e,
+            st,
+            context: const {'where': 'QR code parse failed'},
+          ),
+        );
         if (mounted) {
-          SnackBarHelper.showError(context, AppLocalizations.of(context)?.invalidQrCode ?? 'Invalid QR code format');
+          SnackBarHelper.showError(
+            context,
+            AppLocalizations.of(context).invalidQrCode,
+          );
         }
       }
     }
@@ -208,7 +233,7 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         onPressed: _onBack,
-        tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
+        tooltip: AppLocalizations.of(context).tooltipBack,
       ),
       bodyPadding: EdgeInsets.zero,
       body: AnimatedSwitcher(
@@ -226,76 +251,77 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
       padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPad),
       children: switch (setup.step) {
         SyncSetupStep.mode => [
-            SyncModeStep(
-              onSelectMode: ctrl.selectMode,
-              onStayOffline: () => Navigator.pop(context),
-            ),
-          ],
+          SyncModeStep(
+            onSelectMode: ctrl.selectMode,
+            onStayOffline: () => Navigator.pop(context),
+          ),
+        ],
         SyncSetupStep.credentials => [
-            ListenableBuilder(
-              listenable: Listenable.merge([_urlController, _keyController]),
-              builder: (context, _) {
-                final canContinue = _urlController.text.trim().isNotEmpty &&
-                    _keyController.text.trim().isNotEmpty;
-                // #1703 — private mode walks the user through creating
-                // their own Supabase database with the guided wizard
-                // flow instead of a bare credentials form. The guide's
-                // final step still collects the URL + key, so an
-                // experienced user can skip ahead and paste existing
-                // credentials.
-                if (setup.selectedMode == SyncMode.private) {
-                  return WizardCreateNew(
-                    currentStep: setup.createDbStep,
-                    urlController: _urlController,
-                    keyController: _keyController,
-                    keyField: AnonKeyField(
-                      controller: _keyController,
-                      showKey: setup.showKey,
-                      onToggleVisibility: ctrl.toggleKeyVisibility,
-                      onChanged: ctrl.touch,
-                    ),
-                    onBack: ctrl.prevCreateDbStep,
-                    onNext: ctrl.nextCreateDbStep,
-                    onContinue: canContinue
-                        ? () => ctrl.goToStep(SyncSetupStep.auth)
-                        : null,
-                  );
-                }
-                return SyncCredentialsStep(
-                  selectedMode: setup.selectedMode,
+          ListenableBuilder(
+            listenable: Listenable.merge([_urlController, _keyController]),
+            builder: (context, _) {
+              final canContinue =
+                  _urlController.text.trim().isNotEmpty &&
+                  _keyController.text.trim().isNotEmpty;
+              // #1703 — private mode walks the user through creating
+              // their own Supabase database with the guided wizard
+              // flow instead of a bare credentials form. The guide's
+              // final step still collects the URL + key, so an
+              // experienced user can skip ahead and paste existing
+              // credentials.
+              if (setup.selectedMode == SyncMode.private) {
+                return WizardCreateNew(
+                  currentStep: setup.createDbStep,
                   urlController: _urlController,
                   keyController: _keyController,
-                  showKey: setup.showKey,
-                  onToggleKeyVisibility: ctrl.toggleKeyVisibility,
-                  onScanQr: _scanQr,
+                  keyField: AnonKeyField(
+                    controller: _keyController,
+                    showKey: setup.showKey,
+                    onToggleVisibility: ctrl.toggleKeyVisibility,
+                    onChanged: ctrl.touch,
+                  ),
+                  onBack: ctrl.prevCreateDbStep,
+                  onNext: ctrl.nextCreateDbStep,
                   onContinue: canContinue
                       ? () => ctrl.goToStep(SyncSetupStep.auth)
                       : null,
-                  // Rebuild handled by ListenableBuilder above; no-op.
-                  onChanged: () {},
                 );
-              },
-            ),
-          ],
+              }
+              return SyncCredentialsStep(
+                selectedMode: setup.selectedMode,
+                urlController: _urlController,
+                keyController: _keyController,
+                showKey: setup.showKey,
+                onToggleKeyVisibility: ctrl.toggleKeyVisibility,
+                onScanQr: _scanQr,
+                onContinue: canContinue
+                    ? () => ctrl.goToStep(SyncSetupStep.auth)
+                    : null,
+                // Rebuild handled by ListenableBuilder above; no-op.
+                onChanged: () {},
+              );
+            },
+          ),
+        ],
         SyncSetupStep.auth => [
-            AuthFormWidget(
-              onSubmit: _onAuthSubmit,
-              isLoading: setup.isLoading,
-              error: setup.error,
-            ),
-          ],
+          AuthFormWidget(
+            onSubmit: _onAuthSubmit,
+            isLoading: setup.isLoading,
+            error: setup.error,
+          ),
+        ],
         SyncSetupStep.adopt => [
-            SyncAdoptionStep(
-              email: setup.adoptEmail ?? '',
-              passwordController: _adoptPasswordController,
-              isLoading: setup.isLoading,
-              error: setup.error,
-              showPassword: setup.showPassword,
-              onTogglePassword: ctrl.togglePasswordVisibility,
-              onJoin: _onAdopt,
-              onUseDifferentAccount: ctrl.cancelAdoption,
-            ),
-          ],
+          SyncAdoptionStep(
+            email: setup.adoptEmail ?? '',
+            passwordController: _adoptPasswordController,
+            isLoading: setup.isLoading,
+            error: setup.error,
+            showPassword: setup.showPassword,
+            onTogglePassword: ctrl.togglePasswordVisibility,
+            onJoin: _onAdopt,
+            onUseDifferentAccount: ctrl.cancelAdoption,
+          ),
+        ],
         SyncSetupStep.done => const [SyncDoneStep()],
       },
     );

--- a/lib/features/sync/presentation/screens/sync_wizard_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_wizard_screen.dart
@@ -112,7 +112,7 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
       title: 'Connect TankSync',
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
-        tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
+        tooltip: AppLocalizations.of(context).tooltipBack,
         onPressed: () {
           if (wizard.mode == SyncWizardMode.choose) {
             Navigator.pop(context);
@@ -200,7 +200,7 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
                 }
               },
               onDone: () {
-                SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.tankSyncConnected ?? 'TankSync connected!');
+                SnackBarHelper.showSuccess(context, AppLocalizations.of(context).tankSyncConnected);
                 Navigator.pop(context);
               },
             ),
@@ -233,7 +233,7 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
         }
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'QR code parse failed'}));
-        SnackBarHelper.showError(context, AppLocalizations.of(context)?.invalidQrCodeTankSync ?? 'Invalid QR code — expected TankSync format');
+        SnackBarHelper.showError(context, AppLocalizations.of(context).invalidQrCodeTankSync);
       }
     }
   }
@@ -350,7 +350,7 @@ class _SyncWizardScreenState extends ConsumerState<SyncWizardScreen> {
     if (schema != null && mounted) {
       final allReady = SchemaVerifier.requiredTables.every((t) => schema[t] == true);
       if (allReady && !outdated) {
-        SnackBarHelper.showSuccess(context, AppLocalizations.of(context)?.tankSyncConnected ?? 'TankSync connected!');
+        SnackBarHelper.showSuccess(context, AppLocalizations.of(context).tankSyncConnected);
         Navigator.pop(context);
       } else {
         _notifier.showSchemaStep(

--- a/lib/features/sync/presentation/widgets/anon_key_field.dart
+++ b/lib/features/sync/presentation/widgets/anon_key_field.dart
@@ -18,6 +18,7 @@ class AnonKeyField extends StatelessWidget {
 
   /// Minimum expected length of a Supabase anon key (JWT token).
   static const minExpectedKeyLength = 200;
+
   /// Safe upper bound for key length validation.
   static const maxKeyLength = 512;
 
@@ -41,27 +42,23 @@ class AnonKeyField extends StatelessWidget {
     Color helperColor = DarkModeColors.warning(context);
     if (keyLen > 0) {
       if (isTooLong) {
-        helperText = l?.anonKeyTooLong(keyLen) ??
-            'Key is too long ($keyLen chars) — check for extra text';
+        helperText = l.anonKeyTooLong(keyLen);
         helperColor = DarkModeColors.error(context);
       } else if (isComplete && isJwtFormat) {
-        helperText = l?.anonKeyLooksCorrect(keyLen) ??
-            'Key looks correct ($keyLen chars)';
+        helperText = l.anonKeyLooksCorrect(keyLen);
         helperColor = DarkModeColors.success(context);
       } else if (!isJwtFormat && keyLen > 10) {
-        helperText = l?.anonKeyShouldBeJwt ??
-            'Key should be a JWT (header.payload.signature)';
+        helperText = l.anonKeyShouldBeJwt;
         helperColor = DarkModeColors.error(context);
       } else {
-        helperText = l?.anonKeyMayBeTruncated(keyLen) ??
-            'Key may be truncated ($keyLen of ~208 expected chars)';
+        helperText = l.anonKeyMayBeTruncated(keyLen);
       }
     }
 
     return TextField(
       controller: controller,
       decoration: InputDecoration(
-        labelText: l?.anonKeyLabel ?? 'Anon Key',
+        labelText: l.anonKeyLabel,
         hintText: 'eyJhbGciOiJIUzI1NiIs...',
         border: const OutlineInputBorder(),
         prefixIcon: const Icon(Icons.key),
@@ -82,20 +79,21 @@ class AnonKeyField extends StatelessWidget {
                 ),
               ),
             IconButton(
-              icon: Icon(showKey ? Icons.visibility_off : Icons.visibility, size: 20),
+              icon: Icon(
+                showKey ? Icons.visibility_off : Icons.visibility,
+                size: 20,
+              ),
               onPressed: onToggleVisibility,
               tooltip: showKey
-                  ? (l?.anonKeyHideTooltip ?? 'Hide key')
-                  : (l?.anonKeyShowTooltip ?? 'Show key to verify'),
+                  ? (l.anonKeyHideTooltip)
+                  : (l.anonKeyShowTooltip),
             ),
           ],
         ),
         helperText: helperText,
         helperMaxLines: 2,
         helperStyle: TextStyle(color: helperColor, fontSize: 11),
-        errorText: isTooLong
-            ? (l?.anonKeyExceedsMax ?? 'Key exceeds maximum length')
-            : null,
+        errorText: isTooLong ? (l.anonKeyExceedsMax) : null,
       ),
       obscureText: !showKey,
       maxLines: showKey ? 3 : 1,

--- a/lib/features/sync/presentation/widgets/auth_form_submit_button.dart
+++ b/lib/features/sync/presentation/widgets/auth_form_submit_button.dart
@@ -48,13 +48,12 @@ class AuthFormSubmitButton extends StatelessWidget {
             ),
       label: Text(
         isLoading
-            ? (l10n?.syncConnectingButton ?? 'Connecting...')
+            ? (l10n.syncConnectingButton)
             : useEmail
-                ? (isSignUp
-                    ? (l10n?.authCreateAccountAndConnect ??
-                        'Create account & connect')
-                    : (l10n?.authSignInAndConnect ?? 'Sign in & connect'))
-                : (l10n?.authConnectAnonymously ?? 'Connect anonymously'),
+            ? (isSignUp
+                  ? (l10n.authCreateAccountAndConnect)
+                  : (l10n.authSignInAndConnect))
+            : (l10n.authConnectAnonymously),
       ),
     );
   }

--- a/lib/features/sync/presentation/widgets/auth_form_widget.dart
+++ b/lib/features/sync/presentation/widgets/auth_form_widget.dart
@@ -30,7 +30,8 @@ class AuthFormWidget extends ConsumerStatefulWidget {
     String? email,
     String? password,
     required bool isSignUp,
-  }) onSubmit;
+  })
+  onSubmit;
   final bool isLoading;
   final String? error;
 
@@ -64,17 +65,16 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
     final email = _emailController.text.trim();
     final password = _passwordController.text;
     if (email.isEmpty) {
-      return l10n?.authPleaseEnterEmail ?? 'Please enter your email';
+      return l10n.authPleaseEnterEmail;
     }
     if (!email.contains('@')) {
-      return l10n?.authInvalidEmail ?? 'Invalid email address';
+      return l10n.authInvalidEmail;
     }
     if (form.isSignUp && !PasswordValidator.isValid(password)) {
-      return l10n?.passwordTooWeak ??
-          'Password does not meet all requirements';
+      return l10n.passwordTooWeak;
     }
     if (form.isSignUp && password != _confirmController.text) {
-      return l10n?.authPasswordsDoNotMatch ?? 'Passwords do not match';
+      return l10n.authPasswordsDoNotMatch;
     }
     return null;
   }
@@ -85,12 +85,14 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
       SnackBarHelper.showError(context, error);
       return;
     }
-    unawaited(widget.onSubmit(
-      isEmail: form.useEmail,
-      email: form.useEmail ? _emailController.text.trim() : null,
-      password: form.useEmail ? _passwordController.text : null,
-      isSignUp: form.isSignUp,
-    ));
+    unawaited(
+      widget.onSubmit(
+        isEmail: form.useEmail,
+        email: form.useEmail ? _emailController.text.trim() : null,
+        password: form.useEmail ? _passwordController.text : null,
+        isSignUp: form.isSignUp,
+      ),
+    );
   }
 
   @override
@@ -104,7 +106,7 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l10n?.syncChooseAccountType ?? 'Choose your account type',
+          l10n.syncChooseAccountType,
           style: theme.textTheme.titleSmall?.copyWith(
             fontWeight: FontWeight.bold,
           ),
@@ -116,12 +118,12 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
           segments: [
             ButtonSegment(
               value: false,
-              label: Text(l10n?.authAnonymousSegment ?? 'Anonymous'),
+              label: Text(l10n.authAnonymousSegment),
               icon: const Icon(Icons.person_outline, size: 18),
             ),
             ButtonSegment(
               value: true,
-              label: Text(l10n?.authEmailSegment ?? 'Email'),
+              label: Text(l10n.authEmailSegment),
               icon: const Icon(Icons.email_outlined, size: 18),
             ),
           ],
@@ -133,10 +135,8 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
         // Description text
         Text(
           form.useEmail
-              ? (l10n?.authEmailDescription ??
-                  'Sign in from any device. Recover your data if your phone is lost.')
-              : (l10n?.authAnonymousDescription ??
-                  'Instant access, no email needed. Data tied to this device.'),
+              ? (l10n.authEmailDescription)
+              : (l10n.authAnonymousDescription),
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -148,7 +148,7 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
           TextField(
             controller: _emailController,
             decoration: InputDecoration(
-              labelText: l10n?.authEmailLabel ?? 'Email',
+              labelText: l10n.authEmailLabel,
               border: const OutlineInputBorder(),
               prefixIcon: const Icon(Icons.email, size: 18),
               isDense: true,
@@ -160,7 +160,7 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
           TextField(
             controller: _passwordController,
             decoration: InputDecoration(
-              labelText: l10n?.authPasswordLabel ?? 'Password',
+              labelText: l10n.authPasswordLabel,
               border: const OutlineInputBorder(),
               prefixIcon: const Icon(Icons.lock, size: 18),
               isDense: true,
@@ -170,8 +170,8 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
                   size: 18,
                 ),
                 tooltip: form.showPassword
-                    ? (l10n?.tooltipHidePassword ?? 'Hide password')
-                    : (l10n?.tooltipShowPassword ?? 'Show password'),
+                    ? (l10n.tooltipHidePassword)
+                    : (l10n.tooltipShowPassword),
                 onPressed: notifier.togglePassword,
               ),
             ),
@@ -181,30 +181,26 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
           if (form.isSignUp)
             ListenableBuilder(
               listenable: _passwordController,
-              builder: (context, _) => PasswordStrengthIndicator(
-                password: _passwordController.text,
-              ),
+              builder: (context, _) =>
+                  PasswordStrengthIndicator(password: _passwordController.text),
             ),
           if (form.isSignUp) ...[
             const SizedBox(height: 10),
             TextField(
               controller: _confirmController,
               decoration: InputDecoration(
-                labelText:
-                    l10n?.authConfirmPasswordLabel ?? 'Confirm password',
+                labelText: l10n.authConfirmPasswordLabel,
                 border: const OutlineInputBorder(),
                 prefixIcon: const Icon(Icons.lock_outline, size: 18),
                 isDense: true,
                 suffixIcon: IconButton(
                   icon: Icon(
-                    form.showConfirm
-                        ? Icons.visibility_off
-                        : Icons.visibility,
+                    form.showConfirm ? Icons.visibility_off : Icons.visibility,
                     size: 18,
                   ),
                   tooltip: form.showConfirm
-                      ? (l10n?.tooltipHidePassword ?? 'Hide password')
-                      : (l10n?.tooltipShowPassword ?? 'Show password'),
+                      ? (l10n.tooltipHidePassword)
+                      : (l10n.tooltipShowPassword),
                   onPressed: notifier.toggleConfirm,
                 ),
               ),
@@ -224,9 +220,8 @@ class _AuthFormWidgetState extends ConsumerState<AuthFormWidget> {
                     },
               child: Text(
                 form.isSignUp
-                    ? (l10n?.syncHaveAccountSignIn ??
-                        'Already have an account? Sign in')
-                    : (l10n?.syncCreateNewAccount ?? 'Create new account'),
+                    ? (l10n.syncHaveAccountSignIn)
+                    : (l10n.syncCreateNewAccount),
                 style: const TextStyle(fontSize: 12),
               ),
             ),

--- a/lib/features/sync/presentation/widgets/auth_info_card.dart
+++ b/lib/features/sync/presentation/widgets/auth_info_card.dart
@@ -17,12 +17,10 @@ class AuthInfoCard extends StatelessWidget {
     final l = AppLocalizations.of(context);
 
     final bullets = <String>[
-      l?.authInfoBenefit1 ??
-          '• Sync favorites, alerts, and saved routes across devices',
-      l?.authInfoBenefit2 ??
-          '• Prepare a route on your phone, use it in your car',
-      l?.authInfoBenefit3 ?? '• No data is shared with third parties',
-      l?.authInfoBenefit4 ?? '• You can delete your account at any time',
+      l.authInfoBenefit1,
+      l.authInfoBenefit2,
+      l.authInfoBenefit3,
+      l.authInfoBenefit4,
     ];
 
     return Card(
@@ -35,15 +33,15 @@ class AuthInfoCard extends StatelessWidget {
               children: [
                 const Icon(Icons.info_outline, size: 18),
                 const SizedBox(width: 8),
-                Text(l?.authInfoTitle ?? 'Why create an account?',
-                    style: theme.textTheme.titleSmall),
+                Text(l.authInfoTitle, style: theme.textTheme.titleSmall),
               ],
             ),
             const SizedBox(height: 8),
             Text(
               bullets.join('\n'),
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),

--- a/lib/features/sync/presentation/widgets/auth_status_cards.dart
+++ b/lib/features/sync/presentation/widgets/auth_status_cards.dart
@@ -36,23 +36,25 @@ class EmailUserStatusCard extends StatelessWidget {
               children: [
                 Row(
                   children: [
-                    Icon(Icons.verified_user,
-                        size: 20, color: theme.colorScheme.primary),
+                    Icon(
+                      Icons.verified_user,
+                      size: 20,
+                      color: theme.colorScheme.primary,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
-                        l10n?.syncSignedInAs(userEmail ?? '') ??
-                            'Signed in as $userEmail',
-                        style: theme.textTheme.titleSmall
-                            ?.copyWith(fontWeight: FontWeight.w600),
+                        l10n.syncSignedInAs(userEmail ?? ''),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
                     ),
                   ],
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  l10n?.syncEmailDescription ??
-                      'Your data syncs across all devices with this email.',
+                  l10n.syncEmailDescription,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -65,10 +67,8 @@ class EmailUserStatusCard extends StatelessWidget {
         Card(
           child: ListTile(
             leading: const Icon(Icons.person_outline),
-            title: Text(
-                l10n?.syncSwitchToAnonymousTitle ?? 'Switch to anonymous'),
-            subtitle: Text(l10n?.syncSwitchToAnonymousDesc ??
-                'Continue without email, new anonymous session'),
+            title: Text(l10n.syncSwitchToAnonymousTitle),
+            subtitle: Text(l10n.syncSwitchToAnonymousDesc),
             trailing: const Icon(Icons.arrow_forward_ios, size: 16),
             onTap: isLoading ? null : onSwitchToAnonymous,
           ),
@@ -99,21 +99,23 @@ class GuestOptionCard extends StatelessWidget {
         Card(
           child: ListTile(
             leading: const Icon(Icons.person_outline),
-            title: Text(l10n?.continueAsGuest ?? 'Continue as guest'),
-            subtitle: Text(
-                l10n?.syncGuestDescription ?? 'Anonymous, no email needed.'),
+            title: Text(l10n.continueAsGuest),
+            subtitle: Text(l10n.syncGuestDescription),
             trailing: const Icon(Icons.arrow_forward_ios, size: 16),
             onTap: isLoading ? null : onContinueAsGuest,
           ),
         ),
         const SizedBox(height: 16),
-        Row(children: [
-          const Expanded(child: Divider()),
-          Padding(
+        Row(
+          children: [
+            const Expanded(child: Divider()),
+            Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(l10n?.syncOrDivider ?? 'or')),
-          const Expanded(child: Divider()),
-        ]),
+              child: Text(l10n.syncOrDivider),
+            ),
+            const Expanded(child: Divider()),
+          ],
+        ),
         const SizedBox(height: 16),
       ],
     );
@@ -130,8 +132,9 @@ class AnonymousStatusCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final idPrefix =
-        (userId != null && userId!.length >= 8) ? userId!.substring(0, 8) : '';
+    final idPrefix = (userId != null && userId!.length >= 8)
+        ? userId!.substring(0, 8)
+        : '';
 
     return Column(
       children: [
@@ -145,10 +148,7 @@ class AnonymousStatusCard extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
-                    l10n?.authGuestLinkPrompt(idPrefix) ??
-                        "You're using a guest account ($idPrefix…). "
-                            'Link an email so your favorites and trips '
-                            'sync to your other devices.',
+                    l10n.authGuestLinkPrompt(idPrefix),
                     style: theme.textTheme.bodySmall,
                   ),
                 ),

--- a/lib/features/sync/presentation/widgets/data_transparency_cards.dart
+++ b/lib/features/sync/presentation/widgets/data_transparency_cards.dart
@@ -25,10 +25,16 @@ class AccountInfoCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(l?.account ?? 'Account', style: theme.textTheme.titleMedium),
+            Text(l.account, style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
-            InfoRow(label: l?.anonymousUuid ?? 'Anonymous UUID', value: syncConfig.userId ?? 'Unknown'),
-            InfoRow(label: l?.server ?? 'Server', value: syncConfig.supabaseUrl ?? 'Unknown'),
+            InfoRow(
+              label: l.anonymousUuid,
+              value: syncConfig.userId ?? 'Unknown',
+            ),
+            InfoRow(
+              label: l.server,
+              value: syncConfig.supabaseUrl ?? 'Unknown',
+            ),
           ],
         ),
       ),
@@ -68,24 +74,36 @@ class SyncedDataCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(l?.syncedData ?? 'Synced data', style: theme.textTheme.titleMedium),
+            Text(l.syncedData, style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
-            InfoRow(label: l?.favorites ?? 'Favorites', value: '${(data['favorites'] as List?)?.length ?? 0}'),
-            InfoRow(label: l?.priceAlerts ?? 'Alerts', value: '${(data['alerts'] as List?)?.length ?? 0}'),
-            InfoRow(label: l?.pushTokens ?? 'Push tokens', value: '${(data['push_tokens'] as List?)?.length ?? 0}'),
-            InfoRow(label: l?.priceReports ?? 'Price reports', value: '${(data['reports'] as List?)?.length ?? 0}'),
+            InfoRow(
+              label: l.favorites,
+              value: '${(data['favorites'] as List?)?.length ?? 0}',
+            ),
+            InfoRow(
+              label: l.priceAlerts,
+              value: '${(data['alerts'] as List?)?.length ?? 0}',
+            ),
+            InfoRow(
+              label: l.pushTokens,
+              value: '${(data['push_tokens'] as List?)?.length ?? 0}',
+            ),
+            InfoRow(
+              label: l.priceReports,
+              value: '${(data['reports'] as List?)?.length ?? 0}',
+            ),
             // #2107 — `trip_summaries` is the canonical row-per-trip
             // count; `trip_details` rolls into Total items / Estimated
             // size below via the generic `_countItems` / `_estimateSize`
             // walk over `data.values`, but the user-facing Trips row
             // only shows the summary count (one per trip).
             InfoRow(
-              label: l?.syncedTrips ?? 'Trips',
+              label: l.syncedTrips,
               value: '${(data['trip_summaries'] as List?)?.length ?? 0}',
             ),
             const Divider(height: 24),
-            InfoRow(label: l?.totalItems ?? 'Total items', value: '${_countItems()}'),
-            InfoRow(label: l?.estimatedSize ?? 'Estimated size', value: _estimateSize()),
+            InfoRow(label: l.totalItems, value: '${_countItems()}'),
+            InfoRow(label: l.estimatedSize, value: _estimateSize()),
           ],
         ),
       ),
@@ -123,19 +141,19 @@ class DataActionButtons extends StatelessWidget {
         FilledButton.icon(
           onPressed: loading ? null : onSync,
           icon: const Icon(Icons.sync),
-          label: Text(l?.syncNow ?? 'Sync now'),
+          label: Text(l.syncNow),
         ),
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onViewRawJson,
           icon: const Icon(Icons.code),
-          label: Text(l?.viewRawJson ?? 'View raw data as JSON'),
+          label: Text(l.viewRawJson),
         ),
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onExportJson,
           icon: const Icon(Icons.copy),
-          label: Text(l?.exportJson ?? 'Export as JSON (clipboard)'),
+          label: Text(l.exportJson),
         ),
         const SizedBox(height: 24),
 
@@ -150,7 +168,7 @@ class DataActionButtons extends StatelessWidget {
           ),
           onPressed: onDeleteAll,
           icon: const Icon(Icons.delete_forever),
-          label: Text(l?.deleteAllServerData ?? 'Delete all server data'),
+          label: Text(l.deleteAllServerData),
         ),
         const SizedBox(height: 8),
         // #1541 — narrower destructive action: wipes only the
@@ -166,15 +184,13 @@ class DataActionButtons extends StatelessWidget {
           ),
           onPressed: onForgetAllTrips,
           icon: const Icon(Icons.history_toggle_off),
-          label: Text(
-            l?.forgetAllSyncedTripsButton ?? 'Forget all synced trips',
-          ),
+          label: Text(l.forgetAllSyncedTripsButton),
         ),
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: onDisconnect,
           icon: const Icon(Icons.link_off),
-          label: Text(l?.disconnectTankSync ?? 'Disconnect TankSync'),
+          label: Text(l.disconnectTankSync),
         ),
       ],
     );
@@ -199,7 +215,9 @@ class InfoRow extends StatelessWidget {
           Flexible(
             child: Text(
               value,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
               textAlign: TextAlign.end,
               overflow: TextOverflow.ellipsis,
             ),

--- a/lib/features/sync/presentation/widgets/email_auth_card.dart
+++ b/lib/features/sync/presentation/widgets/email_auth_card.dart
@@ -57,16 +57,11 @@ class EmailAuthCard extends StatelessWidget {
     // current account (UUID + data preserved, #3079) — frame it that way.
     final linking = isSignUp && linkMode;
     final headingText = linking
-        ? (l10n?.authLinkEmailTitle ?? 'Link an email')
-        : (isSignUp
-            ? (l10n?.createAccount ?? 'Create account')
-            : (l10n?.signIn ?? 'Sign in'));
+        ? (l10n.authLinkEmailTitle)
+        : (isSignUp ? (l10n.createAccount) : (l10n.signIn));
     final subtitleText = linking
-        ? (l10n?.authLinkEmailSubtitle ??
-            'Link an email so your data syncs across devices. '
-                'Your current favorites and trips stay on this account.')
-        : (l10n?.authSyncAcrossDevices ??
-            'Sync data automatically across all your devices.');
+        ? (l10n.authLinkEmailSubtitle)
+        : (l10n.authSyncAcrossDevices);
 
     return Card(
       child: Padding(
@@ -81,8 +76,9 @@ class EmailAuthCard extends StatelessWidget {
                 Expanded(
                   child: Text(
                     headingText,
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
               ],
@@ -90,8 +86,9 @@ class EmailAuthCard extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               subtitleText,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: 16),
 
@@ -99,7 +96,7 @@ class EmailAuthCard extends StatelessWidget {
             TextField(
               controller: emailController,
               decoration: InputDecoration(
-                labelText: l10n?.authEmailLabel ?? 'Email',
+                labelText: l10n.authEmailLabel,
                 border: const OutlineInputBorder(),
                 prefixIcon: const Icon(Icons.email, size: 18),
                 isDense: true,
@@ -113,7 +110,7 @@ class EmailAuthCard extends StatelessWidget {
             TextField(
               controller: passwordController,
               decoration: InputDecoration(
-                labelText: l10n?.authPasswordLabel ?? 'Password',
+                labelText: l10n.authPasswordLabel,
                 border: const OutlineInputBorder(),
                 prefixIcon: const Icon(Icons.lock, size: 18),
                 isDense: true,
@@ -123,8 +120,8 @@ class EmailAuthCard extends StatelessWidget {
                     size: 18,
                   ),
                   tooltip: showPassword
-                      ? (l10n?.tooltipHidePassword ?? 'Hide password')
-                      : (l10n?.tooltipShowPassword ?? 'Show password'),
+                      ? (l10n.tooltipHidePassword)
+                      : (l10n.tooltipShowPassword),
                   onPressed: onTogglePassword,
                 ),
               ),
@@ -143,8 +140,7 @@ class EmailAuthCard extends StatelessWidget {
               TextField(
                 controller: confirmController,
                 decoration: InputDecoration(
-                  labelText:
-                      l10n?.authConfirmPasswordLabel ?? 'Confirm password',
+                  labelText: l10n.authConfirmPasswordLabel,
                   border: const OutlineInputBorder(),
                   prefixIcon: const Icon(Icons.lock_outline, size: 18),
                   isDense: true,
@@ -154,8 +150,8 @@ class EmailAuthCard extends StatelessWidget {
                       size: 18,
                     ),
                     tooltip: showConfirm
-                        ? (l10n?.tooltipHidePassword ?? 'Hide password')
-                        : (l10n?.tooltipShowPassword ?? 'Show password'),
+                        ? (l10n.tooltipHidePassword)
+                        : (l10n.tooltipShowPassword),
                     onPressed: onToggleConfirm,
                   ),
                 ),
@@ -172,23 +168,29 @@ class EmailAuthCard extends StatelessWidget {
                       width: 16,
                       height: 16,
                       child: CircularProgressIndicator(
-                          strokeWidth: 2, color: Colors.white))
-                  : Icon(linking
-                      ? Icons.link
-                      : (isSignUp ? Icons.person_add : Icons.login)),
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : Icon(
+                      linking
+                          ? Icons.link
+                          : (isSignUp ? Icons.person_add : Icons.login),
+                    ),
               label: Text(headingText),
               style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(44)),
+                minimumSize: const Size.fromHeight(44),
+              ),
             ),
             const SizedBox(height: 8),
             Center(
               child: TextButton(
                 onPressed: isLoading ? null : onToggleMode,
-                child: Text(isSignUp
-                    ? (l10n?.syncHaveAccountSignIn ??
-                        'Already have an account? Sign in')
-                    : (l10n?.authNewHereCreateAccount ??
-                        'New here? Create account')),
+                child: Text(
+                  isSignUp
+                      ? (l10n.syncHaveAccountSignIn)
+                      : (l10n.authNewHereCreateAccount),
+                ),
               ),
             ),
             if (error != null) ...[
@@ -222,9 +224,10 @@ class _ErrorBanner extends StatelessWidget {
           Icon(Icons.error_outline, size: 16, color: theme.colorScheme.error),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(error,
-                style:
-                    TextStyle(color: theme.colorScheme.error, fontSize: 12)),
+            child: Text(
+              error,
+              style: TextStyle(color: theme.colorScheme.error, fontSize: 12),
+            ),
           ),
         ],
       ),

--- a/lib/features/sync/presentation/widgets/link_device_how_it_works_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_how_it_works_card.dart
@@ -30,21 +30,16 @@ class LinkDeviceHowItWorksCard extends StatelessWidget {
                 const Icon(Icons.info_outline, size: 20),
                 const SizedBox(width: 8),
                 Text(
-                  l10n?.linkDeviceHowItWorksTitle ?? 'How it works',
-                  style: theme.textTheme.titleSmall
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  l10n.linkDeviceHowItWorksTitle,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 8),
             Text(
-              l10n?.linkDeviceHowItWorksBody ??
-                  '1. On Device A: copy the device code above\n'
-                      '2. On Device B: paste it in the "Device code" field\n'
-                      '3. Tap "Import data" to merge favorites and alerts\n'
-                      '4. Both devices will have all combined data\n\n'
-                      'Each device keeps its own anonymous identity. '
-                      'Data is merged, not moved.',
+              l10n.linkDeviceHowItWorksBody,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/lib/features/sync/presentation/widgets/link_device_import_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_import_card.dart
@@ -41,20 +41,19 @@ class LinkDeviceImportCard extends ConsumerWidget {
                 const Icon(Icons.link, size: 20),
                 const SizedBox(width: 8),
                 Text(
-                  l10n?.linkDeviceImportSectionTitle ??
-                      'Import from another device',
-                  style: theme.textTheme.titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  l10n.linkDeviceImportSectionTitle,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 8),
             Text(
-              l10n?.linkDeviceImportDescription ??
-                  'Enter the device code from your other device to import '
-                      'its favorites and alerts.',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              l10n.linkDeviceImportDescription,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: 12),
             // ListenableBuilder so the submit button enables/disables based
@@ -70,32 +69,34 @@ class LinkDeviceImportCard extends ConsumerWidget {
                     TextField(
                       controller: codeController,
                       decoration: InputDecoration(
-                        labelText:
-                            l10n?.linkDeviceCodeFieldLabel ?? 'Device code',
-                        hintText: l10n?.linkDeviceCodeFieldHint ??
-                            'Paste the UUID from other device',
+                        labelText: l10n.linkDeviceCodeFieldLabel,
+                        hintText: l10n.linkDeviceCodeFieldHint,
                         prefixIcon: const Icon(Icons.key, size: 18),
                         isDense: true,
                         contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
                       ),
                     ),
                     const SizedBox(height: 12),
                     FilledButton.icon(
                       onPressed: (hasText && !uiState.isLinking)
                           ? () => ref
-                              .read(linkDeviceControllerProvider.notifier)
-                              .linkDevice(codeController.text)
+                                .read(linkDeviceControllerProvider.notifier)
+                                .linkDevice(codeController.text)
                           : null,
                       icon: uiState.isLinking
                           ? const SizedBox(
                               width: 16,
                               height: 16,
                               child: CircularProgressIndicator(
-                                  strokeWidth: 2, color: Colors.white))
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
                           : const Icon(Icons.sync),
-                      label: Text(
-                          l10n?.linkDeviceImportButton ?? 'Import data'),
+                      label: Text(l10n.linkDeviceImportButton),
                     ),
                   ],
                 );

--- a/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_this_device_card.dart
@@ -37,23 +37,23 @@ class LinkDeviceThisDeviceCard extends StatelessWidget {
                 const Icon(Icons.smartphone, size: 20),
                 const SizedBox(width: 8),
                 Text(
-                  l10n?.linkDeviceThisDeviceLabel ?? 'This device',
-                  style: theme.textTheme.titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  l10n.linkDeviceThisDeviceLabel,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 12),
             Text(
-              l10n?.linkDeviceShareCodeHint ??
-                  'Share this code with your other device:',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              l10n.linkDeviceShareCodeHint,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: 8),
             Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               decoration: BoxDecoration(
                 color: theme.colorScheme.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(8),
@@ -62,28 +62,30 @@ class LinkDeviceThisDeviceCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: SelectableText(
-                      myId ??
-                          (l10n?.linkDeviceNotConnected ?? 'Not connected'),
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(fontFamily: 'monospace'),
+                      myId ?? (l10n.linkDeviceNotConnected),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontFamily: 'monospace',
+                      ),
                     ),
                   ),
                   if (myId != null)
                     IconButton(
                       icon: const Icon(Icons.copy, size: 18),
-                      tooltip:
-                          l10n?.linkDeviceCopyCodeTooltip ?? 'Copy code',
+                      tooltip: l10n.linkDeviceCopyCodeTooltip,
                       onPressed: () {
-                        unawaited(Clipboard.setData(ClipboardData(text: myId!)));
+                        unawaited(
+                          Clipboard.setData(ClipboardData(text: myId!)),
+                        );
                         SnackBarHelper.show(
                           context,
-                          AppLocalizations.of(context)?.deviceCodeCopied ??
-                              'Device code copied',
+                          AppLocalizations.of(context).deviceCodeCopied,
                         );
                       },
                       padding: EdgeInsets.zero,
                       constraints: const BoxConstraints(
-                          minWidth: 32, minHeight: 32),
+                        minWidth: 32,
+                        minHeight: 32,
+                      ),
                     ),
                 ],
               ),

--- a/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
+++ b/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
@@ -133,7 +133,7 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return PageScaffold(
-      title: l10n?.syncWizardScanQrCode ?? 'Scan QR Code',
+      title: l10n.syncWizardScanQrCode,
       bodyPadding: EdgeInsets.zero,
       actions: _phase == _ScannerPhase.scanning
           ? [
@@ -147,48 +147,40 @@ class _QrScannerScreenState extends State<QrScannerScreen> {
     );
   }
 
-  Widget _buildBody(AppLocalizations? l10n) {
+  Widget _buildBody(AppLocalizations l10n) {
     switch (_phase) {
       case _ScannerPhase.probing:
         return const Center(child: CircularProgressIndicator());
       case _ScannerPhase.denied:
         return QrPermissionDenied(
           key: const Key('qrScannerDenied'),
-          message: l10n?.qrScannerPermissionDenied ??
-              'Camera access is needed to scan QR codes.',
-          buttonLabel: l10n?.qrScannerRetryPermission ?? 'Try again',
+          message: l10n.qrScannerPermissionDenied,
+          buttonLabel: l10n.qrScannerRetryPermission,
           onPressed: _probePermission,
         );
       case _ScannerPhase.permanentlyDenied:
         return QrPermissionDenied(
           key: const Key('qrScannerPermanentlyDenied'),
-          message: l10n?.qrScannerPermissionPermanentlyDenied ??
-              'Camera access was denied. Open settings to grant it.',
-          buttonLabel: l10n?.qrScannerOpenSettings ?? 'Open settings',
+          message: l10n.qrScannerPermissionPermanentlyDenied,
+          buttonLabel: l10n.qrScannerOpenSettings,
           onPressed: widget._permissions.openSettings,
         );
       case _ScannerPhase.timeout:
         return QrScanTimeoutPrompt(
-          message: l10n?.qrScannerTimeout ??
-              'No QR code detected. Move closer or try again.',
-          buttonLabel: l10n?.qrScannerRetry ?? 'Try again',
+          message: l10n.qrScannerTimeout,
+          buttonLabel: l10n.qrScannerRetry,
           onPressed: _retry,
         );
       case _ScannerPhase.scanning:
         return Stack(
           fit: StackFit.expand,
           children: [
-            MobileScanner(
-              controller: _controller,
-              onDetect: _onDetect,
-            ),
+            MobileScanner(controller: _controller, onDetect: _onDetect),
             const QrScanFrameOverlay(),
             Align(
               alignment: Alignment.bottomCenter,
               child: _GuidanceCaption(
-                text: widget.guidance ??
-                    l10n?.qrScannerGuidance ??
-                    'Point the camera at a QR code',
+                text: widget.guidance ?? l10n.qrScannerGuidance,
               ),
             ),
           ],
@@ -236,9 +228,7 @@ class QrScannerTorchButton extends StatelessWidget {
         return IconButton(
           key: const Key('qrScannerTorchToggle'),
           icon: Icon(on ? Icons.flash_on : Icons.flash_off),
-          tooltip: on
-              ? (l10n?.torchOff ?? 'Turn flash off')
-              : (l10n?.torchOn ?? 'Turn flash on'),
+          tooltip: on ? (l10n.torchOff) : (l10n.torchOn),
           onPressed: onToggle,
         );
       },

--- a/lib/features/sync/presentation/widgets/qr_share_widget.dart
+++ b/lib/features/sync/presentation/widgets/qr_share_widget.dart
@@ -31,7 +31,9 @@ class QrShareWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final syncState = ref.watch(syncStateProvider);
-    if (!syncState.isConfigured || syncState.supabaseUrl == null || syncState.supabaseAnonKey == null) {
+    if (!syncState.isConfigured ||
+        syncState.supabaseUrl == null ||
+        syncState.supabaseAnonKey == null) {
       return const SizedBox.shrink();
     }
 
@@ -48,12 +50,13 @@ class QrShareWidget extends ConsumerWidget {
 
     return Column(
       children: [
-        Text(l?.qrShareTitle ?? 'Share your database',
-            style: theme.textTheme.titleSmall),
+        Text(l.qrShareTitle, style: theme.textTheme.titleSmall),
         const SizedBox(height: 8),
         Text(
-          l?.qrShareSubtitle ?? 'Others can scan this QR code to connect',
-          style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          l.qrShareSubtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 16),
@@ -69,10 +72,13 @@ class QrShareWidget extends ConsumerWidget {
         OutlinedButton.icon(
           onPressed: () {
             unawaited(Clipboard.setData(ClipboardData(text: qrData)));
-            SnackBarHelper.show(context, AppLocalizations.of(context)?.connectionDataCopied ?? 'Connection data copied');
+            SnackBarHelper.show(
+              context,
+              AppLocalizations.of(context).connectionDataCopied,
+            );
           },
           icon: const Icon(Icons.copy, size: 16),
-          label: Text(l?.qrShareCopyAsText ?? 'Copy as text'),
+          label: Text(l.qrShareCopyAsText),
         ),
       ],
     );

--- a/lib/features/sync/presentation/widgets/sync_adoption_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_adoption_step.dart
@@ -57,26 +57,26 @@ class SyncAdoptionStep extends StatelessWidget {
             const SizedBox(width: 8),
             Expanded(
               child: Text(
-                l10n?.syncAdoptTitle(email) ?? "Join $email's account",
-                style: theme.textTheme.titleMedium
-                    ?.copyWith(fontWeight: FontWeight.bold),
+                l10n.syncAdoptTitle(email),
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
           ],
         ),
         const SizedBox(height: 8),
         Text(
-          l10n?.syncAdoptSubtitle ??
-              "Sign in with this account's password to share its data "
-                  'across both devices.',
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          l10n.syncAdoptSubtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: 16),
         TextField(
           controller: passwordController,
           decoration: InputDecoration(
-            labelText: l10n?.syncAdoptPasswordLabel ?? 'Account password',
+            labelText: l10n.syncAdoptPasswordLabel,
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.lock, size: 18),
             isDense: true,
@@ -86,8 +86,8 @@ class SyncAdoptionStep extends StatelessWidget {
                 size: 18,
               ),
               tooltip: showPassword
-                  ? (l10n?.tooltipHidePassword ?? 'Hide password')
-                  : (l10n?.tooltipShowPassword ?? 'Show password'),
+                  ? (l10n.tooltipHidePassword)
+                  : (l10n.tooltipShowPassword),
               onPressed: onTogglePassword,
             ),
           ),
@@ -106,20 +106,19 @@ class SyncAdoptionStep extends StatelessWidget {
                   width: 16,
                   height: 16,
                   child: CircularProgressIndicator(
-                      strokeWidth: 2, color: Colors.white),
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
                 )
               : const Icon(Icons.login),
-          label: Text(l10n?.syncAdoptJoinButton ?? 'Join account'),
+          label: Text(l10n.syncAdoptJoinButton),
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(44)),
         ),
         const SizedBox(height: 4),
         Center(
           child: TextButton(
             onPressed: isLoading ? null : onUseDifferentAccount,
-            child: Text(
-              l10n?.syncAdoptUseDifferentAccount ??
-                  'Use a different account instead',
-            ),
+            child: Text(l10n.syncAdoptUseDifferentAccount),
           ),
         ),
       ],

--- a/lib/features/sync/presentation/widgets/sync_credentials_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_credentials_step.dart
@@ -45,33 +45,39 @@ class SyncCredentialsStep extends StatelessWidget {
           FilledButton.icon(
             onPressed: onScanQr,
             icon: const Icon(Icons.qr_code_scanner),
-            label: Text(l10n?.syncWizardScanQrCode ?? 'Scan QR Code'),
-            style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+            label: Text(l10n.syncWizardScanQrCode),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+            ),
           ),
           const SizedBox(height: 6),
           Text(
-            l10n?.syncWizardAskOwnerQrShort ??
-                'Ask the database owner to show their QR code',
-            style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            l10n.syncWizardAskOwnerQrShort,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
-          Row(children: [
-            const Expanded(child: Divider()),
-            Padding(
+          Row(
+            children: [
+              const Expanded(child: Divider()),
+              Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(l10n?.syncWizardOrEnterManually ??
-                    'or enter manually')),
-            const Expanded(child: Divider()),
-          ]),
+                child: Text(l10n.syncWizardOrEnterManually),
+              ),
+              const Expanded(child: Divider()),
+            ],
+          ),
           const SizedBox(height: 16),
         ],
 
         if (selectedMode == SyncMode.private) ...[
           Text(
-            l10n?.syncCredentialsPrivateHint ??
-                'Enter your Supabase project credentials. You can find them in your dashboard under Settings > API.',
-            style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            l10n.syncCredentialsPrivateHint,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 16),
         ],
@@ -79,10 +85,8 @@ class SyncCredentialsStep extends StatelessWidget {
         TextField(
           controller: urlController,
           decoration: InputDecoration(
-            labelText:
-                l10n?.syncCredentialsDatabaseUrlLabel ?? 'Database URL',
-            hintText: l10n?.syncWizardSupabaseUrlHint ??
-                'https://your-project.supabase.co',
+            labelText: l10n.syncCredentialsDatabaseUrlLabel,
+            hintText: l10n.syncWizardSupabaseUrlHint,
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.link, size: 18),
             isDense: true,
@@ -94,10 +98,8 @@ class SyncCredentialsStep extends StatelessWidget {
         TextField(
           controller: keyController,
           decoration: InputDecoration(
-            labelText:
-                l10n?.syncCredentialsAccessKeyLabel ?? 'Access Key',
-            hintText: l10n?.syncCredentialsAccessKeyHint ??
-                'eyJhbGciOiJIUzI1NiIs...',
+            labelText: l10n.syncCredentialsAccessKeyLabel,
+            hintText: l10n.syncCredentialsAccessKeyHint,
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.key, size: 18),
             isDense: true,
@@ -107,16 +109,22 @@ class SyncCredentialsStep extends StatelessWidget {
                 if (keyLen > 0)
                   Padding(
                     padding: const EdgeInsets.only(right: 4),
-                    child: Text('$keyLen', style: TextStyle(fontSize: 10,
-                      color: keyLen >= 200
-                          ? DarkModeColors.success(context)
-                          : DarkModeColors.warning(context))),
+                    child: Text(
+                      '$keyLen',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: keyLen >= 200
+                            ? DarkModeColors.success(context)
+                            : DarkModeColors.warning(context),
+                      ),
+                    ),
                   ),
                 IconButton(
-                  icon: Icon(showKey ? Icons.visibility_off : Icons.visibility, size: 18),
-                  tooltip: showKey
-                      ? (l10n?.hideKey ?? 'Hide key')
-                      : (l10n?.showKey ?? 'Show key'),
+                  icon: Icon(
+                    showKey ? Icons.visibility_off : Icons.visibility,
+                    size: 18,
+                  ),
+                  tooltip: showKey ? (l10n.hideKey) : (l10n.showKey),
                   onPressed: onToggleKeyVisibility,
                 ),
               ],
@@ -128,10 +136,7 @@ class SyncCredentialsStep extends StatelessWidget {
           onChanged: (_) => onChanged(),
         ),
         const SizedBox(height: 20),
-        FilledButton(
-          onPressed: onContinue,
-          child: Text(l10n?.continueButton ?? 'Continue'),
-        ),
+        FilledButton(onPressed: onContinue, child: Text(l10n.continueButton)),
       ],
     );
   }

--- a/lib/features/sync/presentation/widgets/sync_done_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_done_step.dart
@@ -15,9 +15,8 @@ class SyncDoneStep extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final successTitle = l10n?.syncSuccessTitle ?? 'Successfully connected!';
-    final successDescription = l10n?.syncSuccessDescription ??
-        'Your data will now sync automatically.';
+    final successTitle = l10n.syncSuccessTitle;
+    final successDescription = l10n.syncSuccessDescription;
     return Column(
       children: [
         const SizedBox(height: 40),
@@ -42,8 +41,9 @@ class SyncDoneStep extends StatelessWidget {
               const SizedBox(height: 8),
               Text(
                 successDescription,
-                style: theme.textTheme.bodyMedium
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/features/sync/presentation/widgets/sync_mode_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_mode_step.dart
@@ -28,19 +28,15 @@ class SyncModeStep extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    final communityTitle =
-        l10n?.syncModeCommunityTitle ?? 'Sparkilo Community';
-    final communitySubtitle = l10n?.syncModeCommunitySubtitle ??
-        'Share favorites & ratings with all users';
-    final communityPrivacy = l10n?.syncPrivacyShared ?? 'Shared';
-    final privateTitle = l10n?.syncModePrivateTitle ?? 'Private Database';
-    final privateSubtitle = l10n?.syncModePrivateSubtitle ??
-        'Your own Supabase — full data control';
-    final privatePrivacy = l10n?.syncPrivacyPrivate ?? 'Private';
-    final groupTitle = l10n?.syncModeGroupTitle ?? 'Join a Group';
-    final groupSubtitle =
-        l10n?.syncModeGroupSubtitle ?? 'Family or friends shared database';
-    final groupPrivacy = l10n?.syncPrivacyGroup ?? 'Group';
+    final communityTitle = l10n.syncModeCommunityTitle;
+    final communitySubtitle = l10n.syncModeCommunitySubtitle;
+    final communityPrivacy = l10n.syncPrivacyShared;
+    final privateTitle = l10n.syncModePrivateTitle;
+    final privateSubtitle = l10n.syncModePrivateSubtitle;
+    final privatePrivacy = l10n.syncPrivacyPrivate;
+    final groupTitle = l10n.syncModeGroupTitle;
+    final groupSubtitle = l10n.syncModeGroupSubtitle;
+    final groupPrivacy = l10n.syncPrivacyGroup;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -48,16 +44,16 @@ class SyncModeStep extends StatelessWidget {
         Semantics(
           header: true,
           child: Text(
-            l10n?.syncHowToSyncQuestion ?? 'How would you like to sync?',
+            l10n.syncHowToSyncQuestion,
             style: theme.textTheme.titleMedium,
           ),
         ),
         const SizedBox(height: 4),
         Text(
-          l10n?.syncOfflineDescription ??
-              'Your app works fully offline. Cloud sync is optional.',
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          l10n.syncOfflineDescription,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: 20),
         Semantics(
@@ -103,7 +99,7 @@ class SyncModeStep extends StatelessWidget {
           child: TextButton.icon(
             onPressed: onStayOffline,
             icon: const Icon(Icons.signal_wifi_off, size: 16),
-            label: Text(l10n?.syncStayOfflineButton ?? 'Stay offline'),
+            label: Text(l10n.syncStayOfflineButton),
           ),
         ),
       ],

--- a/lib/features/sync/presentation/widgets/wizard_auth_step.dart
+++ b/lib/features/sync/presentation/widgets/wizard_auth_step.dart
@@ -48,18 +48,14 @@ class WizardAuthStep extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          l10n?.syncChooseAccountType ?? 'Choose your account type',
-          style: theme.textTheme.titleMedium,
-        ),
+        Text(l10n.syncChooseAccountType, style: theme.textTheme.titleMedium),
         const SizedBox(height: 16),
 
         // Anonymous
         WizardOptionCard(
           icon: Icons.person_outline,
-          title: l10n?.syncAccountTypeAnonymous ?? 'Anonymous',
-          subtitle: l10n?.syncAccountTypeAnonymousDesc ??
-              'Instant, no email needed. Data tied to this device.',
+          title: l10n.syncAccountTypeAnonymous,
+          subtitle: l10n.syncAccountTypeAnonymousDesc,
           selected: !useEmail,
           onTap: () => onUseEmailChanged(false),
         ),
@@ -68,9 +64,8 @@ class WizardAuthStep extends StatelessWidget {
         // Email
         WizardOptionCard(
           icon: Icons.email_outlined,
-          title: l10n?.syncAccountTypeEmail ?? 'Email Account',
-          subtitle: l10n?.syncAccountTypeEmailDesc ??
-              'Sign in from any device. Recover data if phone is lost.',
+          title: l10n.syncAccountTypeEmail,
+          subtitle: l10n.syncAccountTypeEmailDesc,
           selected: useEmail,
           onTap: () => onUseEmailChanged(true),
         ),
@@ -80,7 +75,7 @@ class WizardAuthStep extends StatelessWidget {
           TextField(
             controller: emailController,
             decoration: InputDecoration(
-              labelText: l10n?.authEmailLabel ?? 'Email',
+              labelText: l10n.authEmailLabel,
               border: const OutlineInputBorder(),
               prefixIcon: const Icon(Icons.email),
             ),
@@ -90,7 +85,7 @@ class WizardAuthStep extends StatelessWidget {
           TextField(
             controller: passwordController,
             decoration: InputDecoration(
-              labelText: l10n?.authPasswordLabel ?? 'Password',
+              labelText: l10n.authPasswordLabel,
               border: const OutlineInputBorder(),
               prefixIcon: const Icon(Icons.lock),
             ),
@@ -104,10 +99,11 @@ class WizardAuthStep extends StatelessWidget {
             alignment: Alignment.centerRight,
             child: TextButton(
               onPressed: onToggleSignUp,
-              child: Text(isSignUp
-                  ? (l10n?.syncHaveAccountSignIn ??
-                      'Already have an account? Sign in')
-                  : (l10n?.syncCreateNewAccount ?? 'Create new account')),
+              child: Text(
+                isSignUp
+                    ? (l10n.syncHaveAccountSignIn)
+                    : (l10n.syncCreateNewAccount),
+              ),
             ),
           ),
         ],
@@ -124,13 +120,17 @@ class WizardAuthStep extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(testSuccess ? Icons.check_circle : Icons.error,
-                      color: testSuccess
-                          ? DarkModeColors.success(context)
-                          : DarkModeColors.error(context),
-                      size: 20),
+                  Icon(
+                    testSuccess ? Icons.check_circle : Icons.error,
+                    color: testSuccess
+                        ? DarkModeColors.success(context)
+                        : DarkModeColors.error(context),
+                    size: 20,
+                  ),
                   const SizedBox(width: 8),
-                  Expanded(child: Text(testResult!, style: theme.textTheme.bodySmall)),
+                  Expanded(
+                    child: Text(testResult!, style: theme.textTheme.bodySmall),
+                  ),
                 ],
               ),
             ),
@@ -143,18 +143,22 @@ class WizardAuthStep extends StatelessWidget {
             Expanded(
               child: OutlinedButton(
                 onPressed: !testing ? onTestConnection : null,
-                child: Text(testing
-                    ? (l10n?.syncTestingConnection ?? 'Testing...')
-                    : (l10n?.syncTestConnection ?? 'Test Connection')),
+                child: Text(
+                  testing
+                      ? (l10n.syncTestingConnection)
+                      : (l10n.syncTestConnection),
+                ),
               ),
             ),
             const SizedBox(width: 12),
             Expanded(
               child: FilledButton(
                 onPressed: !connecting ? onConnect : null,
-                child: Text(connecting
-                    ? (l10n?.syncConnectingButton ?? 'Connecting...')
-                    : (l10n?.syncConnectButton ?? 'Connect')),
+                child: Text(
+                  connecting
+                      ? (l10n.syncConnectingButton)
+                      : (l10n.syncConnectButton),
+                ),
               ),
             ),
           ],

--- a/lib/features/sync/presentation/widgets/wizard_choose_mode.dart
+++ b/lib/features/sync/presentation/widgets/wizard_choose_mode.dart
@@ -34,20 +34,21 @@ class WizardChooseMode extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Row(children: [
-                  Icon(Icons.info_outline, color: theme.colorScheme.primary),
-                  const SizedBox(width: 8),
-                  Text(
-                    l10n?.syncOptionalTitle ?? 'TankSync is optional',
-                    style: theme.textTheme.titleSmall
-                        ?.copyWith(color: theme.colorScheme.primary),
-                  ),
-                ]),
+                Row(
+                  children: [
+                    Icon(Icons.info_outline, color: theme.colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Text(
+                      l10n.syncOptionalTitle,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                ),
                 const SizedBox(height: 8),
                 Text(
-                  l10n?.syncOptionalDescription ??
-                      'Your app works fully without cloud sync. TankSync lets you sync '
-                          'favorites, alerts, and ratings across devices using Supabase (free tier available).',
+                  l10n.syncOptionalDescription,
                   style: theme.textTheme.bodyMedium,
                 ),
               ],
@@ -56,18 +57,14 @@ class WizardChooseMode extends StatelessWidget {
         ),
         const SizedBox(height: 24),
 
-        Text(
-          l10n?.syncHowToConnectQuestion ?? 'How would you like to connect?',
-          style: theme.textTheme.titleMedium,
-        ),
+        Text(l10n.syncHowToConnectQuestion, style: theme.textTheme.titleMedium),
         const SizedBox(height: 16),
 
         // Option 1: Create new
         WizardOptionCard(
           icon: Icons.add_circle_outline,
-          title: l10n?.syncCreateOwnTitle ?? 'Create my own database',
-          subtitle: l10n?.syncCreateOwnSubtitle ??
-              'Free Supabase project — we\'ll guide you step by step',
+          title: l10n.syncCreateOwnTitle,
+          subtitle: l10n.syncCreateOwnSubtitle,
           onTap: onCreateNew,
         ),
         const SizedBox(height: 12),
@@ -75,9 +72,8 @@ class WizardChooseMode extends StatelessWidget {
         // Option 2: Join existing
         WizardOptionCard(
           icon: Icons.qr_code_scanner,
-          title: l10n?.syncJoinExistingTitle ?? 'Join an existing database',
-          subtitle: l10n?.syncJoinExistingSubtitle ??
-              'Scan QR code from the database owner or paste credentials',
+          title: l10n.syncJoinExistingTitle,
+          subtitle: l10n.syncJoinExistingSubtitle,
           onTap: onJoinExisting,
         ),
       ],

--- a/lib/features/sync/presentation/widgets/wizard_create_new.dart
+++ b/lib/features/sync/presentation/widgets/wizard_create_new.dart
@@ -45,9 +45,11 @@ class WizardCreateNew extends StatelessWidget {
         const SizedBox(height: 16),
 
         Text(
-            l10n?.syncWizardStepOfSteps(currentStep + 1, steps.length + 1) ??
-                'Step ${currentStep + 1} of ${steps.length + 1}',
-            style: theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.primary)),
+          l10n.syncWizardStepOfSteps(currentStep + 1, steps.length + 1),
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.primary,
+          ),
+        ),
         const SizedBox(height: 8),
         Text(step.title, style: theme.textTheme.titleMedium),
         const SizedBox(height: 16),
@@ -62,7 +64,10 @@ class WizardCreateNew extends StatelessWidget {
 
         if (step.actionUrl != null)
           OutlinedButton.icon(
-            onPressed: () => launchUrl(Uri.parse(step.actionUrl!), mode: LaunchMode.externalApplication),
+            onPressed: () => launchUrl(
+              Uri.parse(step.actionUrl!),
+              mode: LaunchMode.externalApplication,
+            ),
             icon: const Icon(Icons.open_in_new),
             label: Text(step.actionLabel),
           ),
@@ -73,10 +78,8 @@ class WizardCreateNew extends StatelessWidget {
           TextField(
             controller: urlController,
             decoration: InputDecoration(
-              labelText:
-                  l10n?.syncWizardSupabaseUrlLabel ?? 'Supabase URL',
-              hintText: l10n?.syncWizardSupabaseUrlHint ??
-                  'https://your-project.supabase.co',
+              labelText: l10n.syncWizardSupabaseUrlLabel,
+              hintText: l10n.syncWizardSupabaseUrlHint,
               border: const OutlineInputBorder(),
               prefixIcon: const Icon(Icons.link),
             ),
@@ -91,17 +94,14 @@ class WizardCreateNew extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             if (currentStep > 0)
-              TextButton(
-                onPressed: onBack,
-                child: Text(l10n?.syncWizardBack ?? 'Back'),
-              )
+              TextButton(onPressed: onBack, child: Text(l10n.syncWizardBack))
             else
               const SizedBox(),
             FilledButton(
               onPressed: currentStep < 2 ? onNext : onContinue,
-              child: Text(currentStep < 2
-                  ? (l10n?.syncWizardNext ?? 'Next')
-                  : (l10n?.continueButton ?? 'Continue')),
+              child: Text(
+                currentStep < 2 ? (l10n.syncWizardNext) : (l10n.continueButton),
+              ),
             ),
           ],
         ),
@@ -109,37 +109,23 @@ class WizardCreateNew extends StatelessWidget {
     );
   }
 
-  static List<_GuideStep> _guideSteps(AppLocalizations? l10n) => [
+  static List<_GuideStep> _guideSteps(AppLocalizations l10n) => [
     _GuideStep(
-      title: l10n?.syncWizardCreateSupabaseTitle ?? 'Create a Supabase project',
-      instructions: l10n?.syncWizardCreateSupabaseInstructions ??
-          '1. Tap "Open Supabase" below\n'
-              '2. Create a free account (if you don\'t have one)\n'
-              '3. Click "New Project"\n'
-              '4. Choose a name and region\n'
-              '5. Wait ~2 minutes for it to start',
-      actionLabel: l10n?.syncWizardOpenSupabase ?? 'Open Supabase',
+      title: l10n.syncWizardCreateSupabaseTitle,
+      instructions: l10n.syncWizardCreateSupabaseInstructions,
+      actionLabel: l10n.syncWizardOpenSupabase,
       actionUrl: 'https://supabase.com/dashboard/new',
     ),
     _GuideStep(
-      title: l10n?.syncWizardEnableAnonTitle ?? 'Enable Anonymous Sign-ins',
-      instructions: l10n?.syncWizardEnableAnonInstructions ??
-          '1. In your Supabase dashboard:\n'
-              '   Authentication → Providers\n'
-              '2. Find "Anonymous Sign-ins"\n'
-              '3. Toggle it ON\n'
-              '4. Click "Save"',
-      actionLabel: l10n?.syncWizardOpenAuthSettings ?? 'Open Auth Settings',
+      title: l10n.syncWizardEnableAnonTitle,
+      instructions: l10n.syncWizardEnableAnonInstructions,
+      actionLabel: l10n.syncWizardOpenAuthSettings,
       actionUrl: null,
     ),
     _GuideStep(
-      title: l10n?.syncWizardCopyCredentialsTitle ?? 'Copy your credentials',
-      instructions: l10n?.syncWizardCopyCredentialsInstructions ??
-          '1. Go to Settings → API in your dashboard\n'
-              '2. Copy the "Project URL"\n'
-              '3. Copy the "anon public" key\n'
-              '4. Paste them below',
-      actionLabel: l10n?.syncWizardOpenApiSettings ?? 'Open API Settings',
+      title: l10n.syncWizardCopyCredentialsTitle,
+      instructions: l10n.syncWizardCopyCredentialsInstructions,
+      actionLabel: l10n.syncWizardOpenApiSettings,
       actionUrl: null,
     ),
   ];
@@ -150,5 +136,10 @@ class _GuideStep {
   final String instructions;
   final String actionLabel;
   final String? actionUrl;
-  const _GuideStep({required this.title, required this.instructions, required this.actionLabel, this.actionUrl});
+  const _GuideStep({
+    required this.title,
+    required this.instructions,
+    required this.actionLabel,
+    this.actionUrl,
+  });
 }

--- a/lib/features/sync/presentation/widgets/wizard_join_existing.dart
+++ b/lib/features/sync/presentation/widgets/wizard_join_existing.dart
@@ -30,59 +30,61 @@ class WizardJoinExisting extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-            l10n?.syncWizardJoinExistingTitle ?? 'Join an existing database',
-            style: theme.textTheme.titleMedium),
+          l10n.syncWizardJoinExistingTitle,
+          style: theme.textTheme.titleMedium,
+        ),
         const SizedBox(height: 16),
 
         // QR Scanner
         FilledButton.icon(
           onPressed: onScanQr,
           icon: const Icon(Icons.qr_code_scanner),
-          label: Text(l10n?.syncWizardScanQrCode ?? 'Scan QR Code'),
+          label: Text(l10n.syncWizardScanQrCode),
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
         ),
         const SizedBox(height: 8),
         Text(
-          l10n?.syncWizardAskOwnerQr ??
-              'Ask the database owner to show you their QR code\n(Settings → TankSync → Share)',
-          style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          l10n.syncWizardAskOwnerQr,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           textAlign: TextAlign.center,
         ),
 
         const SizedBox(height: 24),
-        Row(children: [
-          const Expanded(child: Divider()),
-          Padding(
+        Row(
+          children: [
+            const Expanded(child: Divider()),
+            Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(l10n?.syncOrDivider ?? 'or')),
-          const Expanded(child: Divider()),
-        ]),
+              child: Text(l10n.syncOrDivider),
+            ),
+            const Expanded(child: Divider()),
+          ],
+        ),
         const SizedBox(height: 24),
 
         // Manual entry
-        Text(l10n?.syncWizardEnterManuallyTitle ?? 'Enter manually',
-            style: theme.textTheme.titleSmall),
+        Text(
+          l10n.syncWizardEnterManuallyTitle,
+          style: theme.textTheme.titleSmall,
+        ),
         const SizedBox(height: 12),
         TextField(
           controller: urlController,
           decoration: InputDecoration(
-            labelText: l10n?.syncWizardSupabaseUrlLabel ?? 'Supabase URL',
-            hintText: l10n?.syncWizardSupabaseUrlHint ??
-                'https://your-project.supabase.co',
+            labelText: l10n.syncWizardSupabaseUrlLabel,
+            hintText: l10n.syncWizardSupabaseUrlHint,
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.link),
-            helperText: l10n?.syncWizardUrlHelperText ??
-                'Whitespace and line breaks removed automatically',
+            helperText: l10n.syncWizardUrlHelperText,
           ),
           maxLines: 1,
         ),
         const SizedBox(height: 12),
         keyField,
         const SizedBox(height: 24),
-        FilledButton(
-          onPressed: onContinue,
-          child: Text(l10n?.continueButton ?? 'Continue'),
-        ),
+        FilledButton(onPressed: onContinue, child: Text(l10n.continueButton)),
       ],
     );
   }

--- a/lib/features/sync/presentation/widgets/wizard_schema_step.dart
+++ b/lib/features/sync/presentation/widgets/wizard_schema_step.dart
@@ -41,8 +41,9 @@ class WizardSchemaStep extends StatelessWidget {
       return const Center(child: CircularProgressIndicator());
     }
 
-    final tablesReady =
-        SchemaVerifier.requiredTables.every((t) => schemaStatus![t] == true);
+    final tablesReady = SchemaVerifier.requiredTables.every(
+      (t) => schemaStatus![t] == true,
+    );
     // Outdated schema must be treated like "not ready": the wizard still
     // needs the self-hoster to re-run the SQL before sync is safe.
     final allReady = tablesReady && !schemaOutdated;
@@ -59,27 +60,27 @@ class WizardSchemaStep extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         Text(
-          allReady
-              ? (l10n?.syncDatabaseReady ?? 'Database ready!')
-              : (l10n?.syncDatabaseNeedsSetup ?? 'Database needs setup'),
+          allReady ? (l10n.syncDatabaseReady) : (l10n.syncDatabaseNeedsSetup),
           style: theme.textTheme.titleMedium,
           textAlign: TextAlign.center,
         ),
         if (tablesReady && schemaOutdated) ...[
           const SizedBox(height: 8),
           Text(
-            l10n?.syncSchemaOutdated ??
-                'Your TankSync schema is outdated — re-run the setup SQL '
-                    'below to enable the latest synced features.',
-            style: theme.textTheme.bodySmall
-                ?.copyWith(color: DarkModeColors.warning(context)),
+            l10n.syncSchemaOutdated,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: DarkModeColors.warning(context),
+            ),
             textAlign: TextAlign.center,
           ),
         ],
         const SizedBox(height: 16),
 
         // Table status list
-        for (final table in [...SchemaVerifier.requiredTables, ...SchemaVerifier.optionalTables])
+        for (final table in [
+          ...SchemaVerifier.requiredTables,
+          ...SchemaVerifier.optionalTables,
+        ])
           ListTile(
             dense: true,
             leading: Icon(
@@ -92,8 +93,8 @@ class WizardSchemaStep extends StatelessWidget {
             title: Text(table, style: theme.textTheme.bodySmall),
             trailing: Text(
               schemaStatus![table] == true
-                  ? (l10n?.syncTableStatusOk ?? 'OK')
-                  : (l10n?.syncTableStatusMissing ?? 'Missing'),
+                  ? (l10n.syncTableStatusOk)
+                  : (l10n.syncTableStatusMissing),
               style: TextStyle(
                 fontSize: 11,
                 color: schemaStatus![table] == true
@@ -106,37 +107,34 @@ class WizardSchemaStep extends StatelessWidget {
         if (!allReady) ...[
           const SizedBox(height: 16),
           Text(
-            l10n?.syncSqlEditorInstructions ??
-                'Copy the SQL below and run it in your Supabase SQL Editor\n'
-                    '(Dashboard → SQL Editor → New Query → Paste → Run)',
-            style: theme.textTheme.bodySmall
-                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            l10n.syncSqlEditorInstructions,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 12),
           FilledButton.icon(
             onPressed: () {
-              unawaited(Clipboard.setData(ClipboardData(text: migrationSql ?? '')));
-              SnackBarHelper.show(context,
-                  l10n?.sqlCopied ?? 'SQL copied to clipboard');
+              unawaited(
+                Clipboard.setData(ClipboardData(text: migrationSql ?? '')),
+              );
+              SnackBarHelper.show(context, l10n.sqlCopied);
             },
             icon: const Icon(Icons.copy),
-            label: Text(l10n?.syncCopySqlButton ?? 'Copy SQL to clipboard'),
+            label: Text(l10n.syncCopySqlButton),
           ),
           const SizedBox(height: 8),
           OutlinedButton.icon(
             onPressed: onRecheck,
             icon: const Icon(Icons.refresh),
-            label: Text(l10n?.syncRecheckSchemaButton ?? 'Re-check schema'),
+            label: Text(l10n.syncRecheckSchemaButton),
           ),
         ],
 
         if (allReady) ...[
           const SizedBox(height: 24),
-          FilledButton(
-            onPressed: onDone,
-            child: Text(l10n?.syncDoneButton ?? 'Done'),
-          ),
+          FilledButton(onPressed: onDone, child: Text(l10n.syncDoneButton)),
         ],
       ],
     );

--- a/lib/features/vehicle/domain/services/service_reminder_evaluator.dart
+++ b/lib/features/vehicle/domain/services/service_reminder_evaluator.dart
@@ -3,38 +3,32 @@
 
 import 'dart:async';
 
-
 import '../../../../core/notifications/notification_service.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../data/repositories/service_reminder_repository.dart';
 import '../entities/service_reminder.dart';
 import 'service_reminder_trigger.dart';
 import '../../../../core/logging/error_logger.dart';
 
-/// Copy of the strings the notification renders. Dart doesn't have
-/// test-time locale resolution for background isolates, so the
-/// evaluator accepts the already-localised title/body pair from the
-/// caller (the provider reads from the active [AppLocalizations]
-/// before invoking `evaluate`).
+/// Copy of the strings the notification renders. The evaluator accepts
+/// the already-localised title/body pair from the caller; context-free
+/// callers (the fill-up save hook) build it via [fromL10n] with a
+/// `lookupAppLocalizations` resolve (the #2766 pattern, #3162) — never
+/// an English fallback table.
 class ServiceReminderMessages {
   final String title;
   final String Function({required String label, required int kmOver}) bodyFor;
 
-  const ServiceReminderMessages({
-    required this.title,
-    required this.bodyFor,
-  });
+  const ServiceReminderMessages({required this.title, required this.bodyFor});
 
-  /// English fallback used when the UI has no [AppLocalizations]
-  /// handy (background isolates, unit tests).
-  static const fallback = ServiceReminderMessages(
-    title: 'Service due',
-    bodyFor: _fallbackBody,
-  );
-
-  static String _fallbackBody({required String label, required int kmOver}) {
-    if (kmOver <= 0) return '$label is due now.';
-    return '$label is due — $kmOver km past the interval.';
-  }
+  /// Builds the localized bundle from [l] (#3162).
+  factory ServiceReminderMessages.fromL10n(AppLocalizations l) =>
+      ServiceReminderMessages(
+        title: l.serviceReminderDueTitle,
+        bodyFor: ({required String label, required int kmOver}) => kmOver <= 0
+            ? l.serviceReminderDueNowBody(label)
+            : l.serviceReminderDueBody(label, kmOver),
+      );
 }
 
 /// Coordinates the three layers of the #584 reminder flow:
@@ -51,9 +45,15 @@ class ServiceReminderEvaluator {
   final NotificationService notifications;
   final ServiceReminderTrigger trigger;
 
+  /// Localized notification copy, injected by the provider (#3162) —
+  /// built there via `lookupAppLocalizations` (the #2766 pattern) so
+  /// the context-free fill-up save hook never falls back to English.
+  final ServiceReminderMessages messages;
+
   const ServiceReminderEvaluator({
     required this.repository,
     required this.notifications,
+    required this.messages,
     this.trigger = const ServiceReminderTrigger(),
   });
 
@@ -75,8 +75,9 @@ class ServiceReminderEvaluator {
   Future<List<ServiceReminder>> evaluate({
     required String vehicleId,
     required double currentOdometerKm,
-    ServiceReminderMessages messages = ServiceReminderMessages.fallback,
+    ServiceReminderMessages? messages,
   }) async {
+    final copy = messages ?? this.messages;
     final all = repository.getForVehicle(vehicleId);
     final triggered = trigger.findTriggered(
       vehicleId: vehicleId,
@@ -93,20 +94,38 @@ class ServiceReminderEvaluator {
       try {
         await repository.save(updated);
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ServiceReminderEvaluator: failed to persist flag'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.other,
+            e,
+            st,
+            context: const {
+              'where': 'ServiceReminderEvaluator: failed to persist flag',
+            },
+          ),
+        );
         continue;
       }
       try {
         await notifications.showServiceReminder(
           id: notificationIdFor(reminder.id),
-          title: messages.title,
-          body: messages.bodyFor(
+          title: copy.title,
+          body: copy.bodyFor(
             label: reminder.label,
             kmOver: reminder.kmOverdue(currentOdometerKm).round(),
           ),
         );
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ServiceReminderEvaluator: notification failed'}));
+        unawaited(
+          errorLogger.log(
+            ErrorLayer.other,
+            e,
+            st,
+            context: const {
+              'where': 'ServiceReminderEvaluator: notification failed',
+            },
+          ),
+        );
       }
       fired.add(updated);
     }

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -262,7 +262,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     if (v == null || v.trim().isEmpty) return null;
     final parsed = double.tryParse(v.trim().replaceAll(',', '.'));
     if (parsed != null) return null;
-    return AppLocalizations.of(context)?.fieldInvalidNumber ?? 'Invalid number';
+    return AppLocalizations.of(context).fieldInvalidNumber;
   }
 
   Future<void> _save() async {
@@ -335,7 +335,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     final vin = _ctrl.vinController.text.trim();
     if (vin.isEmpty) {
       SnackBarHelper.show(
-          context, l?.vinInvalidFormat ?? 'Invalid VIN format');
+          context, l.vinInvalidFormat);
       return;
     }
 
@@ -354,8 +354,8 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       SnackBarHelper.showError(
         context,
         decoded == null
-            ? (l?.vinDecodeError ?? "Couldn't decode this VIN")
-            : (l?.vinInvalidFormat ?? 'Invalid VIN format'),
+            ? (l.vinDecodeError)
+            : (l.vinInvalidFormat),
       );
       return;
     }
@@ -407,10 +407,8 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     }
 
     final message = result.failure == ObdVinFailureReason.unsupported
-        ? (l?.vehicleReadVinFailedUnsupportedSnackbar ??
-            'VIN not available (Mode 09 PID 02 unsupported on pre-2005 vehicles)')
-        : (l?.vehicleReadVinFailedGenericSnackbar ??
-            'VIN read failed — please enter manually');
+        ? (l.vehicleReadVinFailedUnsupportedSnackbar)
+        : (l.vehicleReadVinFailedGenericSnackbar);
     SnackBarHelper.show(context, message);
   }
 
@@ -524,10 +522,9 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     final l = AppLocalizations.of(context);
     SnackBarHelper.show(
       context,
-      l?.vehicleDetectedFromVinSnackbar(summary) ??
-          'Detected from VIN: $summary. Apply?',
+      l.vehicleDetectedFromVinSnackbar(summary),
       action: SnackBarAction(
-        label: l?.vehicleDetectedFromVinApply ?? 'Apply',
+        label: l.vehicleDetectedFromVinApply,
         onPressed: () => _applyDetectedConflicts(updated),
       ),
     );
@@ -647,12 +644,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       onPopInvokedWithResult: _onPopInvoked,
       child: PageScaffold(
       title: isEdit
-          ? (l?.vehicleEditTitle ?? 'Edit vehicle')
-          : (l?.vehicleAddTitle ?? 'Add vehicle'),
+          ? (l.vehicleEditTitle)
+          : (l.vehicleAddTitle),
       actions: [
         IconButton(
           icon: const Icon(Icons.check),
-          tooltip: l?.save ?? 'Save',
+          tooltip: l.save,
           onPressed: _save,
         ),
       ],
@@ -682,13 +679,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
                 onPressed: _openCatalogPicker,
                 icon: const Icon(Icons.directions_car_outlined),
                 label: Text(
-                  l?.pickerButtonLabel ?? 'Pick from catalog',
+                  l.pickerButtonLabel,
                 ),
               ),
               const SizedBox(height: 4),
               Text(
-                l?.pickerHelpText ??
-                    'Pre-fill from 50+ supported vehicles',
+                l.pickerHelpText,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context)
                           .colorScheme

--- a/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
+++ b/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
@@ -23,7 +23,7 @@ class VehicleListScreen extends ConsumerWidget {
     final active = ref.watch(activeVehicleProfileProvider);
 
     return PageScaffold(
-      title: l?.vehiclesTitle ?? 'My vehicles',
+      title: l.vehiclesTitle,
       bodyPadding: EdgeInsets.zero,
       body: vehicles.isEmpty
           ? Column(
@@ -31,18 +31,9 @@ class VehicleListScreen extends ConsumerWidget {
                 HelpBanner(
                   storageKey: StorageKeys.helpBannerVehicles,
                   icon: Icons.tips_and_updates_outlined,
-                  message: l?.helpBannerVehicles ??
-                      'Add your vehicles so fill-ups and fuel preferences '
-                          'default correctly. The first vehicle becomes '
-                          'your default.',
+                  message: l.helpBannerVehicles,
                 ),
-                Expanded(
-                  child: _EmptyState(
-                    message: l?.vehiclesEmptyMessage ??
-                        'Add your car to filter by connector and estimate '
-                            'charging costs.',
-                  ),
-                ),
+                Expanded(child: _EmptyState(message: l.vehiclesEmptyMessage)),
               ],
             )
           : ListView.separated(
@@ -59,10 +50,7 @@ class VehicleListScreen extends ConsumerWidget {
                   return HelpBanner(
                     storageKey: StorageKeys.helpBannerVehicles,
                     icon: Icons.tips_and_updates_outlined,
-                    message: l?.helpBannerVehicles ??
-                        'Add your vehicles so fill-ups and fuel preferences '
-                            'default correctly. The first vehicle becomes '
-                            'your default.',
+                    message: l.helpBannerVehicles,
                   );
                 }
                 final v = vehicles[index - 1];
@@ -81,7 +69,7 @@ class VehicleListScreen extends ConsumerWidget {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => const EditVehicleRoute().push<void>(context),
         icon: const Icon(Icons.add),
-        label: Text(l?.vehicleAdd ?? 'Add vehicle'),
+        label: Text(l.vehicleAdd),
       ),
     );
   }
@@ -100,17 +88,16 @@ class VehicleListScreen extends ConsumerWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(l?.vehicleDeleteTitle ?? 'Delete vehicle?'),
-        content: Text(l?.vehicleDeleteMessage(name) ??
-            'Remove "$name" from your profiles?'),
+        title: Text(l.vehicleDeleteTitle),
+        content: Text(l.vehicleDeleteMessage(name)),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l?.delete ?? 'Delete'),
+            child: Text(l.delete),
           ),
         ],
       ),

--- a/lib/features/vehicle/presentation/widgets/auto_record_section.dart
+++ b/lib/features/vehicle/presentation/widgets/auto_record_section.dart
@@ -112,12 +112,21 @@ class AutoRecordSection extends ConsumerWidget {
     // an empty card keeps the surrounding form rendering.
     VehicleProfile profile;
     try {
-      profile = ref.watch(vehicleProfileListProvider).firstWhere(
+      profile = ref
+          .watch(vehicleProfileListProvider)
+          .firstWhere(
             (v) => v.id == vehicleId,
             orElse: () => const VehicleProfile(id: '', name: ''),
           );
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AutoRecordSection: profile lookup failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'AutoRecordSection: profile lookup failed'},
+        ),
+      );
       return const SizedBox.shrink();
     }
 
@@ -128,7 +137,7 @@ class AutoRecordSection extends ConsumerWidget {
     }
 
     return SectionCard(
-      title: l?.autoRecordSectionTitle ?? 'Auto-record',
+      title: l.autoRecordSectionTitle,
       leadingIcon: Icons.smart_toy_outlined,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -136,7 +145,7 @@ class AutoRecordSection extends ConsumerWidget {
           SwitchListTile(
             key: const Key('autoRecordToggle'),
             contentPadding: EdgeInsets.zero,
-            title: Text(l?.autoRecordToggleLabel ?? 'Auto-record trips'),
+            title: Text(l.autoRecordToggleLabel),
             value: profile.autoRecord,
             onChanged: (next) =>
                 _persist(ref, profile.copyWith(autoRecord: next)),
@@ -152,8 +161,7 @@ class AutoRecordSection extends ConsumerWidget {
             const SizedBox(height: 16),
             _SpeedThresholdSlider(
               value: profile.movementStartThresholdKmh,
-              label: l?.autoRecordSpeedThresholdLabel ??
-                  'Start speed (km/h)',
+              label: l.autoRecordSpeedThresholdLabel,
               onChangeEnd: (v) => _persistWithFeedback(
                 context,
                 ref,
@@ -164,8 +172,7 @@ class AutoRecordSection extends ConsumerWidget {
             const SizedBox(height: 16),
             _SaveDelaySlider(
               value: profile.disconnectSaveDelaySec,
-              label: l?.autoRecordSaveDelayLabel ??
-                  'Save delay after disconnect (seconds)',
+              label: l.autoRecordSaveDelayLabel,
               onChangeEnd: (v) => _persistWithFeedback(
                 context,
                 ref,
@@ -179,10 +186,8 @@ class AutoRecordSection extends ConsumerWidget {
             const SizedBox(height: 16),
             _BackgroundLocationRow(
               consent: profile.backgroundLocationConsent,
-              label: l?.autoRecordBackgroundLocationLabel ??
-                  'Background location allowed',
-              requestLabel: l?.autoRecordBackgroundLocationRequest ??
-                  'Request permission',
+              label: l.autoRecordBackgroundLocationLabel,
+              requestLabel: l.autoRecordBackgroundLocationRequest,
               theme: theme,
               onRequest: () => _handleBackgroundLocationRequest(
                 context: context,
@@ -190,10 +195,8 @@ class AutoRecordSection extends ConsumerWidget {
                 profile: profile,
                 l: l,
               ),
-              onShowExplanation: () => _showConsentExplanationDialog(
-                context: context,
-                l: l,
-              ),
+              onShowExplanation: () =>
+                  _showConsentExplanationDialog(context: context, l: l),
               onRevoke: () => (openSettings ?? _defaultOpenSettings)(),
             ),
           ],
@@ -211,19 +214,24 @@ class AutoRecordSection extends ConsumerWidget {
   Future<void> _persistWithFeedback(
     BuildContext context,
     WidgetRef ref,
-    AppLocalizations? l,
+    AppLocalizations l,
     VehicleProfile next,
   ) async {
     try {
       await _persist(ref, next);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'AutoRecordSection._persistWithFeedback'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {'where': 'AutoRecordSection._persistWithFeedback'},
+        ),
+      );
       if (!context.mounted) return;
       SnackBarHelper.showError(
         context,
-        l?.autoRecordBackgroundLocationRequestFailedSnackbar ??
-            'Could not save setting',
+        l.autoRecordBackgroundLocationRequestFailedSnackbar,
       );
     }
   }
@@ -263,7 +271,7 @@ class AutoRecordSection extends ConsumerWidget {
     required BuildContext context,
     required WidgetRef ref,
     required VehicleProfile profile,
-    required AppLocalizations? l,
+    required AppLocalizations l,
   }) async {
     final navigator = Navigator.maybeOf(context);
     final foregroundPrompt =
@@ -279,8 +287,7 @@ class AutoRecordSection extends ConsumerWidget {
         if (!context.mounted) return;
         SnackBarHelper.show(
           context,
-          l?.autoRecordBackgroundLocationForegroundDeniedSnackbar ??
-              'Location permission required',
+          l.autoRecordBackgroundLocationForegroundDeniedSnackbar,
         );
         return;
       }
@@ -290,10 +297,7 @@ class AutoRecordSection extends ConsumerWidget {
       // rationale dialog → Settings fallback instead of re-prompting.
       final bgStatus = await backgroundPrompt();
       if (bgStatus.isGranted) {
-        await _persist(
-          ref,
-          profile.copyWith(backgroundLocationConsent: true),
-        );
+        await _persist(ref, profile.copyWith(backgroundLocationConsent: true));
         return;
       }
 
@@ -326,15 +330,12 @@ class AutoRecordSection extends ConsumerWidget {
         ErrorLayer.ui,
         e,
         st,
-        context: const {
-          'op': 'autoRecordSection.requestBackgroundLocation',
-        },
+        context: const {'op': 'autoRecordSection.requestBackgroundLocation'},
       );
       if (!context.mounted) return;
       SnackBarHelper.showError(
         context,
-        l?.autoRecordBackgroundLocationRequestFailedSnackbar ??
-            'Could not request background location',
+        l.autoRecordBackgroundLocationRequestFailedSnackbar,
       );
     }
   }
@@ -347,30 +348,20 @@ class AutoRecordSection extends ConsumerWidget {
   /// reported in user feedback (issue #1439).
   Future<void> _showConsentExplanationDialog({
     required BuildContext context,
-    required AppLocalizations? l,
+    required AppLocalizations l,
   }) {
     return showDialog<void>(
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
           key: const Key('autoRecordConsentExplanationDialog'),
-          title: Text(
-            l?.autoRecordConsentExplanationTitle ?? 'About this permission',
-          ),
-          content: Text(
-            l?.autoRecordConsentExplanationBody ??
-                'Auto-record needs background location to detect when you '
-                    'start driving while the app is closed. This grant is '
-                    'used only by auto-record — station search and map '
-                    'centering use a separate foreground location grant.',
-          ),
+          title: Text(l.autoRecordConsentExplanationTitle),
+          content: Text(l.autoRecordConsentExplanationBody),
           actions: [
             TextButton(
               key: const Key('autoRecordConsentExplanationClose'),
               onPressed: () => Navigator.of(dialogContext).pop(),
-              child: Text(
-                l?.autoRecordConsentExplanationCloseButton ?? 'Got it',
-              ),
+              child: Text(l.autoRecordConsentExplanationCloseButton),
             ),
           ],
         );
@@ -382,25 +373,15 @@ class AutoRecordSection extends ConsumerWidget {
     required BuildContext context,
     required NavigatorState? navigator,
     required Future<void> Function() openSettingsFn,
-    required AppLocalizations? l,
+    required AppLocalizations l,
   }) {
     return showDialog<void>(
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
           key: const Key('autoRecordBackgroundLocationRationaleDialog'),
-          title: Text(
-            l?.autoRecordBackgroundLocationRationaleTitle ??
-                'Why "Allow all the time"?',
-          ),
-          content: Text(
-            l?.autoRecordBackgroundLocationRationaleBody ??
-                'Auto-record streams GPS coordinates from the OBD-II '
-                    'foreground service while the screen is off so your '
-                    'trip route stays accurate. Android requires the '
-                    '"Allow all the time" option for that to keep '
-                    'working after the device locks.',
-          ),
+          title: Text(l.autoRecordBackgroundLocationRationaleTitle),
+          content: Text(l.autoRecordBackgroundLocationRationaleBody),
           actions: [
             TextButton(
               key: const Key('autoRecordBackgroundLocationOpenSettings'),
@@ -408,10 +389,7 @@ class AutoRecordSection extends ConsumerWidget {
                 Navigator.of(dialogContext).pop();
                 await openSettingsFn();
               },
-              child: Text(
-                l?.autoRecordBackgroundLocationOpenSettings ??
-                    'Open settings',
-              ),
+              child: Text(l.autoRecordBackgroundLocationOpenSettings),
             ),
           ],
         );
@@ -444,7 +422,7 @@ enum _AutoRecordStatus {
 class _AutoRecordStatusBanner extends StatelessWidget {
   final _AutoRecordStatus state;
   final ThemeData theme;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final VoidCallback? onScrollToObd2Card;
 
   const _AutoRecordStatusBanner({
@@ -493,9 +471,7 @@ class _AutoRecordStatusBanner extends StatelessWidget {
           Expanded(
             child: Text(
               _labelFor(state, l),
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: onContainer,
-              ),
+              style: theme.textTheme.bodySmall?.copyWith(color: onContainer),
             ),
           ),
         ],
@@ -503,22 +479,18 @@ class _AutoRecordStatusBanner extends StatelessWidget {
     );
   }
 
-  static String _labelFor(_AutoRecordStatus s, AppLocalizations? l) {
+  static String _labelFor(_AutoRecordStatus s, AppLocalizations l) {
     switch (s) {
       case _AutoRecordStatus.active:
-        return l?.autoRecordStatusActiveLabel ??
-            'Auto-record will activate the next time you enter the car.';
+        return l.autoRecordStatusActiveLabel;
       case _AutoRecordStatus.needsPairing:
         // Unused for needsPairing — the passive link in
         // [_PairAdapterLink] supplies its own copy. Kept as a fallback
         // for completeness so a future refactor that re-routes this
         // helper for needsPairing still gets a sensible string.
-        return l?.autoRecordStatusNeedsPairingLabel ??
-            'Pair an OBD2 adapter to enable auto-record.';
+        return l.autoRecordStatusNeedsPairingLabel;
       case _AutoRecordStatus.needsBackgroundLocation:
-        return l?.autoRecordStatusNeedsBackgroundLocationLabel ??
-            'Allow background location so auto-record keeps running '
-                'with the screen off.';
+        return l.autoRecordStatusNeedsBackgroundLocationLabel;
     }
   }
 
@@ -543,7 +515,7 @@ class _AutoRecordStatusBanner extends StatelessWidget {
 /// isolated widget tests don't need to wire scroll plumbing.
 class _PairAdapterLink extends StatelessWidget {
   final ThemeData theme;
-  final AppLocalizations? l;
+  final AppLocalizations l;
   final VoidCallback? onTap;
 
   const _PairAdapterLink({
@@ -569,9 +541,7 @@ class _PairAdapterLink extends StatelessWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  l?.autoRecordPairAdapterLinkText ??
-                      'Pair an adapter in the section below to enable '
-                          'auto-recording',
+                  l.autoRecordPairAdapterLinkText,
                   style: theme.textTheme.bodySmall,
                 ),
               ),
@@ -695,10 +665,7 @@ class _SaveDelaySliderState extends State<_SaveDelaySlider> {
             Expanded(
               child: Text(widget.label, style: theme.textTheme.bodyMedium),
             ),
-            Text(
-              _current.toString(),
-              style: theme.textTheme.titleMedium,
-            ),
+            Text(_current.toString(), style: theme.textTheme.titleMedium),
           ],
         ),
         Slider(
@@ -744,12 +711,9 @@ class _BackgroundLocationRow extends StatelessWidget {
       // opens the explanation dialog, tapping the row body opens the
       // system app-settings page so the user can revoke. Hides the
       // pre-#1439 ambiguous "Background location allowed" check.
-      final badgeLabel = l?.autoRecordConsentBadgeLabel ??
-          'Background location — for auto-record only';
-      final revokeHint = l?.autoRecordConsentRevokeAction ??
-          'Tap to manage in system settings';
-      final helpTooltip = l?.autoRecordConsentExplanationTooltip ??
-          'What does this mean?';
+      final badgeLabel = l.autoRecordConsentBadgeLabel;
+      final revokeHint = l.autoRecordConsentRevokeAction;
+      final helpTooltip = l.autoRecordConsentExplanationTooltip;
 
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -772,10 +736,7 @@ class _BackgroundLocationRow extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          badgeLabel,
-                          style: theme.textTheme.bodyMedium,
-                        ),
+                        Text(badgeLabel, style: theme.textTheme.bodyMedium),
                         const SizedBox(height: 2),
                         Text(
                           revokeHint,
@@ -812,9 +773,7 @@ class _BackgroundLocationRow extends StatelessWidget {
               color: theme.colorScheme.onSurfaceVariant,
             ),
             const SizedBox(width: 8),
-            Expanded(
-              child: Text(label, style: theme.textTheme.bodyMedium),
-            ),
+            Expanded(child: Text(label, style: theme.textTheme.bodyMedium)),
           ],
         ),
         const SizedBox(height: 8),

--- a/lib/features/vehicle/presentation/widgets/calibration_section.dart
+++ b/lib/features/vehicle/presentation/widgets/calibration_section.dart
@@ -10,12 +10,7 @@ import '../../../../core/domain/vehicle_profile.dart';
 
 /// One of the four manual-override calibration fields surfaced by
 /// [CalibrationSection] (#1397).
-enum _CalibrationField {
-  displacement,
-  volumetricEfficiency,
-  afr,
-  fuelDensity,
-}
+enum _CalibrationField { displacement, volumetricEfficiency, afr, fuelDensity }
 
 /// Source-of-truth indicator for a single resolved calibration value
 /// (#1397). Drives both the helper-text suffix on each input row and
@@ -135,9 +130,7 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     _veCtrl = TextEditingController(
       text: _initialText(_CalibrationField.volumetricEfficiency),
     );
-    _afrCtrl = TextEditingController(
-      text: _initialText(_CalibrationField.afr),
-    );
+    _afrCtrl = TextEditingController(text: _initialText(_CalibrationField.afr));
     _fuelDensityCtrl = TextEditingController(
       text: _initialText(_CalibrationField.fuelDensity),
     );
@@ -152,7 +145,10 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     // policy is to keep the on-screen text and let the source helper
     // re-render).
     if (oldWidget.profile != widget.profile) {
-      _maybeSync(_displacementCtrl, _initialText(_CalibrationField.displacement));
+      _maybeSync(
+        _displacementCtrl,
+        _initialText(_CalibrationField.displacement),
+      );
       _maybeSync(_veCtrl, _initialText(_CalibrationField.volumetricEfficiency));
       _maybeSync(_afrCtrl, _initialText(_CalibrationField.afr));
       _maybeSync(_fuelDensityCtrl, _initialText(_CalibrationField.fuelDensity));
@@ -245,16 +241,16 @@ class _CalibrationSectionState extends State<CalibrationSection> {
   }
 
   String _sourceLabel(
-    AppLocalizations? l,
+    AppLocalizations l,
     CalibrationValueSource source,
     _CalibrationField field,
   ) {
     final p = widget.profile;
     switch (source) {
       case CalibrationValueSource.manual:
-        return l?.calibrationSourceManual ?? '(manual)';
+        return l.calibrationSourceManual;
       case CalibrationValueSource.detected:
-        return l?.calibrationSourceDetected ?? '(detected from VIN)';
+        return l.calibrationSourceDetected;
       case CalibrationValueSource.catalog:
         final makeModel = [
           if (p.make != null && p.make!.isNotEmpty) p.make,
@@ -271,13 +267,12 @@ class _CalibrationSectionState extends State<CalibrationSection> {
           final basisKey = volumetricEfficiencyBasisKey(ref);
           final basisLabel = _basisLabel(l, basisKey);
           if (basisLabel != null) {
-            return l?.calibrationSourceCatalogWithBasis(label, basisLabel) ??
-                '(catalog: $label — $basisLabel default)';
+            return l.calibrationSourceCatalogWithBasis(label, basisLabel);
           }
         }
-        return l?.calibrationSourceCatalog(label) ?? '(catalog: $label)';
+        return l.calibrationSourceCatalog(label);
       case CalibrationValueSource.defaultConstant:
-        return l?.calibrationSourceDefault ?? '(default)';
+        return l.calibrationSourceDefault;
     }
   }
 
@@ -285,19 +280,19 @@ class _CalibrationSectionState extends State<CalibrationSection> {
   /// or `null` when the helper returned `null` (NA + no-DI baseline —
   /// no enrichment needed). Falls back to the English literal if
   /// localizations are unavailable, matching the rest of this widget.
-  String? _basisLabel(AppLocalizations? l, String? basisKey) {
+  String? _basisLabel(AppLocalizations l, String? basisKey) {
     if (basisKey == null) return null;
     switch (basisKey) {
       case 'calibrationBasisAtkinson':
-        return l?.calibrationBasisAtkinson ?? 'Atkinson cycle';
+        return l.calibrationBasisAtkinson;
       case 'calibrationBasisVnt':
-        return l?.calibrationBasisVnt ?? 'VNT diesel + DI';
+        return l.calibrationBasisVnt;
       case 'calibrationBasisTurboDi':
-        return l?.calibrationBasisTurboDi ?? 'Turbocharged + DI';
+        return l.calibrationBasisTurboDi;
       case 'calibrationBasisTurbo':
-        return l?.calibrationBasisTurbo ?? 'Turbocharged';
+        return l.calibrationBasisTurbo;
       case 'calibrationBasisNaDi':
-        return l?.calibrationBasisNaDi ?? 'Naturally aspirated + DI';
+        return l.calibrationBasisNaDi;
     }
     return null;
   }
@@ -372,11 +367,10 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     }
   }
 
-  String _learnerStatus(AppLocalizations? l) {
+  String _learnerStatus(AppLocalizations l) {
     final samples = widget.profile.volumetricEfficiencySamples;
     if (samples == 0) {
-      return l?.calibrationLearnerStatusNoSamples ??
-          'η_v: 0.85 (default — no plein-complet yet)';
+      return l.calibrationLearnerStatusNoSamples;
     }
     // #1626 — show the ± convergence band so the user sees how settled
     // the learned η_v is. Folded into the `eta` placeholder so the
@@ -385,11 +379,9 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     final band = _formatDouble(veConvergenceHalfWidth(samples));
     final eta = '$etaValue ± $band';
     if (samples < 3) {
-      return l?.calibrationLearnerStatusLearning(eta, samples) ??
-          'η_v: $eta (learning, $samples samples)';
+      return l.calibrationLearnerStatusLearning(eta, samples);
     }
-    return l?.calibrationLearnerStatusCalibrated(eta, samples) ??
-        'η_v: $eta (calibrated, $samples samples)';
+    return l.calibrationLearnerStatusCalibrated(eta, samples);
   }
 
   @override
@@ -397,15 +389,14 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     final l = AppLocalizations.of(context);
     return Card(
       child: ExpansionTile(
-        title: Text(l?.calibrationAdvancedTitle ?? 'Advanced calibration'),
+        title: Text(l.calibrationAdvancedTitle),
         initiallyExpanded: false,
         childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         children: [
           _buildField(
             field: _CalibrationField.displacement,
             controller: _displacementCtrl,
-            labelText: l?.calibrationDisplacementLabel ??
-                'Engine displacement (cc)',
+            labelText: l.calibrationDisplacementLabel,
             l: l,
           ),
           const SizedBox(height: 12),
@@ -418,22 +409,21 @@ class _CalibrationSectionState extends State<CalibrationSection> {
             _buildField(
               field: _CalibrationField.volumetricEfficiency,
               controller: _veCtrl,
-              labelText: l?.calibrationVolumetricEfficiencyLabel ??
-                  'Volumetric efficiency (η_v)',
+              labelText: l.calibrationVolumetricEfficiencyLabel,
               l: l,
             ),
           const SizedBox(height: 12),
           _buildField(
             field: _CalibrationField.afr,
             controller: _afrCtrl,
-            labelText: l?.calibrationAfrLabel ?? 'Air-to-fuel ratio (AFR)',
+            labelText: l.calibrationAfrLabel,
             l: l,
           ),
           const SizedBox(height: 12),
           _buildField(
             field: _CalibrationField.fuelDensity,
             controller: _fuelDensityCtrl,
-            labelText: l?.calibrationFuelDensityLabel ?? 'Fuel density (g/L)',
+            labelText: l.calibrationFuelDensityLabel,
             l: l,
           ),
           // #2837 — the live η_v readout + Reset learner only matter for
@@ -453,7 +443,7 @@ class _CalibrationSectionState extends State<CalibrationSection> {
                 const SizedBox(width: 8),
                 OutlinedButton(
                   onPressed: widget.onResetLearner,
-                  child: Text(l?.calibrationResetLearner ?? 'Reset learner'),
+                  child: Text(l.calibrationResetLearner),
                 ),
               ],
             ),
@@ -467,19 +457,21 @@ class _CalibrationSectionState extends State<CalibrationSection> {
     required _CalibrationField field,
     required TextEditingController controller,
     required String labelText,
-    required AppLocalizations? l,
+    required AppLocalizations l,
   }) {
     final source = _sourceFor(field);
     return TextFormField(
       controller: controller,
-      keyboardType:
-          const TextInputType.numberWithOptions(decimal: true, signed: false),
+      keyboardType: const TextInputType.numberWithOptions(
+        decimal: true,
+        signed: false,
+      ),
       decoration: InputDecoration(
         labelText: labelText,
         helperText: _sourceLabel(l, source, field),
         suffixIcon: IconButton(
           icon: const Icon(Icons.restart_alt),
-          tooltip: l?.calibrationResetToDetected ?? 'Reset to detected value',
+          tooltip: l.calibrationResetToDetected,
           onPressed: () => _resetField(field),
         ),
       ),
@@ -495,7 +487,7 @@ class _CalibrationSectionState extends State<CalibrationSection> {
 class _DirectFuelRateNote extends StatelessWidget {
   const _DirectFuelRateNote({required this.l});
 
-  final AppLocalizations? l;
+  final AppLocalizations l;
 
   @override
   Widget build(BuildContext context) {
@@ -511,10 +503,7 @@ class _DirectFuelRateNote extends StatelessWidget {
         const SizedBox(width: 8),
         Expanded(
           child: Text(
-            l?.calibrationDirectFuelRateNote ??
-                'This vehicle reports its fuel rate directly (PID 5E), so '
-                    'volumetric-efficiency calibration is not used — your '
-                    'consumption is measured, not modelled.',
+            l.calibrationDirectFuelRateNote,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),

--- a/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
@@ -30,10 +30,7 @@ class CatalogReresolveSnackbarHost extends ConsumerStatefulWidget {
   /// Subtree the host wraps. Returned verbatim from `build`.
   final Widget child;
 
-  const CatalogReresolveSnackbarHost({
-    super.key,
-    required this.child,
-  });
+  const CatalogReresolveSnackbarHost({super.key, required this.child});
 
   @override
   ConsumerState<CatalogReresolveSnackbarHost> createState() =>
@@ -77,15 +74,11 @@ class _CatalogReresolveSnackbarHostState
     final messenger = ScaffoldMessenger.maybeOf(context);
     if (messenger == null) return;
 
-    final makeModel =
-        '${candidate.make} ${candidate.model}'.trim();
-    final message = l10n != null
-        ? l10n.catalogReresolveSnackbarMessage(
-            makeModel.isEmpty ? candidate.vehicleId : makeModel,
-          )
-        : 'Your $makeModel is marked as diesel but matches a '
-            'petrol catalog entry. Tap to update.';
-    final action = l10n?.catalogReresolveSnackbarAction ?? 'Update';
+    final makeModel = '${candidate.make} ${candidate.model}'.trim();
+    final message = l10n.catalogReresolveSnackbarMessage(
+      makeModel.isEmpty ? candidate.vehicleId : makeModel,
+    );
+    final action = l10n.catalogReresolveSnackbarAction;
 
     messenger.showSnackBar(
       SnackBarHelper.infoSnackBar(
@@ -114,21 +107,23 @@ class _CatalogReresolveSnackbarHostState
     // again for this vehicle. Done after `showSnackBar` so a failure
     // in the messenger doesn't leave the user permanently un-
     // nudgeable.
-    unawaited(Future<void>(() async {
-      // #3159 — this future is detached, so the host can unmount before it
-      // runs; both the helper's ref.read and the invalidate below would
-      // then throw a StateError. Skipping is safe: the candidate provider
-      // re-fires the nudge on the next build.
-      if (!mounted) return;
-      try {
-        await markCatalogReresolveSuggested(ref, candidate.vehicleId);
-      } finally {
-        // Force the provider to drop this candidate from its list so
-        // the next pending vehicle can take its turn on the next
-        // build.
-        if (mounted) ref.invalidate(catalogReresolveCandidatesProvider);
-      }
-    }));
+    unawaited(
+      Future<void>(() async {
+        // #3159 — this future is detached, so the host can unmount before it
+        // runs; both the helper's ref.read and the invalidate below would
+        // then throw a StateError. Skipping is safe: the candidate provider
+        // re-fires the nudge on the next build.
+        if (!mounted) return;
+        try {
+          await markCatalogReresolveSuggested(ref, candidate.vehicleId);
+        } finally {
+          // Force the provider to drop this candidate from its list so
+          // the next pending vehicle can take its turn on the next
+          // build.
+          if (mounted) ref.invalidate(catalogReresolveCandidatesProvider);
+        }
+      }),
+    );
   }
 }
 
@@ -136,11 +131,11 @@ class _CatalogReresolveSnackbarHostState
 /// search synchronous without throwing on an empty list.
 class _SentinelCandidate extends CatalogReresolveCandidate {
   const _SentinelCandidate()
-      : super(
-          vehicleId: '',
-          make: '',
-          model: '',
-          resolvedReferenceVehicleId: '',
-          resolvedFuelType: '',
-        );
+    : super(
+        vehicleId: '',
+        make: '',
+        model: '',
+        resolvedReferenceVehicleId: '',
+        resolvedFuelType: '',
+      );
 }

--- a/lib/features/vehicle/presentation/widgets/engine_power_field.dart
+++ b/lib/features/vehicle/presentation/widgets/engine_power_field.dart
@@ -23,10 +23,7 @@ import '../../domain/entities/reference_vehicle.dart';
 class EnginePowerField extends StatefulWidget {
   final TextEditingController controller;
 
-  const EnginePowerField({
-    super.key,
-    required this.controller,
-  });
+  const EnginePowerField({super.key, required this.controller});
 
   @override
   State<EnginePowerField> createState() => _EnginePowerFieldState();
@@ -58,7 +55,7 @@ class _EnginePowerFieldState extends State<EnginePowerField> {
     // parses to a positive number, so an empty / bogus field doesn't
     // show a meaningless "≈ 0 PS".
     final helper = (ps != null && ps > 0)
-        ? (l?.vehiclePowerHelper(ps.toString()) ?? '≈ $ps PS')
+        ? (l.vehiclePowerHelper(ps.toString()))
         : null;
     return TextFormField(
       key: const Key('vehicle_engine_power_field'),
@@ -66,7 +63,7 @@ class _EnginePowerFieldState extends State<EnginePowerField> {
       keyboardType: const TextInputType.numberWithOptions(),
       inputFormatters: [FilteringTextInputFormatter.digitsOnly],
       decoration: InputDecoration(
-        labelText: l?.vehiclePowerLabel ?? 'Engine power (kW)',
+        labelText: l.vehiclePowerLabel,
         helperText: helper,
       ),
       // Engine power is optional — an empty field must never block Save.

--- a/lib/features/vehicle/presentation/widgets/obd2_capability_section.dart
+++ b/lib/features/vehicle/presentation/widgets/obd2_capability_section.dart
@@ -38,7 +38,7 @@ class Obd2CapabilitySection extends ConsumerWidget {
     final cs = theme.colorScheme;
 
     return SectionCard(
-      title: l?.obd2CapabilitySectionTitle ?? 'Adapter capabilities',
+      title: l.obd2CapabilitySectionTitle,
       leadingIcon: Icons.memory,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -58,9 +58,7 @@ class Obd2CapabilitySection extends ConsumerWidget {
           if (capability == Obd2AdapterCapability.standardOnly) ...[
             const SizedBox(height: Spacing.md),
             Text(
-              l?.obd2CapabilityUpgradeHintStandard ??
-                  'For exact litres-in-tank on Peugeot/Citroën, the app '
-                      'supports OBDLink MX+/LX/CX (STN chip).',
+              l.obd2CapabilityUpgradeHintStandard,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: cs.onSurfaceVariant,
               ),
@@ -82,17 +80,14 @@ class Obd2CapabilitySection extends ConsumerWidget {
     }
   }
 
-  String _labelFor(
-    Obd2AdapterCapability capability,
-    AppLocalizations? l,
-  ) {
+  String _labelFor(Obd2AdapterCapability capability, AppLocalizations l) {
     switch (capability) {
       case Obd2AdapterCapability.standardOnly:
-        return l?.obd2CapabilityStandardOnly ?? 'Standard';
+        return l.obd2CapabilityStandardOnly;
       case Obd2AdapterCapability.oemPidsCapable:
-        return l?.obd2CapabilityOemPids ?? 'OEM PIDs';
+        return l.obd2CapabilityOemPids;
       case Obd2AdapterCapability.passiveCanCapable:
-        return l?.obd2CapabilityFullCan ?? 'Full CAN';
+        return l.obd2CapabilityFullCan;
     }
   }
 }

--- a/lib/features/vehicle/presentation/widgets/reference_vehicle_picker.dart
+++ b/lib/features/vehicle/presentation/widgets/reference_vehicle_picker.dart
@@ -112,10 +112,12 @@ class _ReferenceVehiclePickerState
   /// search box is non-empty.
   List<ReferenceVehicle> _search(List<ReferenceVehicle> all) {
     if (_query.isEmpty) return const [];
-    return all.where((v) {
-      final haystack = '${v.make} ${v.model} ${v.generation}'.toLowerCase();
-      return haystack.contains(_query);
-    }).toList(growable: false);
+    return all
+        .where((v) {
+          final haystack = '${v.make} ${v.model} ${v.generation}'.toLowerCase();
+          return haystack.contains(_query);
+        })
+        .toList(growable: false);
   }
 
   @override
@@ -143,18 +145,21 @@ class _ReferenceVehiclePickerState
                   if (!searching && _make != null)
                     IconButton(
                       icon: const Icon(Icons.arrow_back),
-                      tooltip: l?.tooltipBack ?? 'Back',
+                      tooltip: l.tooltipBack,
                       onPressed: _drillUp,
                     )
                   else
-                    Icon(Icons.directions_car_outlined,
-                        color: theme.colorScheme.primary),
+                    Icon(
+                      Icons.directions_car_outlined,
+                      color: theme.colorScheme.primary,
+                    ),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
                       _breadcrumb(l),
-                      style: theme.textTheme.titleLarge
-                          ?.copyWith(fontWeight: FontWeight.w600),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                 ],
@@ -164,12 +169,12 @@ class _ReferenceVehiclePickerState
                 controller: _searchController,
                 decoration: InputDecoration(
                   prefixIcon: const Icon(Icons.search),
-                  hintText: l?.pickerSearchHint ?? 'Search make or model',
+                  hintText: l.pickerSearchHint,
                   suffixIcon: _searchController.text.isEmpty
                       ? null
                       : IconButton(
                           icon: const Icon(Icons.clear),
-                          tooltip: l?.pickerCancel ?? 'Cancel',
+                          tooltip: l.pickerCancel,
                           onPressed: () => _searchController.clear(),
                         ),
                   border: const OutlineInputBorder(),
@@ -186,7 +191,7 @@ class _ReferenceVehiclePickerState
                       children: [
                         const CircularProgressIndicator(),
                         const SizedBox(height: 12),
-                        Text(l?.pickerLoading ?? 'Loading catalog…'),
+                        Text(l.pickerLoading),
                       ],
                     ),
                   ),
@@ -194,8 +199,9 @@ class _ReferenceVehiclePickerState
                     padding: const EdgeInsets.all(16),
                     child: Text(
                       'Error: $error',
-                      style: theme.textTheme.bodyMedium
-                          ?.copyWith(color: theme.colorScheme.error),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
                     ),
                   ),
                   data: (catalog) => searching
@@ -208,7 +214,7 @@ class _ReferenceVehiclePickerState
                 alignment: Alignment.centerLeft,
                 child: TextButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l?.pickerCancel ?? 'Cancel'),
+                  child: Text(l.pickerCancel),
                 ),
               ),
             ],
@@ -219,22 +225,24 @@ class _ReferenceVehiclePickerState
   }
 
   /// Title text — plain label at the root, else the drill-down path.
-  String _breadcrumb(AppLocalizations? l) {
-    if (_make == null) return l?.pickerButtonLabel ?? 'Pick from catalog';
+  String _breadcrumb(AppLocalizations l) {
+    if (_make == null) return l.pickerButtonLabel;
     if (_model == null) return _make!;
     return '$_make · $_model';
   }
 
-  Widget _emptyState(AppLocalizations? l, ThemeData theme) => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(l?.pickerEmptyResults ?? 'No matches',
-              style: theme.textTheme.bodyMedium),
-        ),
-      );
+  Widget _emptyState(AppLocalizations l, ThemeData theme) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(24),
+      child: Text(l.pickerEmptyResults, style: theme.textTheme.bodyMedium),
+    ),
+  );
 
   Widget _buildSearchResults(
-      List<ReferenceVehicle> catalog, AppLocalizations? l, ThemeData theme) {
+    List<ReferenceVehicle> catalog,
+    AppLocalizations l,
+    ThemeData theme,
+  ) {
     final results = _search(catalog);
     if (results.isEmpty) return _emptyState(l, theme);
     return ListView.builder(
@@ -249,13 +257,15 @@ class _ReferenceVehiclePickerState
   }
 
   Widget _buildDrillDown(
-      List<ReferenceVehicle> catalog, AppLocalizations? l, ThemeData theme) {
+    List<ReferenceVehicle> catalog,
+    AppLocalizations l,
+    ThemeData theme,
+  ) {
     // Level 3 — generations of the selected make + model.
     if (_make != null && _model != null) {
-      final generations = catalog
-          .where((v) => v.make == _make && v.model == _model)
-          .toList()
-        ..sort((a, b) => b.yearStart.compareTo(a.yearStart));
+      final generations =
+          catalog.where((v) => v.make == _make && v.model == _model).toList()
+            ..sort((a, b) => b.yearStart.compareTo(a.yearStart));
       if (generations.isEmpty) return _emptyState(l, theme);
       return ListView.builder(
         shrinkWrap: true,
@@ -313,8 +323,11 @@ class _GroupTile extends StatelessWidget {
   final int count;
   final VoidCallback onTap;
 
-  const _GroupTile(
-      {required this.label, required this.count, required this.onTap});
+  const _GroupTile({
+    required this.label,
+    required this.count,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -323,10 +336,12 @@ class _GroupTile extends StatelessWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text('$count',
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  )),
+          Text(
+            '$count',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
           const SizedBox(width: 4),
           const Icon(Icons.chevron_right),
         ],
@@ -347,18 +362,22 @@ class _GenerationTile extends StatelessWidget {
   final bool showModel;
   final VoidCallback onTap;
 
-  const _GenerationTile(
-      {required this.entry, required this.showModel, required this.onTap});
+  const _GenerationTile({
+    required this.entry,
+    required this.showModel,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     final yearRange = '${entry.yearStart}–${entry.yearEnd?.toString() ?? ''}';
-    final spec =
-        '$yearRange · ${entry.displacementCc}cc ${entry.fuelType}';
+    final spec = '$yearRange · ${entry.displacementCc}cc ${entry.fuelType}';
     return ListTile(
-      title: Text(showModel
-          ? '${entry.make} ${entry.model} · ${entry.generation}'
-          : entry.generation),
+      title: Text(
+        showModel
+            ? '${entry.make} ${entry.model} · ${entry.generation}'
+            : entry.generation,
+      ),
       subtitle: Text(spec),
       onTap: onTap,
       dense: true,

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
@@ -50,7 +50,7 @@ class ServiceReminderSection extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l?.serviceRemindersSection ?? 'Service reminders',
+          l.serviceRemindersSection,
           style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 8),
@@ -62,8 +62,7 @@ class ServiceReminderSection extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: Text(
-              l?.serviceRemindersEmpty ??
-                  'No reminders yet — pick a preset above.',
+              l.serviceRemindersEmpty,
               style: Theme.of(context).textTheme.bodySmall,
             ),
           )
@@ -79,7 +78,7 @@ class ServiceReminderSection extends ConsumerWidget {
         const SizedBox(height: 8),
         OutlinedButton.icon(
           icon: const Icon(Icons.add),
-          label: Text(l?.addServiceReminder ?? 'Add reminder'),
+          label: Text(l.addServiceReminder),
           onPressed: () => _promptCustom(context, ref),
         ),
       ],
@@ -123,28 +122,26 @@ class ServiceReminderSection extends ConsumerWidget {
       return await showDialog<double>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: Text(l?.serviceReminderMarkDone ?? 'Mark as done'),
+          title: Text(l.serviceReminderMarkDone),
           content: TextField(
             controller: controller,
             autofocus: true,
-            keyboardType:
-                const TextInputType.numberWithOptions(decimal: true),
-            decoration: InputDecoration(
-              labelText: l?.odometerKm ?? 'Odometer (km)',
-            ),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: InputDecoration(labelText: l.odometerKm),
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(),
-              child: Text(l?.cancel ?? 'Cancel'),
+              child: Text(l.cancel),
             ),
             FilledButton(
               onPressed: () {
                 final value = double.tryParse(
-                    controller.text.trim().replaceAll(',', '.'));
+                  controller.text.trim().replaceAll(',', '.'),
+                );
                 Navigator.of(ctx).pop(value);
               },
-              child: Text(l?.save ?? 'Save'),
+              child: Text(l.save),
             ),
           ],
         ),
@@ -165,24 +162,23 @@ class ServiceReminderSection extends ConsumerWidget {
       final added = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: Text(l?.addServiceReminder ?? 'Add reminder'),
+          title: Text(l.addServiceReminder),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               TextField(
                 controller: labelCtrl,
                 autofocus: true,
-                decoration: InputDecoration(
-                  labelText: l?.serviceReminderLabel ?? 'Label',
-                ),
+                decoration: InputDecoration(labelText: l.serviceReminderLabel),
               ),
               const SizedBox(height: 8),
               TextField(
                 controller: intervalCtrl,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: false),
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: false,
+                ),
                 decoration: InputDecoration(
-                  labelText: l?.serviceReminderInterval ?? 'Interval (km)',
+                  labelText: l.serviceReminderInterval,
                 ),
               ),
             ],
@@ -190,11 +186,11 @@ class ServiceReminderSection extends ConsumerWidget {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(false),
-              child: Text(l?.cancel ?? 'Cancel'),
+              child: Text(l.cancel),
             ),
             FilledButton(
               onPressed: () => Navigator.of(ctx).pop(true),
-              child: Text(l?.save ?? 'Save'),
+              child: Text(l.save),
             ),
           ],
         ),
@@ -241,8 +237,8 @@ class _ReminderRow extends StatelessWidget {
     final subtitle = lastService == null
         ? intervalText
         : '$intervalText • '
-            '${l?.serviceReminderLastService ?? 'Last service'}: '
-            '${lastService.round()} km';
+              '${l.serviceReminderLastService}: '
+              '${lastService.round()} km';
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6),
@@ -259,19 +255,18 @@ class _ReminderRow extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(reminder.label),
-                Text(subtitle,
-                    style: Theme.of(context).textTheme.bodySmall),
+                Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
               ],
             ),
           ),
           IconButton(
             icon: const Icon(Icons.check_circle_outline),
-            tooltip: l?.serviceReminderMarkDone ?? 'Mark as done',
+            tooltip: l.serviceReminderMarkDone,
             onPressed: onMarkDone,
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline),
-            tooltip: l?.delete ?? 'Delete',
+            tooltip: l.delete,
             onPressed: onDelete,
           ),
         ],

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section_parts.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section_parts.dart
@@ -27,24 +27,18 @@ class _PresetChipRow extends StatelessWidget {
       children: [
         ActionChip(
           avatar: const Icon(Icons.oil_barrel_outlined, size: 18),
-          label:
-              Text(l?.serviceReminderPresetOil ?? 'Oil (15,000 km)'),
-          onPressed: () =>
-              onAdd(l?.serviceReminderPresetOilLabel ?? 'Oil change', 15000),
+          label: Text(l.serviceReminderPresetOil),
+          onPressed: () => onAdd(l.serviceReminderPresetOilLabel, 15000),
         ),
         ActionChip(
           avatar: const Icon(Icons.tire_repair_outlined, size: 18),
-          label:
-              Text(l?.serviceReminderPresetTires ?? 'Tires (20,000 km)'),
-          onPressed: () =>
-              onAdd(l?.serviceReminderPresetTiresLabel ?? 'Tires', 20000),
+          label: Text(l.serviceReminderPresetTires),
+          onPressed: () => onAdd(l.serviceReminderPresetTiresLabel, 20000),
         ),
         ActionChip(
           avatar: const Icon(Icons.build_outlined, size: 18),
-          label: Text(
-              l?.serviceReminderPresetInspection ?? 'Inspection (30,000 km)'),
-          onPressed: () => onAdd(
-              l?.serviceReminderPresetInspectionLabel ?? 'Inspection', 30000),
+          label: Text(l.serviceReminderPresetInspection),
+          onPressed: () => onAdd(l.serviceReminderPresetInspectionLabel, 30000),
         ),
       ],
     );

--- a/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
@@ -19,25 +19,16 @@ class VeResetConfirmDialog {
     return showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text(
-          l?.veResetConfirmTitle ?? 'Reset volumetric efficiency?',
-        ),
-        content: Text(
-          l?.veResetConfirmBody ??
-              'This will discard the learned volumetric efficiency '
-                  '(η_v) and restore the default value (0.85). Trip-level '
-                  'fuel-flow estimates will fall back to the manufacturer '
-                  'constant until the calibrator collects new samples '
-                  'from upcoming trips.',
-        ),
+        title: Text(l.veResetConfirmTitle),
+        content: Text(l.veResetConfirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l?.cancel ?? 'Cancel'),
+            child: Text(l.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l?.veResetAction ?? 'Reset volumetric efficiency'),
+            child: Text(l.veResetAction),
           ),
         ],
       ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_calibration_mode_selector.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_calibration_mode_selector.dart
@@ -23,10 +23,7 @@ import '../../../../core/logging/error_logger.dart';
 class VehicleCalibrationModeSelector extends ConsumerWidget {
   final String vehicleId;
 
-  const VehicleCalibrationModeSelector({
-    super.key,
-    required this.vehicleId,
-  });
+  const VehicleCalibrationModeSelector({super.key, required this.vehicleId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -39,12 +36,23 @@ class VehicleCalibrationModeSelector extends ConsumerWidget {
     // case rather than crashing the whole screen.
     VehicleProfile profile;
     try {
-      profile = ref.watch(vehicleProfileListProvider).firstWhere(
+      profile = ref
+          .watch(vehicleProfileListProvider)
+          .firstWhere(
             (v) => v.id == vehicleId,
             orElse: () => const VehicleProfile(id: '', name: ''),
           );
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'VehicleCalibrationModeSelector: profile lookup failed'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'VehicleCalibrationModeSelector: profile lookup failed',
+          },
+        ),
+      );
       return const SizedBox.shrink();
     }
 
@@ -53,11 +61,7 @@ class VehicleCalibrationModeSelector extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final tooltip =
-        l?.calibrationModeTooltip ??
-            'Rule-based assigns each driving sample to exactly one '
-                'situation. Fuzzy spreads it across all of them by how well '
-                'each fits.';
+    final tooltip = l.calibrationModeTooltip;
 
     return Card(
       margin: EdgeInsets.zero,
@@ -72,7 +76,7 @@ class VehicleCalibrationModeSelector extends ConsumerWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    l?.calibrationModeLabel ?? 'Calibration mode',
+                    l.calibrationModeLabel,
                     style: theme.textTheme.titleMedium,
                   ),
                 ),
@@ -95,12 +99,12 @@ class VehicleCalibrationModeSelector extends ConsumerWidget {
               segments: [
                 ButtonSegment(
                   value: VehicleCalibrationMode.rule,
-                  label: Text(l?.calibrationModeRule ?? 'Rule-based'),
+                  label: Text(l.calibrationModeRule),
                   icon: const Icon(Icons.rule),
                 ),
                 ButtonSegment(
                   value: VehicleCalibrationMode.fuzzy,
-                  label: Text(l?.calibrationModeFuzzy ?? 'Fuzzy'),
+                  label: Text(l.calibrationModeFuzzy),
                   icon: const Icon(Icons.blur_circular),
                 ),
               ],

--- a/lib/features/vehicle/presentation/widgets/vehicle_card.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_card.dart
@@ -89,8 +89,9 @@ class VehicleCard extends StatelessWidget {
               child: Text(
                 vehicle.name,
                 overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.titleSmall
-                    ?.copyWith(fontWeight: FontWeight.bold),
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
             if (isActive) ...[
@@ -122,12 +123,10 @@ class VehicleCard extends StatelessWidget {
             if (!isActive)
               PopupMenuItem(
                 value: 'activate',
-                child: Text(l10n?.vehicleSetActive ?? 'Set active'),
+                child: Text(l10n.vehicleSetActive),
               ),
-            PopupMenuItem(
-                value: 'edit', child: Text(l10n?.edit ?? 'Edit')),
-            PopupMenuItem(
-                value: 'delete', child: Text(l10n?.delete ?? 'Delete')),
+            PopupMenuItem(value: 'edit', child: Text(l10n.edit)),
+            PopupMenuItem(value: 'delete', child: Text(l10n.delete)),
           ],
         ),
         onTap: onTap,

--- a/lib/features/vehicle/presentation/widgets/vehicle_combustion_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_combustion_section.dart
@@ -79,36 +79,32 @@ class VehicleCombustionSection extends StatelessWidget {
     final l = AppLocalizations.of(context);
     final raw = fuelTypeController.text.trim();
     final parsed = raw.isEmpty ? null : FuelType.fromString(raw);
-    final currentValue =
-        (parsed != null && _combustionFuels.contains(parsed)) ? parsed : null;
+    final currentValue = (parsed != null && _combustionFuels.contains(parsed))
+        ? parsed
+        : null;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l?.vehicleCombustionSectionTitle ?? 'Combustion',
+          l.vehicleCombustionSectionTitle,
           style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 8),
         TextFormField(
           controller: tankController,
-          keyboardType:
-              const TextInputType.numberWithOptions(decimal: true),
-          decoration: InputDecoration(
-            labelText: l?.vehicleTankLabel ?? 'Tank capacity (L)',
-          ),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(labelText: l.vehicleTankLabel),
           validator: numberValidator,
         ),
         const SizedBox(height: 8),
         // Epic #3015 — rated engine power (kW), pre-filled from the
         // catalog pick, user-overridable. Helper text shows the live PS
         // equivalent.
-        EnginePowerField(
-          controller: powerKwController,
-        ),
+        EnginePowerField(controller: powerKwController),
         const SizedBox(height: 8),
         NullableFuelTypeDropdown(
           value: currentValue,
-          labelText: l?.vehiclePreferredFuelLabel ?? 'Preferred fuel',
+          labelText: l.vehiclePreferredFuelLabel,
           prefixIcon: const Icon(Icons.local_gas_station),
           options: _combustionFuels,
           onChanged: (v) {
@@ -129,14 +125,8 @@ class VehicleCombustionSection extends StatelessWidget {
           SwitchListTile(
             key: const Key('vehicle_multi_fuel_capable_switch'),
             contentPadding: EdgeInsets.zero,
-            title: Text(
-              l?.vehicleMultiFuelCapableLabel ??
-                  'I may fill up with different fuel types',
-            ),
-            subtitle: Text(
-              l?.vehicleMultiFuelCapableHelper ??
-                  'Tracks which fuel is cheapest per kilometre',
-            ),
+            title: Text(l.vehicleMultiFuelCapableLabel),
+            subtitle: Text(l.vehicleMultiFuelCapableHelper),
             value: multiFuelCapable,
             onChanged: onMultiFuelCapableChanged,
           ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_drivetrain_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_drivetrain_section.dart
@@ -70,9 +70,8 @@ class VehicleDrivetrainSection extends StatelessWidget {
     final showEv = type != VehicleType.combustion;
     final showCombustion = type != VehicleType.ev;
     return FormSectionCard(
-      title: l?.vehicleSectionDrivetrainTitle ?? 'Drivetrain',
-      subtitle:
-          l?.vehicleSectionDrivetrainSubtitle ?? 'How this vehicle moves',
+      title: l.vehicleSectionDrivetrainTitle,
+      subtitle: l.vehicleSectionDrivetrainSubtitle,
       icon: Icons.settings_outlined,
       accent: accent,
       children: [

--- a/lib/features/vehicle/presentation/widgets/vehicle_ev_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_ev_section.dart
@@ -37,33 +37,26 @@ class VehicleEvSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l?.vehicleEvSectionTitle ?? 'Electric',
+          l.vehicleEvSectionTitle,
           style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 8),
         TextFormField(
           controller: batteryController,
-          keyboardType:
-              const TextInputType.numberWithOptions(decimal: true),
-          decoration: InputDecoration(
-            labelText: l?.vehicleBatteryLabel ?? 'Battery capacity (kWh)',
-          ),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(labelText: l.vehicleBatteryLabel),
           validator: numberValidator,
         ),
         const SizedBox(height: 8),
         TextFormField(
           controller: maxChargingKwController,
-          keyboardType:
-              const TextInputType.numberWithOptions(decimal: true),
-          decoration: InputDecoration(
-            labelText:
-                l?.vehicleMaxChargeLabel ?? 'Max charging power (kW)',
-          ),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(labelText: l.vehicleMaxChargeLabel),
           validator: numberValidator,
         ),
         const SizedBox(height: 16),
         Text(
-          l?.vehicleConnectorsLabel ?? 'Supported connectors',
+          l.vehicleConnectorsLabel,
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         const SizedBox(height: 8),
@@ -86,9 +79,7 @@ class VehicleEvSection extends StatelessWidget {
               child: TextFormField(
                 controller: minSocController,
                 keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: l?.vehicleMinSocLabel ?? 'Min SoC %',
-                ),
+                decoration: InputDecoration(labelText: l.vehicleMinSocLabel),
               ),
             ),
             const SizedBox(width: 16),
@@ -96,9 +87,7 @@ class VehicleEvSection extends StatelessWidget {
               child: TextFormField(
                 controller: maxSocController,
                 keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: l?.vehicleMaxSocLabel ?? 'Max SoC %',
-                ),
+                decoration: InputDecoration(labelText: l.vehicleMaxSocLabel),
               ),
             ),
           ],

--- a/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
@@ -70,7 +70,7 @@ class VehicleExtrasSection {
       OutlinedButton.icon(
         onPressed: onResetVolumetricEfficiency,
         icon: const Icon(Icons.local_gas_station_outlined),
-        label: Text(l?.veResetAction ?? 'Reset volumetric efficiency'),
+        label: Text(l.veResetAction),
       ),
       // Service reminders (#584). Keyed by vehicle id; hidden on Add.
       const SizedBox(height: 16),

--- a/lib/features/vehicle/presentation/widgets/vehicle_header.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_header.dart
@@ -28,12 +28,12 @@ class VehicleHeader extends StatelessWidget {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
     final displayName = name.trim().isEmpty
-        ? (l?.vehicleHeaderUntitled ?? 'New vehicle')
+        ? (l.vehicleHeaderUntitled)
         : name.trim();
     final typeLabel = switch (type) {
-      VehicleType.ev => l?.vehicleTypeEv ?? 'Electric',
-      VehicleType.hybrid => l?.vehicleTypeHybrid ?? 'Hybrid',
-      VehicleType.combustion => l?.vehicleTypeCombustion ?? 'Combustion',
+      VehicleType.ev => l.vehicleTypeEv,
+      VehicleType.hybrid => l.vehicleTypeHybrid,
+      VehicleType.combustion => l.vehicleTypeCombustion,
     };
     final typeIcon = switch (type) {
       VehicleType.ev => Icons.electric_car,

--- a/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_identity_section.dart
@@ -68,8 +68,8 @@ class VehicleIdentitySection extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return FormSectionCard(
-      title: l?.vehicleSectionIdentityTitle ?? 'Identity',
-      subtitle: l?.vehicleSectionIdentitySubtitle ?? 'Name & VIN',
+      title: l.vehicleSectionIdentityTitle,
+      subtitle: l.vehicleSectionIdentitySubtitle,
       icon: Icons.badge_outlined,
       accent: accent,
       children: [
@@ -79,13 +79,12 @@ class VehicleIdentitySection extends StatelessWidget {
           content: TextFormField(
             controller: nameController,
             decoration: InputDecoration(
-              labelText: l?.vehicleNameLabel ?? 'Name',
-              hintText: l?.vehicleNameHint ?? 'e.g. My Tesla Model 3',
+              labelText: l.vehicleNameLabel,
+              hintText: l.vehicleNameHint,
               border: const OutlineInputBorder(),
             ),
-            validator: (v) => (v == null || v.trim().isEmpty)
-                ? (l?.fieldRequired ?? 'Required')
-                : null,
+            validator: (v) =>
+                (v == null || v.trim().isEmpty) ? (l.fieldRequired) : null,
           ),
         ),
         // VIN row — the FormFieldTile keeps the existing input layout,
@@ -103,7 +102,7 @@ class VehicleIdentitySection extends StatelessWidget {
                   controller: vinController,
                   focusNode: vinFocus,
                   decoration: InputDecoration(
-                    labelText: l?.vinLabel ?? 'VIN (optional)',
+                    labelText: l.vinLabel,
                     border: const OutlineInputBorder(),
                     suffixIcon: decodingVin
                         ? const Padding(
@@ -111,13 +110,12 @@ class VehicleIdentitySection extends StatelessWidget {
                             child: SizedBox(
                               width: 20,
                               height: 20,
-                              child: CircularProgressIndicator(
-                                  strokeWidth: 2),
+                              child: CircularProgressIndicator(strokeWidth: 2),
                             ),
                           )
                         : IconButton(
                             icon: const Icon(Icons.search),
-                            tooltip: l?.vinDecodeTooltip ?? 'Decode VIN',
+                            tooltip: l.vinDecodeTooltip,
                             onPressed: onDecodeVin,
                           ),
                   ),
@@ -125,11 +123,11 @@ class VehicleIdentitySection extends StatelessWidget {
               ),
             ),
             Semantics(
-              label: l?.vinInfoTooltip ?? 'What is a VIN?',
+              label: l.vinInfoTooltip,
               button: true,
               child: IconButton(
                 icon: const Icon(Icons.info_outline),
-                tooltip: l?.vinInfoTooltip ?? 'What is a VIN?',
+                tooltip: l.vinInfoTooltip,
                 onPressed: onShowVinInfo,
               ),
             ),
@@ -158,11 +156,8 @@ class VehicleIdentitySection extends StatelessWidget {
                   )
                 : const Icon(Icons.bluetooth_searching),
             label: Tooltip(
-              message: l?.vehicleReadVinFromCarTooltip ??
-                  'Read VIN from the paired OBD2 adapter',
-              child: Text(
-                l?.vehicleReadVinFromCarButton ?? 'Read VIN from car',
-              ),
+              message: l.vehicleReadVinFromCarTooltip,
+              child: Text(l.vehicleReadVinFromCarButton),
             ),
           ),
         ),
@@ -180,12 +175,11 @@ class VehicleIdentitySection extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(left: 12),
               child: Text(
-                l?.vehicleReadVinNoAdapterHint ??
-                    'Pair an OBD2 adapter first to read VIN automatically',
+                l.vehicleReadVinNoAdapterHint,
                 key: const Key('vehicleReadVinNoAdapterHint'),
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
@@ -33,7 +33,7 @@ class VehicleSaveBar extends StatelessWidget {
               minimumSize: const Size.fromHeight(52),
             ),
             icon: const Icon(Icons.save),
-            label: Text(l?.save ?? 'Save'),
+            label: Text(l.save),
           ),
         ),
       ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_type_selector.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_type_selector.dart
@@ -26,17 +26,17 @@ class VehicleTypeSelector extends StatelessWidget {
       segments: [
         ButtonSegment(
           value: VehicleType.combustion,
-          label: Text(l?.vehicleTypeCombustion ?? 'Combustion'),
+          label: Text(l.vehicleTypeCombustion),
           icon: const Icon(Icons.local_gas_station),
         ),
         ButtonSegment(
           value: VehicleType.hybrid,
-          label: Text(l?.vehicleTypeHybrid ?? 'Hybrid'),
+          label: Text(l.vehicleTypeHybrid),
           icon: const Icon(Icons.directions_car_filled),
         ),
         ButtonSegment(
           value: VehicleType.ev,
-          label: Text(l?.vehicleTypeEv ?? 'Electric'),
+          label: Text(l.vehicleTypeEv),
           icon: const Icon(Icons.electric_car),
         ),
       ],

--- a/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/vin_confirm_dialog.dart
@@ -57,12 +57,17 @@ class VinConfirmDialog extends StatelessWidget {
     final cylinders = data.cylinderCount?.toString() ?? '—';
     final fuel = data.fuelTypePrimary ?? '—';
 
-    final body = l?.vinConfirmBody(year, make, model, displacement,
-            cylinders, fuel) ??
-        '$year $make $model — ${displacement}L, $cylinders-cyl, $fuel';
+    final body = l.vinConfirmBody(
+      year,
+      make,
+      model,
+      displacement,
+      cylinders,
+      fuel,
+    );
 
     return AlertDialog(
-      title: Text(l?.vinConfirmTitle ?? 'Is this your car?'),
+      title: Text(l.vinConfirmTitle),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -72,37 +77,32 @@ class VinConfirmDialog extends StatelessWidget {
           // free, public database, the VIN never leaves their device
           // for Tankstellen purposes.
           Text(
-            l?.vinConfirmPrivacyNote ??
-                "We looked up your VIN on NHTSA's free vehicle "
-                    'database — nothing sent to Sparkilo servers.',
+            l.vinConfirmPrivacyNote,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+              color: Theme.of(context).colorScheme.primary,
+            ),
           ),
           const SizedBox(height: 12),
           Text(body),
           if (isPartial) ...[
             const SizedBox(height: 12),
             Text(
-              l?.vinPartialInfoNote ??
-                  'Partial info (offline). You can edit below.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontStyle: FontStyle.italic,
-                  ),
+              l.vinPartialInfoNote,
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
             ),
           ],
         ],
       ),
       actions: [
         TextButton(
-          onPressed: () =>
-              Navigator.of(context).pop(VinConfirmOutcome.modify),
-          child: Text(l?.vinModifyAction ?? 'Modify manually'),
+          onPressed: () => Navigator.of(context).pop(VinConfirmOutcome.modify),
+          child: Text(l.vinModifyAction),
         ),
         FilledButton(
-          onPressed: () =>
-              Navigator.of(context).pop(VinConfirmOutcome.confirm),
-          child: Text(l?.vinConfirmAction ?? 'Yes, auto-fill'),
+          onPressed: () => Navigator.of(context).pop(VinConfirmOutcome.confirm),
+          child: Text(l.vinConfirmAction),
         ),
       ],
     );

--- a/lib/features/vehicle/presentation/widgets/vin_info_sheet.dart
+++ b/lib/features/vehicle/presentation/widgets/vin_info_sheet.dart
@@ -46,14 +46,11 @@ class VinInfoSheet extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  Icon(
-                    Icons.info_outline,
-                    color: theme.colorScheme.primary,
-                  ),
+                  Icon(Icons.info_outline, color: theme.colorScheme.primary),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      l?.vinInfoTooltip ?? 'What is a VIN?',
+                      l.vinInfoTooltip,
                       style: theme.textTheme.titleLarge?.copyWith(
                         fontWeight: FontWeight.w600,
                       ),
@@ -63,50 +60,27 @@ class VinInfoSheet extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               _Section(
-                title: l?.vinInfoSectionWhatTitle ?? 'What is a VIN?',
-                body: l?.vinInfoSectionWhatBody ??
-                    'The Vehicle Identification Number is a 17-character '
-                        'code unique to your car. It\'s stamped on the '
-                        'chassis and printed on your vehicle registration '
-                        'document.',
+                title: l.vinInfoSectionWhatTitle,
+                body: l.vinInfoSectionWhatBody,
               ),
               _Section(
-                title: l?.vinInfoSectionWhyTitle ?? 'Why we ask',
-                body: l?.vinInfoSectionWhyBody ??
-                    'Decoding the VIN auto-fills engine displacement, '
-                        'cylinder count, model year, primary fuel type, '
-                        'and gross weight — saving you from looking up '
-                        'technical specs manually. The OBD2 fuel-rate '
-                        'calculation uses these values to give you '
-                        'accurate consumption numbers.',
+                title: l.vinInfoSectionWhyTitle,
+                body: l.vinInfoSectionWhyBody,
               ),
               _Section(
-                title: l?.vinInfoSectionPrivacyTitle ?? 'Privacy',
-                body: l?.vinInfoSectionPrivacyBody ??
-                    'Your VIN is stored only locally in the app\'s '
-                        'encrypted storage — it\'s never uploaded to '
-                        'Sparkilo servers. The NHTSA vPIC database '
-                        'is queried with the VIN but returns only '
-                        'anonymous technical specs; NHTSA does not '
-                        'link the VIN to any personal data. Without '
-                        'network, an offline lookup returns '
-                        'manufacturer and country only.',
+                title: l.vinInfoSectionPrivacyTitle,
+                body: l.vinInfoSectionPrivacyBody,
               ),
               _Section(
-                title: l?.vinInfoSectionWhereTitle ?? 'Where to find it',
-                body: l?.vinInfoSectionWhereBody ??
-                    'Look through the windshield at the lower-left '
-                        'corner on the driver\'s side, check the '
-                        'driver-side door-frame sticker when the door is '
-                        'open, or read it off your vehicle registration '
-                        'document (card / Carte Grise).',
+                title: l.vinInfoSectionWhereTitle,
+                body: l.vinInfoSectionWhereBody,
               ),
               const SizedBox(height: 4),
               Align(
                 alignment: Alignment.centerRight,
                 child: FilledButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l?.vinInfoDismiss ?? 'Got it'),
+                  child: Text(l.vinInfoDismiss),
                 ),
               ),
             ],
@@ -139,10 +113,7 @@ class _Section extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 4),
-          Text(
-            body,
-            style: theme.textTheme.bodyMedium,
-          ),
+          Text(body, style: theme.textTheme.bodyMedium),
         ],
       ),
     );

--- a/lib/features/vehicle/providers/service_reminder_providers.dart
+++ b/lib/features/vehicle/providers/service_reminder_providers.dart
@@ -1,9 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' as ui;
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/language/language_provider.dart';
 import '../../../core/notifications/notification_providers.dart';
+import '../../../l10n/app_localizations.dart';
 import '../data/repositories/service_reminder_repository.dart';
 import '../domain/entities/service_reminder.dart';
 import '../domain/services/service_reminder_evaluator.dart';
@@ -27,7 +31,27 @@ ServiceReminderEvaluator serviceReminderEvaluator(Ref ref) {
   return ServiceReminderEvaluator(
     repository: ref.watch(serviceReminderRepositoryProvider),
     notifications: ref.watch(notificationServiceProvider),
+    // #3162 — localized notification copy via the context-free
+    // `lookupAppLocalizations` resolve (the #2766 pattern); previously
+    // the evaluator silently fired an English fallback table on every
+    // locale. Guarded so a harness without the language graph degrades
+    // to English; the `en` lookup itself is total (template locale).
+    messages: ServiceReminderMessages.fromL10n(_reminderL10n(ref)),
   );
+}
+
+AppLocalizations _reminderL10n(Ref ref) {
+  String code;
+  try {
+    code = ref.watch(activeLanguageProvider).code;
+  } on Object {
+    code = 'en';
+  }
+  try {
+    return lookupAppLocalizations(ui.Locale(code));
+  } on Object {
+    return lookupAppLocalizations(const ui.Locale('en'));
+  }
 }
 
 /// Mutable list of every stored reminder. Individual screens watch
@@ -75,10 +99,7 @@ class ServiceReminderList extends _$ServiceReminderList {
 /// reminder change on one vehicle doesn't invalidate the edit screen
 /// of another.
 @riverpod
-List<ServiceReminder> serviceRemindersForVehicle(
-  Ref ref,
-  String vehicleId,
-) {
+List<ServiceReminder> serviceRemindersForVehicle(Ref ref, String vehicleId) {
   return ref
       .watch(serviceReminderListProvider)
       .where((r) => r.vehicleId == vehicleId)

--- a/lib/features/vehicle/providers/service_reminder_providers.g.dart
+++ b/lib/features/vehicle/providers/service_reminder_providers.g.dart
@@ -127,7 +127,7 @@ final class ServiceReminderEvaluatorProvider
 }
 
 String _$serviceReminderEvaluatorHash() =>
-    r'b46da525c9cea889a8a7c0c6f9ee484cc0c88835';
+    r'a64dbf1e9c68ba3fd9b018a2abe0d2b886566dcf';
 
 /// Mutable list of every stored reminder. Individual screens watch
 /// [serviceRemindersForVehicle] — this provider is the source of

--- a/lib/features/widget/presentation/widget_help_section.dart
+++ b/lib/features/widget/presentation/widget_help_section.dart
@@ -41,18 +41,7 @@ class WidgetHelpSection extends ConsumerWidget {
       profile = null;
     }
 
-    final lines = <String>[
-      l?.widgetHelpIntro ??
-          'Add the SparKilo widget to your home screen to see fuel and '
-              'charging prices at a glance.',
-      l?.widgetHelpAdd ??
-          "Add it from your launcher's widget picker — long-press an "
-              'empty area of the home screen, choose Widgets, and find '
-              'SparKilo.',
-      l?.widgetHelpTap ??
-          'Tap a station in the widget to open it in the app. Tap the '
-              'refresh icon to update prices.',
-    ];
+    final lines = <String>[l.widgetHelpIntro, l.widgetHelpAdd, l.widgetHelpTap];
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -70,13 +59,7 @@ class WidgetHelpSection extends ConsumerWidget {
           if (profile != null)
             _WidgetDefaultsEditor(profile: profile)
           else
-            Text(
-              l?.widgetHelpConfigure ??
-                  'On Android, long-press the widget and choose '
-                      'Reconfigure to change the profile, colour, and '
-                      'content.',
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(l.widgetHelpConfigure, style: theme.textTheme.bodySmall),
         ],
       ),
     );
@@ -97,27 +80,21 @@ class _WidgetDefaultsEditor extends ConsumerWidget {
       children: [
         const SizedBox(height: 4),
         Text(
-          l?.widgetDefaultsApplyToAllHint ??
-              'Choices below apply to every installed widget on the '
-                  'next refresh.',
+          l.widgetDefaultsApplyToAllHint,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
             fontStyle: FontStyle.italic,
           ),
         ),
         const SizedBox(height: 12),
-        Text(
-          l?.widgetDefaultsColorLabel ?? 'Colour scheme',
-          style: theme.textTheme.labelMedium,
-        ),
+        Text(l.widgetDefaultsColorLabel, style: theme.textTheme.labelMedium),
         const SizedBox(height: 4),
         DropdownButtonFormField<String>(
           key: const Key('widget_color_scheme_dropdown'),
           initialValue: profile.widgetColorScheme,
           decoration: const InputDecoration(
             isDense: true,
-            contentPadding:
-                EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             border: OutlineInputBorder(),
           ),
           items: [
@@ -133,10 +110,7 @@ class _WidgetDefaultsEditor extends ConsumerWidget {
           },
         ),
         const SizedBox(height: 12),
-        Text(
-          l?.widgetDefaultsVariantLabel ?? 'Content variant',
-          style: theme.textTheme.labelMedium,
-        ),
+        Text(l.widgetDefaultsVariantLabel, style: theme.textTheme.labelMedium),
         const SizedBox(height: 4),
         SegmentedButton<String>(
           key: const Key('widget_variant_segmented'),
@@ -144,11 +118,11 @@ class _WidgetDefaultsEditor extends ConsumerWidget {
           segments: [
             ButtonSegment(
               value: defaultWidgetVariant,
-              label: Text(l?.widgetVariantDefault ?? 'Default'),
+              label: Text(l.widgetVariantDefault),
             ),
             ButtonSegment(
               value: predictiveWidgetVariant,
-              label: Text(l?.widgetVariantPredictive ?? 'Predictive'),
+              label: Text(l.widgetVariantPredictive),
             ),
           ],
           onSelectionChanged: (sel) {
@@ -169,23 +143,20 @@ class _WidgetDefaultsEditor extends ConsumerWidget {
     unawaited(ref.read(activeProfileProvider.notifier).updateProfile(next));
   }
 
-  static String _localizedSchemeLabel(
-    AppLocalizations? l,
-    String scheme,
-  ) {
+  static String _localizedSchemeLabel(AppLocalizations l, String scheme) {
     switch (scheme) {
       case 'system':
-        return l?.widgetColorSchemeSystem ?? 'Follow system';
+        return l.widgetColorSchemeSystem;
       case 'light':
-        return l?.widgetColorSchemeLight ?? 'Light';
+        return l.widgetColorSchemeLight;
       case 'dark':
-        return l?.widgetColorSchemeDark ?? 'Dark';
+        return l.widgetColorSchemeDark;
       case 'blue':
-        return l?.widgetColorSchemeBlue ?? 'Blue';
+        return l.widgetColorSchemeBlue;
       case 'green':
-        return l?.widgetColorSchemeGreen ?? 'Green';
+        return l.widgetColorSchemeGreen;
       case 'orange':
-        return l?.widgetColorSchemeOrange ?? 'Orange';
+        return l.widgetColorSchemeOrange;
       default:
         return scheme;
     }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1434,6 +1434,7 @@
   "serviceReminderMarkDone": "Als erledigt markieren",
   "serviceReminderDueTitle": "Wartung fällig",
   "serviceReminderDueBody": "{label} ist fällig — {kmOver} km über dem Intervall.",
+  "serviceReminderDueNowBody": "{label} ist jetzt fällig.",
   "southKoreaApiKeyRequired": "Registrieren Sie sich bei OPINET, um einen kostenlosen API-Schlüssel zu erhalten",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Registrieren Sie sich bei CNE, um einen kostenlosen API-Schlüssel zu erhalten",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1596,6 +1596,15 @@
       }
     }
   },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
+  },
   "southKoreaApiKeyRequired": "Register at OPINET to get a free API key",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Register at CNE to get a free API key",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1442,6 +1442,7 @@
   "serviceReminderMarkDone": "Als erledigt markieren",
   "serviceReminderDueTitle": "Wartung fällig",
   "serviceReminderDueBody": "{label} ist fällig — {kmOver} km über dem Intervall.",
+  "serviceReminderDueNowBody": "{label} ist jetzt fällig.",
   "southKoreaApiKeyRequired": "Registrieren Sie sich bei OPINET, um einen kostenlosen API-Schlüssel zu erhalten",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Registrieren Sie sich bei CNE, um einen kostenlosen API-Schlüssel zu erhalten",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1606,6 +1606,15 @@
       }
     }
   },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
+  },
   "southKoreaApiKeyRequired": "Register at OPINET to get a free API key",
   "southKoreaApiProvider": "OPINET (KNOC)",
   "chileApiKeyRequired": "Register at CNE to get a free API key",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1012,6 +1012,7 @@
   "serviceReminderMarkDone": "⟦Ṁářķ áš đóñé ·····⟧",
   "serviceReminderDueTitle": "⟦Šéřṽîçé đúé ·····⟧",
   "serviceReminderDueBody": "⟦{label} îš đúé — {kmOver} ķɱ ƥášŧ ŧĥé îñŧéřṽáł. ··········⟧",
+  "serviceReminderDueNowBody": "⟦{label} îš đúé ñóŵ. ····⟧",
   "southKoreaApiKeyRequired": "⟦Řéǧîšŧéř áŧ ÓƤÎÑÉŦ ŧó ǧéŧ á ƒřéé ÁƤÎ ķéý ··············⟧",
   "southKoreaApiProvider": "⟦ÓƤÎÑÉŦ (ĶÑÓÇ) ·····⟧",
   "chileApiKeyRequired": "⟦Řéǧîšŧéř áŧ ÇÑÉ ŧó ǧéŧ á ƒřéé ÁƤÎ ķéý ·············⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4874,5 +4874,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6218,6 +6218,12 @@ abstract class AppLocalizations {
   /// **'{label} is due — {kmOver} km past the interval.'**
   String serviceReminderDueBody(String label, int kmOver);
 
+  /// No description provided for @serviceReminderDueNowBody.
+  ///
+  /// In en, this message translates to:
+  /// **'{label} is due now.'**
+  String serviceReminderDueNowBody(String label);
+
   /// No description provided for @southKoreaApiKeyRequired.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -88,8 +88,8 @@ abstract class AppLocalizations {
 
   final String localeName;
 
-  static AppLocalizations? of(BuildContext context) {
-    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
   static const LocalizationsDelegate<AppLocalizations> delegate =

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3385,6 +3385,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Регистрирайте се в OPINET за безплатен API ключ';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3369,6 +3369,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Zaregistrujte se na OPINET pro získání bezplatného klíče API';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3356,6 +3356,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrér dig hos OPINET for at få en gratis API-nøgle';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3377,6 +3377,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label ist jetzt fällig.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrieren Sie sich bei OPINET, um einen kostenlosen API-Schlüssel zu erhalten';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3382,6 +3382,11 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Εγγραφείτε στο OPINET για δωρεάν κλειδί API';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3344,6 +3344,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Register at OPINET to get a free API key';
 
@@ -11209,6 +11214,11 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String serviceReminderDueBody(String label, int kmOver) {
     return '⟦$label îš đúé — $kmOver ķɱ ƥášŧ ŧĥé îñŧéřṽáł. ··········⟧';
+  }
+
+  @override
+  String serviceReminderDueNowBody(String label) {
+    return '⟦$label îš đúé ñóŵ. ····⟧';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3377,6 +3377,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Regístrate en OPINET para obtener una clave de API gratuita';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3356,6 +3356,11 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registreeru OPINETis tasuta API-võtme saamiseks';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3359,6 +3359,11 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Rekisteröidy OPINETissä saadaksesi ilmaisen API-avaimen';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3387,6 +3387,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Inscrivez-vous sur OPINET pour obtenir une clé API gratuite';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3363,6 +3363,11 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrirajte se na OPINET za besplatni API ključ';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3379,6 +3379,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Regisztráljon az OPINET-en ingyenes API-kulcsért';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3373,6 +3373,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrati su OPINET per ottenere una chiave API gratuita';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3377,6 +3377,11 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Užsiregistruokite OPINET, kad gautumėte nemokamą API raktą';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3377,6 +3377,11 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Reģistrējieties OPINET, lai iegūtu bezmaksas API atslēgu';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3356,6 +3356,11 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrer deg på OPINET for å få en gratis API-nøkkel';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3373,6 +3373,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registreer bij OPINET voor een gratis API-sleutel';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3367,6 +3367,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Zarejestruj się w OPINET, aby uzyskać bezpłatny klucz API';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3381,6 +3381,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registe-se no OPINET para obter uma chave de API gratuita';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3379,6 +3379,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Înregistrați-vă la OPINET pentru a obține o cheie API gratuită';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3373,6 +3373,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Zaregistrujte sa na OPINET pre získanie bezplatného kľúča API';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3359,6 +3359,11 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrirajte se na OPINET za brezplačni ključ API';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3356,6 +3356,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String serviceReminderDueNowBody(String label) {
+    return '$label is due now.';
+  }
+
+  @override
   String get southKoreaApiKeyRequired =>
       'Registrera dig på OPINET för att få en gratis API-nyckel';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4771,5 +4771,16 @@
   "@alertsIosBestEffortNote": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "serviceReminderDueNowBody": "{label} is due now.",
+  "@serviceReminderDueNowBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Oil change"
+      }
+    }
   }
 }

--- a/test/app/routes/invalid_id_screen_test.dart
+++ b/test/app/routes/invalid_id_screen_test.dart
@@ -5,9 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tankstellen/app/routes/invalid_id_screen.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 Widget _wrap(String path) {
   return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
     home: Builder(builder: (ctx) => invalidIdScreen(ctx, path)),
   );
 }
@@ -72,7 +75,13 @@ void main() {
       );
       addTearDown(router.dispose);
 
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
       await tester.pump();
 
       // Sanity: started on the invalid screen.
@@ -83,10 +92,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       expect(find.byKey(const Key('homeScreen')), findsOneWidget);
-      expect(
-        router.routerDelegate.currentConfiguration.uri.toString(),
-        '/',
-      );
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/');
     });
   });
 }

--- a/test/app/shell/shell_destinations_test.dart
+++ b/test/app/shell/shell_destinations_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/app/shell/shell_destinations.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Pure-function tests for the destination-resolution helper.
 ///
@@ -20,20 +21,25 @@ import 'package:tankstellen/app/shell/shell_destinations.dart';
 ///     fuel-only:           `Map · Favorites · [Search] · Carburant`
 ///     fuel + trips:        `Map · Favorites · [Search] · Carburant · Trajets`
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('resolveShellDestinations', () {
     test(
       'conso off → Map · [Search] · Favorites (Carburant + Trajets dropped)',
       () {
         final result = resolveShellDestinations(
-          l10n: null,
+          l10n: l10nEn,
           showConsumption: false,
           showTrajets: false,
         );
 
         expect(result.items, hasLength(3));
         expect(result.branchForSlot, [2, 0, 1]);
-        expect(result.items.map((i) => i.label).toList(),
-            ['Favorites', 'Search', 'Map']);
+        expect(result.items.map((i) => i.label).toList(), [
+          'Favorites',
+          'Search',
+          'Map',
+        ]);
 
         // No fuel-station / route icon in the visible items list.
         for (final item in result.items) {
@@ -43,68 +49,67 @@ void main() {
       },
     );
 
-    test(
-      'fuel-only mode → Favorites · Map · [Search] · Carburant '
-      '(#1901: Trajets hidden)',
-      () {
-        final result = resolveShellDestinations(
-          l10n: null,
-          showConsumption: true,
-          showTrajets: false,
-        );
+    test('fuel-only mode → Favorites · Map · [Search] · Carburant '
+        '(#1901: Trajets hidden)', () {
+      final result = resolveShellDestinations(
+        l10n: l10nEn,
+        showConsumption: true,
+        showTrajets: false,
+      );
 
-        expect(result.items, hasLength(4));
-        // Visual slots map back to router branches Search=0, Map=1,
-        // Favorites=2, Carburant=3.
-        expect(result.branchForSlot, [2, 1, 0, 3]);
-        expect(result.items.map((i) => i.label).toList(),
-            ['Favorites', 'Map', 'Search', 'Fuel']);
+      expect(result.items, hasLength(4));
+      // Visual slots map back to router branches Search=0, Map=1,
+      // Favorites=2, Carburant=3.
+      expect(result.branchForSlot, [2, 1, 0, 3]);
+      expect(result.items.map((i) => i.label).toList(), [
+        'Favorites',
+        'Map',
+        'Search',
+        'Fuel',
+      ]);
 
-        // Carburant item carries the fuel-station icon.
-        expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
-        expect(result.items[3].filledIcon, Icons.local_gas_station);
+      // Carburant item carries the fuel-station icon.
+      expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+      expect(result.items[3].filledIcon, Icons.local_gas_station);
 
-        // No Trajets destination in fuel-only mode.
-        for (final item in result.items) {
-          expect(item.outlinedIcon, isNot(Icons.route_outlined));
-        }
-      },
-    );
+      // No Trajets destination in fuel-only mode.
+      for (final item in result.items) {
+        expect(item.outlinedIcon, isNot(Icons.route_outlined));
+      }
+    });
 
-    test(
-      'fuel + trips mode → Favorites · Map · [Search] · Carburant · Trajets '
-      '(#1901)',
-      () {
-        final result = resolveShellDestinations(
-          l10n: null,
-          showConsumption: true,
-          showTrajets: true,
-        );
+    test('fuel + trips mode → Favorites · Map · [Search] · Carburant · Trajets '
+        '(#1901)', () {
+      final result = resolveShellDestinations(
+        l10n: l10nEn,
+        showConsumption: true,
+        showTrajets: true,
+      );
 
-        expect(result.items, hasLength(5));
-        // Search=0, Map=1, Favorites=2, Carburant=3, Trajets=5.
-        expect(result.branchForSlot, [2, 1, 0, 3, kTrajetsBranchIndex]);
-        expect(result.items.map((i) => i.label).toList(),
-            ['Favorites', 'Map', 'Search', 'Fuel', 'Trips']);
+      expect(result.items, hasLength(5));
+      // Search=0, Map=1, Favorites=2, Carburant=3, Trajets=5.
+      expect(result.branchForSlot, [2, 1, 0, 3, kTrajetsBranchIndex]);
+      expect(result.items.map((i) => i.label).toList(), [
+        'Favorites',
+        'Map',
+        'Search',
+        'Fuel',
+        'Trips',
+      ]);
 
-        // Carburant carries the fuel-station icon, Trajets the route icon.
-        expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
-        expect(result.items[3].filledIcon, Icons.local_gas_station);
-        expect(result.items[4].outlinedIcon, Icons.route_outlined);
-        expect(result.items[4].filledIcon, Icons.route);
-      },
-    );
+      // Carburant carries the fuel-station icon, Trajets the route icon.
+      expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+      expect(result.items[3].filledIcon, Icons.local_gas_station);
+      expect(result.items[4].outlinedIcon, Icons.route_outlined);
+      expect(result.items[4].filledIcon, Icons.route);
+    });
 
     test('Search is the only primary (raised, centre) item', () {
       // #1901 — fuel + trips mode has an even item count (5 is odd, so
       // the centre is well-defined); cover all three visibility states.
-      for (final state in const [
-        (false, false),
-        (true, false),
-        (true, true),
-      ]) {
+      for (final state in const [(false, false), (true, false), (true, true)]) {
         final result = resolveShellDestinations(
-          l10n: null,
+          l10n: l10nEn,
           showConsumption: state.$1,
           showTrajets: state.$2,
         );
@@ -118,19 +123,17 @@ void main() {
     });
 
     test('Settings is never a bottom-bar destination (#1874)', () {
-      for (final state in const [
-        (false, false),
-        (true, false),
-        (true, true),
-      ]) {
+      for (final state in const [(false, false), (true, false), (true, true)]) {
         final result = resolveShellDestinations(
-          l10n: null,
+          l10n: l10nEn,
           showConsumption: state.$1,
           showTrajets: state.$2,
         );
         expect(result.items.map((i) => i.label), isNot(contains('Settings')));
-        expect(result.items.map((i) => i.outlinedIcon),
-            isNot(contains(Icons.settings_outlined)));
+        expect(
+          result.items.map((i) => i.outlinedIcon),
+          isNot(contains(Icons.settings_outlined)),
+        );
         // Branch 4 (the Settings/profile branch) is never a slot.
         expect(result.branchForSlot, isNot(contains(4)));
       }
@@ -138,34 +141,41 @@ void main() {
 
     test('falls back to English labels when l10n is null', () {
       final result = resolveShellDestinations(
-        l10n: null,
+        l10n: l10nEn,
         showConsumption: true,
         showTrajets: true,
       );
-      expect(result.items.map((i) => i.label).toList(),
-          ['Favorites', 'Map', 'Search', 'Fuel', 'Trips']);
+      expect(result.items.map((i) => i.label).toList(), [
+        'Favorites',
+        'Map',
+        'Search',
+        'Fuel',
+        'Trips',
+      ]);
     });
 
     test('the Carburant slot routes to kConsumptionBranchIndex', () {
       final result = resolveShellDestinations(
-        l10n: null,
+        l10n: l10nEn,
         showConsumption: true,
         showTrajets: false,
       );
-      final consoSlot = result.items
-          .indexWhere((i) => i.outlinedIcon == Icons.local_gas_station_outlined);
+      final consoSlot = result.items.indexWhere(
+        (i) => i.outlinedIcon == Icons.local_gas_station_outlined,
+      );
       expect(consoSlot, isNonNegative);
       expect(result.branchForSlot[consoSlot], kConsumptionBranchIndex);
     });
 
     test('the Trajets slot routes to kTrajetsBranchIndex (#1901)', () {
       final result = resolveShellDestinations(
-        l10n: null,
+        l10n: l10nEn,
         showConsumption: true,
         showTrajets: true,
       );
-      final trajetsSlot =
-          result.items.indexWhere((i) => i.outlinedIcon == Icons.route_outlined);
+      final trajetsSlot = result.items.indexWhere(
+        (i) => i.outlinedIcon == Icons.route_outlined,
+      );
       expect(trajetsSlot, isNonNegative);
       expect(result.branchForSlot[trajetsSlot], kTrajetsBranchIndex);
     });

--- a/test/core/error/error_localizer_test.dart
+++ b/test/core/error/error_localizer_test.dart
@@ -1,18 +1,24 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/error_localizer.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
-  // Test without l10n (null) to verify English fallbacks
-  group('ErrorLocalizer (no l10n)', () {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
+  // Driven with the real `en` localizations (lookupAppLocalizations —
+  // #3162: the nullable-getter fallback path no longer exists).
+  group('ErrorLocalizer (en l10n)', () {
     test('ApiException with 500+ status returns server error', () {
       final msg = ErrorLocalizer.localize(
         const ApiException(message: 'Internal Server Error', statusCode: 500),
-        null,
+        l10nEn,
       );
       expect(msg, contains('Server error'));
     });
@@ -20,7 +26,7 @@ void main() {
     test('ApiException with 403 returns API key error', () {
       final msg = ErrorLocalizer.localize(
         const ApiException(message: 'Forbidden', statusCode: 403),
-        null,
+        l10nEn,
       );
       expect(msg, contains('API key'));
     });
@@ -28,7 +34,7 @@ void main() {
     test('ApiException with 401 returns API key error', () {
       final msg = ErrorLocalizer.localize(
         const ApiException(message: 'Unauthorized', statusCode: 401),
-        null,
+        l10nEn,
       );
       expect(msg, contains('API key'));
     });
@@ -36,7 +42,7 @@ void main() {
     test('ApiException without status returns network error', () {
       final msg = ErrorLocalizer.localize(
         const ApiException(message: 'timeout'),
-        null,
+        l10nEn,
       );
       expect(msg, contains('Network error'));
     });
@@ -44,25 +50,19 @@ void main() {
     test('LocationException returns location error', () {
       final msg = ErrorLocalizer.localize(
         const LocationException(message: 'GPS off'),
-        null,
+        l10nEn,
       );
       expect(msg, contains('location'));
     });
 
     test('NoApiKeyException returns setup message', () {
-      final msg = ErrorLocalizer.localize(
-        const NoApiKeyException(),
-        null,
-      );
+      final msg = ErrorLocalizer.localize(const NoApiKeyException(), l10nEn);
       expect(msg, contains('API key'));
       expect(msg, contains('Settings'));
     });
 
     test('NoEvApiKeyException returns OpenChargeMap setup message', () {
-      final msg = ErrorLocalizer.localize(
-        const NoEvApiKeyException(),
-        null,
-      );
+      final msg = ErrorLocalizer.localize(const NoEvApiKeyException(), l10nEn);
       expect(msg, contains('OpenChargeMap'));
       expect(msg, contains('Settings'));
     });
@@ -70,7 +70,7 @@ void main() {
     test('ServiceChainExhaustedException returns data load error', () {
       final msg = ErrorLocalizer.localize(
         const ServiceChainExhaustedException(errors: []),
-        null,
+        l10nEn,
       );
       expect(msg, contains('load data'));
     });
@@ -82,7 +82,7 @@ void main() {
           countryCode: 'ar',
           detail: 'HandshakeException: certificate has expired',
         ),
-        null,
+        l10nEn,
       );
       // The user has to know WHO to contact — the host must appear in the
       // message, and we must mention the cert problem so the blame is on
@@ -97,17 +97,20 @@ void main() {
           host: 'example.com',
           detail: 'HandshakeException: bad cert',
         ),
-        null,
+        l10nEn,
       );
       // The low-level `HandshakeException` string is for logs, not for users.
-      expect(msg.contains('HandshakeException'), isFalse,
-          reason: 'Raw Dart exception class should not reach the UI');
+      expect(
+        msg.contains('HandshakeException'),
+        isFalse,
+        reason: 'Raw Dart exception class should not reach the UI',
+      );
     });
 
     test('CacheException returns cache error', () {
       final msg = ErrorLocalizer.localize(
         const CacheException(message: 'corrupt'),
-        null,
+        l10nEn,
       );
       expect(msg, contains('cache'));
     });
@@ -118,7 +121,7 @@ void main() {
           requestOptions: RequestOptions(),
           type: DioExceptionType.connectionTimeout,
         ),
-        null,
+        l10nEn,
       );
       expect(msg, contains('timed out'));
     });
@@ -129,7 +132,7 @@ void main() {
           requestOptions: RequestOptions(),
           type: DioExceptionType.connectionError,
         ),
-        null,
+        l10nEn,
       );
       expect(msg, contains('internet'));
     });
@@ -140,16 +143,13 @@ void main() {
           requestOptions: RequestOptions(),
           type: DioExceptionType.cancel,
         ),
-        null,
+        l10nEn,
       );
       expect(msg, contains('cancelled'));
     });
 
     test('unknown error returns generic message', () {
-      final msg = ErrorLocalizer.localize(
-        Exception('something weird'),
-        null,
-      );
+      final msg = ErrorLocalizer.localize(Exception('something weird'), l10nEn);
       expect(msg, contains('unexpected'));
     });
 
@@ -169,11 +169,17 @@ void main() {
       ];
 
       for (final error in errors) {
-        final msg = ErrorLocalizer.localize(error, null);
-        expect(msg.contains('Exception'), isFalse,
-            reason: 'Message should not contain raw "Exception": $msg');
-        expect(msg.contains('DioException'), isFalse,
-            reason: 'Message should not contain raw "DioException": $msg');
+        final msg = ErrorLocalizer.localize(error, l10nEn);
+        expect(
+          msg.contains('Exception'),
+          isFalse,
+          reason: 'Message should not contain raw "Exception": $msg',
+        );
+        expect(
+          msg.contains('DioException'),
+          isFalse,
+          reason: 'Message should not contain raw "DioException": $msg',
+        );
       }
     });
   });

--- a/test/core/services/impl/flutter_map_provider_test.dart
+++ b/test/core/services/impl/flutter_map_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/core/constants/app_constants.dart';
 import 'package:tankstellen/core/services/impl/flutter_map_provider.dart';
 import 'package:tankstellen/core/services/map_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Tests for [FlutterMapProvider] focusing on the 13 `@override` methods.
 ///
@@ -25,25 +26,27 @@ void main() {
       expect(provider.name, 'OpenStreetMap');
     });
 
-    test('tileConfig wires the effective (proxy) tile URL + UA + attribution',
-        () {
-      final config = provider.tileConfig;
+    test(
+      'tileConfig wires the effective (proxy) tile URL + UA + attribution',
+      () {
+        final config = provider.tileConfig;
 
-      expect(config, isA<TileLayerConfig>());
-      // #2396 — defaults through the Supabase OSM caching proxy
-      // (`effectiveTileUrl`: proxy when set, OSM-direct fallback otherwise).
-      expect(config.urlTemplate, AppConstants.effectiveTileUrl);
-      expect(config.urlTemplate, AppConstants.tileProxyUrl);
-      expect(
-        config.urlTemplate,
-        'https://klelxnkzrxlpzuddhpfg.supabase.co/functions/v1/tiles/{z}/{x}/{y}.png',
-      );
-      expect(config.userAgent, AppConstants.osmUserAgent);
-      expect(config.userAgent, isNotNull);
-      expect(config.userAgent, isNotEmpty);
-      expect(config.attribution, AppConstants.osmAttribution);
-      expect(config.attribution, contains('OpenStreetMap'));
-    });
+        expect(config, isA<TileLayerConfig>());
+        // #2396 — defaults through the Supabase OSM caching proxy
+        // (`effectiveTileUrl`: proxy when set, OSM-direct fallback otherwise).
+        expect(config.urlTemplate, AppConstants.effectiveTileUrl);
+        expect(config.urlTemplate, AppConstants.tileProxyUrl);
+        expect(
+          config.urlTemplate,
+          'https://klelxnkzrxlpzuddhpfg.supabase.co/functions/v1/tiles/{z}/{x}/{y}.png',
+        );
+        expect(config.userAgent, AppConstants.osmUserAgent);
+        expect(config.userAgent, isNotNull);
+        expect(config.userAgent, isNotEmpty);
+        expect(config.attribution, AppConstants.osmAttribution);
+        expect(config.attribution, contains('OpenStreetMap'));
+      },
+    );
 
     test('tileConfig is stable across calls (idempotent getter)', () {
       final c1 = provider.tileConfig;
@@ -107,7 +110,11 @@ void main() {
         );
 
         await tester.pumpWidget(
-          MaterialApp(home: Scaffold(body: SizedBox(width: 400, height: 400, child: map))),
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SizedBox(width: 400, height: 400, child: map)),
+          ),
         );
         // Allow flutter_map to attach the controller to its internal state.
         await tester.pump();
@@ -145,37 +152,44 @@ void main() {
   group('FlutterMapProvider — buildMapWidget', () {
     const provider = FlutterMapProvider();
 
-    testWidgets('returns a FlutterMap with the supplied controller and options',
-        (WidgetTester tester) async {
-      final controller = provider.createController();
-      addTearDown(() => provider.disposeController(controller));
+    testWidgets(
+      'returns a FlutterMap with the supplied controller and options',
+      (WidgetTester tester) async {
+        final controller = provider.createController();
+        addTearDown(() => provider.disposeController(controller));
 
-      final widget = provider.buildMapWidget(
-        controller: controller,
-        initialCenter: const LatLng(52.52, 13.405), // Berlin
-        initialZoom: 12,
-        children: [provider.buildTileLayer()],
-      );
+        final widget = provider.buildMapWidget(
+          controller: controller,
+          initialCenter: const LatLng(52.52, 13.405), // Berlin
+          initialZoom: 12,
+          children: [provider.buildTileLayer()],
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: widget)),
-      );
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: widget),
+          ),
+        );
 
-      final flutterMapFinder = find.byType(FlutterMap);
-      expect(flutterMapFinder, findsOneWidget);
+        final flutterMapFinder = find.byType(FlutterMap);
+        expect(flutterMapFinder, findsOneWidget);
 
-      final flutterMap = tester.widget<FlutterMap>(flutterMapFinder);
-      expect(flutterMap.mapController, same(controller));
-      expect(flutterMap.options.initialCenter, const LatLng(52.52, 13.405));
-      expect(flutterMap.options.initialZoom, 12);
-      expect(
-        flutterMap.options.interactionOptions.flags,
-        InteractiveFlag.all,
-      );
-    });
+        final flutterMap = tester.widget<FlutterMap>(flutterMapFinder);
+        expect(flutterMap.mapController, same(controller));
+        expect(flutterMap.options.initialCenter, const LatLng(52.52, 13.405));
+        expect(flutterMap.options.initialZoom, 12);
+        expect(
+          flutterMap.options.interactionOptions.flags,
+          InteractiveFlag.all,
+        );
+      },
+    );
 
-    testWidgets('forwards children list to the underlying FlutterMap',
-        (WidgetTester tester) async {
+    testWidgets('forwards children list to the underlying FlutterMap', (
+      WidgetTester tester,
+    ) async {
       final controller = provider.createController();
       addTearDown(() => provider.disposeController(controller));
 
@@ -189,7 +203,13 @@ void main() {
         children: [tile, attribution],
       );
 
-      await tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: widget),
+        ),
+      );
 
       expect(find.byType(FlutterMap), findsOneWidget);
       expect(find.byType(TileLayer), findsOneWidget);
@@ -200,12 +220,15 @@ void main() {
   group('FlutterMapProvider — buildTileLayer', () {
     const provider = FlutterMapProvider();
 
-    testWidgets('configures TileLayer from tileConfig URL and userAgent',
-        (WidgetTester tester) async {
+    testWidgets('configures TileLayer from tileConfig URL and userAgent', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildTileLayer();
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -241,6 +264,8 @@ void main() {
     Future<void> pumpInMap(WidgetTester tester, Widget layer) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -252,8 +277,9 @@ void main() {
       );
     }
 
-    testWidgets('returns MarkerLayer when cluster is false',
-        (WidgetTester tester) async {
+    testWidgets('returns MarkerLayer when cluster is false', (
+      WidgetTester tester,
+    ) async {
       final markers = List.generate(
         3,
         (i) => MapMarkerConfig(
@@ -274,8 +300,9 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('returns MarkerLayer when cluster is true but ≤20 markers',
-        (WidgetTester tester) async {
+    testWidgets('returns MarkerLayer when cluster is true but ≤20 markers', (
+      WidgetTester tester,
+    ) async {
       // Boundary: 20 markers should NOT cluster (>20 condition).
       final markers = List.generate(
         20,
@@ -287,18 +314,16 @@ void main() {
         ),
       );
 
-      final widget = provider.buildMarkerLayer(
-        markers: markers,
-        cluster: true,
-      );
+      final widget = provider.buildMarkerLayer(markers: markers, cluster: true);
 
       await pumpInMap(tester, widget);
       expect(find.byType(MarkerLayer), findsOneWidget);
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('returns MarkerClusterLayerWidget when cluster=true and >20',
-        (WidgetTester tester) async {
+    testWidgets('returns MarkerClusterLayerWidget when cluster=true and >20', (
+      WidgetTester tester,
+    ) async {
       final markers = List.generate(
         25,
         (i) => MapMarkerConfig(
@@ -309,17 +334,15 @@ void main() {
         ),
       );
 
-      final widget = provider.buildMarkerLayer(
-        markers: markers,
-        cluster: true,
-      );
+      final widget = provider.buildMarkerLayer(markers: markers, cluster: true);
 
       await pumpInMap(tester, widget);
       expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
     });
 
-    testWidgets('uses custom clusterBuilder when provided (>20 markers)',
-        (WidgetTester tester) async {
+    testWidgets('uses custom clusterBuilder when provided (>20 markers)', (
+      WidgetTester tester,
+    ) async {
       const customKey = Key('custom-cluster-widget');
 
       final markers = List.generate(
@@ -352,6 +375,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: SizedBox(
             width: 400,
             height: 400,
@@ -388,13 +413,12 @@ void main() {
         ),
       );
 
-      final widget = provider.buildMarkerLayer(
-        markers: markers,
-        cluster: true,
-      );
+      final widget = provider.buildMarkerLayer(markers: markers, cluster: true);
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: SizedBox(
             width: 400,
             height: 400,
@@ -420,8 +444,9 @@ void main() {
       expect(boldText, findsWidgets);
     });
 
-    testWidgets('returns MarkerLayer with empty list when no markers',
-        (WidgetTester tester) async {
+    testWidgets('returns MarkerLayer with empty list when no markers', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildMarkerLayer(
         markers: const [],
         cluster: true,
@@ -437,8 +462,9 @@ void main() {
   group('FlutterMapProvider — buildPolylineLayer', () {
     const provider = FlutterMapProvider();
 
-    testWidgets('builds a PolylineLayer with the supplied points/colors',
-        (WidgetTester tester) async {
+    testWidgets('builds a PolylineLayer with the supplied points/colors', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildPolylineLayer(
         polylines: const [
           MapPolylineConfig(
@@ -455,6 +481,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -482,6 +510,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -499,8 +529,9 @@ void main() {
   group('FlutterMapProvider — buildCircleLayer', () {
     const provider = FlutterMapProvider();
 
-    testWidgets('builds a CircleLayer using radius-in-meters mode',
-        (WidgetTester tester) async {
+    testWidgets('builds a CircleLayer using radius-in-meters mode', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildCircleLayer(
         circles: const [
           MapCircleConfig(
@@ -521,6 +552,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -549,6 +582,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -567,35 +602,40 @@ void main() {
     const provider = FlutterMapProvider();
 
     testWidgets(
-        'returns a RichAttributionWidget crediting OSM (#2402 — localized '
-        'wrapper, brand kept literal)', (WidgetTester tester) async {
-      final widget = provider.buildAttribution();
+      'returns a RichAttributionWidget crediting OSM (#2402 — localized '
+      'wrapper, brand kept literal)',
+      (WidgetTester tester) async {
+        final widget = provider.buildAttribution();
 
-      // No `AppLocalizations` in the tree, so the helper takes its English
-      // fallback composition — which still carries the © and the brand.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(48.0, 2.0),
-              initialZoom: 10,
+        // No `AppLocalizations` in the tree, so the helper takes its English
+        // fallback composition — which still carries the © and the brand.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: FlutterMap(
+              options: const MapOptions(
+                initialCenter: LatLng(48.0, 2.0),
+                initialZoom: 10,
+              ),
+              children: [widget],
             ),
-            children: [widget],
           ),
-        ),
-      );
+        );
 
-      final attributionFinder = find.byType(RichAttributionWidget);
-      expect(attributionFinder, findsOneWidget);
+        final attributionFinder = find.byType(RichAttributionWidget);
+        expect(attributionFinder, findsOneWidget);
 
-      final attribution = tester.widget<RichAttributionWidget>(attributionFinder);
-      expect(attribution.attributions, hasLength(1));
-      final source =
-          attribution.attributions.single as TextSourceAttribution;
-      // Brand stays literal; wrapper composes "© OpenStreetMap contributors".
-      expect(source.text, contains('OpenStreetMap'));
-      expect(source.text, startsWith('©'));
-      expect(source.text, '© OpenStreetMap contributors');
-    });
+        final attribution = tester.widget<RichAttributionWidget>(
+          attributionFinder,
+        );
+        expect(attribution.attributions, hasLength(1));
+        final source = attribution.attributions.single as TextSourceAttribution;
+        // Brand stays literal; wrapper composes "© OpenStreetMap contributors".
+        expect(source.text, contains('OpenStreetMap'));
+        expect(source.text, startsWith('©'));
+        expect(source.text, '© OpenStreetMap contributors');
+      },
+    );
   });
 }

--- a/test/core/services/map_provider_test.dart
+++ b/test/core/services/map_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/core/constants/app_constants.dart';
 import 'package:tankstellen/core/services/impl/flutter_map_provider.dart';
 import 'package:tankstellen/core/services/map_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('TileLayerConfig', () {
@@ -115,15 +116,17 @@ void main() {
       expect(provider.name, 'OpenStreetMap');
     });
 
-    test('tileConfig returns the effective (proxy) tile URL from AppConstants',
-        () {
-      final config = provider.tileConfig;
-      // #2396 — flipped to the Supabase OSM caching proxy via
-      // `effectiveTileUrl` (OSM-direct retained as the empty-proxy fallback).
-      expect(config.urlTemplate, AppConstants.effectiveTileUrl);
-      expect(config.userAgent, AppConstants.osmUserAgent);
-      expect(config.attribution, AppConstants.osmAttribution);
-    });
+    test(
+      'tileConfig returns the effective (proxy) tile URL from AppConstants',
+      () {
+        final config = provider.tileConfig;
+        // #2396 — flipped to the Supabase OSM caching proxy via
+        // `effectiveTileUrl` (OSM-direct retained as the empty-proxy fallback).
+        expect(config.urlTemplate, AppConstants.effectiveTileUrl);
+        expect(config.userAgent, AppConstants.osmUserAgent);
+        expect(config.attribution, AppConstants.osmAttribution);
+      },
+    );
 
     test('createController returns a MapController', () {
       final controller = provider.createController();
@@ -136,8 +139,9 @@ void main() {
     });
 
     group('buildMarkerLayer', () {
-      testWidgets('returns MarkerLayer for few markers',
-          (WidgetTester tester) async {
+      testWidgets('returns MarkerLayer for few markers', (
+        WidgetTester tester,
+      ) async {
         final markers = List.generate(
           5,
           (i) => MapMarkerConfig(
@@ -155,6 +159,8 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: FlutterMap(
               options: const MapOptions(
                 initialCenter: LatLng(48.0, 2.0),
@@ -168,77 +174,88 @@ void main() {
         expect(find.byType(MarkerLayer), findsOneWidget);
       });
 
-      testWidgets('returns MarkerLayer when cluster is false even with many markers',
-          (WidgetTester tester) async {
-        final markers = List.generate(
-          30,
-          (i) => MapMarkerConfig(
-            point: LatLng(48.0 + i * 0.001, 2.0),
-            width: 40,
-            height: 40,
-            child: const SizedBox(),
-          ),
-        );
-
-        final widget = provider.buildMarkerLayer(
-          markers: markers,
-          cluster: false,
-        );
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: FlutterMap(
-              options: const MapOptions(
-                initialCenter: LatLng(48.0, 2.0),
-                initialZoom: 10,
-              ),
-              children: [widget],
+      testWidgets(
+        'returns MarkerLayer when cluster is false even with many markers',
+        (WidgetTester tester) async {
+          final markers = List.generate(
+            30,
+            (i) => MapMarkerConfig(
+              point: LatLng(48.0 + i * 0.001, 2.0),
+              width: 40,
+              height: 40,
+              child: const SizedBox(),
             ),
-          ),
-        );
+          );
 
-        expect(find.byType(MarkerLayer), findsOneWidget);
-      });
+          final widget = provider.buildMarkerLayer(
+            markers: markers,
+            cluster: false,
+          );
 
-      testWidgets('returns cluster widget when cluster is true and >20 markers',
-          (WidgetTester tester) async {
-        final markers = List.generate(
-          25,
-          (i) => MapMarkerConfig(
-            point: LatLng(48.0 + i * 0.001, 2.0),
-            width: 40,
-            height: 40,
-            child: const SizedBox(),
-          ),
-        );
-
-        final widget = provider.buildMarkerLayer(
-          markers: markers,
-          cluster: true,
-        );
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: FlutterMap(
-              options: const MapOptions(
-                initialCenter: LatLng(48.0, 2.0),
-                initialZoom: 10,
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: FlutterMap(
+                options: const MapOptions(
+                  initialCenter: LatLng(48.0, 2.0),
+                  initialZoom: 10,
+                ),
+                children: [widget],
               ),
-              children: [widget],
             ),
-          ),
-        );
+          );
 
-        expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-      });
+          expect(find.byType(MarkerLayer), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'returns cluster widget when cluster is true and >20 markers',
+        (WidgetTester tester) async {
+          final markers = List.generate(
+            25,
+            (i) => MapMarkerConfig(
+              point: LatLng(48.0 + i * 0.001, 2.0),
+              width: 40,
+              height: 40,
+              child: const SizedBox(),
+            ),
+          );
+
+          final widget = provider.buildMarkerLayer(
+            markers: markers,
+            cluster: true,
+          );
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: FlutterMap(
+                options: const MapOptions(
+                  initialCenter: LatLng(48.0, 2.0),
+                  initialZoom: 10,
+                ),
+                children: [widget],
+              ),
+            ),
+          );
+
+          expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+        },
+      );
     });
 
-    testWidgets('buildTileLayer returns a TileLayer',
-        (WidgetTester tester) async {
+    testWidgets('buildTileLayer returns a TileLayer', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildTileLayer();
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -252,12 +269,15 @@ void main() {
       expect(find.byType(TileLayer), findsOneWidget);
     });
 
-    testWidgets('buildAttribution returns a RichAttributionWidget',
-        (WidgetTester tester) async {
+    testWidgets('buildAttribution returns a RichAttributionWidget', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildAttribution();
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -271,8 +291,9 @@ void main() {
       expect(find.byType(RichAttributionWidget), findsOneWidget);
     });
 
-    testWidgets('buildPolylineLayer renders polylines',
-        (WidgetTester tester) async {
+    testWidgets('buildPolylineLayer renders polylines', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildPolylineLayer(
         polylines: [
           const MapPolylineConfig(
@@ -284,6 +305,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -297,8 +320,9 @@ void main() {
       expect(find.byType(PolylineLayer), findsOneWidget);
     });
 
-    testWidgets('buildCircleLayer renders circles',
-        (WidgetTester tester) async {
+    testWidgets('buildCircleLayer renders circles', (
+      WidgetTester tester,
+    ) async {
       final widget = provider.buildCircleLayer(
         circles: [
           const MapCircleConfig(
@@ -312,6 +336,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(48.0, 2.0),
@@ -325,8 +351,9 @@ void main() {
       expect(find.byType(CircleLayer), findsOneWidget);
     });
 
-    testWidgets('buildMapWidget renders a FlutterMap',
-        (WidgetTester tester) async {
+    testWidgets('buildMapWidget renders a FlutterMap', (
+      WidgetTester tester,
+    ) async {
       final controller = provider.createController();
 
       try {
@@ -337,7 +364,13 @@ void main() {
           children: [provider.buildTileLayer()],
         );
 
-        await tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: widget),
+          ),
+        );
 
         expect(find.byType(FlutterMap), findsOneWidget);
       } finally {

--- a/test/core/services/widgets/freshness_badge_test.dart
+++ b/test/core/services/widgets/freshness_badge_test.dart
@@ -6,10 +6,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/widgets/freshness_badge.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   Widget wrapInApp(Widget child) {
-    return MaterialApp(home: Scaffold(body: child));
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
   }
 
   /// Resolves the semantic warning / error colours against the same theme
@@ -18,11 +23,17 @@ void main() {
   Future<({Color warning, Color error})> tokensOf(WidgetTester tester) async {
     late Color warning;
     late Color error;
-    await tester.pumpWidget(wrapInApp(Builder(builder: (context) {
-      warning = DarkModeColors.warning(context);
-      error = DarkModeColors.error(context);
-      return const SizedBox();
-    })));
+    await tester.pumpWidget(
+      wrapInApp(
+        Builder(
+          builder: (context) {
+            warning = DarkModeColors.warning(context);
+            error = DarkModeColors.error(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
     return (warning: warning, error: error);
   }
 
@@ -31,8 +42,9 @@ void main() {
       tester.widget<Icon>(find.byIcon(icon)).color!;
 
   group('FreshnessBadge', () {
-    testWidgets('shows green check icon for fresh data (< 5 min)',
-        (tester) async {
+    testWidgets('shows green check icon for fresh data (< 5 min)', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.tankerkoenigApi,
@@ -46,39 +58,43 @@ void main() {
       expect(find.textContaining('2 min'), findsOneWidget);
     });
 
-    testWidgets('shows amber schedule icon for moderately old data (5-15 min)',
-        (tester) async {
-      final result = ServiceResult(
-        data: <String>[],
-        source: ServiceSource.tankerkoenigApi,
-        fetchedAt: DateTime.now().subtract(const Duration(minutes: 10)),
-      );
+    testWidgets(
+      'shows amber schedule icon for moderately old data (5-15 min)',
+      (tester) async {
+        final result = ServiceResult(
+          data: <String>[],
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now().subtract(const Duration(minutes: 10)),
+        );
 
-      await tester.pumpWidget(wrapInApp(FreshnessBadge(result: result)));
+        await tester.pumpWidget(wrapInApp(FreshnessBadge(result: result)));
 
-      expect(find.byIcon(Icons.schedule), findsOneWidget);
-      expect(find.textContaining('10 min'), findsOneWidget);
-    });
+        expect(find.byIcon(Icons.schedule), findsOneWidget);
+        expect(find.textContaining('10 min'), findsOneWidget);
+      },
+    );
 
     testWidgets(
-        'shows amber (warning, not error-red) warning icon for old data '
-        '(> 15 min) [#2492]', (tester) async {
-      final result = ServiceResult(
-        data: <String>[],
-        source: ServiceSource.tankerkoenigApi,
-        fetchedAt: DateTime.now().subtract(const Duration(minutes: 20)),
-      );
-      final tokens = await tokensOf(tester);
+      'shows amber (warning, not error-red) warning icon for old data '
+      '(> 15 min) [#2492]',
+      (tester) async {
+        final result = ServiceResult(
+          data: <String>[],
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now().subtract(const Duration(minutes: 20)),
+        );
+        final tokens = await tokensOf(tester);
 
-      await tester.pumpWidget(wrapInApp(FreshnessBadge(result: result)));
+        await tester.pumpWidget(wrapInApp(FreshnessBadge(result: result)));
 
-      expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
-      expect(find.textContaining('20 min'), findsOneWidget);
-      // #2492 — very-stale stays in the amber/warning family, NOT error-red.
-      final c = iconColor(tester, Icons.warning_amber_rounded);
-      expect(c, tokens.warning);
-      expect(c, isNot(tokens.error));
-    });
+        expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+        expect(find.textContaining('20 min'), findsOneWidget);
+        // #2492 — very-stale stays in the amber/warning family, NOT error-red.
+        final c = iconColor(tester, Icons.warning_amber_rounded);
+        expect(c, tokens.warning);
+        expect(c, isNot(tokens.error));
+      },
+    );
 
     testWidgets('shows "Stale" prefix when result is stale', (tester) async {
       final result = ServiceResult(
@@ -95,8 +111,9 @@ void main() {
       expect(find.textContaining('30 min'), findsOneWidget);
     });
 
-    testWidgets('shows stale with amber icon even for recent stale data',
-        (tester) async {
+    testWidgets('shows stale with amber icon even for recent stale data', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.cache,
@@ -192,8 +209,9 @@ void main() {
       expect(find.byIcon(Icons.schedule), findsOneWidget);
     });
 
-    testWidgets('boundary: exactly 15 minutes shows amber (not red)',
-        (tester) async {
+    testWidgets('boundary: exactly 15 minutes shows amber (not red)', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.tankerkoenigApi,
@@ -206,8 +224,9 @@ void main() {
       expect(find.byIcon(Icons.schedule), findsOneWidget);
     });
 
-    testWidgets('boundary: 16 minutes shows the warning icon (amber)',
-        (tester) async {
+    testWidgets('boundary: 16 minutes shows the warning icon (amber)', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.tankerkoenigApi,

--- a/test/core/services/widgets/service_status_banner_test.dart
+++ b/test/core/services/widgets/service_status_banner_test.dart
@@ -12,7 +12,11 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 void main() {
   group('ServiceStatusBanner', () {
     Widget wrapInApp(Widget child) {
-      return MaterialApp(home: Scaffold(body: child));
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: child),
+      );
     }
 
     test('returns SizedBox.shrink when not stale and no fallbacks', () {
@@ -30,8 +34,9 @@ void main() {
       expect(result.hadFallbacks, isFalse);
     });
 
-    testWidgets('shows nothing when data is fresh and no fallbacks',
-        (tester) async {
+    testWidgets('shows nothing when data is fresh and no fallbacks', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.tankerkoenigApi,
@@ -60,8 +65,9 @@ void main() {
       expect(find.textContaining('Offline'), findsOneWidget);
     });
 
-    testWidgets('shows fallback banner when errors present but not stale',
-        (tester) async {
+    testWidgets('shows fallback banner when errors present but not stale', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.cache,
@@ -82,8 +88,9 @@ void main() {
       expect(find.textContaining('unavailable'), findsOneWidget);
     });
 
-    testWidgets('stale takes priority over fallbacks in display',
-        (tester) async {
+    testWidgets('stale takes priority over fallbacks in display', (
+      tester,
+    ) async {
       final result = ServiceResult(
         data: <String>[],
         source: ServiceSource.cache,
@@ -108,17 +115,23 @@ void main() {
 
   group('ServiceChainErrorWidget', () {
     Widget wrapInApp(Widget child) {
-      return MaterialApp(home: Scaffold(body: SingleChildScrollView(child: child)));
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: SingleChildScrollView(child: child)),
+      );
     }
 
     testWidgets('displays error icon and retry button', (tester) async {
       var retryPressed = false;
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('test error'),
-          onRetry: () => retryPressed = true,
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('test error'),
+            onRetry: () => retryPressed = true,
+          ),
         ),
-      ));
+      );
 
       expect(find.byIcon(Icons.cloud_off), findsOneWidget);
       expect(find.byIcon(Icons.refresh), findsOneWidget);
@@ -128,88 +141,96 @@ void main() {
     });
 
     testWidgets('hides retry button when onRetry is null', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        const ServiceChainErrorWidget(
-          error: NoApiKeyException(),
-        ),
-      ));
+      await tester.pumpWidget(
+        wrapInApp(const ServiceChainErrorWidget(error: NoApiKeyException())),
+      );
 
       expect(find.byType(FilledButton), findsNothing);
     });
 
     testWidgets('shows hint for NoApiKeyException', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        const ServiceChainErrorWidget(
-          error: NoApiKeyException(),
-        ),
-      ));
+      await tester.pumpWidget(
+        wrapInApp(const ServiceChainErrorWidget(error: NoApiKeyException())),
+      );
 
       expect(find.textContaining('API key'), findsWidgets);
     });
 
     testWidgets('shows hint for LocationException', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: const LocationException(message: 'GPS unavailable'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: const LocationException(message: 'GPS unavailable'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       // Should contain location-related hint
       expect(find.textContaining('Location'), findsWidgets);
     });
 
     testWidgets('shows hint for timeout errors', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('connection timeout occurred'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('connection timeout occurred'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.textContaining('internet'), findsOneWidget);
     });
 
     testWidgets('shows hint for route errors', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('Route calculation via OSRM failed'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('Route calculation via OSRM failed'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.textContaining('Route'), findsOneWidget);
     });
 
     testWidgets('shows generic hint for unknown errors', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('something weird'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('something weird'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.textContaining('Try again'), findsWidgets);
     });
 
     testWidgets('shows expandable technical details', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: ServiceChainExhaustedException(errors: [
-            ServiceError(
-              source: ServiceSource.tankerkoenigApi,
-              message: 'API timeout',
-              occurredAt: DateTime.now(),
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: ServiceChainExhaustedException(
+              errors: [
+                ServiceError(
+                  source: ServiceSource.tankerkoenigApi,
+                  message: 'API timeout',
+                  occurredAt: DateTime.now(),
+                ),
+                ServiceError(
+                  source: ServiceSource.cache,
+                  message: 'Cache empty',
+                  occurredAt: DateTime.now(),
+                ),
+              ],
             ),
-            ServiceError(
-              source: ServiceSource.cache,
-              message: 'Cache empty',
-              occurredAt: DateTime.now(),
-            ),
-          ]),
-          onRetry: () {},
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       // Details section exists
       expect(find.text('Details'), findsOneWidget);
@@ -224,12 +245,14 @@ void main() {
     });
 
     testWidgets('shows technical details for plain exception', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('plain error'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('plain error'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       // Expand details
       await tester.tap(find.text('Details'));
@@ -239,12 +262,14 @@ void main() {
     });
 
     testWidgets('shows no stations found hint', (tester) async {
-      await tester.pumpWidget(wrapInApp(
-        ServiceChainErrorWidget(
-          error: Exception('no stations found in area'),
-          onRetry: () {},
+      await tester.pumpWidget(
+        wrapInApp(
+          ServiceChainErrorWidget(
+            error: Exception('no stations found in area'),
+            onRetry: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.textContaining('search radius'), findsOneWidget);
     });
@@ -259,29 +284,34 @@ void main() {
       }
 
       testWidgets('renders a "Report this issue" button', (tester) async {
-        await tester.pumpWidget(wrapWithL10n(
-          ServiceChainErrorWidget(
-            error: const ApiException(
-              message: 'Upstream broken',
-              statusCode: 404,
+        await tester.pumpWidget(
+          wrapWithL10n(
+            ServiceChainErrorWidget(
+              error: const ApiException(
+                message: 'Upstream broken',
+                statusCode: 404,
+              ),
+              onRetry: () {},
             ),
-            onRetry: () {},
           ),
-        ));
+        );
         await tester.pumpAndSettle();
 
         expect(find.text('Report this issue'), findsOneWidget);
         expect(find.byIcon(Icons.bug_report_outlined), findsOneWidget);
       });
 
-      testWidgets('hides the report CTA for a tracked stop-gap error (#1606)',
-          (tester) async {
-        await tester.pumpWidget(wrapWithL10n(
-          ServiceChainErrorWidget(
-            error: Exception('NSW FuelCheck retired. Tracked in #504'),
-            onRetry: () {},
+      testWidgets('hides the report CTA for a tracked stop-gap error (#1606)', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          wrapWithL10n(
+            ServiceChainErrorWidget(
+              error: Exception('NSW FuelCheck retired. Tracked in #504'),
+              onRetry: () {},
+            ),
           ),
-        ));
+        );
         await tester.pumpAndSettle();
 
         // A designed-in message tied to a tracked issue must not offer
@@ -290,23 +320,28 @@ void main() {
         expect(find.byIcon(Icons.bug_report_outlined), findsNothing);
       });
 
-      testWidgets('hides the report CTA for a transient network error (#1606)',
-          (tester) async {
-        await tester.pumpWidget(wrapWithL10n(
-          ServiceChainErrorWidget(
-            error: Exception('Network error (status: null)'),
-            onRetry: () {},
-          ),
-        ));
-        await tester.pumpAndSettle();
+      testWidgets(
+        'hides the report CTA for a transient network error (#1606)',
+        (tester) async {
+          await tester.pumpWidget(
+            wrapWithL10n(
+              ServiceChainErrorWidget(
+                error: Exception('Network error (status: null)'),
+                onRetry: () {},
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
 
-        // A status-less connectivity failure is non-actionable as a bug
-        // report — the hint tells the user to check their connection.
-        expect(find.text('Report this issue'), findsNothing);
-      });
+          // A status-less connectivity failure is non-actionable as a bug
+          // report — the hint tells the user to check their connection.
+          expect(find.text('Report this issue'), findsNothing);
+        },
+      );
 
-      testWidgets('tapping report opens the consent dialog, not the browser',
-          (tester) async {
+      testWidgets('tapping report opens the consent dialog, not the browser', (
+        tester,
+      ) async {
         Uri? launched;
         final reporter = ErrorReporter(
           launcher: (uri) async {
@@ -315,17 +350,19 @@ void main() {
           },
         );
 
-        await tester.pumpWidget(wrapWithL10n(
-          ServiceChainErrorWidget(
-            error: const ApiException(
-              message: 'Upstream broken',
-              statusCode: 404,
+        await tester.pumpWidget(
+          wrapWithL10n(
+            ServiceChainErrorWidget(
+              error: const ApiException(
+                message: 'Upstream broken',
+                statusCode: 404,
+              ),
+              onRetry: () {},
+              reporter: reporter,
+              countryCode: 'GB',
             ),
-            onRetry: () {},
-            reporter: reporter,
-            countryCode: 'GB',
           ),
-        ));
+        );
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Report this issue'));
@@ -346,8 +383,9 @@ void main() {
         expect(launched!.queryParameters['title'], contains('GB'));
       });
 
-      testWidgets('cancelling the consent dialog does not launch a URL',
-          (tester) async {
+      testWidgets('cancelling the consent dialog does not launch a URL', (
+        tester,
+      ) async {
         Uri? launched;
         final reporter = ErrorReporter(
           launcher: (uri) async {
@@ -356,13 +394,15 @@ void main() {
           },
         );
 
-        await tester.pumpWidget(wrapWithL10n(
-          ServiceChainErrorWidget(
-            error: Exception('weird error'),
-            onRetry: () {},
-            reporter: reporter,
+        await tester.pumpWidget(
+          wrapWithL10n(
+            ServiceChainErrorWidget(
+              error: Exception('weird error'),
+              onRetry: () {},
+              reporter: reporter,
+            ),
           ),
-        ));
+        );
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Report this issue'));

--- a/test/core/widgets/star_rating_test.dart
+++ b/test/core/widgets/star_rating_test.dart
@@ -4,18 +4,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/widgets/star_rating.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('StarRating', () {
     testWidgets('renders 5 star icons', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 0,
-              onRatingChanged: (_) {},
-            ),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: StarRating(rating: 0, onRatingChanged: (_) {})),
         ),
       );
 
@@ -31,12 +29,9 @@ void main() {
     testWidgets('rating=3 shows 3 filled and 2 border stars', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 3,
-              onRatingChanged: (_) {},
-            ),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: StarRating(rating: 3, onRatingChanged: (_) {})),
         ),
       );
 
@@ -50,11 +45,10 @@ void main() {
     testWidgets('rating=null shows all 5 border stars', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: StarRating(
-              rating: null,
-              onRatingChanged: (_) {},
-            ),
+            body: StarRating(rating: null, onRatingChanged: (_) {}),
           ),
         ),
       );
@@ -69,12 +63,9 @@ void main() {
     testWidgets('rating=5 shows all 5 filled stars', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 5,
-              onRatingChanged: (_) {},
-            ),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: StarRating(rating: 5, onRatingChanged: (_) {})),
         ),
       );
 
@@ -90,6 +81,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: StarRating(
               rating: null,
@@ -121,6 +114,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: StarRating(
               rating: 3,
@@ -151,10 +146,10 @@ void main() {
   // reader announced nothing.
   group('StarRating accessibility (#1687)', () {
     Widget harness() => MaterialApp(
-          home: Scaffold(
-            body: StarRating(rating: 2, onRatingChanged: (_) {}),
-          ),
-        );
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: StarRating(rating: 2, onRatingChanged: (_) {})),
+    );
 
     testWidgets('each star has at least a 48dp tap target', (tester) async {
       await tester.pumpWidget(harness());
@@ -171,8 +166,9 @@ void main() {
       expect(boxes.length, 5);
     });
 
-    testWidgets('star tap targets meet the Android tap-target guideline',
-        (tester) async {
+    testWidgets('star tap targets meet the Android tap-target guideline', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
       await tester.pumpWidget(harness());
 
@@ -183,12 +179,11 @@ void main() {
     testWidgets('each star exposes a button semantics label', (tester) async {
       await tester.pumpWidget(harness());
 
-      // Bare harness has no AppLocalizations → the fallback label.
+      // en ARB plural: 'Rate 1 star' / 'Rate {n} stars' (#3162).
       for (var n = 1; n <= 5; n++) {
+        final expected = n == 1 ? 'Rate 1 star' : 'Rate $n stars';
         final semantics = tester.widgetList<Semantics>(find.byType(Semantics));
-        final star = semantics.where(
-          (s) => s.properties.label == 'Rate $n stars',
-        );
+        final star = semantics.where((s) => s.properties.label == expected);
         expect(star.length, 1, reason: 'star $n missing its semantics label');
         expect(star.first.properties.button, isTrue);
       }

--- a/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
+++ b/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
@@ -12,11 +12,13 @@ import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dar
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('RadiusAlertCreateSheet (#578 phase 2)', () {
-    testWidgets('no longer shows the Germany-only gating note (#2865)',
-        (tester) async {
+    testWidgets('no longer shows the Germany-only gating note (#2865)', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -37,8 +39,9 @@ void main() {
       );
     });
 
-    testWidgets('threshold label uses the centre country currency (#2865)',
-        (tester) async {
+    testWidgets('threshold label uses the centre country currency (#2865)', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -62,8 +65,9 @@ void main() {
       expect(find.text('Threshold (€/L)'), findsNothing);
     });
 
-    testWidgets('save button builds a RadiusAlert and calls add()',
-        (tester) async {
+    testWidgets('save button builds a RadiusAlert and calls add()', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -123,8 +127,9 @@ void main() {
       expect(a.radiusKm, 10);
     });
 
-    testWidgets('save is disabled until label + center are set',
-        (tester) async {
+    testWidgets('save is disabled until label + center are set', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -141,83 +146,95 @@ void main() {
       );
 
       // No label, no center → save must be disabled.
-      final saveButton =
-          tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
+      final saveButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save'),
+      );
       expect(saveButton.onPressed, isNull);
     });
 
-    testWidgets('Pick-on-map returns a LatLng and enables Save (#578 phase 3)',
-        (tester) async {
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    testWidgets(
+      'Pick-on-map returns a LatLng and enables Save (#578 phase 3)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
-      final fake = _CapturingRadiusAlerts();
+        final fake = _CapturingRadiusAlerts();
 
-      // Stub the map-picker so we do not need to build the
-      // FlutterMap widget tree inside the create-sheet test. The
-      // stub synchronously returns a deterministic LatLng, which is
-      // exactly what a user-confirmed picker would hand back.
-      const picked = LatLng(52.5200, 13.4050);
+        // Stub the map-picker so we do not need to build the
+        // FlutterMap widget tree inside the create-sheet test. The
+        // stub synchronously returns a deterministic LatLng, which is
+        // exactly what a user-confirmed picker would hand back.
+        const picked = LatLng(52.5200, 13.4050);
 
-      await pumpApp(
-        tester,
-        RadiusAlertCreateSheet(
-          idGenerator: () => 'map-id-1',
-          mapPickerOpener: (_) async => picked,
-        ),
-        overrides: [
-          ...test.overrides,
-          radiusAlertsProvider.overrideWith(() => fake),
-          userPositionNullOverride(),
-        ],
-      );
+        await pumpApp(
+          tester,
+          RadiusAlertCreateSheet(
+            idGenerator: () => 'map-id-1',
+            mapPickerOpener: (_) async => picked,
+          ),
+          overrides: [
+            ...test.overrides,
+            radiusAlertsProvider.overrideWith(() => fake),
+            userPositionNullOverride(),
+          ],
+        );
 
-      await tester.enterText(
-        find.widgetWithText(TextField, 'Label (e.g. Home diesel)'),
-        'Berlin diesel',
-      );
-      await tester.pump();
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Label (e.g. Home diesel)'),
+          'Berlin diesel',
+        );
+        await tester.pump();
 
-      // Before picking on the map, Save must still be disabled —
-      // label alone is not enough because no center has been set.
-      FilledButton save = tester
-          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
-      expect(save.onPressed, isNull,
-          reason: 'label only → save still disabled before a center exists');
+        // Before picking on the map, Save must still be disabled —
+        // label alone is not enough because no center has been set.
+        FilledButton save = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        expect(
+          save.onPressed,
+          isNull,
+          reason: 'label only → save still disabled before a center exists',
+        );
 
-      // Tap the map-picker button; the stub pops the fake LatLng
-      // straight back into the sheet.
-      await tester.tap(find.text('Pick on map'));
-      await tester.pumpAndSettle();
+        // Tap the map-picker button; the stub pops the fake LatLng
+        // straight back into the sheet.
+        await tester.tap(find.text('Pick on map'));
+        await tester.pumpAndSettle();
 
-      // Save is now enabled because the picker populated the center.
-      save = tester
-          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
-      expect(save.onPressed, isNotNull,
-          reason: 'picked LatLng should unlock Save');
+        // Save is now enabled because the picker populated the center.
+        save = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        expect(
+          save.onPressed,
+          isNotNull,
+          reason: 'picked LatLng should unlock Save',
+        );
 
-      // The "Map location" caption is what tells the user which
-      // source is currently bound to the alert.
-      expect(find.text('Map location'), findsOneWidget);
+        // The "Map location" caption is what tells the user which
+        // source is currently bound to the alert.
+        expect(find.text('Map location'), findsOneWidget);
 
-      // Scroll Save into view (the sheet grew with #1012 phase 1).
-      final saveBtn = find.widgetWithText(FilledButton, 'Save');
-      await tester.scrollUntilVisible(
-        saveBtn,
-        100,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.tap(saveBtn);
-      await tester.pumpAndSettle();
+        // Scroll Save into view (the sheet grew with #1012 phase 1).
+        final saveBtn = find.widgetWithText(FilledButton, 'Save');
+        await tester.scrollUntilVisible(
+          saveBtn,
+          100,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.tap(saveBtn);
+        await tester.pumpAndSettle();
 
-      expect(fake.addedAlerts, hasLength(1));
-      final a = fake.addedAlerts.single;
-      expect(a.centerLat, closeTo(52.52, 1e-6));
-      expect(a.centerLng, closeTo(13.405, 1e-6));
-    });
+        expect(fake.addedAlerts, hasLength(1));
+        final a = fake.addedAlerts.single;
+        expect(a.centerLat, closeTo(52.52, 1e-6));
+        expect(a.centerLng, closeTo(13.405, 1e-6));
+      },
+    );
 
-    testWidgets('Pick-on-map cancel keeps the sheet empty (#578 phase 3)',
-        (tester) async {
+    testWidgets('Pick-on-map cancel keeps the sheet empty (#578 phase 3)', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -246,14 +263,14 @@ void main() {
 
       // Save must still be disabled — a cancelled picker must not
       // leave a stale (0,0) center behind.
-      final save = tester
-          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
+      final save = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save'),
+      );
       expect(save.onPressed, isNull);
       expect(find.text('Map location'), findsNothing);
     });
 
-    testWidgets(
-        'frequency dropdown writes selected value into the saved alert '
+    testWidgets('frequency dropdown writes selected value into the saved alert '
         '(#1012 phase 1)', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -310,8 +327,7 @@ void main() {
       expect(fake.addedAlerts.single.frequencyPerDay, 4);
     });
 
-    testWidgets(
-        'frequency dropdown defaults to once-a-day when left untouched '
+    testWidgets('frequency dropdown defaults to once-a-day when left untouched '
         '(#1012 phase 1)', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -349,8 +365,9 @@ void main() {
       expect(fake.addedAlerts.single.frequencyPerDay, 1);
     });
 
-    testWidgets('cancel button dismisses without calling add()',
-        (tester) async {
+    testWidgets('cancel button dismisses without calling add()', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -366,6 +383,8 @@ void main() {
             userPositionOverride(lat: 48.85, lng: 2.35),
           ].cast(),
           child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Builder(
               builder: (context) => Scaffold(
                 body: Center(

--- a/test/features/carbon/presentation/widgets/monthly_bar_chart_test.dart
+++ b/test/features/carbon/presentation/widgets/monthly_bar_chart_test.dart
@@ -17,14 +17,13 @@ MonthlySummary _summary({
   double liters = 0,
   double co2 = 0,
   int count = 0,
-}) =>
-    MonthlySummary(
-      month: month,
-      totalCost: cost,
-      totalLiters: liters,
-      totalCo2Kg: co2,
-      fillUpCount: count,
-    );
+}) => MonthlySummary(
+  month: month,
+  totalCost: cost,
+  totalLiters: liters,
+  totalCo2Kg: co2,
+  fillUpCount: count,
+);
 
 double _co2(MonthlySummary s) => s.totalCo2Kg;
 double _cost(MonthlySummary s) => s.totalCost;
@@ -53,7 +52,9 @@ void main() {
       _summary(month: DateTime(2026, 2), co2: 30),
     ];
 
-    testWidgets('axis month abbreviations localize under French', (tester) async {
+    testWidgets('axis month abbreviations localize under French', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         MonthlyBarChart(
@@ -71,8 +72,9 @@ void main() {
       expect(label, isNot('Jan'));
     });
 
-    testWidgets('axis month abbreviations stay English under English',
-        (tester) async {
+    testWidgets('axis month abbreviations stay English under English', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         MonthlyBarChart(
@@ -114,45 +116,22 @@ void main() {
       },
     );
 
-    testWidgets(
-      'falls back to "No data" when AppLocalizations is absent',
-      (tester) async {
-        // Pump without localization delegates so .of(context) returns null.
-        await tester.pumpWidget(
-          const MaterialApp(
-            home: Scaffold(
-              body: MonthlyBarChart(
-                summaries: [],
-                valueOf: _co2,
-                color: Colors.green,
-                unitLabel: 'kg',
-              ),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
+    testWidgets('uses the French translation for the empty placeholder', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const MonthlyBarChart(
+          summaries: [],
+          valueOf: _co2,
+          color: Colors.green,
+          unitLabel: 'kg',
+        ),
+        locale: const Locale('fr'),
+      );
 
-        expect(find.text('No data'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'uses the French translation for the empty placeholder',
-      (tester) async {
-        await pumpApp(
-          tester,
-          const MonthlyBarChart(
-            summaries: [],
-            valueOf: _co2,
-            color: Colors.green,
-            unitLabel: 'kg',
-          ),
-          locale: const Locale('fr'),
-        );
-
-        expect(find.text('Pas de données'), findsOneWidget);
-      },
-    );
+      expect(find.text('Pas de données'), findsOneWidget);
+    });
 
     testWidgets(
       'renders a single CustomPaint with a painter when summaries are present',
@@ -181,141 +160,139 @@ void main() {
         final painters = tester
             .widgetList<CustomPaint>(find.byType(CustomPaint))
             .map((p) => p.painter)
-            .where((p) => p != null && p.runtimeType.toString().contains('BarChart'))
-            .toList();
-        expect(painters, hasLength(1));
-      },
-    );
-
-    testWidgets(
-      'forwards color and unitLabel into the painter',
-      (tester) async {
-        const probeColor = Color(0xFF112233);
-        const probeUnit = '€';
-        final summaries = [
-          _summary(month: DateTime(2026, 1), cost: 50),
-          _summary(month: DateTime(2026, 2), cost: 80),
-        ];
-
-        await pumpApp(
-          tester,
-          MonthlyBarChart(
-            summaries: summaries,
-            valueOf: _cost,
-            color: probeColor,
-            unitLabel: probeUnit,
-          ),
-        );
-
-        final painter = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .firstWhere(
+            .where(
               (p) => p != null && p.runtimeType.toString().contains('BarChart'),
-            );
-
-        // Use dynamic dispatch to inspect the private painter's public fields.
-        // ignore: avoid_dynamic_calls
-        final dynamic dyn = painter;
-        // ignore: avoid_dynamic_calls
-        expect(dyn.color, probeColor);
-        // ignore: avoid_dynamic_calls
-        expect(dyn.unitLabel, probeUnit);
-        // ignore: avoid_dynamic_calls
-        expect((dyn.summaries as List).length, summaries.length);
-      },
-    );
-
-    testWidgets(
-      'invokes valueOf for every summary when painted',
-      (tester) async {
-        var calls = 0;
-        double counting(MonthlySummary s) {
-          calls++;
-          return s.totalCo2Kg;
-        }
-
-        final summaries = [
-          _summary(month: DateTime(2026, 1), co2: 5),
-          _summary(month: DateTime(2026, 2), co2: 7),
-          _summary(month: DateTime(2026, 3), co2: 9),
-          _summary(month: DateTime(2026, 4), co2: 11),
-        ];
-
-        await pumpApp(
-          tester,
-          MonthlyBarChart(
-            summaries: summaries,
-            valueOf: counting,
-            color: Colors.blue,
-            unitLabel: 'kg',
-          ),
-        );
-
-        // Painter calls valueOf once per summary inside its `paint` method;
-        // a single layout/paint cycle must hit every entry at least once.
-        expect(
-          calls,
-          greaterThanOrEqualTo(summaries.length),
-          reason: 'painter must call valueOf at least once per summary',
-        );
-      },
-    );
-
-    testWidgets(
-      'renders without throwing when every value is zero',
-      (tester) async {
-        final summaries = [
-          _summary(month: DateTime(2026, 1), co2: 0),
-          _summary(month: DateTime(2026, 2), co2: 0),
-          _summary(month: DateTime(2026, 3), co2: 0),
-        ];
-
-        await pumpApp(
-          tester,
-          MonthlyBarChart(
-            summaries: summaries,
-            valueOf: _co2,
-            color: Colors.red,
-            unitLabel: 'kg',
-          ),
-        );
-
-        // No exceptions surface to the test binding when all values are 0.
-        expect(tester.takeException(), isNull);
-
-        // Painter is still mounted (we don't fall back to the empty path).
-        final painters = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .where((p) => p != null && p.runtimeType.toString().contains('BarChart'))
+            )
             .toList();
         expect(painters, hasLength(1));
       },
     );
 
-    testWidgets(
-      'renders without throwing when only one summary is provided',
-      (tester) async {
-        // Single-bar layout exercises the slot/barWidth math at minimum count.
-        final summaries = [
-          _summary(month: DateTime(2026, 6), co2: 42),
-        ];
+    testWidgets('forwards color and unitLabel into the painter', (
+      tester,
+    ) async {
+      const probeColor = Color(0xFF112233);
+      const probeUnit = '€';
+      final summaries = [
+        _summary(month: DateTime(2026, 1), cost: 50),
+        _summary(month: DateTime(2026, 2), cost: 80),
+      ];
 
-        await pumpApp(
-          tester,
-          MonthlyBarChart(
-            summaries: summaries,
-            valueOf: _co2,
-            color: Colors.orange,
-            unitLabel: 'kg',
-          ),
-        );
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: _cost,
+          color: probeColor,
+          unitLabel: probeUnit,
+        ),
+      );
 
-        expect(tester.takeException(), isNull);
-        expect(find.text('No data'), findsNothing);
-      },
-    );
+      final painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('BarChart'),
+          );
+
+      // Use dynamic dispatch to inspect the private painter's public fields.
+      // ignore: avoid_dynamic_calls
+      final dynamic dyn = painter;
+      // ignore: avoid_dynamic_calls
+      expect(dyn.color, probeColor);
+      // ignore: avoid_dynamic_calls
+      expect(dyn.unitLabel, probeUnit);
+      // ignore: avoid_dynamic_calls
+      expect((dyn.summaries as List).length, summaries.length);
+    });
+
+    testWidgets('invokes valueOf for every summary when painted', (
+      tester,
+    ) async {
+      var calls = 0;
+      double counting(MonthlySummary s) {
+        calls++;
+        return s.totalCo2Kg;
+      }
+
+      final summaries = [
+        _summary(month: DateTime(2026, 1), co2: 5),
+        _summary(month: DateTime(2026, 2), co2: 7),
+        _summary(month: DateTime(2026, 3), co2: 9),
+        _summary(month: DateTime(2026, 4), co2: 11),
+      ];
+
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: counting,
+          color: Colors.blue,
+          unitLabel: 'kg',
+        ),
+      );
+
+      // Painter calls valueOf once per summary inside its `paint` method;
+      // a single layout/paint cycle must hit every entry at least once.
+      expect(
+        calls,
+        greaterThanOrEqualTo(summaries.length),
+        reason: 'painter must call valueOf at least once per summary',
+      );
+    });
+
+    testWidgets('renders without throwing when every value is zero', (
+      tester,
+    ) async {
+      final summaries = [
+        _summary(month: DateTime(2026, 1), co2: 0),
+        _summary(month: DateTime(2026, 2), co2: 0),
+        _summary(month: DateTime(2026, 3), co2: 0),
+      ];
+
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: _co2,
+          color: Colors.red,
+          unitLabel: 'kg',
+        ),
+      );
+
+      // No exceptions surface to the test binding when all values are 0.
+      expect(tester.takeException(), isNull);
+
+      // Painter is still mounted (we don't fall back to the empty path).
+      final painters = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .where(
+            (p) => p != null && p.runtimeType.toString().contains('BarChart'),
+          )
+          .toList();
+      expect(painters, hasLength(1));
+    });
+
+    testWidgets('renders without throwing when only one summary is provided', (
+      tester,
+    ) async {
+      // Single-bar layout exercises the slot/barWidth math at minimum count.
+      final summaries = [_summary(month: DateTime(2026, 6), co2: 42)];
+
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: _co2,
+          color: Colors.orange,
+          unitLabel: 'kg',
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('No data'), findsNothing);
+    });
 
     testWidgets(
       'fixed 180dp height is preserved regardless of available space',
@@ -338,81 +315,79 @@ void main() {
       },
     );
 
-    testWidgets(
-      'empty-state placeholder also uses the 180dp height contract',
-      (tester) async {
-        await pumpApp(
-          tester,
-          const MonthlyBarChart(
-            summaries: [],
-            valueOf: _co2,
-            color: Colors.teal,
-            unitLabel: 'kg',
-          ),
-        );
+    testWidgets('empty-state placeholder also uses the 180dp height contract', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const MonthlyBarChart(
+          summaries: [],
+          valueOf: _co2,
+          color: Colors.teal,
+          unitLabel: 'kg',
+        ),
+      );
 
-        final size = tester.getSize(find.byType(MonthlyBarChart));
-        expect(size.height, 180.0);
-      },
-    );
+      final size = tester.getSize(find.byType(MonthlyBarChart));
+      expect(size.height, 180.0);
+    });
 
-    testWidgets(
-      'rebuilds with new props when summaries reference changes',
-      (tester) async {
-        final initial = [
-          _summary(month: DateTime(2026, 1), co2: 5),
-          _summary(month: DateTime(2026, 2), co2: 10),
-        ];
-        final next = [
-          _summary(month: DateTime(2026, 3), co2: 7),
-          _summary(month: DateTime(2026, 4), co2: 14),
-          _summary(month: DateTime(2026, 5), co2: 21),
-        ];
+    testWidgets('rebuilds with new props when summaries reference changes', (
+      tester,
+    ) async {
+      final initial = [
+        _summary(month: DateTime(2026, 1), co2: 5),
+        _summary(month: DateTime(2026, 2), co2: 10),
+      ];
+      final next = [
+        _summary(month: DateTime(2026, 3), co2: 7),
+        _summary(month: DateTime(2026, 4), co2: 14),
+        _summary(month: DateTime(2026, 5), co2: 21),
+      ];
 
-        await pumpApp(
-          tester,
-          MonthlyBarChart(
-            summaries: initial,
-            valueOf: _co2,
-            color: Colors.purple,
-            unitLabel: 'kg',
-          ),
-        );
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: initial,
+          valueOf: _co2,
+          color: Colors.purple,
+          unitLabel: 'kg',
+        ),
+      );
 
-        // ignore: avoid_dynamic_calls
-        var painter = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .firstWhere(
-              (p) => p != null && p.runtimeType.toString().contains('BarChart'),
-            );
-        // ignore: avoid_dynamic_calls
-        expect(((painter as dynamic).summaries as List).length, 2);
+      // ignore: avoid_dynamic_calls
+      var painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('BarChart'),
+          );
+      // ignore: avoid_dynamic_calls
+      expect(((painter as dynamic).summaries as List).length, 2);
 
-        // Re-pump with a different summaries list — same widget type, new data.
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: MonthlyBarChart(
-                summaries: next,
-                valueOf: _co2,
-                color: Colors.purple,
-                unitLabel: 'kg',
-              ),
+      // Re-pump with a different summaries list — same widget type, new data.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MonthlyBarChart(
+              summaries: next,
+              valueOf: _co2,
+              color: Colors.purple,
+              unitLabel: 'kg',
             ),
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        painter = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .firstWhere(
-              (p) => p != null && p.runtimeType.toString().contains('BarChart'),
-            );
-        // ignore: avoid_dynamic_calls
-        expect(((painter as dynamic).summaries as List).length, 3);
-      },
-    );
+      painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('BarChart'),
+          );
+      // ignore: avoid_dynamic_calls
+      expect(((painter as dynamic).summaries as List).length, 3);
+    });
   });
 }

--- a/test/features/carbon/presentation/widgets/speed_consumption_card_test.dart
+++ b/test/features/carbon/presentation/widgets/speed_consumption_card_test.dart
@@ -18,17 +18,14 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 ///   * the title + localised band labels resolve through the bundle
 void main() {
   group('SpeedConsumptionCard — happy path', () {
-    testWidgets('renders one bar per band when telemetry is sufficient',
-        (tester) async {
+    testWidgets('renders one bar per band when telemetry is sufficient', (
+      tester,
+    ) async {
       // Build a histogram with 1800+ s of total telemetry so the card
       // renders the bars instead of the empty-state placeholder.
       final bins = _binsWithTotalSeconds(2000);
 
-      await _pumpCard(
-        tester,
-        bins: bins,
-        overallAvgLPer100Km: 7.5,
-      );
+      await _pumpCard(tester, bins: bins, overallAvgLPer100Km: 7.5);
 
       // Title must resolve from the localisations bundle.
       expect(find.text('Consumption by speed'), findsOneWidget);
@@ -55,11 +52,7 @@ void main() {
       (tester) async {
         final bins = _binsWithTotalSeconds(2000);
 
-        await _pumpCard(
-          tester,
-          bins: bins,
-          overallAvgLPer100Km: 7.5,
-        );
+        await _pumpCard(tester, bins: bins, overallAvgLPer100Km: 7.5);
 
         // The reference line is keyed once per bar that has an avg.
         // At least one bar in our fixture has an avg → at least one
@@ -79,11 +72,7 @@ void main() {
         // 1500 s = 25 min — under the 1800-s floor.
         final bins = _binsWithTotalSeconds(1500);
 
-        await _pumpCard(
-          tester,
-          bins: bins,
-          overallAvgLPer100Km: 7.5,
-        );
+        await _pumpCard(tester, bins: bins, overallAvgLPer100Km: 7.5);
 
         // Empty-state copy is visible.
         expect(
@@ -94,10 +83,7 @@ void main() {
           findsOneWidget,
         );
         // No per-band bar widgets render in the empty-state.
-        expect(
-          find.byKey(const Key('speed_bar_${'urban'}')),
-          findsNothing,
-        );
+        expect(find.byKey(const Key('speed_bar_${'urban'}')), findsNothing);
         // The empty-state widget itself is keyed for stable assertion.
         expect(
           find.byKey(const ValueKey('speed_consumption_insufficient_data')),
@@ -106,58 +92,48 @@ void main() {
       },
     );
 
-    testWidgets(
-      'shows the placeholder when there are zero OBD2 samples',
-      (tester) async {
-        // Every band empty (0 samples) → 0 s total → placeholder.
-        final bins = <SpeedConsumptionBin>[
-          for (final band in SpeedBand.values)
-            SpeedConsumptionBin(
-              band: band,
-              sampleCount: 0,
-              timeShareSeconds: 0,
-              avgLPer100Km: null,
-            ),
-        ];
+    testWidgets('shows the placeholder when there are zero OBD2 samples', (
+      tester,
+    ) async {
+      // Every band empty (0 samples) → 0 s total → placeholder.
+      final bins = <SpeedConsumptionBin>[
+        for (final band in SpeedBand.values)
+          SpeedConsumptionBin(
+            band: band,
+            sampleCount: 0,
+            timeShareSeconds: 0,
+            avgLPer100Km: null,
+          ),
+      ];
 
-        await _pumpCard(
-          tester,
-          bins: bins,
-          overallAvgLPer100Km: null,
-        );
+      await _pumpCard(tester, bins: bins, overallAvgLPer100Km: null);
 
-        expect(
-          find.byKey(const ValueKey('speed_consumption_insufficient_data')),
-          findsOneWidget,
-        );
-        // Reference line is suppressed in the empty state — there's no
-        // bar to anchor it against.
-        expect(
-          find.byKey(const ValueKey('speed_consumption_reference_line')),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.byKey(const ValueKey('speed_consumption_insufficient_data')),
+        findsOneWidget,
+      );
+      // Reference line is suppressed in the empty state — there's no
+      // bar to anchor it against.
+      expect(
+        find.byKey(const ValueKey('speed_consumption_reference_line')),
+        findsNothing,
+      );
+    });
   });
 
   group('SpeedConsumptionCard — reference line suppression', () {
-    testWidgets(
-      'no reference line renders when overallAvgLPer100Km is null',
-      (tester) async {
-        final bins = _binsWithTotalSeconds(2000);
+    testWidgets('no reference line renders when overallAvgLPer100Km is null', (
+      tester,
+    ) async {
+      final bins = _binsWithTotalSeconds(2000);
 
-        await _pumpCard(
-          tester,
-          bins: bins,
-          overallAvgLPer100Km: null,
-        );
+      await _pumpCard(tester, bins: bins, overallAvgLPer100Km: null);
 
-        expect(
-          find.byKey(const ValueKey('speed_consumption_reference_line')),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.byKey(const ValueKey('speed_consumption_reference_line')),
+        findsNothing,
+      );
+    });
   });
 }
 
@@ -176,23 +152,23 @@ List<SpeedConsumptionBin> _binsWithTotalSeconds(int totalSeconds) {
     for (final band in SpeedBand.values)
       switch (band) {
         SpeedBand.rural => SpeedConsumptionBin(
-            band: band,
-            sampleCount: ruralSeconds,
-            timeShareSeconds: ruralSeconds.toDouble(),
-            avgLPer100Km: 7.0,
-          ),
+          band: band,
+          sampleCount: ruralSeconds,
+          timeShareSeconds: ruralSeconds.toDouble(),
+          avgLPer100Km: 7.0,
+        ),
         SpeedBand.motorway => SpeedConsumptionBin(
-            band: band,
-            sampleCount: motorwaySeconds,
-            timeShareSeconds: motorwaySeconds.toDouble(),
-            avgLPer100Km: 8.5,
-          ),
+          band: band,
+          sampleCount: motorwaySeconds,
+          timeShareSeconds: motorwaySeconds.toDouble(),
+          avgLPer100Km: 8.5,
+        ),
         _ => SpeedConsumptionBin(
-            band: band,
-            sampleCount: 0,
-            timeShareSeconds: 0,
-            avgLPer100Km: null,
-          ),
+          band: band,
+          sampleCount: 0,
+          timeShareSeconds: 0,
+          avgLPer100Km: null,
+        ),
       },
   ];
 }
@@ -222,7 +198,6 @@ Future<void> _pumpCard(
             builder: (context) {
               final l = AppLocalizations.of(context);
               final theme = Theme.of(context);
-              if (l == null) return const SizedBox.shrink();
               return SpeedConsumptionCard(
                 bins: bins,
                 overallAvgLPer100Km: overallAvgLPer100Km,

--- a/test/features/carbon/presentation/widgets/trip_length_breakdown_card_test.dart
+++ b/test/features/carbon/presentation/widgets/trip_length_breakdown_card_test.dart
@@ -21,8 +21,9 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 ///     bucket has >=5 trips AND the bucket avg differs from overall
 void main() {
   group('TripLengthBreakdownCard — labels + tile presence', () {
-    testWidgets('renders the localised title + three bucket labels',
-        (tester) async {
+    testWidgets('renders the localised title + three bucket labels', (
+      tester,
+    ) async {
       await _pumpCard(
         tester,
         breakdown: const TripLengthBreakdown(
@@ -56,8 +57,9 @@ void main() {
       expect(find.byKey(const Key('trip_length_tile_long')), findsOneWidget);
     });
 
-    testWidgets('renders the average L/100 km on tiles with >=5 trips',
-        (tester) async {
+    testWidgets('renders the average L/100 km on tiles with >=5 trips', (
+      tester,
+    ) async {
       await _pumpCard(
         tester,
         breakdown: const TripLengthBreakdown(
@@ -85,24 +87,23 @@ void main() {
   });
 
   group('TripLengthBreakdownCard — empty + "need more data"', () {
-    testWidgets(
-      'renders SizedBox.shrink (no card) when all buckets are zero',
-      (tester) async {
-        await _pumpCard(
-          tester,
-          breakdown: TripLengthBreakdown.empty,
-          overallAvgLPer100Km: null,
-        );
+    testWidgets('renders SizedBox.shrink (no card) when all buckets are zero', (
+      tester,
+    ) async {
+      await _pumpCard(
+        tester,
+        breakdown: TripLengthBreakdown.empty,
+        overallAvgLPer100Km: null,
+      );
 
-        // The title must NOT render when the card is hidden.
-        expect(find.text('Consumption by trip length'), findsNothing);
-        // The internal Card root key must not be in the tree either.
-        expect(
-          find.byKey(const ValueKey('trip_length_breakdown_card')),
-          findsNothing,
-        );
-      },
-    );
+      // The title must NOT render when the card is hidden.
+      expect(find.text('Consumption by trip length'), findsNothing);
+      // The internal Card root key must not be in the tree either.
+      expect(
+        find.byKey(const ValueKey('trip_length_breakdown_card')),
+        findsNothing,
+      );
+    });
 
     testWidgets(
       'shows "Need more data" on the medium tile when count is between 1 and 4',
@@ -139,29 +140,28 @@ void main() {
   });
 
   group('TripLengthBreakdownCard — above/below arrows', () {
-    testWidgets(
-      'renders red up arrow when bucket avg is above overall avg',
-      (tester) async {
-        await _pumpCard(
-          tester,
-          breakdown: const TripLengthBreakdown(
-            short: TripLengthBucketStats(
-              tripCount: 6,
-              totalDistanceKm: 18.0,
-              totalLitres: 2.0,
-              avgLPer100Km: 11.1, // above overall (7.5)
-            ),
-            medium: TripLengthBucketStats.empty,
-            long: TripLengthBucketStats.empty,
+    testWidgets('renders red up arrow when bucket avg is above overall avg', (
+      tester,
+    ) async {
+      await _pumpCard(
+        tester,
+        breakdown: const TripLengthBreakdown(
+          short: TripLengthBucketStats(
+            tripCount: 6,
+            totalDistanceKm: 18.0,
+            totalLitres: 2.0,
+            avgLPer100Km: 11.1, // above overall (7.5)
           ),
-          overallAvgLPer100Km: 7.5,
-        );
+          medium: TripLengthBucketStats.empty,
+          long: TripLengthBucketStats.empty,
+        ),
+        overallAvgLPer100Km: 7.5,
+      );
 
-        // Up arrow for the worse-than-overall short bucket.
-        expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
-        expect(find.byIcon(Icons.arrow_downward), findsNothing);
-      },
-    );
+      // Up arrow for the worse-than-overall short bucket.
+      expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_downward), findsNothing);
+    });
 
     testWidgets(
       'renders green down arrow when bucket avg is below overall avg',
@@ -186,28 +186,27 @@ void main() {
       },
     );
 
-    testWidgets(
-      'no arrows render when overallAvgLPer100Km is null',
-      (tester) async {
-        await _pumpCard(
-          tester,
-          breakdown: const TripLengthBreakdown(
-            short: TripLengthBucketStats.empty,
-            medium: TripLengthBucketStats(
-              tripCount: 6,
-              totalDistanceKm: 60.0,
-              totalLitres: 4.0,
-              avgLPer100Km: 6.667,
-            ),
-            long: TripLengthBucketStats.empty,
+    testWidgets('no arrows render when overallAvgLPer100Km is null', (
+      tester,
+    ) async {
+      await _pumpCard(
+        tester,
+        breakdown: const TripLengthBreakdown(
+          short: TripLengthBucketStats.empty,
+          medium: TripLengthBucketStats(
+            tripCount: 6,
+            totalDistanceKm: 60.0,
+            totalLitres: 4.0,
+            avgLPer100Km: 6.667,
           ),
-          overallAvgLPer100Km: null,
-        );
+          long: TripLengthBucketStats.empty,
+        ),
+        overallAvgLPer100Km: null,
+      );
 
-        expect(find.byIcon(Icons.arrow_upward), findsNothing);
-        expect(find.byIcon(Icons.arrow_downward), findsNothing);
-      },
-    );
+      expect(find.byIcon(Icons.arrow_upward), findsNothing);
+      expect(find.byIcon(Icons.arrow_downward), findsNothing);
+    });
   });
 }
 
@@ -235,9 +234,6 @@ Future<void> _pumpCard(
           builder: (context) {
             final l = AppLocalizations.of(context);
             final theme = Theme.of(context);
-            // pumpApp would have loaded the delegate by the next pump,
-            // so AppLocalizations.of must resolve before we hand it in.
-            if (l == null) return const SizedBox.shrink();
             return TripLengthBreakdownCard(
               breakdown: breakdown,
               overallAvgLPer100Km: overallAvgLPer100Km,

--- a/test/features/consumption/domain/add_fill_up_validators_test.dart
+++ b/test/features/consumption/domain/add_fill_up_validators_test.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/domain/add_fill_up_validators.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Unit tests for the pure validators / parsers extracted from
 /// `add_fill_up_screen.dart` (#563 refactor). Each rule is covered
@@ -15,79 +18,69 @@ import 'package:tankstellen/features/consumption/domain/add_fill_up_validators.d
 /// they take in widget tests that don't pump a MaterialApp with
 /// AppLocalizations.delegate.
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('AddFillUpValidators.positiveNumber', () {
     test('returns Required when value is null', () {
       expect(
-        AddFillUpValidators.positiveNumber(null, null),
+        AddFillUpValidators.positiveNumber(null, l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Required when value is empty', () {
       expect(
-        AddFillUpValidators.positiveNumber('', null),
+        AddFillUpValidators.positiveNumber('', l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Required when value is whitespace only', () {
       expect(
-        AddFillUpValidators.positiveNumber('   ', null),
+        AddFillUpValidators.positiveNumber('   ', l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Invalid number when value is not numeric', () {
       expect(
-        AddFillUpValidators.positiveNumber('abc', null),
+        AddFillUpValidators.positiveNumber('abc', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns Invalid number when value is zero', () {
       expect(
-        AddFillUpValidators.positiveNumber('0', null),
+        AddFillUpValidators.positiveNumber('0', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns Invalid number when value is negative', () {
       expect(
-        AddFillUpValidators.positiveNumber('-1', null),
+        AddFillUpValidators.positiveNumber('-1', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns null on a positive integer', () {
-      expect(
-        AddFillUpValidators.positiveNumber('40', null),
-        isNull,
-      );
+      expect(AddFillUpValidators.positiveNumber('40', l10nEn), isNull);
     });
 
     test('returns null on a positive decimal with dot', () {
-      expect(
-        AddFillUpValidators.positiveNumber('1.859', null),
-        isNull,
-      );
+      expect(AddFillUpValidators.positiveNumber('1.859', l10nEn), isNull);
     });
 
     test('returns null on a positive decimal with comma (FR/DE locale)', () {
       // The form is bilingual — French / German users type a comma
       // separator. The validator must accept both.
-      expect(
-        AddFillUpValidators.positiveNumber('1,859', null),
-        isNull,
-      );
+      expect(AddFillUpValidators.positiveNumber('1,859', l10nEn), isNull);
     });
 
     test('returns null on a tiny positive value', () {
       // The validator's lower bound is "> 0", not ">= 0.01". A 0.01 L
       // dribble is implausible but not invalid.
-      expect(
-        AddFillUpValidators.positiveNumber('0.01', null),
-        isNull,
-      );
+      expect(AddFillUpValidators.positiveNumber('0.01', l10nEn), isNull);
     });
   });
 

--- a/test/features/consumption/domain/charging_log_validators_test.dart
+++ b/test/features/consumption/domain/charging_log_validators_test.dart
@@ -1,136 +1,122 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/domain/charging_log_validators.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Unit tests for the pure validators / parsers extracted from
 /// `add_charging_log_screen.dart` (#563 refactor). Each rule is
 /// covered for: blank/null input, unparseable input, boundary
 /// values (zero, negative), and at least one happy-path case.
 ///
-/// All tests pass `null` for [AppLocalizations] — the validators
-/// must degrade to English fallbacks ("Required", "Invalid number")
-/// when no localizations are in the tree, which is exactly the path
-/// they take in widget tests that don't pump a MaterialApp with
-/// AppLocalizations.delegate.
+/// All tests pass the real `en` localizations (lookupAppLocalizations
+/// is a pure synchronous constructor — #3162 removed the nullable
+/// fallback path), asserting the canonical ARB strings ("Required",
+/// "Invalid number").
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('ChargingLogValidators.positiveNumber', () {
     test('returns Required when value is null', () {
       expect(
-        ChargingLogValidators.positiveNumber(null, null),
+        ChargingLogValidators.positiveNumber(null, l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Required when value is empty', () {
       expect(
-        ChargingLogValidators.positiveNumber('', null),
+        ChargingLogValidators.positiveNumber('', l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Required when value is whitespace only', () {
       expect(
-        ChargingLogValidators.positiveNumber('   ', null),
+        ChargingLogValidators.positiveNumber('   ', l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Invalid number when value is not numeric', () {
       expect(
-        ChargingLogValidators.positiveNumber('abc', null),
+        ChargingLogValidators.positiveNumber('abc', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns Invalid number when value is zero', () {
       expect(
-        ChargingLogValidators.positiveNumber('0', null),
+        ChargingLogValidators.positiveNumber('0', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns Invalid number when value is negative', () {
       expect(
-        ChargingLogValidators.positiveNumber('-1.5', null),
+        ChargingLogValidators.positiveNumber('-1.5', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('accepts a positive double with dot decimal', () {
-      expect(
-        ChargingLogValidators.positiveNumber('12.5', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.positiveNumber('12.5', l10nEn), isNull);
     });
 
     test('accepts a positive double with comma decimal', () {
-      expect(
-        ChargingLogValidators.positiveNumber('12,5', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.positiveNumber('12,5', l10nEn), isNull);
     });
 
     test('accepts a positive integer string', () {
-      expect(
-        ChargingLogValidators.positiveNumber('42', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.positiveNumber('42', l10nEn), isNull);
     });
   });
 
   group('ChargingLogValidators.nonNegativeInt', () {
     test('returns Required when value is null', () {
       expect(
-        ChargingLogValidators.nonNegativeInt(null, null),
+        ChargingLogValidators.nonNegativeInt(null, l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Required when value is empty', () {
       expect(
-        ChargingLogValidators.nonNegativeInt('', null),
+        ChargingLogValidators.nonNegativeInt('', l10nEn),
         equals('Required'),
       );
     });
 
     test('returns Invalid number when value is not numeric', () {
       expect(
-        ChargingLogValidators.nonNegativeInt('xx', null),
+        ChargingLogValidators.nonNegativeInt('xx', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('returns Invalid number when value is negative', () {
       expect(
-        ChargingLogValidators.nonNegativeInt('-3', null),
+        ChargingLogValidators.nonNegativeInt('-3', l10nEn),
         equals('Invalid number'),
       );
     });
 
     test('accepts zero (a 0-minute charge session is valid)', () {
-      expect(
-        ChargingLogValidators.nonNegativeInt('0', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.nonNegativeInt('0', l10nEn), isNull);
     });
 
     test('accepts a positive integer', () {
-      expect(
-        ChargingLogValidators.nonNegativeInt('30', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.nonNegativeInt('30', l10nEn), isNull);
     });
 
     test('accepts a decimal by truncating to its integer part', () {
       // The validator parses the integer prefix only — "30.5" reads
       // as 30 and passes. This mirrors the behaviour the UI relied
       // on before the refactor.
-      expect(
-        ChargingLogValidators.nonNegativeInt('30.5', null),
-        isNull,
-      );
+      expect(ChargingLogValidators.nonNegativeInt('30.5', l10nEn), isNull);
     });
   });
 

--- a/test/features/consumption/domain/live_activity_content_test.dart
+++ b/test/features/consumption/domain/live_activity_content_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
@@ -10,12 +12,15 @@ import 'package:tankstellen/features/consumption/domain/live_activity_content.da
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Decision-table coverage for [buildLiveActivityContent] (#3170) — the
 /// pure mapper from (recorder state, approach state, radar fallback) to
 /// the Live Activity payload. Mirrors `TripRecordingPipView`'s layout
 /// precedence so the two glanceable surfaces can never disagree.
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   final now = DateTime(2026, 6, 10, 12);
 
   Station station({
@@ -24,32 +29,31 @@ void main() {
     String brand = 'ARAL',
     double? e10 = 1.789,
     double dist = 0,
-  }) =>
-      Station(
-        id: id,
-        name: name,
-        brand: brand,
-        street: 'Hauptstr. 1',
-        postCode: '12345',
-        place: 'Teststadt',
-        lat: 50.0,
-        lng: 8.0,
-        dist: dist,
-        e10: e10,
-      );
+  }) => Station(
+    id: id,
+    name: name,
+    brand: brand,
+    street: 'Hauptstr. 1',
+    postCode: '12345',
+    place: 'Teststadt',
+    lat: 50.0,
+    lng: 8.0,
+    dist: dist,
+    e10: e10,
+  );
 
   TripRecordingState recording({
     TripRecordingPhase phase = TripRecordingPhase.recording,
     TripLiveReading? live,
-  }) =>
-      TripRecordingState(
-        phase: phase,
-        live: live ??
-            const TripLiveReading(
-              distanceKmSoFar: 12.34,
-              elapsed: Duration(minutes: 10),
-            ),
-      );
+  }) => TripRecordingState(
+    phase: phase,
+    live:
+        live ??
+        const TripLiveReading(
+          distanceKmSoFar: 12.34,
+          elapsed: Duration(minutes: 10),
+        ),
+  );
 
   LiveActivityContent? build({
     TripRecordingState? state,
@@ -57,16 +61,15 @@ void main() {
     Station? radarStation,
     FuelType fuel = FuelType.e10,
     double? radiusMeters = 3000,
-  }) =>
-      buildLiveActivityContent(
-        state: state ?? recording(),
-        approach: approach,
-        radarStation: radarStation,
-        fuel: fuel,
-        radiusMeters: radiusMeters,
-        l: null, // exercises the English fallbacks (harness convention)
-        now: now,
-      );
+  }) => buildLiveActivityContent(
+    state: state ?? recording(),
+    approach: approach,
+    radarStation: radarStation,
+    fuel: fuel,
+    radiusMeters: radiusMeters,
+    l: l10nEn,
+    now: now,
+  );
 
   group('no active trip', () {
     test('idle state yields null (→ coordinator ends the activity)', () {
@@ -133,24 +136,26 @@ void main() {
       expect(content.isEstimate, isTrue);
     });
 
-    test('paused trip → paused flag set and the measured figure suppressed',
-        () {
-      final content = build(
-        state: recording(
-          phase: TripRecordingPhase.paused,
-          live: const TripLiveReading(
-            distanceKmSoFar: 12.34,
-            elapsed: Duration(minutes: 10),
-            fuelRateLPerHour: 3.0,
-            speedKmh: 50,
+    test(
+      'paused trip → paused flag set and the measured figure suppressed',
+      () {
+        final content = build(
+          state: recording(
+            phase: TripRecordingPhase.paused,
+            live: const TripLiveReading(
+              distanceKmSoFar: 12.34,
+              elapsed: Duration(minutes: 10),
+              fuelRateLPerHour: 3.0,
+              speedKmh: 50,
+            ),
           ),
-        ),
-      )!;
+        )!;
 
-      expect(content.paused, isTrue);
-      expect(content.bigFigure, '~');
-      expect(content.pausedLabel, 'Paused');
-    });
+        expect(content.paused, isTrue);
+        expect(content.bigFigure, '~');
+        expect(content.pausedLabel, l10nEn.tripBannerPaused);
+      },
+    );
 
     test('distance under 0.1 km is hidden', () {
       final content = build(
@@ -183,8 +188,7 @@ void main() {
   });
 
   group('approach mode — in-radius wins (PiP precedence #2084)', () {
-    test('ApproachInRadius → price lead with metres caption + closeness',
-        () {
+    test('ApproachInRadius → price lead with metres caption + closeness', () {
       final content = build(
         approach: ApproachInRadius(station: station(), distanceMeters: 450),
         // The radar fallback must NOT win over the locked target.
@@ -195,14 +199,12 @@ void main() {
       expect(content.stationName, 'ARAL Hauptstr.');
       expect(content.priceText, PriceFormatter.formatPrice(1.789));
       expect(content.fuelLabel, FuelType.e10.displayName);
-      expect(content.stationDistanceText, '450 m');
+      expect(content.stationDistanceText, l10nEn.approachStationDistance('450'));
       expect(content.progress, RadarCloseness.fillFor(450, 3000));
     });
 
     test('ApproachLeaving keeps the last station, drops distance + bar', () {
-      final content = build(
-        approach: ApproachLeaving(lastStation: station()),
-      )!;
+      final content = build(approach: ApproachLeaving(lastStation: station()))!;
 
       expect(content.mode, LiveActivityMode.approach);
       expect(content.stationDistanceText, isNull);
@@ -231,12 +233,11 @@ void main() {
   });
 
   group('approach mode — polling radar fallback (#2661 parity)', () {
-    test('radar station leads with a km caption when nothing is in radius',
-        () {
+    test('radar station leads with a km caption when nothing is in radius', () {
       final content = build(radarStation: station(dist: 1.2))!;
 
       expect(content.mode, LiveActivityMode.approach);
-      expect(content.stationDistanceText, '1.2 km');
+      expect(content.stationDistanceText, l10nEn.fuelStationRadarDistanceKm('1.2'));
       expect(content.progress, RadarCloseness.fillFor(1200, 3000));
       // The consumption hero stays populated for the expanded island.
       expect(content.bigFigure, isNotEmpty);
@@ -253,7 +254,7 @@ void main() {
         radarStation: station(dist: 1.2),
         radiusMeters: null,
       )!;
-      expect(content.stationDistanceText, '1.2 km');
+      expect(content.stationDistanceText, l10nEn.fuelStationRadarDistanceKm('1.2'));
       expect(content.progress, isNull);
     });
   });

--- a/test/features/consumption/presentation/screens/consumption_app_bar_actions_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_app_bar_actions_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #2756 — the consumption app bar was crammed with 5–6 trailing actions
 /// (OBD2 chip + export + restore + carbon[gated] + Settings, plus the
@@ -43,11 +44,11 @@ class _FixedChargingLogs extends ChargingLogs {
 class _PairedVehicle extends ActiveVehicleProfile {
   @override
   VehicleProfile? build() => const VehicleProfile(
-        id: 'paired',
-        name: 'Paired',
-        type: VehicleType.combustion,
-        obd2AdapterMac: 'AA:BB:CC:DD:EE:FF',
-      );
+    id: 'paired',
+    name: 'Paired',
+    type: VehicleType.combustion,
+    obd2AdapterMac: 'AA:BB:CC:DD:EE:FF',
+  );
 }
 
 class _EmptyVehicleList extends VehicleProfileList {
@@ -64,17 +65,15 @@ class _FixedTripHistoryList extends TripHistoryList {
 class _CarbonOnFlags extends FeatureFlags {
   @override
   Future<Set<Feature>> build() async => <Feature>{
-        Feature.showConsumptionTab,
-        Feature.carbonDashboard,
-      };
+    Feature.showConsumptionTab,
+    Feature.carbonDashboard,
+  };
 }
 
 /// Feature flags with the carbon dashboard DISABLED.
 class _CarbonOffFlags extends FeatureFlags {
   @override
-  Future<Set<Feature>> build() async => <Feature>{
-        Feature.showConsumptionTab,
-      };
+  Future<Set<Feature>> build() async => <Feature>{Feature.showConsumptionTab};
 }
 
 Future<void> _pump(
@@ -101,7 +100,11 @@ Future<void> _pump(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList()),
       chargingLogsProvider.overrideWith(() => _FixedChargingLogs()),
@@ -118,24 +121,28 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ConsumptionAppBarActions — title no longer truncates (#2756)', () {
-    testWidgets('Carburant: full title, no visible IconButton but the kebab',
-        (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOnFlags());
+    testWidgets('Carburant: full title, no visible IconButton but the kebab', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOnFlags(),
+      );
 
       // The full "Fuel" title is rendered (no "Car…" truncation).
       expect(
-        find.descendant(
-          of: find.byType(AppBar),
-          matching: find.text('Fuel'),
-        ),
+        find.descendant(of: find.byType(AppBar), matching: find.text('Fuel')),
         findsOneWidget,
       );
 
       // Only the overflow kebab is a visible trailing IconButton (the
       // OBD2 chip self-hides for a paired-but-disconnected adapter; the
       // leading car icon is not a trailing action). No map on Carburant.
-      expect(find.byKey(const Key('consumption_overflow_menu')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_overflow_menu')),
+        findsOneWidget,
+      );
       expect(find.byKey(const Key('trajets_view_all_on_map')), findsNothing);
       expect(
         find.descendant(
@@ -158,16 +165,17 @@ void main() {
       expect(tester.widgetList(appBarIconButtons).length, 2);
     });
 
-    testWidgets('Trajets: map shortcut + kebab are both visible, full title',
-        (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.trajets, flags: () => _CarbonOnFlags());
+    testWidgets('Trajets: map shortcut + kebab are both visible, full title', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        section: ConsumptionSection.trajets,
+        flags: () => _CarbonOnFlags(),
+      );
 
       expect(
-        find.descendant(
-          of: find.byType(AppBar),
-          matching: find.text('Trips'),
-        ),
+        find.descendant(of: find.byType(AppBar), matching: find.text('Trips')),
         findsOneWidget,
       );
       // The Trajets map shortcut is a visible primary action in the bar.
@@ -178,15 +186,22 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(find.byKey(const Key('consumption_overflow_menu')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_overflow_menu')),
+        findsOneWidget,
+      );
     });
   });
 
   group('ConsumptionAppBarActions — overflow kebab contents (#2756)', () {
-    testWidgets('opens to export / restore / carbon / Settings (carbon on)',
-        (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOnFlags());
+    testWidgets('opens to export / restore / carbon / Settings (carbon on)', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOnFlags(),
+      );
 
       await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
       await tester.pumpAndSettle();
@@ -204,10 +219,14 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
     });
 
-    testWidgets('hides the carbon item when the feature is disabled',
-        (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOffFlags());
+    testWidgets('hides the carbon item when the feature is disabled', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOffFlags(),
+      );
 
       await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
       await tester.pumpAndSettle();
@@ -221,15 +240,22 @@ void main() {
     });
 
     testWidgets('the kebab carries a "More" tooltip for a11y', (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOnFlags());
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOnFlags(),
+      );
       expect(find.byTooltip('More'), findsOneWidget);
     });
 
-    testWidgets('choosing the carbon item routes to /carbon (gated)',
-        (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOnFlags());
+    testWidgets('choosing the carbon item routes to /carbon (gated)', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOnFlags(),
+      );
 
       await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
       await tester.pumpAndSettle();
@@ -241,8 +267,11 @@ void main() {
     });
 
     testWidgets('choosing Settings routes to /profile', (tester) async {
-      await _pump(tester,
-          section: ConsumptionSection.fuel, flags: () => _CarbonOnFlags());
+      await _pump(
+        tester,
+        section: ConsumptionSection.fuel,
+        flags: () => _CarbonOnFlags(),
+      );
 
       await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
       await tester.pumpAndSettle();

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
@@ -13,6 +13,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #582 phase 2 — the ConsumptionScreen grows a Fuel/Charging tab
 /// toggle. These tests verify that both tabs render, empty states
@@ -64,7 +65,11 @@ Future<void> _pumpScreen(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
       chargingLogsProvider.overrideWith(() => _FixedChargingLogs(chargingLogs)),
@@ -89,8 +94,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.descendant(
-            of: find.byType(Tab), matching: find.text('Charging')),
+        find.descendant(of: find.byType(Tab), matching: find.text('Charging')),
         findsOneWidget,
       );
       // The Fuel/Charging switcher has exactly two entries (#1901 —
@@ -98,22 +102,20 @@ void main() {
       expect(find.byType(Tab), findsNWidgets(2));
     });
 
-    testWidgets('Fuel tab shows its empty state with 0 fill-ups',
-        (tester) async {
+    testWidgets('Fuel tab shows its empty state with 0 fill-ups', (
+      tester,
+    ) async {
       await _pumpScreen(tester);
       expect(find.textContaining('No fill-ups'), findsOneWidget);
     });
 
-    testWidgets(
-        'Charging tab shows its empty state with 0 charging logs',
-        (tester) async {
+    testWidgets('Charging tab shows its empty state with 0 charging logs', (
+      tester,
+    ) async {
       await _pumpScreen(tester);
       await tester.tap(find.text('Charging'));
       await tester.pumpAndSettle();
-      expect(
-        find.byKey(const Key('charging_empty_state')),
-        findsOneWidget,
-      );
+      expect(find.byKey(const Key('charging_empty_state')), findsOneWidget);
       expect(find.textContaining('No charging logs'), findsOneWidget);
     });
 
@@ -129,8 +131,9 @@ void main() {
       expect(find.byKey(const Key('fab_add_fillup')), findsNothing);
     });
 
-    testWidgets('Charging tab renders a card per logged session',
-        (tester) async {
+    testWidgets('Charging tab renders a card per logged session', (
+      tester,
+    ) async {
       // Phase-3 added a charts header above the log list. On the
       // default 800px test surface the cards end up below the fold,
       // so we enlarge the viewport for this assertion only —

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Enables the consumption surface. #1901 — Trajets is no longer a tab
 /// of this screen, so the Fuel section just needs the Conso surface
@@ -22,9 +23,9 @@ import '../../../../helpers/pump_app.dart';
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
-        Feature.showConsumptionTab,
-        Feature.obd2TripRecording,
-      };
+    Feature.showConsumptionTab,
+    Feature.obd2TripRecording,
+  };
 }
 
 /// #892 / #1901 — the Charging slot on the Fuel section of
@@ -125,14 +126,18 @@ Future<_MutableActiveVehicle> _pumpScreen(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
-      chargingLogsProvider
-          .overrideWith(() => _FixedChargingLogs(chargingLogs)),
+      chargingLogsProvider.overrideWith(() => _FixedChargingLogs(chargingLogs)),
       activeVehicleProfileProvider.overrideWith(() => activeNotifier),
-      vehicleProfileListProvider
-          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
+      vehicleProfileListProvider.overrideWith(
+        () => _FixedVehicleProfileList(vehicles),
+      ),
       featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
     ],
   );
@@ -147,10 +152,8 @@ void main() {
     /// Matches a [Tab] whose `text` carries the given label — the Fuel
     /// section's AppBar title is also 'Fuel', so the bare text finder
     /// would be ambiguous.
-    Finder tabLabelled(String label) => find.descendant(
-          of: find.byType(Tab),
-          matching: find.text(label),
-        );
+    Finder tabLabelled(String label) =>
+        find.descendant(of: find.byType(Tab), matching: find.text(label));
 
     testWidgets(
       'ICE vehicle active → no Fuel/Charging switcher, no "Charging" [AC1]',
@@ -164,8 +167,11 @@ void main() {
         // #1901 — a pure-combustion vehicle gets no Fuel/Charging
         // switcher at all: the Fuel section renders the fill-up list
         // directly with no `Tab` widgets.
-        expect(find.byType(Tab), findsNothing,
-            reason: 'ICE vehicle has no Fuel/Charging switcher');
+        expect(
+          find.byType(Tab),
+          findsNothing,
+          reason: 'ICE vehicle has no Fuel/Charging switcher',
+        );
 
         // The localised tab labels for Charging must not appear.
         expect(find.text('Charging'), findsNothing);
@@ -175,25 +181,24 @@ void main() {
       },
     );
 
-    testWidgets(
-      'EV vehicle active → 2-entry Fuel / Charging switcher [AC2]',
-      (tester) async {
-        await _pumpScreen(
-          tester,
-          activeVehicle: _evVehicle,
-          vehicles: const [_evVehicle],
-        );
+    testWidgets('EV vehicle active → 2-entry Fuel / Charging switcher [AC2]', (
+      tester,
+    ) async {
+      await _pumpScreen(
+        tester,
+        activeVehicle: _evVehicle,
+        vehicles: const [_evVehicle],
+      );
 
-        expect(tabLabelled('Fuel'), findsOneWidget);
-        expect(
-          tabLabelled('Charging'),
-          findsOneWidget,
-          reason: 'Charging tab must render for EV vehicles',
-        );
-        // #1901 — Trajets is no longer a tab of this screen.
-        expect(find.byType(Tab), findsNWidgets(2));
-      },
-    );
+      expect(tabLabelled('Fuel'), findsOneWidget);
+      expect(
+        tabLabelled('Charging'),
+        findsOneWidget,
+        reason: 'Charging tab must render for EV vehicles',
+      );
+      // #1901 — Trajets is no longer a tab of this screen.
+      expect(find.byType(Tab), findsNWidgets(2));
+    });
 
     testWidgets(
       'Hybrid vehicle active → 2-entry Fuel / Charging switcher [AC3]',
@@ -213,63 +218,62 @@ void main() {
       },
     );
 
-    testWidgets(
-      'Live switch EV → ICE while on Charging sub-tab: '
-      'switcher disappears, no crash, screen falls back to Fuel [AC4]',
-      (tester) async {
-        // Start on the EV profile with the Charging tab visible and a
-        // couple of logs seeded so the data layer has state we can
-        // observe *doesn't* get cleared by the switch.
-        final activeNotifier = await _pumpScreen(
-          tester,
-          activeVehicle: _evVehicle,
-          vehicles: const [_evVehicle, _iceVehicle],
-          chargingLogs: [
-            ChargingLog(
-              id: 'c1',
-              vehicleId: 'v-ev',
-              date: DateTime.utc(2026, 4, 20),
-              kWh: 30.0,
-              costEur: 12.0,
-              chargeTimeMin: 30,
-              odometerKm: 10000,
-              stationName: 'Ionity Castelnau',
-            ),
-          ],
-        );
+    testWidgets('Live switch EV → ICE while on Charging sub-tab: '
+        'switcher disappears, no crash, screen falls back to Fuel [AC4]', (
+      tester,
+    ) async {
+      // Start on the EV profile with the Charging tab visible and a
+      // couple of logs seeded so the data layer has state we can
+      // observe *doesn't* get cleared by the switch.
+      final activeNotifier = await _pumpScreen(
+        tester,
+        activeVehicle: _evVehicle,
+        vehicles: const [_evVehicle, _iceVehicle],
+        chargingLogs: [
+          ChargingLog(
+            id: 'c1',
+            vehicleId: 'v-ev',
+            date: DateTime.utc(2026, 4, 20),
+            kWh: 30.0,
+            costEur: 12.0,
+            chargeTimeMin: 30,
+            odometerKm: 10000,
+            stationName: 'Ionity Castelnau',
+          ),
+        ],
+      );
 
-        // Sanity: Charging tab is there.
-        expect(tabLabelled('Charging'), findsOneWidget);
+      // Sanity: Charging tab is there.
+      expect(tabLabelled('Charging'), findsOneWidget);
 
-        // Tap onto Charging so we're ON the tab that will vanish.
-        await tester.tap(tabLabelled('Charging'));
-        await tester.pumpAndSettle();
+      // Tap onto Charging so we're ON the tab that will vanish.
+      await tester.tap(tabLabelled('Charging'));
+      await tester.pumpAndSettle();
 
-        // Flip the active vehicle to ICE — the switcher should vanish.
-        activeNotifier.setVehicle(_iceVehicle);
-        await tester.pumpAndSettle();
+      // Flip the active vehicle to ICE — the switcher should vanish.
+      activeNotifier.setVehicle(_iceVehicle);
+      await tester.pumpAndSettle();
 
-        // No exception was surfaced by the harness (TestWidgetsFlutter
-        // Binding rethrows on pump if one occurred).
-        expect(tester.takeException(), isNull);
+      // No exception was surfaced by the harness (TestWidgetsFlutter
+      // Binding rethrows on pump if one occurred).
+      expect(tester.takeException(), isNull);
 
-        // #1901 — a combustion vehicle has no Fuel/Charging switcher
-        // at all: the screen falls back to the plain fuel list, the
-        // `Tab` widgets and the TabBar are gone.
-        expect(find.text('Charging'), findsNothing);
-        expect(find.byType(Tab), findsNothing);
-        expect(find.byType(TabBar), findsNothing);
+      // #1901 — a combustion vehicle has no Fuel/Charging switcher
+      // at all: the screen falls back to the plain fuel list, the
+      // `Tab` widgets and the TabBar are gone.
+      expect(find.text('Charging'), findsNothing);
+      expect(find.byType(Tab), findsNothing);
+      expect(find.byType(TabBar), findsNothing);
 
-        // Flip back to EV — the Fuel/Charging switcher must return and
-        // the logs must still be available from the unchanged provider.
-        activeNotifier.setVehicle(_evVehicle);
-        await tester.pumpAndSettle();
-        expect(
-          tabLabelled('Charging'),
-          findsOneWidget,
-          reason: 'Charging tab must come back when vehicle is EV again',
-        );
-      },
-    );
+      // Flip back to EV — the Fuel/Charging switcher must return and
+      // the logs must still be available from the unchanged provider.
+      activeNotifier.setVehicle(_evVehicle);
+      await tester.pumpAndSettle();
+      expect(
+        tabLabelled('Charging'),
+        findsOneWidget,
+        reason: 'Charging tab must come back when vehicle is EV again',
+      );
+    });
   });
 }

--- a/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
@@ -17,6 +17,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 class _FixedFillUpList extends FillUpList {
   final List<FillUp> _value;
@@ -46,7 +47,7 @@ class _RecordingExporter extends FullBackupExporter {
   List<VehicleProfile>? lastVehicles;
 
   _RecordingExporter()
-      : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
+    : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
 
   @override
   Future<FullBackupExportResult> export({
@@ -68,7 +69,7 @@ class _RecordingExporter extends FullBackupExporter {
 
 class _ThrowingExporter extends FullBackupExporter {
   _ThrowingExporter()
-      : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
+    : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
 
   @override
   Future<FullBackupExportResult> export({
@@ -85,7 +86,7 @@ class _ThrowingExporter extends FullBackupExporter {
 /// success snackbar takes the #2815 "Saved to Downloads as {fileName}" branch.
 class _SavedExporter extends FullBackupExporter {
   _SavedExporter()
-      : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
+    : super(xmlWriter: BackupXmlWriter(), zipper: const BackupZipper());
 
   @override
   Future<FullBackupExportResult> export({
@@ -121,7 +122,11 @@ Future<void> _pumpScreen(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
       activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
@@ -176,8 +181,9 @@ void main() {
       expect(find.byKey(const Key('export_backup')), findsOneWidget);
     });
 
-    testWidgets('tapping the kebab item invokes the FullBackupExporter',
-        (tester) async {
+    testWidgets('tapping the kebab item invokes the FullBackupExporter', (
+      tester,
+    ) async {
       final exporter = _RecordingExporter();
       ConsumptionScreen.debugExporterOverride = exporter;
 
@@ -200,8 +206,9 @@ void main() {
       expect(exporter.lastFillUps!.single.id, '1');
     });
 
-    testWidgets('shows confirmation snackbar after a successful export',
-        (tester) async {
+    testWidgets('shows confirmation snackbar after a successful export', (
+      tester,
+    ) async {
       ConsumptionScreen.debugExporterOverride = _RecordingExporter();
 
       final fillUp = FillUp(
@@ -216,14 +223,12 @@ void main() {
 
       await openExport(tester);
 
-      expect(
-        find.textContaining('Backup ready'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Backup ready'), findsOneWidget);
     });
 
-    testWidgets('names the saved file in the success snackbar (#2815)',
-        (tester) async {
+    testWidgets('names the saved file in the success snackbar (#2815)', (
+      tester,
+    ) async {
       ConsumptionScreen.debugExporterOverride = _SavedExporter();
 
       final fillUp = FillUp(
@@ -240,11 +245,15 @@ void main() {
 
       // The user is told the exact filename to look for (in Downloads / the
       // restore picker), not a generic "saved to folder".
-      expect(find.textContaining('tankstellen_backup_2026.zip'), findsOneWidget);
+      expect(
+        find.textContaining('tankstellen_backup_2026.zip'),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('surfaces an error snackbar when the exporter throws',
-        (tester) async {
+    testWidgets('surfaces an error snackbar when the exporter throws', (
+      tester,
+    ) async {
       ConsumptionScreen.debugExporterOverride = _ThrowingExporter();
 
       final fillUp = FillUp(
@@ -259,10 +268,7 @@ void main() {
 
       await openExport(tester);
 
-      expect(
-        find.textContaining('Backup export failed'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Backup export failed'), findsOneWidget);
     });
   });
 
@@ -274,45 +280,45 @@ void main() {
   // title and carries NO precision chip — only the OBD2 chip, the
   // download/export action, the gated Carbon entry and Settings.
   group('ConsumptionScreen Fuel app-bar after #2433', () {
-    testWidgets('shows the plain Fuel title (no precision chip in the app-bar)',
-        (tester) async {
-      final fillUp = FillUp(
-        id: '1',
-        date: DateTime.utc(2026, 4, 15),
-        liters: 40,
-        totalCost: 60,
-        odometerKm: 10000,
-        fuelType: FuelType.e10,
-      );
-      await _pumpScreen(tester, fillUps: [fillUp]);
+    testWidgets(
+      'shows the plain Fuel title (no precision chip in the app-bar)',
+      (tester) async {
+        final fillUp = FillUp(
+          id: '1',
+          date: DateTime.utc(2026, 4, 15),
+          liters: 40,
+          totalCost: 60,
+          odometerKm: 10000,
+          fuelType: FuelType.e10,
+        );
+        await _pumpScreen(tester, fillUps: [fillUp]);
 
-      // The restored app-bar title (reuses consumptionTabFuel — #2433).
-      expect(
-        find.descendant(
-          of: find.byType(AppBar),
-          matching: find.text('Fuel'),
-        ),
-        findsOneWidget,
-      );
-      // No precision chip surfaces anywhere in the app-bar.
-      expect(
-        find.descendant(
-          of: find.byType(AppBar),
-          matching: find.textContaining('Accuracy:'),
-        ),
-        findsNothing,
-      );
-      expect(
-        find.descendant(
-          of: find.byType(AppBar),
-          matching: find.textContaining('η_v'),
-        ),
-        findsNothing,
-      );
-    });
+        // The restored app-bar title (reuses consumptionTabFuel — #2433).
+        expect(
+          find.descendant(of: find.byType(AppBar), matching: find.text('Fuel')),
+          findsOneWidget,
+        );
+        // No precision chip surfaces anywhere in the app-bar.
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.textContaining('Accuracy:'),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.textContaining('η_v'),
+          ),
+          findsNothing,
+        );
+      },
+    );
 
-    testWidgets('keeps the export action reachable via the overflow kebab',
-        (tester) async {
+    testWidgets('keeps the export action reachable via the overflow kebab', (
+      tester,
+    ) async {
       final fillUp = FillUp(
         id: '1',
         date: DateTime.utc(2026, 4, 15),
@@ -325,7 +331,10 @@ void main() {
 
       // #2756 — export moved into the kebab; the kebab itself is the
       // app-bar action and export appears once it is opened.
-      expect(find.byKey(const Key('consumption_overflow_menu')), findsOneWidget);
+      expect(
+        find.byKey(const Key('consumption_overflow_menu')),
+        findsOneWidget,
+      );
       expect(find.byKey(const Key('export_backup')), findsNothing);
       await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
       await tester.pumpAndSettle();

--- a/test/features/consumption/presentation/screens/consumption_screen_restore_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_restore_test.dart
@@ -19,13 +19,15 @@ import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import '../../../../helpers/pump_app.dart';
 import '../../../../helpers/silence_error_logger.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 class _FakeSettings implements SettingsStorage {
   final Map<String, dynamic> _data = {};
   @override
   dynamic getSetting(String key) => _data[key];
   @override
-  Future<void> putSetting(String key, dynamic value) async => _data[key] = value;
+  Future<void> putSetting(String key, dynamic value) async =>
+      _data[key] = value;
   @override
   bool get isSetupComplete => true;
   @override
@@ -75,7 +77,11 @@ Future<void> _pumpScreen(WidgetTester tester) async {
   );
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       settingsStorageProvider.overrideWithValue(storage),
       gamificationEnabledProvider.overrideWithValue(true),
@@ -102,23 +108,26 @@ void main() {
   }
 
   group('ConsumptionScreen full-backup restore (#2571)', () {
-    testWidgets('Restore and Export both appear in the overflow kebab (#2756)',
-        (tester) async {
-      await _pumpScreen(tester);
-      // Neither is a visible trailing button anymore.
-      expect(find.byKey(const Key('restore_backup')), findsNothing);
-      expect(find.byKey(const Key('export_backup')), findsNothing);
-      // Both surface once the kebab opens.
-      await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
-      await tester.pumpAndSettle();
-      expect(find.byKey(const Key('restore_backup')), findsOneWidget);
-      expect(find.byKey(const Key('export_backup')), findsOneWidget);
-    });
+    testWidgets(
+      'Restore and Export both appear in the overflow kebab (#2756)',
+      (tester) async {
+        await _pumpScreen(tester);
+        // Neither is a visible trailing button anymore.
+        expect(find.byKey(const Key('restore_backup')), findsNothing);
+        expect(find.byKey(const Key('export_backup')), findsNothing);
+        // Both surface once the kebab opens.
+        await tester.tap(find.byKey(const Key('consumption_overflow_menu')));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('restore_backup')), findsOneWidget);
+        expect(find.byKey(const Key('export_backup')), findsOneWidget);
+      },
+    );
 
-    testWidgets('tapping Restore opens the merge-vs-replace dialog',
-        (tester) async {
-      BackupRestoreFlow.debugFilePickerOverride =
-          () async => _sampleBackupBytes();
+    testWidgets('tapping Restore opens the merge-vs-replace dialog', (
+      tester,
+    ) async {
+      BackupRestoreFlow.debugFilePickerOverride = () async =>
+          _sampleBackupBytes();
       await _pumpScreen(tester);
 
       await openRestore(tester);
@@ -129,8 +138,9 @@ void main() {
       expect(find.text('Cancel'), findsOneWidget);
     });
 
-    testWidgets('cancelling the picker does nothing (no dialog)',
-        (tester) async {
+    testWidgets('cancelling the picker does nothing (no dialog)', (
+      tester,
+    ) async {
       BackupRestoreFlow.debugFilePickerOverride = () async => null;
       await _pumpScreen(tester);
 
@@ -139,10 +149,11 @@ void main() {
       expect(find.text('Merge'), findsNothing);
     });
 
-    testWidgets('choosing Merge shows a per-entity MERGED summary (#2815)',
-        (tester) async {
-      BackupRestoreFlow.debugFilePickerOverride =
-          () async => _sampleBackupBytes();
+    testWidgets('choosing Merge shows a per-entity MERGED summary (#2815)', (
+      tester,
+    ) async {
+      BackupRestoreFlow.debugFilePickerOverride = () async =>
+          _sampleBackupBytes();
       await _pumpScreen(tester);
 
       await openRestore(tester);
@@ -157,10 +168,11 @@ void main() {
       expect(find.textContaining('1 fill-ups'), findsOneWidget);
     });
 
-    testWidgets('choosing Replace all shows a REPLACED summary (#2815)',
-        (tester) async {
-      BackupRestoreFlow.debugFilePickerOverride =
-          () async => _sampleBackupBytes();
+    testWidgets('choosing Replace all shows a REPLACED summary (#2815)', (
+      tester,
+    ) async {
+      BackupRestoreFlow.debugFilePickerOverride = () async =>
+          _sampleBackupBytes();
       await _pumpScreen(tester);
 
       await openRestore(tester);
@@ -172,18 +184,21 @@ void main() {
       expect(find.textContaining('Merged'), findsNothing);
     });
 
-    testWidgets('a corrupt file surfaces a localized error snackbar',
-        (tester) async {
-      BackupRestoreFlow.debugFilePickerOverride =
-          () async => Uint8List.fromList([1, 2, 3, 4]);
+    testWidgets('a corrupt file surfaces a localized error snackbar', (
+      tester,
+    ) async {
+      BackupRestoreFlow.debugFilePickerOverride = () async =>
+          Uint8List.fromList([1, 2, 3, 4]);
       await _pumpScreen(tester);
 
       await openRestore(tester);
       await tester.tap(find.text('Merge'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('not a valid Tankstellen backup'),
-          findsOneWidget);
+      expect(
+        find.textContaining('not a valid Tankstellen backup'),
+        findsOneWidget,
+      );
       // And the exception type is the typed one (sanity on the path).
       expect(const BackupZipReader().runtimeType, BackupZipReader);
     });

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -15,15 +15,16 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Enables the consumption surface. #1901 — the Fuel section's
 /// Fuel/Charging switcher does not depend on the OBD2 flag.
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
-        Feature.showConsumptionTab,
-        Feature.obd2TripRecording,
-      };
+    Feature.showConsumptionTab,
+    Feature.obd2TripRecording,
+  };
 }
 
 /// #1163 — counterpart to `favorites_screen_tab_icons_test.dart`.
@@ -76,8 +77,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ConsumptionScreen sub-tab icons (#1163)', () {
-    testWidgets('every TabSwitcher entry renders a leading Icon',
-        (tester) async {
+    testWidgets('every TabSwitcher entry renders a leading Icon', (
+      tester,
+    ) async {
       final router = GoRouter(
         initialLocation: '/consumption',
         routes: [
@@ -94,28 +96,27 @@ void main() {
             builder: (_, _) => const SizedBox(),
           ),
           GoRoute(path: '/carbon', builder: (_, _) => const SizedBox()),
-          GoRoute(
-            path: '/trip-history',
-            builder: (_, _) => const SizedBox(),
-          ),
-          GoRoute(
-            path: '/vehicles/edit',
-            builder: (_, _) => const SizedBox(),
-          ),
+          GoRoute(path: '/trip-history', builder: (_, _) => const SizedBox()),
+          GoRoute(path: '/vehicles/edit', builder: (_, _) => const SizedBox()),
         ],
       );
 
       await pumpApp(
         tester,
-        MaterialApp.router(routerConfig: router),
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
         overrides: [
           fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
-          chargingLogsProvider
-              .overrideWith(() => _FixedChargingLogs(const [])),
-          activeVehicleProfileProvider
-              .overrideWith(() => _FixedActiveVehicle(_evVehicle)),
-          vehicleProfileListProvider
-              .overrideWith(() => _FixedVehicleProfileList(const [_evVehicle])),
+          chargingLogsProvider.overrideWith(() => _FixedChargingLogs(const [])),
+          activeVehicleProfileProvider.overrideWith(
+            () => _FixedActiveVehicle(_evVehicle),
+          ),
+          vehicleProfileListProvider.overrideWith(
+            () => _FixedVehicleProfileList(const [_evVehicle]),
+          ),
           featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
         ],
       );
@@ -123,8 +124,11 @@ void main() {
       // #1901 — EV profile renders the 2-entry Fuel / Charging
       // switcher (Trajets moved out to its own destination).
       final tabs = tester.widgetList<Tab>(find.byType(Tab)).toList();
-      expect(tabs, hasLength(2),
-          reason: 'EV profile must render the Fuel + Charging switcher');
+      expect(
+        tabs,
+        hasLength(2),
+        reason: 'EV profile must render the Fuel + Charging switcher',
+      );
 
       // Every Tab must render a leading icon — the visual contract this
       // issue locked across both Conso and Favoris. #2237 made the tab

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #889 / #1901 — the Trajets surface (OBD2 trip history).
 ///
@@ -43,9 +44,9 @@ import '../../../../helpers/pump_app.dart';
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
-        Feature.showConsumptionTab,
-        Feature.obd2TripRecording,
-      };
+    Feature.showConsumptionTab,
+    Feature.obd2TripRecording,
+  };
 }
 
 class _FixedFillUpList extends FillUpList {
@@ -134,9 +135,8 @@ Future<void> _pumpScreen(
     routes: [
       GoRoute(
         path: '/trajets-tab',
-        builder: (_, _) => const ConsumptionScreen(
-          section: ConsumptionSection.trajets,
-        ),
+        builder: (_, _) =>
+            const ConsumptionScreen(section: ConsumptionSection.trajets),
       ),
       GoRoute(path: '/consumption/add', builder: (_, _) => const SizedBox()),
       GoRoute(
@@ -158,16 +158,21 @@ Future<void> _pumpScreen(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
       chargingLogsProvider.overrideWith(() => _FixedChargingLogs(chargingLogs)),
-      activeVehicleProfileProvider
-          .overrideWith(() => _FixedActiveVehicle(activeVehicle)),
-      vehicleProfileListProvider
-          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
-      tripHistoryListProvider
-          .overrideWith(() => _FixedTripHistoryList(trips)),
+      activeVehicleProfileProvider.overrideWith(
+        () => _FixedActiveVehicle(activeVehicle),
+      ),
+      vehicleProfileListProvider.overrideWith(
+        () => _FixedVehicleProfileList(vehicles),
+      ),
+      tripHistoryListProvider.overrideWith(() => _FixedTripHistoryList(trips)),
       featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
     ],
   );
@@ -188,13 +193,10 @@ void main() {
       type: VehicleType.hybrid,
     );
 
-    testWidgets('renders the Trajets section directly — no tab bar, no FAB',
-        (tester) async {
-      await _pumpScreen(
-        tester,
-        activeVehicle: vehicle,
-        vehicles: [vehicle],
-      );
+    testWidgets('renders the Trajets section directly — no tab bar, no FAB', (
+      tester,
+    ) async {
+      await _pumpScreen(tester, activeVehicle: vehicle, vehicles: [vehicle]);
       // #1901 — the Trajets destination has no in-screen TabSwitcher
       // and no screen-level FAB (the "Start recording" CTA lives in
       // the tab header).
@@ -203,13 +205,10 @@ void main() {
       expect(find.byKey(const Key('fab_add_charging')), findsNothing);
     });
 
-    testWidgets('Trajets empty state renders CTA + "Start recording" button',
-        (tester) async {
-      await _pumpScreen(
-        tester,
-        activeVehicle: vehicle,
-        vehicles: [vehicle],
-      );
+    testWidgets('Trajets empty state renders CTA + "Start recording" button', (
+      tester,
+    ) async {
+      await _pumpScreen(tester, activeVehicle: vehicle, vehicles: [vehicle]);
 
       expect(find.byKey(const Key('trajets_empty_state')), findsOneWidget);
       expect(
@@ -260,12 +259,18 @@ void main() {
       );
 
       // Every trip should render a row.
-      expect(find.byKey(const ValueKey('trajet-2026-04-20T09:00:00.000Z')),
-          findsOneWidget);
-      expect(find.byKey(const ValueKey('trajet-2026-04-21T09:00:00.000Z')),
-          findsOneWidget);
-      expect(find.byKey(const ValueKey('trajet-2026-04-22T09:00:00.000Z')),
-          findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('trajet-2026-04-20T09:00:00.000Z')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('trajet-2026-04-21T09:00:00.000Z')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('trajet-2026-04-22T09:00:00.000Z')),
+        findsOneWidget,
+      );
 
       // Newest-first: the April 22nd row must sit above April 20th.
       final newestY = tester
@@ -278,12 +283,16 @@ void main() {
             find.byKey(const ValueKey('trajet-2026-04-20T09:00:00.000Z')),
           )
           .dy;
-      expect(newestY, lessThan(oldestY),
-          reason: 'Newest trip should appear above the oldest');
+      expect(
+        newestY,
+        lessThan(oldestY),
+        reason: 'Newest trip should appear above the oldest',
+      );
     });
 
-    testWidgets('tap row navigates to /trip/:id with the correct id',
-        (tester) async {
+    testWidgets('tap row navigates to /trip/:id with the correct id', (
+      tester,
+    ) async {
       final trips = <TripHistoryEntry>[
         _entry(
           id: '2026-04-22T09:00:00.000Z',
@@ -330,9 +339,9 @@ void main() {
       type: VehicleType.combustion,
     );
 
-    testWidgets(
-        'map IconButton is present in the AppBar when trips exist',
-        (tester) async {
+    testWidgets('map IconButton is present in the AppBar when trips exist', (
+      tester,
+    ) async {
       final trips = <TripHistoryEntry>[
         _entry(
           id: 'trip-1',
@@ -351,10 +360,7 @@ void main() {
 
       // The AppBar map IconButton carries the localized tooltip and
       // the map_outlined icon.
-      expect(
-        find.byKey(const Key('trajets_view_all_on_map')),
-        findsOneWidget,
-      );
+      expect(find.byKey(const Key('trajets_view_all_on_map')), findsOneWidget);
       final btn = tester.widget<IconButton>(
         find.byKey(const Key('trajets_view_all_on_map')),
       );
@@ -368,26 +374,19 @@ void main() {
       );
     });
 
-    testWidgets(
-        'map IconButton is present even with an empty trip list',
-        (tester) async {
-      await _pumpScreen(
-        tester,
-        activeVehicle: vehicle,
-        vehicles: [vehicle],
-      );
+    testWidgets('map IconButton is present even with an empty trip list', (
+      tester,
+    ) async {
+      await _pumpScreen(tester, activeVehicle: vehicle, vehicles: [vehicle]);
 
       // The button is always present (empty tripIds list is valid for
       // TrajetsMapScreen — it renders its own empty state).
-      expect(
-        find.byKey(const Key('trajets_view_all_on_map')),
-        findsOneWidget,
-      );
+      expect(find.byKey(const Key('trajets_view_all_on_map')), findsOneWidget);
     });
 
-    testWidgets(
-        'standalone TextButton.icon row is absent from the body',
-        (tester) async {
+    testWidgets('standalone TextButton.icon row is absent from the body', (
+      tester,
+    ) async {
       final trips = <TripHistoryEntry>[
         _entry(
           id: 'trip-2',
@@ -407,6 +406,5 @@ void main() {
       // body scroll area; it must be gone now.
       expect(find.byType(TextButton), findsNothing);
     });
-
   });
 }

--- a/test/features/consumption/presentation/screens/consumption_screen_vehicle_leading_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_vehicle_leading_test.dart
@@ -17,6 +17,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #2223 — the vehicles (car) entry point moved from the trailing
 /// AppBar actions to the leading slot, so the car icon reads as part
@@ -28,9 +29,9 @@ import '../../../../helpers/pump_app.dart';
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
-        Feature.showConsumptionTab,
-        Feature.obd2TripRecording,
-      };
+    Feature.showConsumptionTab,
+    Feature.obd2TripRecording,
+  };
 }
 
 class _FixedFillUpList extends FillUpList {
@@ -46,10 +47,10 @@ class _FixedChargingLogs extends ChargingLogs {
 class _FixedActiveVehicle extends ActiveVehicleProfile {
   @override
   VehicleProfile? build() => const VehicleProfile(
-        id: 'daily-driver',
-        name: 'Daily Driver',
-        type: VehicleType.combustion,
-      );
+    id: 'daily-driver',
+    name: 'Daily Driver',
+    type: VehicleType.combustion,
+  );
 }
 
 class _FixedVehicleProfileList extends VehicleProfileList {
@@ -71,9 +72,8 @@ Future<void> _pumpTrajets(WidgetTester tester) async {
     routes: [
       GoRoute(
         path: '/trajets-tab',
-        builder: (_, _) => const ConsumptionScreen(
-          section: ConsumptionSection.trajets,
-        ),
+        builder: (_, _) =>
+            const ConsumptionScreen(section: ConsumptionSection.trajets),
       ),
       GoRoute(
         path: '/consumption/pick-station',
@@ -92,7 +92,11 @@ Future<void> _pumpTrajets(WidgetTester tester) async {
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList()),
       chargingLogsProvider.overrideWith(() => _FixedChargingLogs()),
@@ -129,11 +133,11 @@ void main() {
       );
     });
 
-    testWidgets('car icon sits to the left of the trailing actions',
-        (tester) async {
+    testWidgets('car icon sits to the left of the trailing actions', (
+      tester,
+    ) async {
       await _pumpTrajets(tester);
-      final iconX =
-          tester.getCenter(find.byKey(const Key('open_vehicles'))).dx;
+      final iconX = tester.getCenter(find.byKey(const Key('open_vehicles'))).dx;
       // #2756 — export moved into the overflow kebab; the kebab is now
       // the right-most trailing action. The car icon must still sit
       // left of it.
@@ -143,8 +147,9 @@ void main() {
       expect(iconX, lessThan(kebabX));
     });
 
-    testWidgets('the overflow kebab carries the export action (#2756)',
-        (tester) async {
+    testWidgets('the overflow kebab carries the export action (#2756)', (
+      tester,
+    ) async {
       await _pumpTrajets(tester);
       // Export is no longer a visible trailing button — it lives in the
       // overflow kebab and appears once the menu is opened.
@@ -154,8 +159,9 @@ void main() {
       expect(find.byKey(const Key('export_backup')), findsOneWidget);
     });
 
-    testWidgets('tapping the car icon still navigates to /vehicles',
-        (tester) async {
+    testWidgets('tapping the car icon still navigates to /vehicles', (
+      tester,
+    ) async {
       await _pumpTrajets(tester);
       await tester.tap(find.byKey(const Key('open_vehicles')));
       await tester.pumpAndSettle();

--- a/test/features/consumption/presentation/screens/consumption_screen_vehicle_shortcut_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_vehicle_shortcut_test.dart
@@ -11,6 +11,7 @@ import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #702 originally surfaced an "edit vehicle" shortcut in the
 /// ConsumptionScreen AppBar. #1313 removed it (alongside the
@@ -26,10 +27,10 @@ class _FixedFillUpList extends FillUpList {
 class _OneActiveVehicle extends ActiveVehicleProfile {
   @override
   VehicleProfile? build() => const VehicleProfile(
-        id: 'daily-driver',
-        name: 'Daily Driver',
-        type: VehicleType.combustion,
-      );
+    id: 'daily-driver',
+    name: 'Daily Driver',
+    type: VehicleType.combustion,
+  );
 }
 
 class _NoActiveVehicle extends ActiveVehicleProfile {
@@ -49,14 +50,20 @@ Future<void> _pump(
         builder: (_, _) => const ConsumptionScreen(),
       ),
       GoRoute(path: '/consumption/add', builder: (_, _) => const SizedBox()),
-      GoRoute(path: '/consumption/pick-station',
-          builder: (_, _) => const SizedBox()),
+      GoRoute(
+        path: '/consumption/pick-station',
+        builder: (_, _) => const SizedBox(),
+      ),
       GoRoute(path: '/carbon', builder: (_, _) => const SizedBox()),
     ],
   );
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       fillUpListProvider.overrideWith(() => _FixedFillUpList()),
       activeVehicleProfileProvider.overrideWith(
@@ -70,20 +77,23 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ConsumptionScreen vehicle shortcut removed (#1313)', () {
-    testWidgets('no Edit-vehicle IconButton when a vehicle is active',
-        (tester) async {
+    testWidgets('no Edit-vehicle IconButton when a vehicle is active', (
+      tester,
+    ) async {
       await _pump(tester, withActiveVehicle: true);
       expect(find.byKey(const Key('open_active_vehicle')), findsNothing);
     });
 
-    testWidgets('no Edit-vehicle IconButton when no vehicle is active',
-        (tester) async {
+    testWidgets('no Edit-vehicle IconButton when no vehicle is active', (
+      tester,
+    ) async {
       await _pump(tester, withActiveVehicle: false);
       expect(find.byKey(const Key('open_active_vehicle')), findsNothing);
     });
 
-    testWidgets('no trip-history IconButton (the Trajets sub-tab covers it)',
-        (tester) async {
+    testWidgets('no trip-history IconButton (the Trajets sub-tab covers it)', (
+      tester,
+    ) async {
       await _pump(tester, withActiveVehicle: true);
       expect(find.byKey(const Key('open_trip_history')), findsNothing);
     });

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #890 — the Trajets detail screen renders the full recording
 /// profile (speed / fuel-rate / RPM) plus a summary card, share +
@@ -128,10 +129,8 @@ Future<({_FixedTripHistoryList tripsNotifier})> _pumpDetail(
     routes: [
       GoRoute(
         path: '/trajets-stub',
-        builder: (_, _) => const Scaffold(
-          key: Key('trajets-stub'),
-          body: Text('TrajetsStub'),
-        ),
+        builder: (_, _) =>
+            const Scaffold(key: Key('trajets-stub'), body: Text('TrajetsStub')),
       ),
       GoRoute(
         path: '/trip/:id',
@@ -144,13 +143,19 @@ Future<({_FixedTripHistoryList tripsNotifier})> _pumpDetail(
   );
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       tripHistoryListProvider.overrideWith(() => tripsNotifier),
-      activeVehicleProfileProvider
-          .overrideWith(() => _FixedActiveVehicle(activeVehicle)),
-      vehicleProfileListProvider
-          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
+      activeVehicleProfileProvider.overrideWith(
+        () => _FixedActiveVehicle(activeVehicle),
+      ),
+      vehicleProfileListProvider.overrideWith(
+        () => _FixedVehicleProfileList(vehicles),
+      ),
       // #1194 — TripDetailBody now reads gamificationEnabledProvider;
       // override here so it doesn't fall through to the central
       // featureFlagsProvider chain that these tests don't seed.
@@ -181,7 +186,9 @@ void main() {
   );
 
   group('TripDetailScreen summary card (#890)', () {
-    testWidgets('renders all 8 summary fields for a seeded trip', (tester) async {
+    testWidgets('renders all 8 summary fields for a seeded trip', (
+      tester,
+    ) async {
       final samples = _seedSamples();
       final entry = _seedEntry();
       await _pumpDetail(
@@ -227,9 +234,12 @@ void main() {
         final samples = [
           for (var i = 0; i < 100; i++)
             TripDetailSample(
-              timestamp: DateTime.utc(2026, 4, 22, 10).add(
-                Duration(seconds: i),
-              ),
+              timestamp: DateTime.utc(
+                2026,
+                4,
+                22,
+                10,
+              ).add(Duration(seconds: i)),
               speedKmh: i.toDouble(),
               fuelRateLPerHour: 4.5,
             ),
@@ -259,32 +269,29 @@ void main() {
       },
     );
 
-    testWidgets(
-      'RPM chart hidden when every sample carries a null RPM',
-      (tester) async {
-        final samples = [
-          for (var i = 0; i < 5; i++)
-            TripDetailSample(
-              timestamp: DateTime.utc(2026, 4, 22, 10).add(
-                Duration(seconds: i),
-              ),
-              speedKmh: 40 + i.toDouble(),
-            ),
-        ];
-        await _pumpDetail(
-          tester,
-          entry: _seedEntry(),
-          activeVehicle: vehicle,
-          vehicles: const [vehicle],
-          samples: samples,
-        );
-        await tester.pumpAndSettle();
-        expect(
-          find.byType(TripDetailRpmChart, skipOffstage: false),
-          findsNothing,
-        );
-      },
-    );
+    testWidgets('RPM chart hidden when every sample carries a null RPM', (
+      tester,
+    ) async {
+      final samples = [
+        for (var i = 0; i < 5; i++)
+          TripDetailSample(
+            timestamp: DateTime.utc(2026, 4, 22, 10).add(Duration(seconds: i)),
+            speedKmh: 40 + i.toDouble(),
+          ),
+      ];
+      await _pumpDetail(
+        tester,
+        entry: _seedEntry(),
+        activeVehicle: vehicle,
+        vehicles: const [vehicle],
+        samples: samples,
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byType(TripDetailRpmChart, skipOffstage: false),
+        findsNothing,
+      );
+    });
 
     testWidgets(
       'RPM chart appears when at least one sample carries a non-null RPM',
@@ -332,15 +339,16 @@ void main() {
         GlobalKey? capturedKey;
         String? capturedSubject;
         String? capturedFileNameStem;
-        debugTripDetailShareOverride = ({
-          required GlobalKey boundaryKey,
-          required String subject,
-          required String fileNameStem,
-        }) async {
-          capturedKey = boundaryKey;
-          capturedSubject = subject;
-          capturedFileNameStem = fileNameStem;
-        };
+        debugTripDetailShareOverride =
+            ({
+              required GlobalKey boundaryKey,
+              required String subject,
+              required String fileNameStem,
+            }) async {
+              capturedKey = boundaryKey;
+              capturedSubject = subject;
+              capturedFileNameStem = fileNameStem;
+            };
 
         final samples = _seedSamples();
         await _pumpDetail(
@@ -359,11 +367,18 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(capturedKey, isNotNull,
-            reason: 'share renderer was not invoked');
-        expect(capturedKey!.currentContext, isNotNull,
-            reason: 'boundary key must point at a mounted widget so the '
-                'real renderer can rasterise it');
+        expect(
+          capturedKey,
+          isNotNull,
+          reason: 'share renderer was not invoked',
+        );
+        expect(
+          capturedKey!.currentContext,
+          isNotNull,
+          reason:
+              'boundary key must point at a mounted widget so the '
+              'real renderer can rasterise it',
+        );
         // The subject template is "Sparkilo — trip on {date}" in
         // English (the trip's startedAt is 2026-04-22). Verify the
         // brand + the year ended up in the share subject.
@@ -381,17 +396,21 @@ void main() {
       'Share works with empty samples (no chart crash, still hands off PNG)',
       (tester) async {
         var rendererCalled = false;
-        debugTripDetailShareOverride = ({
-          required GlobalKey boundaryKey,
-          required String subject,
-          required String fileNameStem,
-        }) async {
-          rendererCalled = true;
-          // The empty-samples body must still produce a render-target
-          // boundary, otherwise the production renderer would throw.
-          expect(boundaryKey.currentContext, isNotNull,
-              reason: 'empty-samples body must mount the share boundary');
-        };
+        debugTripDetailShareOverride =
+            ({
+              required GlobalKey boundaryKey,
+              required String subject,
+              required String fileNameStem,
+            }) async {
+              rendererCalled = true;
+              // The empty-samples body must still produce a render-target
+              // boundary, otherwise the production renderer would throw.
+              expect(
+                boundaryKey.currentContext,
+                isNotNull,
+                reason: 'empty-samples body must mount the share boundary',
+              );
+            };
 
         await _pumpDetail(
           tester,
@@ -412,46 +431,44 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(rendererCalled, isTrue,
-            reason: 'share renderer must run even when samples are empty');
-      },
-    );
-
-    testWidgets(
-      'Share surfaces a snackbar when the renderer throws',
-      (tester) async {
-        debugTripDetailShareOverride = ({
-          required GlobalKey boundaryKey,
-          required String subject,
-          required String fileNameStem,
-        }) async {
-          throw StateError('boom');
-        };
-
-        await _pumpDetail(
-          tester,
-          entry: _seedEntry(),
-          activeVehicle: vehicle,
-          vehicles: const [vehicle],
-          samples: _seedSamples(),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
-        await tester.pumpAndSettle();
-        await tester.tap(
-          find.byKey(const Key('trip_detail_share_image_option')),
-        );
-        await tester.pumpAndSettle();
-
-        // The error snackbar surfaces — exact message is the EN
-        // fallback because the test pumps the default locale.
         expect(
-          find.text("Couldn't generate share image"),
-          findsOneWidget,
+          rendererCalled,
+          isTrue,
+          reason: 'share renderer must run even when samples are empty',
         );
       },
     );
+
+    testWidgets('Share surfaces a snackbar when the renderer throws', (
+      tester,
+    ) async {
+      debugTripDetailShareOverride =
+          ({
+            required GlobalKey boundaryKey,
+            required String subject,
+            required String fileNameStem,
+          }) async {
+            throw StateError('boom');
+          };
+
+      await _pumpDetail(
+        tester,
+        entry: _seedEntry(),
+        activeVehicle: vehicle,
+        vehicles: const [vehicle],
+        samples: _seedSamples(),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('trip_detail_share_image_option')));
+      await tester.pumpAndSettle();
+
+      // The error snackbar surfaces — exact message is the EN
+      // fallback because the test pumps the default locale.
+      expect(find.text("Couldn't generate share image"), findsOneWidget);
+    });
   });
 
   group('TripDetailScreen telemetry download (#2652)', () {
@@ -490,20 +507,22 @@ void main() {
       );
     }
 
-    testWidgets('CSV item saves a .csv file with text/csv mime + success',
-        (tester) async {
+    testWidgets('CSV item saves a .csv file with text/csv mime + success', (
+      tester,
+    ) async {
       String? capturedFileName;
       String? capturedMime;
       String? capturedText;
-      debugTripDetailDownloadOverride = ({
-        required String text,
-        required String fileName,
-        required String mimeType,
-      }) async {
-        capturedText = text;
-        capturedFileName = fileName;
-        capturedMime = mimeType;
-      };
+      debugTripDetailDownloadOverride =
+          ({
+            required String text,
+            required String fileName,
+            required String mimeType,
+          }) async {
+            capturedText = text;
+            capturedFileName = fileName;
+            capturedMime = mimeType;
+          };
 
       await _pumpDetail(
         tester,
@@ -516,7 +535,9 @@ void main() {
 
       await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('trip_detail_download_csv_option')));
+      await tester.tap(
+        find.byKey(const Key('trip_detail_download_csv_option')),
+      );
       await tester.pumpAndSettle();
 
       // The test seam captures the save call (and returns before the
@@ -528,20 +549,22 @@ void main() {
       expect(capturedText, contains('timestamp_iso8601'));
     });
 
-    testWidgets('JSON item saves a .json file with application/json mime',
-        (tester) async {
+    testWidgets('JSON item saves a .json file with application/json mime', (
+      tester,
+    ) async {
       String? capturedFileName;
       String? capturedMime;
       String? capturedText;
-      debugTripDetailDownloadOverride = ({
-        required String text,
-        required String fileName,
-        required String mimeType,
-      }) async {
-        capturedText = text;
-        capturedFileName = fileName;
-        capturedMime = mimeType;
-      };
+      debugTripDetailDownloadOverride =
+          ({
+            required String text,
+            required String fileName,
+            required String mimeType,
+          }) async {
+            capturedText = text;
+            capturedFileName = fileName;
+            capturedMime = mimeType;
+          };
 
       await _pumpDetail(
         tester,
@@ -554,8 +577,9 @@ void main() {
 
       await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
       await tester.pumpAndSettle();
-      await tester
-          .tap(find.byKey(const Key('trip_detail_download_json_option')));
+      await tester.tap(
+        find.byKey(const Key('trip_detail_download_json_option')),
+      );
       await tester.pumpAndSettle();
 
       expect(capturedMime, 'application/json');
@@ -564,17 +588,15 @@ void main() {
       expect(capturedText, contains('"samples"'));
     });
 
-    testWidgets('successful save surfaces the Downloads-folder snackbar',
-        (tester) async {
+    testWidgets('successful save surfaces the Downloads-folder snackbar', (
+      tester,
+    ) async {
       // Drive the FULL handler (no high-level download override) through
       // the low-level PublicFileExporter seam so the success snackbar
       // fires — the path the high-level override returns before.
-      debugPublicFileExporterOverride = ({
-        required bytes,
-        required fileName,
-        required mimeType,
-      }) async =>
-          '/tmp/$fileName';
+      debugPublicFileExporterOverride =
+          ({required bytes, required fileName, required mimeType}) async =>
+              '/tmp/$fileName';
 
       await _pumpDetail(
         tester,
@@ -587,22 +609,26 @@ void main() {
 
       await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('trip_detail_download_csv_option')));
+      await tester.tap(
+        find.byKey(const Key('trip_detail_download_csv_option')),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Saved to your Downloads folder'), findsOneWidget);
     });
 
-    testWidgets('empty-samples trip short-circuits with the empty message',
-        (tester) async {
+    testWidgets('empty-samples trip short-circuits with the empty message', (
+      tester,
+    ) async {
       var saverCalled = false;
-      debugTripDetailDownloadOverride = ({
-        required String text,
-        required String fileName,
-        required String mimeType,
-      }) async {
-        saverCalled = true;
-      };
+      debugTripDetailDownloadOverride =
+          ({
+            required String text,
+            required String fileName,
+            required String mimeType,
+          }) async {
+            saverCalled = true;
+          };
 
       // _seedEntry has no entry.samples — the handler must not save.
       await _pumpDetail(
@@ -616,7 +642,9 @@ void main() {
 
       await tester.tap(find.byKey(const Key('trip_detail_share_menu')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('trip_detail_download_csv_option')));
+      await tester.tap(
+        find.byKey(const Key('trip_detail_download_csv_option')),
+      );
       await tester.pumpAndSettle();
 
       expect(saverCalled, isFalse, reason: 'empty trip must not write a file');
@@ -647,10 +675,7 @@ void main() {
       // Screen popped back to the Trajets stub — the stub text is
       // visible and the detail screen's AppBar is gone.
       expect(find.text('TrajetsStub'), findsOneWidget);
-      expect(
-        find.byKey(const Key('trip_detail_delete_button')),
-        findsNothing,
-      );
+      expect(find.byKey(const Key('trip_detail_delete_button')), findsNothing);
     });
 
     testWidgets('cancel → delete NOT called', (tester) async {
@@ -725,62 +750,61 @@ void main() {
         expect(handles.tripsNotifier.saveCalls, hasLength(1));
         final saved = handles.tripsNotifier.saveCalls.single;
         expect(saved.id, entry.id);
-        expect(saved.samples, hasLength(1),
-            reason: 'merged entry must carry the fetched samples so a '
-                'subsequent mount renders the charts from local cache');
+        expect(
+          saved.samples,
+          hasLength(1),
+          reason:
+              'merged entry must carry the fetched samples so a '
+              'subsequent mount renders the charts from local cache',
+        );
         expect(saved.samples.single.speedKmh, 42.0);
       },
     );
 
-    testWidgets(
-      'entry that already has samples skips the lazy fetch '
-      '(no wasted round-trip)',
-      (tester) async {
-        var fetchCalls = 0;
-        debugTripDetailFetchDetailsOverride = (tripId) async {
-          fetchCalls++;
-          return null;
-        };
+    testWidgets('entry that already has samples skips the lazy fetch '
+        '(no wasted round-trip)', (tester) async {
+      var fetchCalls = 0;
+      debugTripDetailFetchDetailsOverride = (tripId) async {
+        fetchCalls++;
+        return null;
+      };
 
-        // Seed the entry with a non-empty samples list — mirrors the
-        // happy path where the trip was recorded on this device and
-        // the per-tick blob is already on disk.
-        final start = DateTime.utc(2026, 5, 11, 12);
-        final entry = TripHistoryEntry(
-          id: 'local-trip',
-          vehicleId: 'v1',
-          summary: TripSummary(
-            startedAt: start,
-            endedAt: start.add(const Duration(minutes: 20)),
-            distanceKm: 10,
-            maxRpm: 2500,
-            highRpmSeconds: 0,
-            idleSeconds: 0,
-            harshBrakes: 0,
-            harshAccelerations: 0,
-          ),
-          samples: [
-            TripSample(
-              timestamp: start,
-              speedKmh: 30,
-              rpm: 1500,
-            ),
-          ],
-        );
+      // Seed the entry with a non-empty samples list — mirrors the
+      // happy path where the trip was recorded on this device and
+      // the per-tick blob is already on disk.
+      final start = DateTime.utc(2026, 5, 11, 12);
+      final entry = TripHistoryEntry(
+        id: 'local-trip',
+        vehicleId: 'v1',
+        summary: TripSummary(
+          startedAt: start,
+          endedAt: start.add(const Duration(minutes: 20)),
+          distanceKm: 10,
+          maxRpm: 2500,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+        ),
+        samples: [TripSample(timestamp: start, speedKmh: 30, rpm: 1500)],
+      );
 
-        final handles = await _pumpDetail(
-          tester,
-          entry: entry,
-          activeVehicle: vehicle,
-          vehicles: const [vehicle],
-        );
-        await tester.pumpAndSettle();
+      final handles = await _pumpDetail(
+        tester,
+        entry: entry,
+        activeVehicle: vehicle,
+        vehicles: const [vehicle],
+      );
+      await tester.pumpAndSettle();
 
-        expect(fetchCalls, 0,
-            reason: 'an entry with local samples must short-circuit '
-                'before the post-frame fetch fires');
-        expect(handles.tripsNotifier.saveCalls, isEmpty);
-      },
-    );
+      expect(
+        fetchCalls,
+        0,
+        reason:
+            'an entry with local samples must short-circuit '
+            'before the post-frame fetch fires',
+      );
+      expect(handles.tripsNotifier.saveCalls, isEmpty);
+    });
   });
 }

--- a/test/features/consumption/presentation/widgets/bad_scan_report_formatters_test.dart
+++ b/test/features/consumption/presentation/widgets/bad_scan_report_formatters_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/feedback/github_issue_reporter.dart';
 import 'package:tankstellen/features/consumption/data/pump_display_parse_result.dart';
@@ -8,12 +10,15 @@ import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_scan_service.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/bad_scan_report_formatters.dart';
 import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Unit tests for the pure formatting helpers in
 /// [bad_scan_report_formatters.dart]. These functions must stay pure
 /// — no `BuildContext`, no provider reads — so a plain `flutter_test`
 /// without `pumpWidget` is the right fixture.
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   // ── Fixtures ────────────────────────────────────────────────────────
 
   ReceiptScanOutcome buildReceiptOutcome({
@@ -74,7 +79,7 @@ void main() {
         pumpScan: null,
         enteredLiters: 32.4,
         enteredTotalCost: 55.20,
-        l: null,
+        l: l10nEn,
       );
 
       expect(rows, hasLength(7));
@@ -129,7 +134,7 @@ void main() {
         pumpScan: null,
         enteredLiters: null,
         enteredTotalCost: null,
-        l: null,
+        l: l10nEn,
       );
 
       // Liters / Total / Price/L scanned-side dashes.
@@ -158,7 +163,7 @@ void main() {
         pumpScan: null,
         enteredLiters: 12.345,
         enteredTotalCost: 24,
-        l: null,
+        l: l10nEn,
       );
 
       expect(rows[1].scanned, '12.00');
@@ -179,7 +184,7 @@ void main() {
         pumpScan: buildPumpOutcome(),
         enteredLiters: 39.9,
         enteredTotalCost: 69.85,
-        l: null,
+        l: l10nEn,
       );
 
       expect(rows, hasLength(3));
@@ -209,7 +214,7 @@ void main() {
         ),
         enteredLiters: null,
         enteredTotalCost: null,
-        l: null,
+        l: l10nEn,
       );
 
       for (final row in rows) {
@@ -317,15 +322,18 @@ void main() {
         pumpScan: null,
       );
 
-      expect(fields.keys, containsAll(<String>[
-        'brandLayout',
-        'liters',
-        'totalCost',
-        'pricePerLiter',
-        'stationName',
-        'fuelType',
-        'date',
-      ]));
+      expect(
+        fields.keys,
+        containsAll(<String>[
+          'brandLayout',
+          'liters',
+          'totalCost',
+          'pricePerLiter',
+          'stationName',
+          'fuelType',
+          'date',
+        ]),
+      );
       expect(fields['brandLayout'], 'carrefour');
       expect(fields['liters'], '32.50');
       expect(fields['totalCost'], '55.12');
@@ -388,10 +396,7 @@ void main() {
         enteredLiters: 41.234,
         enteredTotalCost: 71.5,
       );
-      expect(map, <String, String?>{
-        'liters': '41.23',
-        'totalCost': '71.50',
-      });
+      expect(map, <String, String?>{'liters': '41.23', 'totalCost': '71.50'});
     });
 
     test('preserves null values on either field', () {
@@ -399,10 +404,7 @@ void main() {
         enteredLiters: null,
         enteredTotalCost: null,
       );
-      expect(mapBoth, <String, String?>{
-        'liters': null,
-        'totalCost': null,
-      });
+      expect(mapBoth, <String, String?>{'liters': null, 'totalCost': null});
 
       final mapPartial = buildBadScanUserCorrections(
         enteredLiters: 32,
@@ -418,19 +420,17 @@ void main() {
   // ── resolveBadScanTitle ─────────────────────────────────────────────
 
   group('resolveBadScanTitle', () {
-    test('receipt falls back to the kind-specific English string when l is null',
-        () {
+    test('receipt resolves the kind-specific localized title', () {
       expect(
-        resolveBadScanTitle(ScanKind.receipt, null),
-        'Report a scan error — Receipt',
+        resolveBadScanTitle(ScanKind.receipt, l10nEn),
+        l10nEn.badScanReportTitleReceipt,
       );
     });
 
-    test('pumpDisplay falls back to its own English string when l is null',
-        () {
+    test('pumpDisplay resolves its own localized title', () {
       expect(
-        resolveBadScanTitle(ScanKind.pumpDisplay, null),
-        'Report a scan error — Pump display',
+        resolveBadScanTitle(ScanKind.pumpDisplay, l10nEn),
+        l10nEn.badScanReportTitlePumpDisplay,
       );
     });
   });

--- a/test/features/consumption/presentation/widgets/charging_cost_trend_chart_test.dart
+++ b/test/features/consumption/presentation/widgets/charging_cost_trend_chart_test.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/charging_cost_trend_chart.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// The painter draws month labels and the max value directly onto the
 /// canvas, so structural assertions stick to the [CustomPaint] widget
@@ -15,10 +16,11 @@ import '../../../../helpers/pump_app.dart';
 /// Filtering by `painter.runtimeType.toString().contains('CostTrend')`
 /// keeps us isolated from the framework-supplied [CustomPaint]s that
 /// [Material] / [Scaffold] mount around our subject.
-Iterable<CustomPaint> _chartPaints(WidgetTester tester) =>
-    tester.widgetList<CustomPaint>(find.byType(CustomPaint)).where(
-          (p) => p.painter?.runtimeType.toString().contains('CostTrend') ?? false,
-        );
+Iterable<CustomPaint> _chartPaints(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.byType(CustomPaint))
+    .where(
+      (p) => p.painter?.runtimeType.toString().contains('CostTrend') ?? false,
+    );
 
 void main() {
   group('ChargingCostTrendChart month-axis i18n (#2971)', () {
@@ -33,7 +35,9 @@ void main() {
       DateTime(2026, 2): 30.0,
     };
 
-    testWidgets('axis month abbreviations localize under French', (tester) async {
+    testWidgets('axis month abbreviations localize under French', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         ChargingCostTrendChart(monthlyCost: monthly),
@@ -45,12 +49,10 @@ void main() {
       expect(label, isNot('Jan'));
     });
 
-    testWidgets('axis month abbreviations stay English under English',
-        (tester) async {
-      await pumpApp(
-        tester,
-        ChargingCostTrendChart(monthlyCost: monthly),
-      );
+    testWidgets('axis month abbreviations stay English under English', (
+      tester,
+    ) async {
+      await pumpApp(tester, ChargingCostTrendChart(monthlyCost: monthly));
 
       expect(monthFormatFor(tester).format(DateTime(2026, 1)), 'Jan');
     });
@@ -60,10 +62,7 @@ void main() {
     testWidgets(
       'renders the localized empty placeholder when monthlyCost is empty',
       (tester) async {
-        await pumpApp(
-          tester,
-          const ChargingCostTrendChart(monthlyCost: {}),
-        );
+        await pumpApp(tester, const ChargingCostTrendChart(monthlyCost: {}));
 
         // English locale (pumpApp default) → chargingChartsEmpty.
         expect(find.text('Not enough data yet'), findsOneWidget);
@@ -72,60 +71,34 @@ void main() {
       },
     );
 
-    testWidgets(
-      'renders the empty placeholder when every month value is 0.0',
-      (tester) async {
-        // The provider pads missing months with 0.0; six all-zero months
-        // is the realistic "user has no charging logs yet" scenario.
-        final monthlyCost = <DateTime, double>{
-          DateTime(2026, 1): 0,
-          DateTime(2026, 2): 0,
-          DateTime(2026, 3): 0,
-          DateTime(2026, 4): 0,
-          DateTime(2026, 5): 0,
-          DateTime(2026, 6): 0,
-        };
+    testWidgets('renders the empty placeholder when every month value is 0.0', (
+      tester,
+    ) async {
+      // The provider pads missing months with 0.0; six all-zero months
+      // is the realistic "user has no charging logs yet" scenario.
+      final monthlyCost = <DateTime, double>{
+        DateTime(2026, 1): 0,
+        DateTime(2026, 2): 0,
+        DateTime(2026, 3): 0,
+        DateTime(2026, 4): 0,
+        DateTime(2026, 5): 0,
+        DateTime(2026, 6): 0,
+      };
 
-        await pumpApp(
-          tester,
-          ChargingCostTrendChart(monthlyCost: monthlyCost),
-        );
+      await pumpApp(tester, ChargingCostTrendChart(monthlyCost: monthlyCost));
 
-        expect(find.text('Not enough data yet'), findsOneWidget);
-        expect(_chartPaints(tester), isEmpty);
-      },
-    );
-
-    testWidgets(
-      'falls back to the English string when AppLocalizations is absent',
-      (tester) async {
-        // Pump without localization delegates so .of(context) returns null.
-        await tester.pumpWidget(
-          const MaterialApp(
-            home: Scaffold(
-              body: ChargingCostTrendChart(monthlyCost: {}),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(find.text('Not enough data yet'), findsOneWidget);
-      },
-    );
+      expect(find.text('Not enough data yet'), findsOneWidget);
+      expect(_chartPaints(tester), isEmpty);
+    });
 
     testWidgets(
       'paints a single chart painter when given one populated month',
       (tester) async {
         // Single-bar layout exercises the slot/barWidth math at minimum
         // count without tripping the empty-state branch.
-        final monthlyCost = <DateTime, double>{
-          DateTime(2026, 6): 42.5,
-        };
+        final monthlyCost = <DateTime, double>{DateTime(2026, 6): 42.5};
 
-        await pumpApp(
-          tester,
-          ChargingCostTrendChart(monthlyCost: monthlyCost),
-        );
+        await pumpApp(tester, ChargingCostTrendChart(monthlyCost: monthlyCost));
 
         expect(tester.takeException(), isNull);
         // Empty placeholder text must NOT be present in the populated path.
@@ -134,94 +107,83 @@ void main() {
       },
     );
 
-    testWidgets(
-      'paints a chart when multiple months have non-zero values',
-      (tester) async {
-        final monthlyCost = <DateTime, double>{
-          DateTime(2026, 1): 12.0,
-          DateTime(2026, 2): 30.0,
-          DateTime(2026, 3): 0.0, // mixed-zero is allowed; ANY > 0 wins
-          DateTime(2026, 4): 18.0,
-          DateTime(2026, 5): 25.5,
-          DateTime(2026, 6): 9.75,
-        };
+    testWidgets('paints a chart when multiple months have non-zero values', (
+      tester,
+    ) async {
+      final monthlyCost = <DateTime, double>{
+        DateTime(2026, 1): 12.0,
+        DateTime(2026, 2): 30.0,
+        DateTime(2026, 3): 0.0, // mixed-zero is allowed; ANY > 0 wins
+        DateTime(2026, 4): 18.0,
+        DateTime(2026, 5): 25.5,
+        DateTime(2026, 6): 9.75,
+      };
 
-        await pumpApp(
-          tester,
-          ChargingCostTrendChart(monthlyCost: monthlyCost),
-        );
+      await pumpApp(tester, ChargingCostTrendChart(monthlyCost: monthlyCost));
 
-        expect(tester.takeException(), isNull);
-        expect(find.text('Not enough data yet'), findsNothing);
-        // At least one chart-owned painter is mounted.
-        expect(_chartPaints(tester).length, greaterThan(0));
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(find.text('Not enough data yet'), findsNothing);
+      // At least one chart-owned painter is mounted.
+      expect(_chartPaints(tester).length, greaterThan(0));
+    });
 
-    testWidgets(
-      'forwards an explicit color override into the painter',
-      (tester) async {
-        const probeColor = Color(0xFFAA1234);
-        final monthlyCost = <DateTime, double>{
-          DateTime(2026, 1): 50.0,
-          DateTime(2026, 2): 80.0,
-        };
+    testWidgets('forwards an explicit color override into the painter', (
+      tester,
+    ) async {
+      const probeColor = Color(0xFFAA1234);
+      final monthlyCost = <DateTime, double>{
+        DateTime(2026, 1): 50.0,
+        DateTime(2026, 2): 80.0,
+      };
 
-        await pumpApp(
-          tester,
-          ChargingCostTrendChart(
-            monthlyCost: monthlyCost,
-            color: probeColor,
+      await pumpApp(
+        tester,
+        ChargingCostTrendChart(monthlyCost: monthlyCost, color: probeColor),
+      );
+
+      expect(tester.takeException(), isNull);
+
+      final painter = _chartPaints(tester).first.painter;
+      // Use dynamic dispatch to inspect the private painter's `color`
+      // field — same approach as the carbon MonthlyBarChart precedent.
+      // ignore: avoid_dynamic_calls
+      final dynamic dyn = painter;
+      // ignore: avoid_dynamic_calls
+      expect(dyn.color, probeColor);
+    });
+
+    testWidgets('falls back to theme.colorScheme.primary when color is null', (
+      tester,
+    ) async {
+      const themedPrimary = Color(0xFF00BCD4);
+      final monthlyCost = <DateTime, double>{DateTime(2026, 5): 5.0};
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: themedPrimary),
           ),
-        );
-
-        expect(tester.takeException(), isNull);
-
-        final painter = _chartPaints(tester).first.painter;
-        // Use dynamic dispatch to inspect the private painter's `color`
-        // field — same approach as the carbon MonthlyBarChart precedent.
-        // ignore: avoid_dynamic_calls
-        final dynamic dyn = painter;
-        // ignore: avoid_dynamic_calls
-        expect(dyn.color, probeColor);
-      },
-    );
-
-    testWidgets(
-      'falls back to theme.colorScheme.primary when color is null',
-      (tester) async {
-        const themedPrimary = Color(0xFF00BCD4);
-        final monthlyCost = <DateTime, double>{
-          DateTime(2026, 5): 5.0,
-        };
-
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(
-              colorScheme: const ColorScheme.light(primary: themedPrimary),
-            ),
-            home: Scaffold(
-              body: ChargingCostTrendChart(monthlyCost: monthlyCost),
-            ),
+          home: Scaffold(
+            body: ChargingCostTrendChart(monthlyCost: monthlyCost),
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        final painter = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .firstWhere(
-              (p) =>
-                  p != null &&
-                  p.runtimeType.toString().contains('CostTrend'),
-            );
+      final painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('CostTrend'),
+          );
 
-        // ignore: avoid_dynamic_calls
-        final dynamic dyn = painter;
-        // ignore: avoid_dynamic_calls
-        expect(dyn.color, themedPrimary);
-      },
-    );
+      // ignore: avoid_dynamic_calls
+      final dynamic dyn = painter;
+      // ignore: avoid_dynamic_calls
+      expect(dyn.color, themedPrimary);
+    });
 
     testWidgets(
       'renders without throwing when only a single non-zero entry exists',
@@ -235,10 +197,7 @@ void main() {
           DateTime(2026, 4): 0,
         };
 
-        await pumpApp(
-          tester,
-          ChargingCostTrendChart(monthlyCost: monthlyCost),
-        );
+        await pumpApp(tester, ChargingCostTrendChart(monthlyCost: monthlyCost));
 
         expect(tester.takeException(), isNull);
         expect(find.text('Not enough data yet'), findsNothing);

--- a/test/features/consumption/presentation/widgets/charging_efficiency_chart_test.dart
+++ b/test/features/consumption/presentation/widgets/charging_efficiency_chart_test.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/charging_efficiency_chart.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// The chart paints lines and dots directly onto the canvas (no Text widgets
 /// for the data series), so structural assertions stick to the [CustomPaint]
@@ -33,7 +34,9 @@ void main() {
       DateTime(2026, 2): 15.8,
     };
 
-    testWidgets('axis month abbreviations localize under French', (tester) async {
+    testWidgets('axis month abbreviations localize under French', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         ChargingEfficiencyChart(monthlyEfficiency: monthly),
@@ -45,8 +48,9 @@ void main() {
       expect(label, isNot('Jan'));
     });
 
-    testWidgets('axis month abbreviations stay English under English',
-        (tester) async {
+    testWidgets('axis month abbreviations stay English under English', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         ChargingEfficiencyChart(monthlyEfficiency: monthly),
@@ -107,50 +111,26 @@ void main() {
       },
     );
 
-    testWidgets(
-      'falls back to "Not enough data yet" when AppLocalizations is absent',
-      (tester) async {
-        // No localization delegates → AppLocalizations.of(context) is null,
-        // so the widget must use its hard-coded English fallback string.
-        await tester.pumpWidget(
-          const MaterialApp(
-            home: Scaffold(
-              body: ChargingEfficiencyChart(monthlyEfficiency: {}),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
+    testWidgets('uses the German translation for the empty caption', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const ChargingEfficiencyChart(monthlyEfficiency: {}),
+        locale: const Locale('de'),
+      );
 
-        expect(find.text('Not enough data yet'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'uses the German translation for the empty caption',
-      (tester) async {
-        await pumpApp(
-          tester,
-          const ChargingEfficiencyChart(monthlyEfficiency: {}),
-          locale: const Locale('de'),
-        );
-
-        expect(find.text('Noch nicht genügend Daten'), findsOneWidget);
-      },
-    );
+      expect(find.text('Noch nicht genügend Daten'), findsOneWidget);
+    });
 
     testWidgets(
       'renders a CustomPaint with a painter when one non-null month exists',
       (tester) async {
         // Single-point layout exercises the entries.length == 1 branch
         // inside `xForIndex` (centre of chart instead of normalised stride).
-        final data = <DateTime, double?>{
-          DateTime(2026, 6): 17.5,
-        };
+        final data = <DateTime, double?>{DateTime(2026, 6): 17.5};
 
-        await pumpApp(
-          tester,
-          ChargingEfficiencyChart(monthlyEfficiency: data),
-        );
+        await pumpApp(tester, ChargingEfficiencyChart(monthlyEfficiency: data));
 
         // Must not fall back to the empty-state text on a non-null sample.
         expect(find.text('Not enough data yet'), findsNothing);
@@ -182,10 +162,7 @@ void main() {
           DateTime(2026, 4): 16.9,
         };
 
-        await pumpApp(
-          tester,
-          ChargingEfficiencyChart(monthlyEfficiency: data),
-        );
+        await pumpApp(tester, ChargingEfficiencyChart(monthlyEfficiency: data));
 
         expect(tester.takeException(), isNull);
         expect(find.text('Not enough data yet'), findsNothing);
@@ -202,44 +179,39 @@ void main() {
       },
     );
 
-    testWidgets(
-      'forwards an explicit color override into the painter',
-      (tester) async {
-        const probeColor = Color(0xFF00C0AA);
-        final data = <DateTime, double?>{
-          DateTime(2026, 1): 15.0,
-          DateTime(2026, 2): 17.0,
-          DateTime(2026, 3): 14.5,
-        };
+    testWidgets('forwards an explicit color override into the painter', (
+      tester,
+    ) async {
+      const probeColor = Color(0xFF00C0AA);
+      final data = <DateTime, double?>{
+        DateTime(2026, 1): 15.0,
+        DateTime(2026, 2): 17.0,
+        DateTime(2026, 3): 14.5,
+      };
 
-        await pumpApp(
-          tester,
-          ChargingEfficiencyChart(
-            monthlyEfficiency: data,
-            color: probeColor,
-          ),
-        );
+      await pumpApp(
+        tester,
+        ChargingEfficiencyChart(monthlyEfficiency: data, color: probeColor),
+      );
 
-        expect(tester.takeException(), isNull);
+      expect(tester.takeException(), isNull);
 
-        final painter = tester
-            .widgetList<CustomPaint>(find.byType(CustomPaint))
-            .map((p) => p.painter)
-            .firstWhere(
-              (p) =>
-                  p != null && p.runtimeType.toString().contains('Efficiency'),
-            );
+      final painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('Efficiency'),
+          );
 
-        // Inspect the private painter's exposed `color` field via dynamic
-        // dispatch — the painter type is intentionally library-private.
-        // ignore: avoid_dynamic_calls
-        final dynamic dyn = painter;
-        // ignore: avoid_dynamic_calls
-        expect(dyn.color, probeColor);
-        // ignore: avoid_dynamic_calls
-        expect((dyn.entries as List).length, data.length);
-      },
-    );
+      // Inspect the private painter's exposed `color` field via dynamic
+      // dispatch — the painter type is intentionally library-private.
+      // ignore: avoid_dynamic_calls
+      final dynamic dyn = painter;
+      // ignore: avoid_dynamic_calls
+      expect(dyn.color, probeColor);
+      // ignore: avoid_dynamic_calls
+      expect((dyn.entries as List).length, data.length);
+    });
 
     testWidgets(
       'falls back to theme.colorScheme.primary when no color is provided',
@@ -252,6 +224,8 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             theme: ThemeData(
               colorScheme: const ColorScheme.light(primary: themePrimary),
             ),
@@ -352,6 +326,8 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: ChargingEfficiencyChart(monthlyEfficiency: next),
             ),
@@ -372,4 +348,3 @@ void main() {
     );
   });
 }
-

--- a/test/features/consumption/presentation/widgets/fab_over_list_clearance_test.dart
+++ b/test/features/consumption/presentation/widgets/fab_over_list_clearance_test.dart
@@ -21,6 +21,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 import '../../../../helpers/silence_error_logger.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #2494 — both the Carburant fill-up list and the Trajets trip list float
 /// their "add" / "start recording" FAB over the list through the SAME
@@ -33,13 +34,14 @@ import '../../../../helpers/silence_error_logger.dart';
 /// `kFabScrollClearance` at the bottom (no `viewPadding.bottom` added on
 /// top).
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   EdgeInsets listPadding(WidgetTester tester) {
-    final padding = tester
-        .widget<ListView>(find.byType(ListView))
-        .padding as EdgeInsets;
+    final padding =
+        tester.widget<ListView>(find.byType(ListView)).padding as EdgeInsets;
     return padding;
   }
 
@@ -62,81 +64,89 @@ void main() {
     );
 
     testWidgets(
-        'reserves exactly kFabScrollClearance and owns no FAB / Stack',
-        (tester) async {
-      await pumpApp(
-        tester,
-        FuelTab(fillUps: fillUps, stats: stats, l: null),
-        overrides: [
-          achievementsProvider.overrideWithValue(const <EarnedAchievement>[]),
-          gamificationEnabledProvider.overrideWithValue(false),
-          activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
-          fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
-        ],
-      );
+      'reserves exactly kFabScrollClearance and owns no FAB / Stack',
+      (tester) async {
+        await pumpApp(
+          tester,
+          FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
+          overrides: [
+            achievementsProvider.overrideWithValue(const <EarnedAchievement>[]),
+            gamificationEnabledProvider.overrideWithValue(false),
+            activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
+            fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
+          ],
+        );
 
-      expect(listPadding(tester).bottom, kFabScrollClearance);
-      // The FAB is hosted by the Scaffold (PageScaffold) in production, not
-      // by the tab body — so the body must not embed its own FAB overlay.
-      expect(find.byType(FloatingActionButton), findsNothing);
-    });
+        expect(listPadding(tester).bottom, kFabScrollClearance);
+        // The FAB is hosted by the Scaffold (PageScaffold) in production, not
+        // by the tab body — so the body must not embed its own FAB overlay.
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
   });
 
   group('TrajetsTab FAB-over-list clearance', () {
     TripHistoryEntry entry(String id) => TripHistoryEntry(
-          id: id,
-          vehicleId: 'v1',
-          summary: TripSummary(
-            distanceKm: 10,
-            maxRpm: 0,
-            highRpmSeconds: 0,
-            idleSeconds: 0,
-            harshBrakes: 0,
-            harshAccelerations: 0,
-            startedAt: DateTime(2026, 4, 22, 9),
-          ),
-        );
+      id: id,
+      vehicleId: 'v1',
+      summary: TripSummary(
+        distanceKm: 10,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: DateTime(2026, 4, 22, 9),
+      ),
+    );
 
     testWidgets(
-        'reserves exactly kFabScrollClearance and owns no FAB / Stack',
-        (tester) async {
-      tester.view.physicalSize = const Size(900, 1600);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+      'reserves exactly kFabScrollClearance and owns no FAB / Stack',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
 
-      await pumpApp(
-        tester,
-        const Scaffold(body: TrajetsTab(vehicleId: null)),
-        overrides: [
-          tripHistoryListProvider
-              .overrideWith(() => _FixedTripHistoryList([entry('trip-a')])),
-          vehicleProfileListProvider
-              .overrideWith(() => _FixedVehicleProfileList(const [
-                    VehicleProfile(
-                      id: 'v1',
-                      name: 'Daily Driver',
-                      type: VehicleType.combustion,
-                    ),
-                  ])),
-          activeVehicleProfileProvider.overrideWith(
-            () => _FixedActiveVehicle(const VehicleProfile(
-              id: 'v1',
-              name: 'Daily Driver',
-              type: VehicleType.combustion,
-            )),
-          ),
-        ],
-      );
+        await pumpApp(
+          tester,
+          const Scaffold(body: TrajetsTab(vehicleId: null)),
+          overrides: [
+            tripHistoryListProvider.overrideWith(
+              () => _FixedTripHistoryList([entry('trip-a')]),
+            ),
+            vehicleProfileListProvider.overrideWith(
+              () => _FixedVehicleProfileList(const [
+                VehicleProfile(
+                  id: 'v1',
+                  name: 'Daily Driver',
+                  type: VehicleType.combustion,
+                ),
+              ]),
+            ),
+            activeVehicleProfileProvider.overrideWith(
+              () => _FixedActiveVehicle(
+                const VehicleProfile(
+                  id: 'v1',
+                  name: 'Daily Driver',
+                  type: VehicleType.combustion,
+                ),
+              ),
+            ),
+          ],
+        );
 
-      final padding = tester
-          .widget<ListView>(find.byKey(const Key('trajets_list')))
-          .padding as EdgeInsets;
-      expect(padding.bottom, kFabScrollClearance);
-      // No hand-rolled overlay inside the tab body — the record FAB lives
-      // in the Scaffold FAB slot (TrajetsRecordFab) in production.
-      expect(find.byType(FloatingActionButton), findsNothing);
-    });
+        final padding =
+            tester
+                    .widget<ListView>(find.byKey(const Key('trajets_list')))
+                    .padding
+                as EdgeInsets;
+        expect(padding.bottom, kFabScrollClearance);
+        // No hand-rolled overlay inside the tab body — the record FAB lives
+        // in the Scaffold FAB slot (TrajetsRecordFab) in production.
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
   });
 }
 

--- a/test/features/consumption/presentation/widgets/fill_up_share_scan_handlers_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_share_scan_handlers_test.dart
@@ -83,31 +83,31 @@ class _CapturedState {
   ReceiptScanService? service;
 
   FillUpScanHostState host({String? country}) => FillUpScanHostState(
-        litersCtrl: litersCtrl,
-        costCtrl: costCtrl,
-        vehicleId: vehicleId,
-        readService: () => service,
-        writeService: (s) => service = s,
-        setScanning: (v) => scanning = v,
-        setScanningPump: (_) {},
-        setDate: (d) => date = d,
-        setFuelType: (f) => fuelType = f,
-        setScannedPricePerLiter: (p) => scannedPricePerLiter = p,
-        setLastScan: (o) => lastScan = o,
-        isMounted: () => true,
-        capturePumpImage: (_) async => null,
-        activeCountry: country,
-      );
+    litersCtrl: litersCtrl,
+    costCtrl: costCtrl,
+    vehicleId: vehicleId,
+    readService: () => service,
+    writeService: (s) => service = s,
+    setScanning: (v) => scanning = v,
+    setScanningPump: (_) {},
+    setDate: (d) => date = d,
+    setFuelType: (f) => fuelType = f,
+    setScannedPricePerLiter: (p) => scannedPricePerLiter = p,
+    setLastScan: (o) => lastScan = o,
+    isMounted: () => true,
+    capturePumpImage: (_) async => null,
+    activeCountry: country,
+  );
 
   /// A serialisable snapshot of the form fields the prefill touches,
   /// so two flows can be compared with a single `equals`.
   Map<String, Object?> snapshot() => {
-        'liters': litersCtrl.text,
-        'cost': costCtrl.text,
-        'date': date?.toIso8601String(),
-        'fuelType': fuelType?.name,
-        'scannedPricePerLiter': scannedPricePerLiter,
-      };
+    'liters': litersCtrl.text,
+    'cost': costCtrl.text,
+    'date': date?.toIso8601String(),
+    'fuelType': fuelType?.name,
+    'scannedPricePerLiter': scannedPricePerLiter,
+  };
 
   void dispose() {
     litersCtrl.dispose();
@@ -120,17 +120,16 @@ class _CapturedState {
 ReceiptScanService _realParserService({
   required _FakePicker picker,
   required _FakeRecognizer recognizer,
-}) =>
-    ReceiptScanService(
-      picker: picker,
-      recognizer: recognizer,
-      parser: const ReceiptParser(),
-    );
+}) => ReceiptScanService(
+  picker: picker,
+  recognizer: recognizer,
+  parser: const ReceiptParser(),
+);
 
 /// Reads a shipped receipt OCR fixture's raw text.
 String _fixture(String name) => File(
-      'test/features/consumption/data/receipt_parser/fixtures/$name',
-    ).readAsStringSync();
+  'test/features/consumption/data/receipt_parser/fixtures/$name',
+).readAsStringSync();
 
 /// Writes a throwaway capture file (minimal JPEG bytes) and returns its
 /// path. `bakeImageOrientation` can't decode it, so the recognizer reads
@@ -152,10 +151,12 @@ Future<BuildContext> _localizedContext(WidgetTester tester) async {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: const Locale('en'),
-      home: Builder(builder: (context) {
-        captured = context;
-        return const Scaffold(body: SizedBox());
-      }),
+      home: Builder(
+        builder: (context) {
+          captured = context;
+          return const Scaffold(body: SizedBox());
+        },
+      ),
     ),
   );
   return captured;
@@ -189,14 +190,16 @@ void main() {
         expect(state.costCtrl.text, '10.47');
         expect(state.date, DateTime(2026, 4, 19));
         expect(state.scannedPricePerLiter, closeTo(1.999, 0.005));
-        expect(state.fuelType, FuelType.e10,
-            reason: 'no vehicle bound → the receipt fuel pre-selects');
+        expect(
+          state.fuelType,
+          FuelType.e10,
+          reason: 'no vehicle bound → the receipt fuel pre-selects',
+        );
         expect(state.lastScan, same(outcome));
       },
     );
 
-    test('does NOT pre-select fuel when a vehicle is already bound (#698)',
-        () {
+    test('does NOT pre-select fuel when a vehicle is already bound (#698)', () {
       final parse = const ReceiptParser().parse(_fixture(_fixtureName));
       final outcome = ReceiptScanOutcome(
         parse: parse,
@@ -208,17 +211,22 @@ void main() {
 
       applyReceiptOutcome(state.host(), outcome);
 
-      expect(state.fuelType, isNull,
-          reason: 'the bound vehicle owns the fuel — receipt must not '
-              'override it');
+      expect(
+        state.fuelType,
+        isNull,
+        reason:
+            'the bound vehicle owns the fuel — receipt must not '
+            'override it',
+      );
       // The numeric prefill still happens.
       expect(state.litersCtrl.text, '5.24');
     });
   });
 
   group('receiptScanSuccessMessage (#2734 station banner)', () {
-    testWidgets('prepends the detected station name when present',
-        (tester) async {
+    testWidgets('prepends the detected station name when present', (
+      tester,
+    ) async {
       final context = await _localizedContext(tester);
       final l = AppLocalizations.of(context);
       const outcome = ReceiptScanOutcome(
@@ -233,14 +241,21 @@ void main() {
 
       final msg = receiptScanSuccessMessage(l, outcome);
 
-      expect(msg, startsWith('SUPER U'),
-          reason: 'the station hint is surfaced inline, non-blocking');
-      expect(msg, contains(l!.scanReceiptSuccess),
-          reason: 'the existing success copy is reused verbatim');
+      expect(
+        msg,
+        startsWith('SUPER U'),
+        reason: 'the station hint is surfaced inline, non-blocking',
+      );
+      expect(
+        msg,
+        contains(l.scanReceiptSuccess),
+        reason: 'the existing success copy is reused verbatim',
+      );
     });
 
-    testWidgets('falls back to the plain success copy with no station',
-        (tester) async {
+    testWidgets('falls back to the plain success copy with no station', (
+      tester,
+    ) async {
       final context = await _localizedContext(tester);
       final l = AppLocalizations.of(context);
       const outcome = ReceiptScanOutcome(
@@ -249,7 +264,7 @@ void main() {
         imagePath: '/tmp/x.jpg',
       );
 
-      expect(receiptScanSuccessMessage(l, outcome), l!.scanReceiptSuccess);
+      expect(receiptScanSuccessMessage(l, outcome), l.scanReceiptSuccess);
     });
   });
 
@@ -271,7 +286,8 @@ void main() {
           final cameraCapture = await _tempCapture();
           cameraState.service = _realParserService(
             picker: _FakePicker(cameraCapture.path),
-            recognizer: _FakeRecognizer()..textToReturn = _fixture(_fixtureName),
+            recognizer: _FakeRecognizer()
+              ..textToReturn = _fixture(_fixtureName),
           );
           await runReceiptScan(context, cameraState.host());
 
@@ -279,10 +295,14 @@ void main() {
           final shareCapture = await _tempCapture();
           shareState.service = _realParserService(
             picker: _FakePicker(null),
-            recognizer: _FakeRecognizer()..textToReturn = _fixture(_fixtureName),
+            recognizer: _FakeRecognizer()
+              ..textToReturn = _fixture(_fixtureName),
           );
           await runSharedReceiptScan(
-              context, shareState.host(), shareCapture.path);
+            context,
+            shareState.host(),
+            shareCapture.path,
+          );
 
           await cameraCapture.dir.delete(recursive: true);
           await shareCapture.dir.delete(recursive: true);
@@ -303,8 +323,9 @@ void main() {
   });
 
   group('runSharedReceiptScan — never throws (#2349 fault injection)', () {
-    testWidgets('completes normally when the recognizer throws',
-        (tester) async {
+    testWidgets('completes normally when the recognizer throws', (
+      tester,
+    ) async {
       final context = await _localizedContext(tester);
       final state = _CapturedState();
       addTearDown(state.dispose);
@@ -327,12 +348,16 @@ void main() {
       // A thrown OCR error must leave the form untouched, not half-filled.
       expect(state.litersCtrl.text, isEmpty);
       expect(state.lastScan, isNull);
-      expect(state.scanning, isFalse,
-          reason: 'the finally-block must always clear the loading flag');
+      expect(
+        state.scanning,
+        isFalse,
+        reason: 'the finally-block must always clear the loading flag',
+      );
     });
 
-    testWidgets('shows no-data (not success) when OCR yields nothing usable',
-        (tester) async {
+    testWidgets('shows no-data (not success) when OCR yields nothing usable', (
+      tester,
+    ) async {
       final context = await _localizedContext(tester);
       final state = _CapturedState();
       addTearDown(state.dispose);
@@ -353,8 +378,11 @@ void main() {
         }
       });
 
-      expect(state.lastScan, isNull,
-          reason: 'no usable data → no prefill, no cached scan');
+      expect(
+        state.lastScan,
+        isNull,
+        reason: 'no usable data → no prefill, no cached scan',
+      );
       expect(state.litersCtrl.text, isEmpty);
     });
   });

--- a/test/features/consumption/presentation/widgets/fuel_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/fuel_tab_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for the gamification opt-out gate on [FuelTab] (#1194).
 ///
@@ -26,6 +27,8 @@ import '../../../../helpers/pump_app.dart';
 /// widget tree entirely (not merely hidden) so the consumption screen
 /// shows nothing achievement-related.
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   silenceErrorLoggerSpool();
   final fillUps = <FillUp>[
     FillUp(
@@ -51,17 +54,16 @@ void main() {
   ];
 
   List<Object> overrides({required bool gamification}) => [
-        achievementsProvider.overrideWithValue(earned),
-        gamificationEnabledProvider.overrideWithValue(gamification),
-        activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
-        fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
-      ];
+    achievementsProvider.overrideWithValue(earned),
+    gamificationEnabledProvider.overrideWithValue(gamification),
+    activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
+    fillUpListProvider.overrideWith(() => _FixedFillUpList(fillUps)),
+  ];
 
-  testWidgets('mounts BadgeShelf when gamification is enabled',
-      (tester) async {
+  testWidgets('mounts BadgeShelf when gamification is enabled', (tester) async {
     await pumpApp(
       tester,
-      FuelTab(fillUps: fillUps, stats: stats, l: null),
+      FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
       overrides: overrides(gamification: true),
     );
 
@@ -70,11 +72,10 @@ void main() {
     expect(find.text('Achievements'), findsOneWidget);
   });
 
-  testWidgets('omits BadgeShelf when gamification is disabled',
-      (tester) async {
+  testWidgets('omits BadgeShelf when gamification is disabled', (tester) async {
     await pumpApp(
       tester,
-      FuelTab(fillUps: fillUps, stats: stats, l: null),
+      FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
       overrides: overrides(gamification: false),
     );
 
@@ -87,53 +88,55 @@ void main() {
 
   // #1361 phase 2b — tapping a correction card opens the editor sheet.
   testWidgets(
-      'tapping a correction fill-up card opens EditCorrectionFillUpSheet',
-      (tester) async {
-    final correctionFills = <FillUp>[
-      FillUp(
-        id: 'correction_p1',
-        date: DateTime(2026, 4, 15),
-        liters: 3.4,
-        totalCost: 0,
-        odometerKm: 12500,
-        fuelType: FuelType.e10,
-        isCorrection: true,
-      ),
-    ];
-    await pumpApp(
-      tester,
-      FuelTab(fillUps: correctionFills, stats: stats, l: null),
-      overrides: [
-        achievementsProvider.overrideWithValue(const <EarnedAchievement>[]),
-        gamificationEnabledProvider.overrideWithValue(false),
-        activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
-        fillUpListProvider
-            .overrideWith(() => _FixedFillUpList(correctionFills)),
-      ],
-    );
+    'tapping a correction fill-up card opens EditCorrectionFillUpSheet',
+    (tester) async {
+      final correctionFills = <FillUp>[
+        FillUp(
+          id: 'correction_p1',
+          date: DateTime(2026, 4, 15),
+          liters: 3.4,
+          totalCost: 0,
+          odometerKm: 12500,
+          fuelType: FuelType.e10,
+          isCorrection: true,
+        ),
+      ];
+      await pumpApp(
+        tester,
+        FuelTab(fillUps: correctionFills, stats: stats, l: l10nEn),
+        overrides: [
+          achievementsProvider.overrideWithValue(const <EarnedAchievement>[]),
+          gamificationEnabledProvider.overrideWithValue(false),
+          activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
+          fillUpListProvider.overrideWith(
+            () => _FixedFillUpList(correctionFills),
+          ),
+        ],
+      );
 
-    expect(find.byType(EditCorrectionFillUpSheet), findsNothing);
+      expect(find.byType(EditCorrectionFillUpSheet), findsNothing);
 
-    // Tap the correction card. The card lives inside a Dismissible so
-    // we target the auto_fix_high icon (only present on corrections)
-    // to disambiguate from the header column items.
-    await tester.tap(find.byIcon(Icons.auto_fix_high));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      // Tap the correction card. The card lives inside a Dismissible so
+      // we target the auto_fix_high icon (only present on corrections)
+      // to disambiguate from the header column items.
+      await tester.tap(find.byIcon(Icons.auto_fix_high));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
 
-    expect(
-      find.byType(EditCorrectionFillUpSheet),
-      findsOneWidget,
-      reason:
-          'Tapping a correction card must open the bottom-sheet editor.',
-    );
-  });
+      expect(
+        find.byType(EditCorrectionFillUpSheet),
+        findsOneWidget,
+        reason: 'Tapping a correction card must open the bottom-sheet editor.',
+      );
+    },
+  );
 
   // #2530 — the wide-screen split now goes through the shared
   // ResponsiveMasterDetail scaffold. Structural pane-count assertions.
   group('#2530 responsive panes', () {
-    testWidgets('compact width renders a single pane (no VerticalDivider)',
-        (tester) async {
+    testWidgets('compact width renders a single pane (no VerticalDivider)', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -141,15 +144,16 @@ void main() {
 
       await pumpApp(
         tester,
-        FuelTab(fillUps: fillUps, stats: stats, l: null),
+        FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
         overrides: overrides(gamification: false),
       );
 
       expect(find.byType(VerticalDivider), findsNothing);
     });
 
-    testWidgets('expanded width renders two panes with the 2:3 ratio',
-        (tester) async {
+    testWidgets('expanded width renders two panes with the 2:3 ratio', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(1024, 768);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -157,7 +161,7 @@ void main() {
 
       await pumpApp(
         tester,
-        FuelTab(fillUps: fillUps, stats: stats, l: null),
+        FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
         overrides: overrides(gamification: false),
       );
 

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -22,6 +22,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for [TrajetsTab] (#561 zero-coverage backlog).
 ///
@@ -108,13 +109,12 @@ class _ConnectLaterTripRecording extends TripRecording {
 /// Bluetooth stack. The constructor uses the existing fake permissions
 /// + bluetooth facades so the underlying scan path also stays inert.
 class _RecordingFakeConnection extends Obd2ConnectionService {
-  _RecordingFakeConnection({
-    this.connectByMacDirectResult,
-  }) : super(
-          registry: Obd2AdapterRegistry.defaults(),
-          permissions: _AlwaysGrantedPermissions(),
-          bluetooth: _EmptyBluetoothFacade(),
-        );
+  _RecordingFakeConnection({this.connectByMacDirectResult})
+    : super(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _AlwaysGrantedPermissions(),
+        bluetooth: _EmptyBluetoothFacade(),
+      );
 
   /// #2274 concern 3 — what the pre-warm direct-connect resolves to.
   /// Null ⇒ pre-warm misses and the start flow falls back to the picker.
@@ -291,15 +291,22 @@ Future<void> _pumpTab(
 
   await pumpApp(
     tester,
-    MaterialApp.router(routerConfig: router),
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
     overrides: [
       tripHistoryListProvider.overrideWith(() => _FixedTripHistoryList(trips)),
-      vehicleProfileListProvider
-          .overrideWith(() => _FixedVehicleProfileList(vehicles)),
-      activeVehicleProfileProvider
-          .overrideWith(() => _FixedActiveVehicle(activeVehicle)),
-      tripRecordingProvider
-          .overrideWith(recordingFactory ?? () => _IdleTripRecording()),
+      vehicleProfileListProvider.overrideWith(
+        () => _FixedVehicleProfileList(vehicles),
+      ),
+      activeVehicleProfileProvider.overrideWith(
+        () => _FixedActiveVehicle(activeVehicle),
+      ),
+      tripRecordingProvider.overrideWith(
+        recordingFactory ?? () => _IdleTripRecording(),
+      ),
       if (obd2Connection != null)
         obd2ConnectionProvider.overrideWith((_) => obd2Connection),
     ],
@@ -315,11 +322,7 @@ void main() {
     name: 'Daily Driver',
     type: VehicleType.combustion,
   );
-  const evVehicle = VehicleProfile(
-    id: 'ev1',
-    name: 'EV',
-    type: VehicleType.ev,
-  );
+  const evVehicle = VehicleProfile(id: 'ev1', name: 'EV', type: VehicleType.ev);
 
   group('TrajetsTab — empty list', () {
     testWidgets('renders the EmptyState with localized copy', (tester) async {
@@ -341,16 +344,14 @@ void main() {
       expect(find.byKey(const Key('trajets_list')), findsNothing);
       // Phase-4 monthly card is gated behind "trips exist" — empty
       // state shows the CTA only, not the card.
-      expect(
-        find.byKey(const ValueKey('monthly_insights_card')),
-        findsNothing,
-      );
+      expect(find.byKey(const ValueKey('monthly_insights_card')), findsNothing);
     });
   });
 
   group('TrajetsTab — monthly insights card slot (#1041 phase 4)', () {
-    testWidgets('renders the card above the trip list when trips exist',
-        (tester) async {
+    testWidgets('renders the card above the trip list when trips exist', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(900, 1600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -386,8 +387,9 @@ void main() {
   });
 
   group('TrajetsTab — populated list', () {
-    testWidgets('renders one row per trip when no vehicleId is set',
-        (tester) async {
+    testWidgets('renders one row per trip when no vehicleId is set', (
+      tester,
+    ) async {
       final trips = [
         _entry(
           id: 'trip-a',
@@ -425,8 +427,9 @@ void main() {
       expect(find.byKey(const ValueKey('trajet-trip-c')), findsOneWidget);
     });
 
-    testWidgets('newest-first sort is applied even on un-sorted input',
-        (tester) async {
+    testWidgets('newest-first sort is applied even on un-sorted input', (
+      tester,
+    ) async {
       // Seed in oldest-first order — the tab must sort by startedAt
       // descending itself.
       final trips = [
@@ -462,14 +465,18 @@ void main() {
       final oldestY = tester
           .getTopLeft(find.byKey(const ValueKey('trajet-trip-old')))
           .dy;
-      expect(newestY, lessThan(oldestY),
-          reason: 'Newest trip should appear above the oldest');
+      expect(
+        newestY,
+        lessThan(oldestY),
+        reason: 'Newest trip should appear above the oldest',
+      );
     });
   });
 
   group('TrajetsTab — vehicle filtering', () {
-    testWidgets('drops trips whose vehicleId differs from widget.vehicleId',
-        (tester) async {
+    testWidgets('drops trips whose vehicleId differs from widget.vehicleId', (
+      tester,
+    ) async {
       final trips = [
         // Matching vehicle — must show.
         _entry(
@@ -517,86 +524,94 @@ void main() {
     });
 
     testWidgets(
-        '#2274 concern 2 — tapping the CTA enters the connecting phase and '
-        'consumes a pre-warmed service via start()', (tester) async {
-      final fakeService = _NoopObd2Service();
-      final connection = _RecordingFakeConnection(
-        connectByMacDirectResult: fakeService,
-      );
-      final notifier = _ConnectLaterTripRecording();
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        // A pinned MAC so the pre-warm fires the direct connect on open.
-        activeVehicle: const VehicleProfile(
-          id: 'v1',
-          name: 'Daily Driver',
-          type: VehicleType.combustion,
-          obd2AdapterMac: 'AA:BB:CC:DD:EE:FF',
-          obd2AdapterName: 'vLinker FS',
-        ),
-        trips: const [],
-        recordingFactory: () => notifier,
-        obd2Connection: connection,
-      );
-      // Let the post-frame pre-warm fire + resolve.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 10));
-      // #3025 — pre-warm (concern 3) fires the TRANSPORT-AWARE connect on open.
-      expect(connection.connectByMacTransportAwareCalls, ['AA:BB:CC:DD:EE:FF'],
-          reason: 'pre-warm (concern 3) fires the transport-aware connect');
+      '#2274 concern 2 — tapping the CTA enters the connecting phase and '
+      'consumes a pre-warmed service via start()',
+      (tester) async {
+        final fakeService = _NoopObd2Service();
+        final connection = _RecordingFakeConnection(
+          connectByMacDirectResult: fakeService,
+        );
+        final notifier = _ConnectLaterTripRecording();
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          // A pinned MAC so the pre-warm fires the direct connect on open.
+          activeVehicle: const VehicleProfile(
+            id: 'v1',
+            name: 'Daily Driver',
+            type: VehicleType.combustion,
+            obd2AdapterMac: 'AA:BB:CC:DD:EE:FF',
+            obd2AdapterName: 'vLinker FS',
+          ),
+          trips: const [],
+          recordingFactory: () => notifier,
+          obd2Connection: connection,
+        );
+        // Let the post-frame pre-warm fire + resolve.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+        // #3025 — pre-warm (concern 3) fires the TRANSPORT-AWARE connect on open.
+        expect(
+          connection.connectByMacTransportAwareCalls,
+          ['AA:BB:CC:DD:EE:FF'],
+          reason: 'pre-warm (concern 3) fires the transport-aware connect',
+        );
 
-      await tester.tap(
-        find.byKey(const Key('trajets_start_recording_button')),
-      );
-      // Don't pumpAndSettle — the recording-screen push would build the
-      // full screen. A bounded pump lets the connect future chain.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        // Don't pumpAndSettle — the recording-screen push would build the
+        // full screen. A bounded pump lets the connect future chain.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      // The pre-warmed service was consumed via start() — no second
-      // connect, no picker sheet.
-      expect(notifier.startServiceCallCount, 1);
-      expect(notifier.lastStartedService, same(fakeService));
-      expect(find.text('Pick an OBD2 adapter'), findsNothing);
-    });
+        // The pre-warmed service was consumed via start() — no second
+        // connect, no picker sheet.
+        expect(notifier.startServiceCallCount, 1);
+        expect(notifier.lastStartedService, same(fakeService));
+        expect(find.text('Pick an OBD2 adapter'), findsNothing);
+      },
+    );
 
     testWidgets(
-        '#2274 concern 2 — an unpaired vehicle (pre-warm miss) still opens '
-        'the picker sheet from the connecting flow', (tester) async {
-      final notifier = _ConnectLaterTripRecording();
-      // No pinned MAC ⇒ pre-warm misses ⇒ the start flow falls back to
-      // the picker, which opens its modal sheet.
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        activeVehicle: const VehicleProfile(
-          id: 'v2',
-          name: 'Daily Driver',
-          type: VehicleType.combustion,
-        ),
-        trips: const [],
-        recordingFactory: () => notifier,
-        obd2Connection: _RecordingFakeConnection(),
-      );
-      await tester.pump();
+      '#2274 concern 2 — an unpaired vehicle (pre-warm miss) still opens '
+      'the picker sheet from the connecting flow',
+      (tester) async {
+        final notifier = _ConnectLaterTripRecording();
+        // No pinned MAC ⇒ pre-warm misses ⇒ the start flow falls back to
+        // the picker, which opens its modal sheet.
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          activeVehicle: const VehicleProfile(
+            id: 'v2',
+            name: 'Daily Driver',
+            type: VehicleType.combustion,
+          ),
+          trips: const [],
+          recordingFactory: () => notifier,
+          obd2Connection: _RecordingFakeConnection(),
+        );
+        await tester.pump();
 
-      await tester.tap(
-        find.byKey(const Key('trajets_start_recording_button')),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      // No pre-warm hit (no pinned MAC) → the picker sheet opens and no
-      // service reached start().
-      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
-      expect(notifier.startServiceCallCount, 0);
-    });
+        // No pre-warm hit (no pinned MAC) → the picker sheet opens and no
+        // service reached start().
+        expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
+        expect(notifier.startServiceCallCount, 0);
+      },
+    );
   });
 
   group('TrajetsTab — row tap navigation', () {
-    testWidgets('tapping a trip row pushes /trip/:id with the row id',
-        (tester) async {
+    testWidgets('tapping a trip row pushes /trip/:id with the row id', (
+      tester,
+    ) async {
       final trips = [
         _entry(
           id: '2026-04-22T09:00:00.000Z',
@@ -680,46 +695,47 @@ void main() {
   // 0x05 — keep the flag false and the chip stays hidden.
   group('TrajetsTab — cold-start chip (#1262 phase 3)', () {
     testWidgets(
-        'renders the chip with localized label and tooltip when the flag is true',
-        (tester) async {
-      final trips = [
-        _entry(
-          id: 'trip-cold',
-          vehicleId: 'v1',
-          startedAt: DateTime(2026, 4, 22, 9),
-          endedAt: DateTime(2026, 4, 22, 9, 5),
-          distanceKm: 1.8,
-          coldStartSurcharge: true,
-        ),
-      ];
+      'renders the chip with localized label and tooltip when the flag is true',
+      (tester) async {
+        final trips = [
+          _entry(
+            id: 'trip-cold',
+            vehicleId: 'v1',
+            startedAt: DateTime(2026, 4, 22, 9),
+            endedAt: DateTime(2026, 4, 22, 9, 5),
+            distanceKm: 1.8,
+            coldStartSurcharge: true,
+          ),
+        ];
 
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        trips: trips,
-        vehicles: [combustionVehicle],
-        activeVehicle: combustionVehicle,
-      );
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: trips,
+          vehicles: [combustionVehicle],
+          activeVehicle: combustionVehicle,
+        );
 
-      // Chip label is the localized "Cold start" string.
-      expect(find.text('Cold start'), findsOneWidget);
-      // Tooltip widget wraps the chip with the localized explanation
-      // (find.byTooltip matches the message string against the
-      // surrounding Tooltip / RawTooltip — this asserts the tooltip
-      // is wired up regardless of which concrete class Flutter
-      // instantiates internally).
-      expect(
-        find.byTooltip(
-          "Engine didn't reach operating temperature during this trip — "
-          'fuel consumption was higher than usual.',
-        ),
-        findsOneWidget,
-      );
-    });
+        // Chip label is the localized "Cold start" string.
+        expect(find.text('Cold start'), findsOneWidget);
+        // Tooltip widget wraps the chip with the localized explanation
+        // (find.byTooltip matches the message string against the
+        // surrounding Tooltip / RawTooltip — this asserts the tooltip
+        // is wired up regardless of which concrete class Flutter
+        // instantiates internally).
+        expect(
+          find.byTooltip(
+            "Engine didn't reach operating temperature during this trip — "
+            'fuel consumption was higher than usual.',
+          ),
+          findsOneWidget,
+        );
+      },
+    );
 
-    testWidgets(
-        "does NOT render the chip when the trip's flag is false",
-        (tester) async {
+    testWidgets("does NOT render the chip when the trip's flag is false", (
+      tester,
+    ) async {
       final trips = [
         _entry(
           id: 'trip-warm',
@@ -770,92 +786,99 @@ void main() {
     );
 
     testWidgets(
-        'paired vehicle pre-warms via the transport-aware connect on open and '
-        'starts with the warm service (no picker) — #3025', (tester) async {
-      final fakeService = _NoopObd2Service();
-      final connection = _RecordingFakeConnection(
-        connectByMacDirectResult: fakeService,
-      );
-      final notifier = _ConnectLaterTripRecording();
+      'paired vehicle pre-warms via the transport-aware connect on open and '
+      'starts with the warm service (no picker) — #3025',
+      (tester) async {
+        final fakeService = _NoopObd2Service();
+        final connection = _RecordingFakeConnection(
+          connectByMacDirectResult: fakeService,
+        );
+        final notifier = _ConnectLaterTripRecording();
 
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        trips: const [],
-        activeVehicle: pairedVehicle,
-        recordingFactory: () => notifier,
-        obd2Connection: connection,
-      );
-      // Post-frame pre-warm fires + resolves before any tap.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 10));
-      // #3025 — the pre-warm goes through the TRANSPORT-AWARE entry (which routes
-      // 'vLinker FS' — a Classic adapter — to RFCOMM), NOT the BLE-only
-      // connectByMacDirect that 4 s-timed-out + poisoned the socket.
-      expect(connection.connectByMacTransportAwareCalls, ['AA:BB:CC:DD:EE:FF']);
-      expect(connection.connectByMacDirectCalls, isEmpty,
-          reason: 'a Classic adapter must NEVER pre-warm over the BLE path');
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: const [],
+          activeVehicle: pairedVehicle,
+          recordingFactory: () => notifier,
+          obd2Connection: connection,
+        );
+        // Post-frame pre-warm fires + resolves before any tap.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+        // #3025 — the pre-warm goes through the TRANSPORT-AWARE entry (which routes
+        // 'vLinker FS' — a Classic adapter — to RFCOMM), NOT the BLE-only
+        // connectByMacDirect that 4 s-timed-out + poisoned the socket.
+        expect(connection.connectByMacTransportAwareCalls, [
+          'AA:BB:CC:DD:EE:FF',
+        ]);
+        expect(
+          connection.connectByMacDirectCalls,
+          isEmpty,
+          reason: 'a Classic adapter must NEVER pre-warm over the BLE path',
+        );
 
-      await tester.tap(
-        find.byKey(const Key('trajets_start_recording_button')),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      // Warm link consumed via start(); picker never opens.
-      expect(notifier.startServiceCallCount, 1);
-      expect(notifier.lastStartedService, same(fakeService));
-      expect(find.text('Pick an OBD2 adapter'), findsNothing);
-    });
+        // Warm link consumed via start(); picker never opens.
+        expect(notifier.startServiceCallCount, 1);
+        expect(notifier.lastStartedService, same(fakeService));
+        expect(find.text('Pick an OBD2 adapter'), findsNothing);
+      },
+    );
 
     testWidgets(
-        'unpaired vehicle warms nothing on open and opens the picker on Start',
-        (tester) async {
-      final connection = _RecordingFakeConnection();
-      final notifier = _ConnectLaterTripRecording();
+      'unpaired vehicle warms nothing on open and opens the picker on Start',
+      (tester) async {
+        final connection = _RecordingFakeConnection();
+        final notifier = _ConnectLaterTripRecording();
 
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        trips: const [],
-        activeVehicle: unpairedVehicle,
-        recordingFactory: () => notifier,
-        obd2Connection: connection,
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 10));
-      // No pinned MAC → nothing pre-warmed (neither path is touched).
-      expect(connection.connectByMacDirectCalls, isEmpty);
-      expect(connection.connectByMacTransportAwareCalls, isEmpty);
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: const [],
+          activeVehicle: unpairedVehicle,
+          recordingFactory: () => notifier,
+          obd2Connection: connection,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+        // No pinned MAC → nothing pre-warmed (neither path is touched).
+        expect(connection.connectByMacDirectCalls, isEmpty);
+        expect(connection.connectByMacTransportAwareCalls, isEmpty);
 
-      await tester.tap(
-        find.byKey(const Key('trajets_start_recording_button')),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      // Falls back to the picker sheet; no service reached start().
-      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
-      expect(notifier.startServiceCallCount, 0);
-    });
+        // Falls back to the picker sheet; no service reached start().
+        expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
+        expect(notifier.startServiceCallCount, 0);
+      },
+    );
   });
 
   group('TrajetsTab — active recording CTA discoverability (#1237)', () {
-    testWidgets(
-      'idle state shows "Start recording" with the record-dot icon',
-      (tester) async {
-        await _pumpTab(tester, vehicleId: null, trips: const []);
+    testWidgets('idle state shows "Start recording" with the record-dot icon', (
+      tester,
+    ) async {
+      await _pumpTab(tester, vehicleId: null, trips: const []);
 
-        expect(find.text('Start recording'), findsOneWidget);
-        expect(find.text('Resume recording'), findsNothing);
-        // #1889 — the CTA is an extended FAB (matching the fuel tab's
-        // "add" button) and is enabled when no trip is active.
-        final button = tester.widget<FloatingActionButton>(
-          find.byKey(const Key('trajets_start_recording_button')),
-        );
-        expect(button.onPressed, isNotNull);
-      },
-    );
+      expect(find.text('Start recording'), findsOneWidget);
+      expect(find.text('Resume recording'), findsNothing);
+      // #1889 — the CTA is an extended FAB (matching the fuel tab's
+      // "add" button) and is enabled when no trip is active.
+      final button = tester.widget<FloatingActionButton>(
+        find.byKey(const Key('trajets_start_recording_button')),
+      );
+      expect(button.onPressed, isNotNull);
+    });
 
     testWidgets(
       'active recording switches CTA to "Resume recording" + visibility icon',
@@ -893,26 +916,30 @@ void main() {
   // disabling + relabelling so a glance at the tab matches.
   group('TrajetsTab — connecting-phase CTA (#2274 concern 2)', () {
     testWidgets(
-        'a connecting trip disables the CTA and shows the connecting label',
-        (tester) async {
-      await _pumpTab(
-        tester,
-        vehicleId: null,
-        trips: const [],
-        recordingFactory: () => _ConnectingTrip(),
-      );
-      await tester.pump();
+      'a connecting trip disables the CTA and shows the connecting label',
+      (tester) async {
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: const [],
+          recordingFactory: () => _ConnectingTrip(),
+        );
+        await tester.pump();
 
-      // The inline progress card no longer exists on the tab.
-      expect(find.byKey(const Key('trajets_start_progress')), findsNothing);
-      // CTA relabelled + disabled while connecting.
-      expect(find.text('Connecting to OBD2 adapter…'), findsOneWidget);
-      final button = tester.widget<FloatingActionButton>(
-        find.byKey(const Key('trajets_start_recording_button')),
-      );
-      expect(button.onPressed, isNull,
-          reason: 'CTA is disabled while a start is connecting');
-    });
+        // The inline progress card no longer exists on the tab.
+        expect(find.byKey(const Key('trajets_start_progress')), findsNothing);
+        // CTA relabelled + disabled while connecting.
+        expect(find.text('Connecting to OBD2 adapter…'), findsOneWidget);
+        final button = tester.widget<FloatingActionButton>(
+          find.byKey(const Key('trajets_start_recording_button')),
+        );
+        expect(
+          button.onPressed,
+          isNull,
+          reason: 'CTA is disabled while a start is connecting',
+        );
+      },
+    );
   });
 
   // #2530 — the wide-screen split now goes through the shared
@@ -927,8 +954,9 @@ void main() {
       ),
     ];
 
-    testWidgets('compact width renders a single pane (no VerticalDivider)',
-        (tester) async {
+    testWidgets('compact width renders a single pane (no VerticalDivider)', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -946,8 +974,9 @@ void main() {
       expect(find.byKey(const Key('trajets_list')), findsOneWidget);
     });
 
-    testWidgets('expanded width renders two panes with the 2:3 ratio',
-        (tester) async {
+    testWidgets('expanded width renders two panes with the 2:3 ratio', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(1024, 768);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -977,9 +1006,9 @@ void main() {
 class _ConnectingTrip extends TripRecording {
   @override
   TripRecordingState build() => const TripRecordingState(
-        phase: TripRecordingPhase.connecting,
-        connectStage: TripStartStage.connectingAdapter,
-      );
+    phase: TripRecordingPhase.connecting,
+    connectStage: TripStartStage.connectingAdapter,
+  );
 }
 
 /// Returns an [TripRecordingState] whose [TripRecordingState.isActive] is
@@ -987,9 +1016,8 @@ class _ConnectingTrip extends TripRecording {
 /// without having to spin up the OBD2 service stack.
 class _ActiveRecordingTrip extends TripRecording {
   @override
-  TripRecordingState build() => const TripRecordingState(
-        phase: TripRecordingPhase.recording,
-      );
+  TripRecordingState build() =>
+      const TripRecordingState(phase: TripRecordingPhase.recording);
 
   @override
   Future<StartTripOutcome> startTrip({
@@ -997,6 +1025,5 @@ class _ActiveRecordingTrip extends TripRecording {
     String? adapterMac,
     Obd2Service? service,
     bool automatic = false,
-  }) async =>
-      StartTripOutcome.alreadyActive;
+  }) async => StartTripOutcome.alreadyActive;
 }

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -62,8 +62,7 @@ void main() {
         tester,
         const DrivingSettingsSection(),
         overrides: [
-          settingsStorageProvider
-              .overrideWithValue(_FakeSettingsStorage()),
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
           storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
           featureFlagsProvider.overrideWith(() => fakeFlags),
         ],
@@ -114,8 +113,7 @@ void main() {
         tester,
         const DrivingSettingsSection(),
         overrides: [
-          settingsStorageProvider
-              .overrideWithValue(_FakeSettingsStorage()),
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
           storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
           featureFlagsProvider.overrideWith(() => fakeFlags),
         ],
@@ -134,55 +132,56 @@ void main() {
     },
   );
 
-  testWidgets(
-    'composes vehicles + fuel-club tiles above the eco-coach toggle '
-    '(#1242 — Console grouping)',
-    (tester) async {
-      await pumpApp(
-        tester,
-        const DrivingSettingsSection(),
-        overrides: [
-          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
-          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
-          // #1517 / #1520 — the Fuel club cards tile is now gated by
-          // `Feature.loyaltyCards`. Pin it on so this composition test
-          // still asserts both tiles render together. Default-off
-          // semantics are covered separately by the gating-audit
-          // unit tests.
-          featureFlagsProvider.overrideWith(
-            () => _TestFeatureFlags(<Feature>{Feature.loyaltyCards}),
-          ),
-        ],
-      );
+  testWidgets('composes vehicles + fuel-club tiles above the eco-coach toggle '
+      '(#1242 — Console grouping)', (tester) async {
+    await pumpApp(
+      tester,
+      const DrivingSettingsSection(),
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+        storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
+        // #1517 / #1520 — the Fuel club cards tile is now gated by
+        // `Feature.loyaltyCards`. Pin it on so this composition test
+        // still asserts both tiles render together. Default-off
+        // semantics are covered separately by the gating-audit
+        // unit tests.
+        featureFlagsProvider.overrideWith(
+          () => _TestFeatureFlags(<Feature>{Feature.loyaltyCards}),
+        ),
+      ],
+    );
 
-      // #2566 — the vehicles tile is the first group (Vehicles); the
-      // fuel-club tile lives in the Rewards & savings group.
-      expect(
-        find.byKey(const Key('consoleVehiclesTile')),
-        findsOneWidget,
-        reason: 'My vehicles tile must render inside the Conso section '
-            'as the first (Vehicles) group after #2566.',
-      );
-      expect(
-        find.byKey(const Key('consoleFuelClubCardsTile')),
-        findsOneWidget,
-        reason: 'Fuel club cards tile is part of the Rewards & savings '
-            'group.',
-      );
+    // #2566 — the vehicles tile is the first group (Vehicles); the
+    // fuel-club tile lives in the Rewards & savings group.
+    expect(
+      find.byKey(const Key('consoleVehiclesTile')),
+      findsOneWidget,
+      reason:
+          'My vehicles tile must render inside the Conso section '
+          'as the first (Vehicles) group after #2566.',
+    );
+    expect(
+      find.byKey(const Key('consoleFuelClubCardsTile')),
+      findsOneWidget,
+      reason:
+          'Fuel club cards tile is part of the Rewards & savings '
+          'group.',
+    );
 
-      final children = <Widget>[
-        for (final t in tester
-            .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile)))
-          t,
-      ];
-      expect(
-        children.length,
-        2,
-        reason: 'Exactly two SettingsMenuTile children: the vehicles tile '
-            '(Vehicles group) + Fuel club cards (Rewards & savings group).',
-      );
-    },
-  );
+    final children = <Widget>[
+      for (final t in tester.widgetList<SettingsMenuTile>(
+        find.byType(SettingsMenuTile),
+      ))
+        t,
+    ];
+    expect(
+      children.length,
+      2,
+      reason:
+          'Exactly two SettingsMenuTile children: the vehicles tile '
+          '(Vehicles group) + Fuel club cards (Rewards & savings group).',
+    );
+  });
 
   testWidgets(
     'regroups the section into the #2566 purpose-driven IA — Vehicles, '
@@ -214,7 +213,7 @@ void main() {
       // Resolve the localized group-header strings from the running app.
       final l = AppLocalizations.of(
         tester.element(find.byType(DrivingSettingsSection)),
-      )!;
+      );
       final headerTitles = tester
           .widgetList<SectionHeader>(find.byType(SectionHeader))
           .map((h) => h.title)
@@ -227,7 +226,8 @@ void main() {
           l.consoGroupRewards,
           l.consoGroupTroubleshooting,
         ],
-        reason: 'The four purpose-driven groups must render in IA order '
+        reason:
+            'The four purpose-driven groups must render in IA order '
             '(#2566): Vehicles, Coaching while driving, Rewards & savings, '
             'Troubleshooting.',
       );
@@ -241,7 +241,8 @@ void main() {
       expect(
         find.byKey(const Key('obd2DebugLoggingToggle')),
         findsOneWidget,
-        reason: 'The OBD2 debug-logging diagnostic lives in the '
+        reason:
+            'The OBD2 debug-logging diagnostic lives in the '
             'Troubleshooting group, shown only when the OBD2 stack is on.',
       );
 
@@ -250,12 +251,14 @@ void main() {
       final ecoY = tester
           .getTopLeft(find.byKey(const Key('hapticEcoCoachToggle')))
           .dy;
-      final glideY =
-          tester.getTopLeft(find.byKey(const Key('glideCoachToggle'))).dy;
+      final glideY = tester
+          .getTopLeft(find.byKey(const Key('glideCoachToggle')))
+          .dy;
       expect(
         ecoY < glideY,
         isTrue,
-        reason: 'Eco-coaching must render above glide-coach within the '
+        reason:
+            'Eco-coaching must render above glide-coach within the '
             'Coaching while driving group.',
       );
     },
@@ -277,7 +280,7 @@ void main() {
 
       final l = AppLocalizations.of(
         tester.element(find.byType(DrivingSettingsSection)),
-      )!;
+      );
       final headerTitles = tester
           .widgetList<SectionHeader>(find.byType(SectionHeader))
           .map((h) => h.title)
@@ -285,7 +288,8 @@ void main() {
       expect(
         headerTitles,
         isNot(contains(l.consoGroupTroubleshooting)),
-        reason: 'No Troubleshooting group without the OBD2 stack — the '
+        reason:
+            'No Troubleshooting group without the OBD2 stack — the '
             'debug-logging diagnostic only concerns the OBD2 link.',
       );
       expect(find.byKey(const Key('obd2DebugLoggingToggle')), findsNothing);
@@ -319,34 +323,31 @@ void main() {
     },
   );
 
-  testWidgets(
-    'nests the gamification opt-out tile inside the Conso section '
-    '(#1249 — moved out of the standalone settings card)',
-    (tester) async {
-      await pumpApp(
-        tester,
-        const DrivingSettingsSection(),
-        overrides: [
-          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
-          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
-          featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
-        ],
-      );
+  testWidgets('nests the gamification opt-out tile inside the Conso section '
+      '(#1249 — moved out of the standalone settings card)', (tester) async {
+    await pumpApp(
+      tester,
+      const DrivingSettingsSection(),
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+        storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
+        featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
+      ],
+    );
 
-      // The gamification toggle now lives as the last child of the
-      // Consumption foldable instead of as a sibling Card on the
-      // Settings page. Asserting it is present here pins that
-      // placement so a future rewrite can't silently move it back.
-      expect(
-        find.byType(GamificationSettingsTile),
-        findsOneWidget,
-        reason:
-            'Exactly one GamificationSettingsTile must render inside '
-            'DrivingSettingsSection — duplication or absence indicates '
-            'the #1249 placement regressed.',
-      );
-    },
-  );
+    // The gamification toggle now lives as the last child of the
+    // Consumption foldable instead of as a sibling Card on the
+    // Settings page. Asserting it is present here pins that
+    // placement so a future rewrite can't silently move it back.
+    expect(
+      find.byType(GamificationSettingsTile),
+      findsOneWidget,
+      reason:
+          'Exactly one GamificationSettingsTile must render inside '
+          'DrivingSettingsSection — duplication or absence indicates '
+          'the #1249 placement regressed.',
+    );
+  });
 
   testWidgets(
     'voice-announcement sliders show their CURRENT value as visible text at '
@@ -370,8 +371,9 @@ void main() {
           featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
           // The voice-announcements tile is gated behind this master flag.
           voiceAnnouncementsEnabledProvider.overrideWithValue(true),
-          voiceAnnouncementSettingsProvider
-              .overrideWith(() => _FakeVoiceSettings(config)),
+          voiceAnnouncementSettingsProvider.overrideWith(
+            () => _FakeVoiceSettings(config),
+          ),
         ],
       );
 
@@ -379,7 +381,8 @@ void main() {
       expect(
         find.byType(LabeledValueSlider),
         findsNWidgets(3),
-        reason: 'All three voice sliders must use the shared '
+        reason:
+            'All three voice sliders must use the shared '
             'LabeledValueSlider so the value is always visible.',
       );
 
@@ -388,7 +391,8 @@ void main() {
       expect(
         find.text('2.5 km'),
         findsOneWidget,
-        reason: 'The announcement-radius slider must show "2.5 km" at rest '
+        reason:
+            'The announcement-radius slider must show "2.5 km" at rest '
             '(#2920) — a bare Slider.label is invisible until dragged.',
       );
       expect(
@@ -400,7 +404,8 @@ void main() {
       expect(
         find.text(priceText),
         findsOneWidget,
-        reason: 'The price-limit slider must show the formatted price '
+        reason:
+            'The price-limit slider must show the formatted price '
             '("$priceText") at rest.',
       );
 
@@ -408,17 +413,19 @@ void main() {
       // subtitle text it used to fall back to (#2920 mislabel).
       final l = AppLocalizations.of(
         tester.element(find.byType(DrivingSettingsSection)),
-      )!;
+      );
       expect(
         find.text(l.voiceAnnouncementPriceLimit),
         findsOneWidget,
-        reason: 'The price-threshold slider must show a distinct '
+        reason:
+            'The price-threshold slider must show a distinct '
             '"Maximum price" label — not the duplicated section subtitle.',
       );
       expect(
         find.text(l.voiceAnnouncementsDescription),
         findsOneWidget,
-        reason: 'The section subtitle text must appear exactly once (on the '
+        reason:
+            'The section subtitle text must appear exactly once (on the '
             'enable toggle) — never duplicated onto the price slider.',
       );
     },
@@ -434,7 +441,8 @@ void main() {
 ///     that throw [StateError] for prerequisite violations to mirror
 ///     the real central-provider contract the shim relies on.
 class _TestFeatureFlags extends FeatureFlags {
-  _TestFeatureFlags([Set<Feature>? initial]) : _initial = initial ?? <Feature>{};
+  _TestFeatureFlags([Set<Feature>? initial])
+    : _initial = initial ?? <Feature>{};
 
   final Set<Feature> _initial;
 
@@ -443,13 +451,15 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    final current = state.value ?? const <Feature>{};
+    if (current.contains(feature)) return;
     state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    final current = state.value ?? const <Feature>{};
+    if (!current.contains(feature)) return;
     state = AsyncData({...current}..remove(feature));
   }
 }

--- a/test/features/driving/presentation/widgets/driving_bottom_bar_test.dart
+++ b/test/features/driving/presentation/widgets/driving_bottom_bar_test.dart
@@ -10,8 +10,9 @@ import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('DrivingBottomBar', () {
-    testWidgets('fires onRecenter exactly once when the location button taps',
-        (tester) async {
+    testWidgets('fires onRecenter exactly once when the location button taps', (
+      tester,
+    ) async {
       var recenter = 0;
       var nearest = 0;
       var exit = 0;
@@ -34,31 +35,33 @@ void main() {
     });
 
     testWidgets(
-        'fires onNearestStation exactly once when the gas-station button taps',
-        (tester) async {
-      var recenter = 0;
-      var nearest = 0;
-      var exit = 0;
+      'fires onNearestStation exactly once when the gas-station button taps',
+      (tester) async {
+        var recenter = 0;
+        var nearest = 0;
+        var exit = 0;
 
-      await pumpApp(
-        tester,
-        DrivingBottomBar(
-          onRecenter: () => recenter++,
-          onNearestStation: () => nearest++,
-          onExit: () => exit++,
-        ),
-      );
+        await pumpApp(
+          tester,
+          DrivingBottomBar(
+            onRecenter: () => recenter++,
+            onNearestStation: () => nearest++,
+            onExit: () => exit++,
+          ),
+        );
 
-      await tester.tap(find.byIcon(Icons.local_gas_station));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.local_gas_station));
+        await tester.pumpAndSettle();
 
-      expect(nearest, 1);
-      expect(recenter, 0);
-      expect(exit, 0);
-    });
+        expect(nearest, 1);
+        expect(recenter, 0);
+        expect(exit, 0);
+      },
+    );
 
-    testWidgets('fires onExit exactly once when the close button taps',
-        (tester) async {
+    testWidgets('fires onExit exactly once when the close button taps', (
+      tester,
+    ) async {
       var recenter = 0;
       var nearest = 0;
       var exit = 0;
@@ -80,30 +83,9 @@ void main() {
       expect(nearest, 0);
     });
 
-    testWidgets('renders English fallback labels when no l10n delegate wired',
-        (tester) async {
-      // Builds the bar with a bare MaterialApp that has no
-      // AppLocalizations delegate, forcing the `?? 'fallback'` arms.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: DrivingBottomBar(
-              onRecenter: () {},
-              onNearestStation: () {},
-              onExit: () {},
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('Location'), findsOneWidget);
-      expect(find.text('Nearest'), findsOneWidget);
-      expect(find.text('Exit'), findsOneWidget);
-    });
-
-    testWidgets('renders the localized labels when AppLocalizations is wired',
-        (tester) async {
+    testWidgets('renders the localized labels when AppLocalizations is wired', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         DrivingBottomBar(
@@ -120,29 +102,29 @@ void main() {
       expect(find.text('Exit'), findsOneWidget);
     });
 
-    testWidgets('all three buttons meet the Android tap-target guideline (>=48dp)',
-        (tester) async {
-      final handle = tester.ensureSemantics();
+    testWidgets(
+      'all three buttons meet the Android tap-target guideline (>=48dp)',
+      (tester) async {
+        final handle = tester.ensureSemantics();
 
-      await pumpApp(
-        tester,
-        DrivingBottomBar(
-          onRecenter: () {},
-          onNearestStation: () {},
-          onExit: () {},
-        ),
-      );
+        await pumpApp(
+          tester,
+          DrivingBottomBar(
+            onRecenter: () {},
+            onNearestStation: () {},
+            onExit: () {},
+          ),
+        );
 
-      await expectLater(
-        tester,
-        meetsGuideline(androidTapTargetGuideline),
-      );
+        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
 
-      handle.dispose();
-    });
+        handle.dispose();
+      },
+    );
 
-    testWidgets('bottom padding includes MediaQuery viewPadding.bottom',
-        (tester) async {
+    testWidgets('bottom padding includes MediaQuery viewPadding.bottom', (
+      tester,
+    ) async {
       const inset = 34.0;
 
       await tester.pumpWidget(
@@ -186,8 +168,7 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('lays out the three buttons in a single Row',
-        (tester) async {
+    testWidgets('lays out the three buttons in a single Row', (tester) async {
       await pumpApp(
         tester,
         DrivingBottomBar(

--- a/test/features/driving/presentation/widgets/driving_map_view_test.dart
+++ b/test/features/driving/presentation/widgets/driving_map_view_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/map/presentation/widgets/station_map_layers
 import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
 import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 Station _station({
   required String id,
@@ -117,6 +118,8 @@ void main() {
     }) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SizedBox(
               width: 400,
@@ -135,8 +138,28 @@ void main() {
       await tester.pump();
     }
 
-    testWidgets('renders the shared StationMapLayers, not a bespoke MarkerLayer',
-        (tester) async {
+    testWidgets(
+      'renders the shared StationMapLayers, not a bespoke MarkerLayer',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+        await pumpView(
+          tester,
+          controller: controller,
+          stations: [
+            _station(id: 'a', lat: 52.0, lng: 13.0),
+            _station(id: 'b', lat: 52.1, lng: 13.1),
+          ],
+        );
+
+        // Driving now consumes the ONE shared map stack.
+        expect(find.byType(StationMapLayers), findsOneWidget);
+      },
+    );
+
+    testWidgets('passes the driving marker variant + NO clustering', (
+      tester,
+    ) async {
       final controller = MapController();
       addTearDown(controller.dispose);
       await pumpView(
@@ -148,25 +171,9 @@ void main() {
         ],
       );
 
-      // Driving now consumes the ONE shared map stack.
-      expect(find.byType(StationMapLayers), findsOneWidget);
-    });
-
-    testWidgets('passes the driving marker variant + NO clustering',
-        (tester) async {
-      final controller = MapController();
-      addTearDown(controller.dispose);
-      await pumpView(
-        tester,
-        controller: controller,
-        stations: [
-          _station(id: 'a', lat: 52.0, lng: 13.0),
-          _station(id: 'b', lat: 52.1, lng: 13.1),
-        ],
+      final layers = tester.widget<StationMapLayers>(
+        find.byType(StationMapLayers),
       );
-
-      final layers =
-          tester.widget<StationMapLayers>(find.byType(StationMapLayers));
       // The big driver-legible marker variant.
       expect(layers.markerVariant, StationMarkerVariant.driving);
       // Driving shows few stations and needs immediate tap-to-open-sheet —
@@ -192,8 +199,9 @@ void main() {
         onInteraction: () => interacted = true,
       );
 
-      final layers =
-          tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+      final layers = tester.widget<StationMapLayers>(
+        find.byType(StationMapLayers),
+      );
       // The shared layer surfaces a station-id tap hook; driving wires it to
       // its onMarkerTap (which shows DrivingStationSheet), not a GoRouter push.
       expect(layers.onStationTap, isNotNull);
@@ -203,8 +211,9 @@ void main() {
       expect(interacted, isTrue);
     });
 
-    testWidgets('keeps the restricted driving interaction (no pinch zoom)',
-        (tester) async {
+    testWidgets('keeps the restricted driving interaction (no pinch zoom)', (
+      tester,
+    ) async {
       final controller = MapController();
       addTearDown(controller.dispose);
       await pumpView(
@@ -213,8 +222,9 @@ void main() {
         stations: [_station(id: 'a', lat: 52.0, lng: 13.0)],
       );
 
-      final layers =
-          tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+      final layers = tester.widget<StationMapLayers>(
+        find.byType(StationMapLayers),
+      );
       final flags = layers.interactionOptions!.flags;
       // Drag + fling + double-tap-zoom are allowed; pinch/rotate are not.
       expect(flags & InteractiveFlag.drag, isNot(0));

--- a/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
+++ b/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
@@ -20,6 +20,7 @@ import 'package:tankstellen/features/search/presentation/screens/ev_station_deta
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for [EvMapLayer] and [EvToggleButton] from
 /// `lib/features/ev/presentation/widgets/ev_map_overlay.dart`.
@@ -33,7 +34,11 @@ void main() {
 
   /// Builds a single [ChargingStation] with the supplied [id] so we can
   /// quickly spin up large lists for the cluster threshold (>20).
-  ChargingStation buildStation(String id, {double lat = 0.1, double lng = 0.1}) {
+  ChargingStation buildStation(
+    String id, {
+    double lat = 0.1,
+    double lng = 0.1,
+  }) {
     return ChargingStation(
       id: 'ocm-$id',
       name: 'Station $id',
@@ -50,10 +55,7 @@ void main() {
       width: 400,
       height: 600,
       child: FlutterMap(
-        options: const MapOptions(
-          initialCenter: LatLng(0, 0),
-          initialZoom: 5,
-        ),
+        options: const MapOptions(initialCenter: LatLng(0, 0), initialZoom: 5),
         children: [child],
       ),
     );
@@ -64,29 +66,32 @@ void main() {
       await pumpApp(
         tester,
         const EvToggleButton(),
-        overrides: [
-          evShowOnMapProvider.overrideWith(_FakeEvShowOnMap.new),
-        ],
+        overrides: [evShowOnMapProvider.overrideWith(_FakeEvShowOnMap.new)],
       );
 
       expect(find.byIcon(Icons.ev_station), findsOneWidget);
     });
 
-    testWidgets('off state shows white background and dark icon',
-        (tester) async {
+    testWidgets('off state shows white background and dark icon', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const EvToggleButton(),
         overrides: [
-          evShowOnMapProvider.overrideWith(() => _FakeEvShowOnMap(initial: false)),
+          evShowOnMapProvider.overrideWith(
+            () => _FakeEvShowOnMap(initial: false),
+          ),
         ],
       );
 
       final material = tester.widget<Material>(
-        find.ancestor(
-          of: find.byIcon(Icons.ev_station),
-          matching: find.byType(Material),
-        ).first,
+        find
+            .ancestor(
+              of: find.byIcon(Icons.ev_station),
+              matching: find.byType(Material),
+            )
+            .first,
       );
       expect(material.color, Colors.white);
 
@@ -94,21 +99,26 @@ void main() {
       expect(icon.color, Colors.black54);
     });
 
-    testWidgets('on state flips background to green and icon to white',
-        (tester) async {
+    testWidgets('on state flips background to green and icon to white', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const EvToggleButton(),
         overrides: [
-          evShowOnMapProvider.overrideWith(() => _FakeEvShowOnMap(initial: true)),
+          evShowOnMapProvider.overrideWith(
+            () => _FakeEvShowOnMap(initial: true),
+          ),
         ],
       );
 
       final material = tester.widget<Material>(
-        find.ancestor(
-          of: find.byIcon(Icons.ev_station),
-          matching: find.byType(Material),
-        ).first,
+        find
+            .ancestor(
+              of: find.byIcon(Icons.ev_station),
+              matching: find.byType(Material),
+            )
+            .first,
       );
       expect(
         material.color,
@@ -119,15 +129,14 @@ void main() {
       expect(icon.color, Colors.white);
     });
 
-    testWidgets('tap calls notifier.toggle() and flips the state',
-        (tester) async {
+    testWidgets('tap calls notifier.toggle() and flips the state', (
+      tester,
+    ) async {
       final fake = _FakeEvShowOnMap(initial: false);
       await pumpApp(
         tester,
         const EvToggleButton(),
-        overrides: [
-          evShowOnMapProvider.overrideWith(() => fake),
-        ],
+        overrides: [evShowOnMapProvider.overrideWith(() => fake)],
       );
 
       await tester.tap(find.byIcon(Icons.ev_station));
@@ -141,8 +150,9 @@ void main() {
   });
 
   group('EvMapLayer', () {
-    testWidgets('loading state renders SizedBox.shrink (no marker layer)',
-        (tester) async {
+    testWidgets('loading state renders SizedBox.shrink (no marker layer)', (
+      tester,
+    ) async {
       // Never-completing future keeps the AsyncValue in the loading state.
       final completer = Completer<List<ChargingStation>>();
       addTearDown(() {
@@ -155,6 +165,8 @@ void main() {
             evStationsProvider(viewport).overrideWith((_) => completer.future),
           ],
           child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: hostInMap(const EvMapLayer(viewport: viewport)),
             ),
@@ -169,14 +181,16 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('error state renders SizedBox.shrink (no marker layer)',
-        (tester) async {
+    testWidgets('error state renders SizedBox.shrink (no marker layer)', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         hostInMap(const EvMapLayer(viewport: viewport)),
         overrides: [
-          evStationsProvider(viewport)
-              .overrideWith((_) async => throw Exception('boom')),
+          evStationsProvider(
+            viewport,
+          ).overrideWith((_) async => throw Exception('boom')),
         ],
       );
 
@@ -184,8 +198,9 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('empty data renders SizedBox.shrink (no marker layer)',
-        (tester) async {
+    testWidgets('empty data renders SizedBox.shrink (no marker layer)', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         hostInMap(const EvMapLayer(viewport: viewport)),
@@ -198,8 +213,9 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('non-empty data with <=20 stations renders MarkerLayer',
-        (tester) async {
+    testWidgets('non-empty data with <=20 stations renders MarkerLayer', (
+      tester,
+    ) async {
       final stations = List.generate(
         5,
         (i) => buildStation('s$i', lat: i * 0.001, lng: i * 0.001),
@@ -217,8 +233,9 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('non-empty data with >20 stations renders cluster layer',
-        (tester) async {
+    testWidgets('non-empty data with >20 stations renders cluster layer', (
+      tester,
+    ) async {
       final stations = List.generate(
         25,
         (i) => buildStation('s$i', lat: i * 0.001, lng: i * 0.001),
@@ -238,8 +255,7 @@ void main() {
       expect(find.byType(MarkerLayer), findsNothing);
     });
 
-    testWidgets(
-        'marker tap navigates to the routed rich EVStationDetailScreen '
+    testWidgets('marker tap navigates to the routed rich EVStationDetailScreen '
         'via /ev-station (#3174)', (tester) async {
       // #3174 — the overlay used to push a diverged 238-line legacy copy
       // (lib/features/ev/.../ev_station_detail_screen.dart) directly,
@@ -264,17 +280,15 @@ void main() {
         routes: [
           GoRoute(
             path: '/',
-            builder: (_, _) => Scaffold(
-              body: hostInMap(const EvMapLayer(viewport: viewport)),
-            ),
+            builder: (_, _) =>
+                Scaffold(body: hostInMap(const EvMapLayer(viewport: viewport))),
           ),
           // Mirrors the production `/ev-station` route in
           // `lib/app/routes/station_routes.dart` (extra-hydrated).
           GoRoute(
             path: '/ev-station',
-            builder: (_, state) => EVStationDetailScreen(
-              station: state.extra as ChargingStation,
-            ),
+            builder: (_, state) =>
+                EVStationDetailScreen(station: state.extra as ChargingStation),
           ),
         ],
       );
@@ -286,7 +300,11 @@ void main() {
             ...test.overrides,
             evStationsProvider(viewport).overrideWith((_) async => [station]),
           ].cast(),
-          child: MaterialApp.router(routerConfig: router),
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -298,13 +316,15 @@ void main() {
       expect(
         find.byType(EVStationDetailScreen),
         findsOneWidget,
-        reason: 'the marker tap must open the routed rich detail screen, '
+        reason:
+            'the marker tap must open the routed rich detail screen, '
             'not a private legacy copy',
       );
     });
 
-    testWidgets('memoises the marker list across host rebuilds (#2175)',
-        (tester) async {
+    testWidgets('memoises the marker list across host rebuilds (#2175)', (
+      tester,
+    ) async {
       final stations = List.generate(
         5,
         (i) => buildStation('s$i', lat: i * 0.001, lng: i * 0.001),
@@ -327,16 +347,21 @@ void main() {
         ],
       );
 
-      final first = tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+      final first = tester
+          .widget<MarkerLayer>(find.byType(MarkerLayer))
+          .markers;
       // Force a host rebuild WITHOUT changing the station list identity.
       rebuild.value++;
       await tester.pump();
-      final second = tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+      final second = tester
+          .widget<MarkerLayer>(find.byType(MarkerLayer))
+          .markers;
 
       expect(
         identical(first, second),
         isTrue,
-        reason: 'marker list must be memoised, not re-allocated, when the '
+        reason:
+            'marker list must be memoised, not re-allocated, when the '
             'station list is unchanged',
       );
     });

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -13,6 +13,7 @@ import 'package:tankstellen/features/map/presentation/widgets/station_marker.dar
 import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('StationMapLayers.zoomForRadius', () {
@@ -95,36 +96,36 @@ void main() {
       expect(StationMapLayers.maxZoom, 19.0);
     });
 
-    test('minZoom keeps every pin from collapsing into a single pixel',
-        () {
+    test('minZoom keeps every pin from collapsing into a single pixel', () {
       // Zoom 3 shows a continent-scale viewport; below that, station
       // markers cluster into a single illegible blob and the search
       // affordances stop being meaningful.
       expect(StationMapLayers.minZoom, 3.0);
     });
 
-    test('the clamp expression in the +/− handlers is well-formed',
-        () {
+    test('the clamp expression in the +/− handlers is well-formed', () {
       // Mirror the exact expression both ZoomButton handlers use so a
       // future rename or sign-flip in the production code is caught
       // by this test rather than silently shipping. The clamp turns a
       // tap-at-the-cap into a graceful no-op (camera stays at the
       // bound) instead of pushing past where there are tiles.
-      double inc(double current) =>
-          (current + 1).clamp(StationMapLayers.minZoom, StationMapLayers.maxZoom);
-      double dec(double current) =>
-          (current - 1).clamp(StationMapLayers.minZoom, StationMapLayers.maxZoom);
+      double inc(double current) => (current + 1).clamp(
+        StationMapLayers.minZoom,
+        StationMapLayers.maxZoom,
+      );
+      double dec(double current) => (current - 1).clamp(
+        StationMapLayers.minZoom,
+        StationMapLayers.maxZoom,
+      );
       // Below the cap → increment normally.
       expect(inc(13.0), 14.0);
       expect(dec(13.0), 12.0);
       // At the upper cap → + becomes a no-op, − still moves.
       expect(inc(StationMapLayers.maxZoom), StationMapLayers.maxZoom);
-      expect(dec(StationMapLayers.maxZoom),
-          StationMapLayers.maxZoom - 1.0);
+      expect(dec(StationMapLayers.maxZoom), StationMapLayers.maxZoom - 1.0);
       // At the lower cap → − becomes a no-op, + still moves.
       expect(dec(StationMapLayers.minZoom), StationMapLayers.minZoom);
-      expect(inc(StationMapLayers.minZoom),
-          StationMapLayers.minZoom + 1.0);
+      expect(inc(StationMapLayers.minZoom), StationMapLayers.minZoom + 1.0);
       // Past the upper cap (e.g. via prior pinch-zoom that escaped
       // the camera before #1457 set MapOptions.maxZoom) → the next
       // tap snaps back to the cap rather than pushing further.
@@ -154,6 +155,8 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: StationMapLayers(
                 mapController: mapController,
@@ -174,8 +177,9 @@ void main() {
         // unified path means there is one keyed tile widget and one
         // reset behaviour shared with every other map surface.
         expect(find.byType(SparkiloTileLayer), findsOneWidget);
-        final sparkilo =
-            tester.widget<SparkiloTileLayer>(find.byType(SparkiloTileLayer));
+        final sparkilo = tester.widget<SparkiloTileLayer>(
+          find.byType(SparkiloTileLayer),
+        );
         expect(sparkilo.key, const ValueKey('main-tiles'));
         expect(
           sparkilo.reset,
@@ -188,45 +192,46 @@ void main() {
       },
     );
 
-    testWidgets(
-      'survives parent rebuilds without re-keying the tile widget '
-      '(provider lifetime is owned inside SparkiloTileLayer)',
-      (tester) async {
-        tester.view.physicalSize = const Size(900, 1600);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
+    testWidgets('survives parent rebuilds without re-keying the tile widget '
+        '(provider lifetime is owned inside SparkiloTileLayer)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(900, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
 
-        final mapController = MapController();
-        addTearDown(mapController.dispose);
+      final mapController = MapController();
+      addTearDown(mapController.dispose);
 
-        Widget pumpAt(int rebuildToken) => MaterialApp(
-              home: Scaffold(
-                body: KeyedSubtree(
-                  key: ValueKey('rebuild-$rebuildToken'),
-                  child: StationMapLayers(
-                    mapController: mapController,
-                    stations: const [_seedStation],
-                    center: const LatLng(52.5210, 13.4100),
-                    zoom: 12,
-                    searchRadiusKm: 10,
-                    selectedFuel: FuelType.diesel,
-                  ),
-                ),
-              ),
-            );
+      Widget pumpAt(int rebuildToken) => MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: ValueKey('rebuild-$rebuildToken'),
+            child: StationMapLayers(
+              mapController: mapController,
+              stations: const [_seedStation],
+              center: const LatLng(52.5210, 13.4100),
+              zoom: 12,
+              searchRadiusKm: 10,
+              selectedFuel: FuelType.diesel,
+            ),
+          ),
+        ),
+      );
 
-        await tester.pumpWidget(pumpAt(0));
-        await tester.pumpWidget(pumpAt(0));
-        await tester.pumpWidget(pumpAt(0));
+      await tester.pumpWidget(pumpAt(0));
+      await tester.pumpWidget(pumpAt(0));
+      await tester.pumpWidget(pumpAt(0));
 
-        // The keyed SparkiloTileLayer is preserved across rebuilds, so
-        // its State (and the retry provider's http.Client) lives for
-        // the map's whole visible lifetime — the #1234 invariant now
-        // lives inside the wrapper rather than this widget.
-        expect(find.byType(SparkiloTileLayer), findsOneWidget);
-      },
-    );
+      // The keyed SparkiloTileLayer is preserved across rebuilds, so
+      // its State (and the retry provider's http.Client) lives for
+      // the map's whole visible lifetime — the #1234 invariant now
+      // lives inside the wrapper rather than this widget.
+      expect(find.byType(SparkiloTileLayer), findsOneWidget);
+    });
   });
 
   group('StationMapLayers.orderedByPriceForPainting (#2434)', () {
@@ -235,20 +240,20 @@ void main() {
     // stations so the cheapest (green) marker ends up LAST (top) and a
     // price-less marker ends up FIRST (bottom, beneath every real price).
     Station station(String id, {double? diesel, double? e10}) => Station(
-          id: id,
-          name: id,
-          brand: 'Brand $id',
-          street: 'Street',
-          houseNumber: '1',
-          postCode: '10178',
-          place: 'Berlin',
-          lat: 52.0,
-          lng: 13.0,
-          dist: 1.0,
-          diesel: diesel,
-          e10: e10,
-          isOpen: true,
-        );
+      id: id,
+      name: id,
+      brand: 'Brand $id',
+      street: 'Street',
+      houseNumber: '1',
+      postCode: '10178',
+      place: 'Berlin',
+      lat: 52.0,
+      lng: 13.0,
+      dist: 1.0,
+      diesel: diesel,
+      e10: e10,
+      isOpen: true,
+    );
 
     test('orders cheapest LAST (painted on top), most expensive FIRST', () {
       final cheap = station('cheap', diesel: 1.50);
@@ -256,10 +261,11 @@ void main() {
       final expensive = station('expensive', diesel: 1.90);
 
       // Feed them in an arbitrary order.
-      final ordered = StationMapLayers.orderedByPriceForPainting(
-        [mid, expensive, cheap],
-        FuelType.diesel,
-      );
+      final ordered = StationMapLayers.orderedByPriceForPainting([
+        mid,
+        expensive,
+        cheap,
+      ], FuelType.diesel);
 
       // Bottom → top of the paint stack: expensive, mid, cheap.
       expect(
@@ -274,21 +280,27 @@ void main() {
       final expensive = station('expensive', diesel: 1.90);
       final noPrice = station('noprice'); // no diesel, no fallback fuel
 
-      final ordered = StationMapLayers.orderedByPriceForPainting(
-        [cheap, noPrice, expensive],
-        FuelType.diesel,
-      );
+      final ordered = StationMapLayers.orderedByPriceForPainting([
+        cheap,
+        noPrice,
+        expensive,
+      ], FuelType.diesel);
 
       // The null-price marker is first (very bottom) so it can never
       // cover a real green one; cheapest is still last (top).
-      expect(ordered.first.id, 'noprice',
-          reason: 'price-less marker must sit beneath every priced one');
-      expect(ordered.last.id, 'cheap',
-          reason: 'cheapest priced marker must still paint on top');
+      expect(
+        ordered.first.id,
+        'noprice',
+        reason: 'price-less marker must sit beneath every priced one',
+      );
+      expect(
+        ordered.last.id,
+        'cheap',
+        reason: 'cheapest priced marker must still paint on top',
+      );
     });
 
-    test(
-        'orders by the STRICT selected-fuel price, matching the marker '
+    test('orders by the STRICT selected-fuel price, matching the marker '
         'colour (#2510)', () {
       // User has DIESEL selected. `e10Only` has NO diesel price — under
       // #2510 the marker shows "--" (no E10 fallback), so its z-order key
@@ -297,10 +309,10 @@ void main() {
       final dieselPriced = station('diesel-priced', diesel: 1.95);
       final e10Only = station('e10-only', e10: 1.40);
 
-      final ordered = StationMapLayers.orderedByPriceForPainting(
-        [dieselPriced, e10Only],
-        FuelType.diesel,
-      );
+      final ordered = StationMapLayers.orderedByPriceForPainting([
+        dieselPriced,
+        e10Only,
+      ], FuelType.diesel);
 
       // The price-less (for diesel) station sits at the bottom; the real
       // diesel marker paints on top of it.
@@ -309,23 +321,23 @@ void main() {
     });
 
     test('is a pure function — does not mutate the input list', () {
-      final input = [
-        station('a', diesel: 1.90),
-        station('b', diesel: 1.50),
-      ];
+      final input = [station('a', diesel: 1.90), station('b', diesel: 1.50)];
       final before = input.map((s) => s.id).toList();
       StationMapLayers.orderedByPriceForPainting(input, FuelType.diesel);
-      expect(input.map((s) => s.id).toList(), before,
-          reason: 'helper must return a new list, leaving the input intact');
+      expect(
+        input.map((s) => s.id).toList(),
+        before,
+        reason: 'helper must return a new list, leaving the input intact',
+      );
     });
 
     test('is stable for equal prices (preserves relative order)', () {
       final first = station('first', diesel: 1.70);
       final second = station('second', diesel: 1.70);
-      final ordered = StationMapLayers.orderedByPriceForPainting(
-        [first, second],
-        FuelType.diesel,
-      );
+      final ordered = StationMapLayers.orderedByPriceForPainting([
+        first,
+        second,
+      ], FuelType.diesel);
       expect(ordered.map((s) => s.id).toList(), ['first', 'second']);
     });
   });
@@ -338,23 +350,23 @@ void main() {
   // huge / zoomed-far set (>= [StationMapLayers.clusterThreshold]).
   group('StationMapLayers de-clustering (#2510)', () {
     List<Station> nStations(int n) => List.generate(
-          n,
-          (i) => Station(
-            id: 'st-$i',
-            name: 'Station $i',
-            brand: 'Brand',
-            street: 'Street',
-            houseNumber: '$i',
-            postCode: '10178',
-            place: 'Berlin',
-            // Cluster them tightly around the centre so overlap is realistic.
-            lat: 52.5210 + i * 0.0005,
-            lng: 13.4100 + i * 0.0005,
-            dist: 0.8 + i * 0.1,
-            diesel: 1.50 + i * 0.01,
-            isOpen: true,
-          ),
-        );
+      n,
+      (i) => Station(
+        id: 'st-$i',
+        name: 'Station $i',
+        brand: 'Brand',
+        street: 'Street',
+        houseNumber: '$i',
+        postCode: '10178',
+        place: 'Berlin',
+        // Cluster them tightly around the centre so overlap is realistic.
+        lat: 52.5210 + i * 0.0005,
+        lng: 13.4100 + i * 0.0005,
+        dist: 0.8 + i * 0.1,
+        diesel: 1.50 + i * 0.01,
+        isOpen: true,
+      ),
+    );
 
     Future<void> pumpWith(
       WidgetTester tester,
@@ -371,6 +383,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: StationMapLayers(
               mapController: mapController,
@@ -399,21 +413,20 @@ void main() {
       },
     );
 
-    testWidgets(
-      'every one of the 10 stations renders its own marker',
-      (tester) async {
-        await pumpWith(tester, nStations(10));
-        // Collect the markers from the station MarkerLayer(s) — exclude the
-        // single-marker centre layer.
-        final stationMarkers = tester
-            .widgetList<MarkerLayer>(find.byType(MarkerLayer))
-            .expand((l) => l.markers)
-            .where((m) => m.width != 20) // 20 == the centre dot
-            .toList();
-        // All 10 stations are present as individual markers, none hidden.
-        expect(stationMarkers.length, 10);
-      },
-    );
+    testWidgets('every one of the 10 stations renders its own marker', (
+      tester,
+    ) async {
+      await pumpWith(tester, nStations(10));
+      // Collect the markers from the station MarkerLayer(s) — exclude the
+      // single-marker centre layer.
+      final stationMarkers = tester
+          .widgetList<MarkerLayer>(find.byType(MarkerLayer))
+          .expand((l) => l.markers)
+          .where((m) => m.width != 20) // 20 == the centre dot
+          .toList();
+      // All 10 stations are present as individual markers, none hidden.
+      expect(stationMarkers.length, 10);
+    });
 
     testWidgets(
       'the cheapest stations are EMPHASIZED with the full price bubble '
@@ -427,17 +440,20 @@ void main() {
             .expand((l) => l.markers)
             .where((m) => m.width != 20)
             .toList();
-        final fullBubbles =
-            stationMarkers.where((m) => m.width == kStationMarkerWidth).length;
-        final dots =
-            stationMarkers.where((m) => m.width == kStationDotSize).length;
+        final fullBubbles = stationMarkers
+            .where((m) => m.width == kStationMarkerWidth)
+            .length;
+        final dots = stationMarkers
+            .where((m) => m.width == kStationDotSize)
+            .length;
         expect(fullBubbles, StationMapLayers.emphasisCount);
         expect(dots, 10 - StationMapLayers.emphasisCount);
       },
     );
 
-    testWidgets('a SINGLE station renders as its own marker (no cluster)',
-        (tester) async {
+    testWidgets('a SINGLE station renders as its own marker (no cluster)', (
+      tester,
+    ) async {
       await pumpWith(tester, const [_seedStation]);
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
@@ -451,8 +467,9 @@ void main() {
       },
     );
 
-    testWidgets('renders no marker/cluster layer for an empty station set',
-        (tester) async {
+    testWidgets('renders no marker/cluster layer for an empty station set', (
+      tester,
+    ) async {
       await pumpWith(tester, const []);
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
@@ -556,6 +573,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: StationMapLayers(
               mapController: mapController,
@@ -609,12 +628,20 @@ void main() {
         // The legacy blanket path: every station goes through the cluster
         // layer, and there is NO separate un-clustered selected pill layer.
         final cluster = tester.widget<MarkerClusterLayerWidget>(
-            find.byType(MarkerClusterLayerWidget));
-        expect(cluster.options.markers.length, 5,
-            reason: 'blanket clusterAlways routes ALL stations through the '
-                'cluster layer');
-        expect(stationMarkerLayerMarkers(tester), isEmpty,
-            reason: 'no station MarkerLayer when everything is clustered');
+          find.byType(MarkerClusterLayerWidget),
+        );
+        expect(
+          cluster.options.markers.length,
+          5,
+          reason:
+              'blanket clusterAlways routes ALL stations through the '
+              'cluster layer',
+        );
+        expect(
+          stationMarkerLayerMarkers(tester),
+          isEmpty,
+          reason: 'no station MarkerLayer when everything is clustered',
+        );
       },
     );
 
@@ -632,9 +659,13 @@ void main() {
 
         // The cluster layer receives ONLY the 3 unselected markers.
         final cluster = tester.widget<MarkerClusterLayerWidget>(
-            find.byType(MarkerClusterLayerWidget));
-        expect(cluster.options.markers.length, 3,
-            reason: 'only the unselected stations are clustered');
+          find.byType(MarkerClusterLayerWidget),
+        );
+        expect(
+          cluster.options.markers.length,
+          3,
+          reason: 'only the unselected stations are clustered',
+        );
         final clusteredIds = cluster.options.markers
             .map((m) => stationForMarker(m, unselected)?.id)
             .toSet();
@@ -644,10 +675,13 @@ void main() {
         // a plain MarkerLayer (1:1 list↔map mapping survives).
         final pills = stationMarkerLayerMarkers(tester);
         final allStations = [...selected, ...unselected];
-        final pillIds =
-            pills.map((m) => stationForMarker(m, allStations)?.id).toSet();
-        expect(pillIds, {'sel-a', 'sel-b'},
-            reason: 'exactly the selected stations stay un-clustered');
+        final pillIds = pills
+            .map((m) => stationForMarker(m, allStations)?.id)
+            .toSet();
+        expect(pillIds, {
+          'sel-a',
+          'sel-b',
+        }, reason: 'exactly the selected stations stay un-clustered');
       },
     );
 
@@ -667,66 +701,71 @@ void main() {
         // A selected station is ALWAYS the full pill (kStationMarkerWidth),
         // never a compact dot — the vivid selected styling is preserved.
         for (final m in pills) {
-          expect(m.width, kStationMarkerWidth,
-              reason: 'selected markers keep the full price pill, not a dot');
+          expect(
+            m.width,
+            kStationMarkerWidth,
+            reason: 'selected markers keep the full price pill, not a dot',
+          );
         }
       },
     );
 
-    testWidgets(
-      'GREEN: a cross-border UNSELECTED station clusters with its '
-      'fuelResolver-derived price (not "--") — cheapest rollup composes with '
-      'the resolved MarkerMeta.price (#2631)',
-      (tester) async {
-        // `crossBorder` has NO e10 but DOES have e5; the resolver maps it to
-        // e5 (its country fuel) so its cluster contributes a real price.
-        const crossBorder = Station(
-          id: 'un-cross',
-          name: 'Cross-border ES',
-          brand: 'Brand',
-          street: 'Street',
-          postCode: '00000',
-          place: 'Girona',
-          lat: 52.5215,
-          lng: 13.4105,
-          dist: 0.75,
-          e5: 1.42, // its real price is in e5, NOT e10
-          isOpen: true,
-        );
-        FuelType resolve(Station s) =>
-            s.id == 'un-cross' ? FuelType.e5 : FuelType.e10;
+    testWidgets('GREEN: a cross-border UNSELECTED station clusters with its '
+        'fuelResolver-derived price (not "--") — cheapest rollup composes with '
+        'the resolved MarkerMeta.price (#2631)', (tester) async {
+      // `crossBorder` has NO e10 but DOES have e5; the resolver maps it to
+      // e5 (its country fuel) so its cluster contributes a real price.
+      const crossBorder = Station(
+        id: 'un-cross',
+        name: 'Cross-border ES',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '00000',
+        place: 'Girona',
+        lat: 52.5215,
+        lng: 13.4105,
+        dist: 0.75,
+        e5: 1.42, // its real price is in e5, NOT e10
+        isOpen: true,
+      );
+      FuelType resolve(Station s) =>
+          s.id == 'un-cross' ? FuelType.e5 : FuelType.e10;
 
-        await pumpSelectionAware(
-          tester,
-          stations: [...selected, crossBorder, ...unselected],
-          selectedIds: {'sel-a', 'sel-b'},
-          excludeSelectedFromClustering: true,
-          fuelResolver: resolve,
-        );
+      await pumpSelectionAware(
+        tester,
+        stations: [...selected, crossBorder, ...unselected],
+        selectedIds: {'sel-a', 'sel-b'},
+        excludeSelectedFromClustering: true,
+        fuelResolver: resolve,
+      );
 
-        // The cross-border station is unselected → it goes to the cluster.
-        final cluster = tester.widget<MarkerClusterLayerWidget>(
-            find.byType(MarkerClusterLayerWidget));
-        final crossMarker = cluster.options.markers.firstWhere(
-          (m) =>
-              (m.point.latitude - crossBorder.lat).abs() < 1e-9 &&
-              (m.point.longitude - crossBorder.lng).abs() < 1e-9,
-        );
+      // The cross-border station is unselected → it goes to the cluster.
+      final cluster = tester.widget<MarkerClusterLayerWidget>(
+        find.byType(MarkerClusterLayerWidget),
+      );
+      final crossMarker = cluster.options.markers.firstWhere(
+        (m) =>
+            (m.point.latitude - crossBorder.lat).abs() < 1e-9 &&
+            (m.point.longitude - crossBorder.lng).abs() < 1e-9,
+      );
 
-        // The per-marker meta the cluster builder rolls up from. The clustered
-        // cross-border station carries its RESOLVED e5 price (1.42), not the
-        // strict-e10 '--' (null) it would otherwise have — so the cheapest
-        // rollup uses a real value, not '--' (#2631).
-        final state = tester.state(find.byType(StationMapLayers));
-        final metaMap = (state as dynamic).markerMetaForTesting
-            as Map<Marker, MarkerMeta>;
-        final meta = metaMap[crossMarker];
-        expect(meta, isNotNull);
-        expect(meta!.price, 1.42,
-            reason: 'cluster rollup uses the fuelResolver-derived price so a '
-                'cross-border station contributes a real value, not "--"');
-      },
-    );
+      // The per-marker meta the cluster builder rolls up from. The clustered
+      // cross-border station carries its RESOLVED e5 price (1.42), not the
+      // strict-e10 '--' (null) it would otherwise have — so the cheapest
+      // rollup uses a real value, not '--' (#2631).
+      final state = tester.state(find.byType(StationMapLayers));
+      final metaMap =
+          (state as dynamic).markerMetaForTesting as Map<Marker, MarkerMeta>;
+      final meta = metaMap[crossMarker];
+      expect(meta, isNotNull);
+      expect(
+        meta!.price,
+        1.42,
+        reason:
+            'cluster rollup uses the fuelResolver-derived price so a '
+            'cross-border station contributes a real value, not "--"',
+      );
+    });
 
     testWidgets(
       'with NO selection, excludeSelectedFromClustering folds everything into '
@@ -740,9 +779,13 @@ void main() {
         );
 
         final cluster = tester.widget<MarkerClusterLayerWidget>(
-            find.byType(MarkerClusterLayerWidget));
-        expect(cluster.options.markers.length, 5,
-            reason: 'with no selection, every station clusters as normal');
+          find.byType(MarkerClusterLayerWidget),
+        );
+        expect(
+          cluster.options.markers.length,
+          5,
+          reason: 'with no selection, every station clusters as normal',
+        );
         expect(stationMarkerLayerMarkers(tester), isEmpty);
       },
     );

--- a/test/features/obd2/presentation/obd2_connection_error_l10n_test.dart
+++ b/test/features/obd2/presentation/obd2_connection_error_l10n_test.dart
@@ -40,12 +40,9 @@ void main() {
     expect(engineOff.toLowerCase(), contains('engine'));
     expect(engineOff, isNot(l10n.obd2ErrorAdapterUnresponsive));
     // The reworded adapter-unresponsive string no longer says "ignition".
-    expect(l10n.obd2ErrorAdapterUnresponsive.toLowerCase(),
-        isNot(contains('ignition')));
-  });
-
-  test('falls back to the English diagnostic when l10n is null', () {
-    const error = Obd2ScanTimeout();
-    expect(error.localizedMessage(null), error.message);
+    expect(
+      l10n.obd2ErrorAdapterUnresponsive.toLowerCase(),
+      isNot(contains('ignition')),
+    );
   });
 }

--- a/test/features/obd2/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/obd2/presentation/widgets/obd2_adapter_picker_test.dart
@@ -32,8 +32,9 @@ void main() {
       expect(find.byKey(const Key('obdPickerScanning')), findsOneWidget);
     });
 
-    testWidgets('renders the ranked candidates once scan emits',
-        (tester) async {
+    testWidgets('renders the ranked candidates once scan emits', (
+      tester,
+    ) async {
       final svc = _buildService([
         [
           _scanHit(name: 'vLinker FD', rssi: -55),
@@ -51,36 +52,38 @@ void main() {
     });
 
     testWidgets(
-        '#3103 — recognized + NAMED-unrecognized render in two sections, with '
-        'the BLE-only notice when Classic discovery is unavailable',
-        (tester) async {
-      final svc = _buildService([
-        [
-          _scanHit(name: 'vLinker FD', rssi: -50), // recognized BLE profile
-          _scanHit(name: 'My Random Dongle', rssi: -70), // named, unknown
-        ],
-      ]);
-      await _pump(tester, svc);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+      '#3103 — recognized + NAMED-unrecognized render in two sections, with '
+      'the BLE-only notice when Classic discovery is unavailable',
+      (tester) async {
+        final svc = _buildService([
+          [
+            _scanHit(name: 'vLinker FD', rssi: -50), // recognized BLE profile
+            _scanHit(name: 'My Random Dongle', rssi: -70), // named, unknown
+          ],
+        ]);
+        await _pump(tester, svc);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      // The recognized adapter shows as before.
-      expect(find.text('vLinker FD'), findsOneWidget);
-      // The unrecognized device is SURFACED (not dropped) under the "other
-      // devices" header with a tap-to-try subtitle.
-      expect(find.text('My Random Dongle'), findsOneWidget);
-      expect(find.text('Other Bluetooth devices'), findsOneWidget);
-      expect(find.textContaining('Unrecognized — tap to try'), findsOneWidget);
-      // _buildService wires no Classic facade ⇒ supportsClassicDiscovery is
-      // false ⇒ the iOS-style "BLE adapters only" notice is shown.
-      expect(
-        find.byKey(const Key('obdPickerBleOnlyNotice')),
-        findsOneWidget,
-      );
-    });
+        // The recognized adapter shows as before.
+        expect(find.text('vLinker FD'), findsOneWidget);
+        // The unrecognized device is SURFACED (not dropped) under the "other
+        // devices" header with a tap-to-try subtitle.
+        expect(find.text('My Random Dongle'), findsOneWidget);
+        expect(find.text('Other Bluetooth devices'), findsOneWidget);
+        expect(
+          find.textContaining('Unrecognized — tap to try'),
+          findsOneWidget,
+        );
+        // _buildService wires no Classic facade ⇒ supportsClassicDiscovery is
+        // false ⇒ the iOS-style "BLE adapters only" notice is shown.
+        expect(find.byKey(const Key('obdPickerBleOnlyNotice')), findsOneWidget);
+      },
+    );
 
-    testWidgets('tapping a candidate transitions to connecting state',
-        (tester) async {
+    testWidgets('tapping a candidate transitions to connecting state', (
+      tester,
+    ) async {
       final svc = _buildService([
         [_scanHit(name: 'vLinker FD', rssi: -55)],
       ]);
@@ -106,33 +109,33 @@ void main() {
     });
 
     testWidgets(
-        'shows the retry button + error message + open-settings CTA on permission denied',
-        (tester) async {
-      final svc = Obd2ConnectionService(
-        registry: Obd2AdapterRegistry.defaults(),
-        permissions: _FakePermissions(Obd2PermissionState.denied),
-        bluetooth: _StreamingFacade(const []),
-      );
-      await _pump(tester, svc);
-      await tester.pumpAndSettle();
-      expect(find.byKey(const Key('obdPickerError')), findsOneWidget);
-      // The denial error message itself is rendered.
-      expect(
-        find.text('Bluetooth permission denied'),
-        findsOneWidget,
-      );
-      // Retry stays visible — the user might be on a transient denial
-      // (first prompt, "Don't Allow") and Retry will re-prompt.
-      expect(find.byKey(const Key('obdPickerRetry')), findsOneWidget);
-      // New CTA introduced for the iOS permanently-denied case: deep-
-      // link into the app's Settings row so the user can flip the
-      // Bluetooth toggle. Tappable by key — we don't verify the platform
-      // channel call here (it's a no-op in widget tests by default).
-      expect(
-        find.byKey(const Key('obdPickerOpenSettings')),
-        findsOneWidget,
-      );
-    });
+      'shows the retry button + error message + open-settings CTA on permission denied',
+      (tester) async {
+        final svc = Obd2ConnectionService(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _FakePermissions(Obd2PermissionState.denied),
+          bluetooth: _StreamingFacade(const []),
+        );
+        await _pump(tester, svc);
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('obdPickerError')), findsOneWidget);
+        // The denial error message itself is rendered.
+        expect(
+          find.text(
+            'Bluetooth permission is required to connect to an OBD2 adapter.',
+          ),
+          findsOneWidget,
+        );
+        // Retry stays visible — the user might be on a transient denial
+        // (first prompt, "Don't Allow") and Retry will re-prompt.
+        expect(find.byKey(const Key('obdPickerRetry')), findsOneWidget);
+        // New CTA introduced for the iOS permanently-denied case: deep-
+        // link into the app's Settings row so the user can flip the
+        // Bluetooth toggle. Tappable by key — we don't verify the platform
+        // channel call here (it's a no-op in widget tests by default).
+        expect(find.byKey(const Key('obdPickerOpenSettings')), findsOneWidget);
+      },
+    );
   });
 
   // #1188 — pinned-MAC fast path. `showObd2AdapterPicker` accepts a
@@ -140,8 +143,9 @@ void main() {
   // a silent direct connect via [Obd2ConnectionService.connectByMac]
   // and only falls back to the modal sheet when that fails.
   group('showObd2AdapterPicker pinned-MAC fast path (#1188)', () {
-    testWidgets('pinnedMac=null shows the sheet (regression check)',
-        (tester) async {
+    testWidgets('pinnedMac=null shows the sheet (regression check)', (
+      tester,
+    ) async {
       final svc = _RecordingFakeConnection.success();
       final completer = Completer<Obd2Service?>();
 
@@ -170,106 +174,108 @@ void main() {
       expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
       expect(svc.connectByMacCalls, isEmpty);
       // Tear down the open future cleanly.
-      Navigator.of(tester.element(find.text('Pick an OBD2 adapter')))
-          .pop();
+      Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
       await tester.pumpAndSettle();
       await completer.future;
     });
 
     testWidgets(
-        'pinnedMac with successful connect resolves silently (no sheet)',
-        (tester) async {
-      final fakeService = _NoopObd2Service();
-      final svc = _RecordingFakeConnection(
-        connectByMacResult: fakeService,
-      );
-      final completer = Completer<Obd2Service?>();
+      'pinnedMac with successful connect resolves silently (no sheet)',
+      (tester) async {
+        final fakeService = _NoopObd2Service();
+        final svc = _RecordingFakeConnection(connectByMacResult: fakeService);
+        final completer = Completer<Obd2Service?>();
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: Builder(
-                builder: (ctx) => ElevatedButton(
-                  onPressed: () {
-                    completer.complete(showObd2AdapterPicker(
-                      ctx,
-                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
-                      pinnedAdapterName: 'vLinker FS',
-                    ));
-                  },
-                  child: const Text('open'),
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Builder(
+                  builder: (ctx) => ElevatedButton(
+                    onPressed: () {
+                      completer.complete(
+                        showObd2AdapterPicker(
+                          ctx,
+                          pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                          pinnedAdapterName: 'vLinker FS',
+                        ),
+                      );
+                    },
+                    child: const Text('open'),
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      );
-      await tester.tap(find.text('open'));
-      await tester.pumpAndSettle();
+        );
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
 
-      expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
-      // No sheet rendered.
-      expect(find.text('Pick an OBD2 adapter'), findsNothing);
-      // Future resolved with the service.
-      final resolved = await completer.future;
-      expect(resolved, same(fakeService));
-    });
+        expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
+        // No sheet rendered.
+        expect(find.text('Pick an OBD2 adapter'), findsNothing);
+        // Future resolved with the service.
+        final resolved = await completer.future;
+        expect(resolved, same(fakeService));
+      },
+    );
 
     testWidgets(
-        'pinnedMac with failed connect (returns null) opens sheet + snackbar',
-        (tester) async {
-      final svc = _RecordingFakeConnection(
-        connectByMacResult: null, // simulate timeout / out-of-range
-      );
-      final completer = Completer<Obd2Service?>();
+      'pinnedMac with failed connect (returns null) opens sheet + snackbar',
+      (tester) async {
+        final svc = _RecordingFakeConnection(
+          connectByMacResult: null, // simulate timeout / out-of-range
+        );
+        final completer = Completer<Obd2Service?>();
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: Builder(
-                builder: (ctx) => ElevatedButton(
-                  onPressed: () {
-                    completer.complete(showObd2AdapterPicker(
-                      ctx,
-                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
-                      pinnedAdapterName: 'vLinker FS',
-                    ));
-                  },
-                  child: const Text('open'),
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Builder(
+                  builder: (ctx) => ElevatedButton(
+                    onPressed: () {
+                      completer.complete(
+                        showObd2AdapterPicker(
+                          ctx,
+                          pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                          pinnedAdapterName: 'vLinker FS',
+                        ),
+                      );
+                    },
+                    child: const Text('open'),
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      );
-      await tester.tap(find.text('open'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        );
+        await tester.tap(find.text('open'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
-      // Sheet IS rendered now (fallback) — its title shows.
-      expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
-      // Snackbar with the pinned name carries the localized message.
-      expect(
-        find.textContaining("Couldn't reach 'vLinker FS'"),
-        findsOneWidget,
-      );
+        expect(svc.connectByMacCalls, ['AA:BB:CC:DD:EE:FF']);
+        // Sheet IS rendered now (fallback) — its title shows.
+        expect(find.text('Pick an OBD2 adapter'), findsOneWidget);
+        // Snackbar with the pinned name carries the localized message.
+        expect(
+          find.textContaining("Couldn't reach 'vLinker FS'"),
+          findsOneWidget,
+        );
 
-      // Drain the picker — the underlying scan stream is empty so it
-      // sits in `scanning`. Pop the sheet to resolve the future.
-      Navigator.of(tester.element(find.text('Pick an OBD2 adapter')))
-          .pop();
-      await tester.pumpAndSettle();
-      await completer.future;
-    });
+        // Drain the picker — the underlying scan stream is empty so it
+        // sits in `scanning`. Pop the sheet to resolve the future.
+        Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
+        await tester.pumpAndSettle();
+        await completer.future;
+      },
+    );
   });
 
   // #2745 — error-log #14 trace #5: an `[ui] Obd2AdapterUnresponsive` ERROR
@@ -297,9 +303,11 @@ void main() {
             home: Scaffold(
               body: Builder(
                 builder: (ctx) => ElevatedButton(
-                  onPressed: () => showObd2AdapterPicker(ctx,
-                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
-                      pinnedAdapterName: 'vLinker FS'),
+                  onPressed: () => showObd2AdapterPicker(
+                    ctx,
+                    pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                    pinnedAdapterName: 'vLinker FS',
+                  ),
                   child: const Text('open'),
                 ),
               ),
@@ -313,27 +321,35 @@ void main() {
     }
 
     testWidgets(
-        'an expected Obd2AdapterUnresponsive is a breadcrumb, NOT an ERROR',
-        (tester) async {
-      await pumpAndOpen(tester, const Obd2AdapterUnresponsive());
+      'an expected Obd2AdapterUnresponsive is a breadcrumb, NOT an ERROR',
+      (tester) async {
+        await pumpAndOpen(tester, const Obd2AdapterUnresponsive());
 
-      expect(rec.errors, isEmpty,
-          reason: 'an already-user-surfaced condition must NOT ERROR-log');
-      expect(
-        BreadcrumbCollector.snapshot().map((b) => b.action),
-        contains('OBD2 connect failed — expected user condition'),
-      );
+        expect(
+          rec.errors,
+          isEmpty,
+          reason: 'an already-user-surfaced condition must NOT ERROR-log',
+        );
+        expect(
+          BreadcrumbCollector.snapshot().map((b) => b.action),
+          contains('OBD2 connect failed — expected user condition'),
+        );
 
-      Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
-      await tester.pumpAndSettle();
-    });
+        Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
+        await tester.pumpAndSettle();
+      },
+    );
 
-    testWidgets('a genuine Obd2PermissionDenied STILL ERROR-logs (the guard)',
-        (tester) async {
+    testWidgets('a genuine Obd2PermissionDenied STILL ERROR-logs (the guard)', (
+      tester,
+    ) async {
       await pumpAndOpen(tester, const Obd2PermissionDenied());
 
-      expect(rec.errors, hasLength(1),
-          reason: 'permission denial is a genuine, diagnostic-worthy fault');
+      expect(
+        rec.errors,
+        hasLength(1),
+        reason: 'permission denial is a genuine, diagnostic-worthy fault',
+      );
       expect(rec.errors.single.toString(), contains('pinned connect failed'));
 
       Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
@@ -359,73 +375,77 @@ void main() {
     });
 
     testWidgets(
-        'unmounting the sheet before connect resolves does NOT ref-after-unmount',
-        (tester) async {
-      final list = _RecordingVehicleList([
-        const VehicleProfile(id: 'v1', name: 'Golf'),
-      ]);
-      // connect() is gated on a completer the test controls, so we can
-      // unmount the sheet while it is still pending.
-      final svc = _GatedConnection();
+      'unmounting the sheet before connect resolves does NOT ref-after-unmount',
+      (tester) async {
+        final list = _RecordingVehicleList([
+          const VehicleProfile(id: 'v1', name: 'Golf'),
+        ]);
+        // connect() is gated on a completer the test controls, so we can
+        // unmount the sheet while it is still pending.
+        final svc = _GatedConnection();
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            obd2ConnectionProvider.overrideWith((_) => svc),
-            vehicleProfileListProvider.overrideWith(() => list),
-            activeVehicleProfileProvider.overrideWith(
-              () => _StubActiveVehicle(
-                const VehicleProfile(id: 'v1', name: 'Golf'),
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              obd2ConnectionProvider.overrideWith((_) => svc),
+              vehicleProfileListProvider.overrideWith(() => list),
+              activeVehicleProfileProvider.overrideWith(
+                () => _StubActiveVehicle(
+                  const VehicleProfile(id: 'v1', name: 'Golf'),
+                ),
               ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: Obd2AdapterPickerSheet()),
             ),
-          ],
-          child: const MaterialApp(
-            home: Scaffold(body: Obd2AdapterPickerSheet()),
           ),
-        ),
-      );
-      // Scan emits one candidate → selecting state with a tappable tile.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tap(find.text('vLinker FD'));
-      await tester.pump(); // flips to connecting; connect() now pending.
+        );
+        // Scan emits one candidate → selecting state with a tappable tile.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(find.text('vLinker FD'));
+        await tester.pump(); // flips to connecting; connect() now pending.
 
-      // Dismiss the sheet WHILE connect() is still in flight — this is the
-      // crash window: the sheet unmounts, then connect() resolves and the
-      // post-await persist runs.
-      await tester.pumpWidget(
-        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
-      );
-      expect(
-        find.byType(Obd2AdapterPickerSheet),
-        findsNothing,
-        reason: 'sheet must be unmounted before connect resolves',
-      );
+        // Dismiss the sheet WHILE connect() is still in flight — this is the
+        // crash window: the sheet unmounts, then connect() resolves and the
+        // post-await persist runs.
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+        );
+        expect(
+          find.byType(Obd2AdapterPickerSheet),
+          findsNothing,
+          reason: 'sheet must be unmounted before connect resolves',
+        );
 
-      // Now resolve the connect — on master this drove a ref read after
-      // unmount, swallowed into a `[ui] Bad state` ERROR trace.
-      svc.completeConnect(_NoopObd2Service());
-      await tester.pump();
-      await tester.pump();
+        // Now resolve the connect — on master this drove a ref read after
+        // unmount, swallowed into a `[ui] Bad state` ERROR trace.
+        svc.completeConnect(_NoopObd2Service());
+        await tester.pump();
+        await tester.pump();
 
-      // No ref-after-unmount StateError reached the error logger.
-      final unmountErrors = rec.errors
-          .map((e) => e.toString())
-          .where((s) => s.contains('unmounted') || s.contains('Bad state'))
-          .toList();
-      expect(
-        unmountErrors,
-        isEmpty,
-        reason: 'post-await persist must not touch `ref` after unmount',
-      );
-      // The persist still happened via the pre-await capture — the picked
-      // adapter MAC was written even though the sheet was gone.
-      expect(list.savedProfiles, hasLength(1));
-      expect(list.savedProfiles.single.obd2AdapterMac, 'id-vLinker FD');
-    });
+        // No ref-after-unmount StateError reached the error logger.
+        final unmountErrors = rec.errors
+            .map((e) => e.toString())
+            .where((s) => s.contains('unmounted') || s.contains('Bad state'))
+            .toList();
+        expect(
+          unmountErrors,
+          isEmpty,
+          reason: 'post-await persist must not touch `ref` after unmount',
+        );
+        // The persist still happened via the pre-await capture — the picked
+        // adapter MAC was written even though the sheet was gone.
+        expect(list.savedProfiles, hasLength(1));
+        expect(list.savedProfiles.single.obd2AdapterMac, 'id-vLinker FD');
+      },
+    );
 
-    testWidgets('the mounted path still persists the picked adapter',
-        (tester) async {
+    testWidgets('the mounted path still persists the picked adapter', (
+      tester,
+    ) async {
       final list = _RecordingVehicleList([
         const VehicleProfile(id: 'v1', name: 'Golf'),
       ]);
@@ -444,6 +464,8 @@ void main() {
             ),
           ],
           child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: Obd2AdapterPickerSheet()),
           ),
         ),
@@ -498,11 +520,11 @@ class _StubActiveVehicle extends ActiveVehicleProfile {
 /// single candidate so the picker reaches `selecting` with a tappable tile.
 class _GatedConnection extends Obd2ConnectionService {
   _GatedConnection()
-      : super(
-          registry: Obd2AdapterRegistry.defaults(),
-          permissions: _FakePermissions(Obd2PermissionState.granted),
-          bluetooth: _StreamingFacade(const []),
-        );
+    : super(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.granted),
+        bluetooth: _StreamingFacade(const []),
+      );
 
   final Completer<Obd2Service> _connectGate = Completer<Obd2Service>();
 
@@ -533,8 +555,11 @@ class _GatedConnection extends Obd2ConnectionService {
 class _CaptureRecorder implements TraceRecorder {
   final errors = <Object>[];
   @override
-  Future<void> record(Object error, StackTrace stackTrace,
-      {ServiceChainSnapshot? serviceChainState}) async {
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
     errors.add(error);
   }
 
@@ -551,11 +576,11 @@ class _CaptureRecorder implements TraceRecorder {
 /// "the sheet IS rendered" without chasing further state transitions.
 class _RecordingFakeConnection extends Obd2ConnectionService {
   _RecordingFakeConnection({this.connectByMacResult, this.connectByMacError})
-      : super(
-          registry: Obd2AdapterRegistry.defaults(),
-          permissions: _FakePermissions(Obd2PermissionState.granted),
-          bluetooth: _StreamingFacade(const []),
-        );
+    : super(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.granted),
+        bluetooth: _StreamingFacade(const []),
+      );
   factory _RecordingFakeConnection.success() =>
       _RecordingFakeConnection(connectByMacResult: _NoopObd2Service());
 
@@ -591,10 +616,7 @@ class _NoopObd2Service implements Obd2Service {
 
 // --- helpers ---------------------------------------------------------
 
-Future<void> _pump(
-  WidgetTester tester,
-  Obd2ConnectionService svc,
-) async {
+Future<void> _pump(WidgetTester tester, Obd2ConnectionService svc) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -611,14 +633,15 @@ Future<void> _pump(
         ),
       ],
       child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(body: Obd2AdapterPickerSheet()),
       ),
     ),
   );
 }
 
-Obd2ConnectionService _buildService(
-    List<List<Obd2AdapterCandidate>> batches) {
+Obd2ConnectionService _buildService(List<List<Obd2AdapterCandidate>> batches) {
   return Obd2ConnectionService(
     registry: Obd2AdapterRegistry.defaults(),
     permissions: _FakePermissions(Obd2PermissionState.granted),
@@ -663,10 +686,7 @@ class _StreamingFacade implements BluetoothFacade {
   Future<void> stopScan() async {}
 
   @override
-  ElmByteChannel channelFor(
-    String deviceId,
-    Obd2AdapterProfile profile,
-  ) =>
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
       _SilentChannel();
 
   @override
@@ -674,8 +694,7 @@ class _StreamingFacade implements BluetoothFacade {
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
     bool autoConnect = false,
-  }) =>
-      _SilentChannel();
+  }) => _SilentChannel();
 }
 
 /// Silent channel — never answers, so the transport's init sequence

--- a/test/features/payment/presentation/scan_payment_dispatcher_test.dart
+++ b/test/features/payment/presentation/scan_payment_dispatcher_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/payment/domain/qr_payment_decoder.dart';
 import 'package:tankstellen/features/payment/presentation/scan_payment_dispatcher.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   setUp(() {
@@ -24,12 +25,10 @@ void main() {
         const QrPaymentUrl('https://example.com/pay?id=42'),
       );
       expect(outcome, ScanPaymentOutcome.launched);
-      expect(_launchedUris.single.toString(),
-          'https://example.com/pay?id=42');
+      expect(_launchedUris.single.toString(), 'https://example.com/pay?id=42');
     });
 
-    test('QrPaymentAppLink → launcher called with the scheme URI',
-        () async {
+    test('QrPaymentAppLink → launcher called with the scheme URI', () async {
       _launcherReturn = true;
       final outcome = await ScanPaymentDispatcher.handle(
         const QrPaymentAppLink(
@@ -55,8 +54,9 @@ void main() {
     });
 
     test('QrPaymentUnknown → unknown outcome', () async {
-      final outcome =
-          await ScanPaymentDispatcher.handle(const QrPaymentUnknown('???'));
+      final outcome = await ScanPaymentDispatcher.handle(
+        const QrPaymentUnknown('???'),
+      );
       expect(outcome, ScanPaymentOutcome.unknown);
       expect(_launchedUris, isEmpty);
     });
@@ -72,8 +72,8 @@ void main() {
     test('launcher throwing → launchFailed (no crash)', () async {
       ScanPaymentDispatcher.launcher =
           (uri, {mode = LaunchMode.externalApplication}) async {
-        throw Exception('boom');
-      };
+            throw Exception('boom');
+          };
       final outcome = await ScanPaymentDispatcher.handle(
         const QrPaymentUrl('https://example.com'),
       );
@@ -108,12 +108,11 @@ void main() {
       expect(_launchedUris.single.scheme, 'iban');
     });
 
-    test('falls back to clipboard when no scheme handler exists',
-        () async {
+    test('falls back to clipboard when no scheme handler exists', () async {
       ScanPaymentDispatcher.probe = (_) async => false;
       _clipboardWrites.clear();
-      ScanPaymentDispatcher.clipboardWriter =
-          (text) async => _clipboardWrites.add(text);
+      ScanPaymentDispatcher.clipboardWriter = (text) async =>
+          _clipboardWrites.add(text);
 
       final outcome = await ScanPaymentDispatcher.tryLaunchEpc(sample);
       expect(outcome, EpcLaunchOutcome.copiedToClipboard);
@@ -124,19 +123,21 @@ void main() {
 
     test('clipboard failure surfaces as failed outcome', () async {
       ScanPaymentDispatcher.probe = (_) async => false;
-      ScanPaymentDispatcher.clipboardWriter =
-          (_) async => throw Exception('no clipboard');
+      ScanPaymentDispatcher.clipboardWriter = (_) async =>
+          throw Exception('no clipboard');
       final outcome = await ScanPaymentDispatcher.tryLaunchEpc(sample);
       expect(outcome, EpcLaunchOutcome.failed);
     });
 
-    test('missing IBAN → failed (cannot copy or launch anything useful)',
-        () async {
-      ScanPaymentDispatcher.probe = (_) async => false;
-      const noIban = QrPaymentEpc(raw: 'BCD', beneficiary: 'ACME');
-      final outcome = await ScanPaymentDispatcher.tryLaunchEpc(noIban);
-      expect(outcome, EpcLaunchOutcome.failed);
-    });
+    test(
+      'missing IBAN → failed (cannot copy or launch anything useful)',
+      () async {
+        ScanPaymentDispatcher.probe = (_) async => false;
+        const noIban = QrPaymentEpc(raw: 'BCD', beneficiary: 'ACME');
+        final outcome = await ScanPaymentDispatcher.tryLaunchEpc(noIban);
+        expect(outcome, EpcLaunchOutcome.failed);
+      },
+    );
   });
 
   group('buildEpcDialog (#587)', () {
@@ -157,10 +158,7 @@ void main() {
     });
 
     testWidgets('Cancel pops with false', (tester) async {
-      await _pumpEpcDialog(
-        tester,
-        const QrPaymentEpc(raw: ''),
-      );
+      await _pumpEpcDialog(tester, const QrPaymentEpc(raw: ''));
       await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
       expect(_dialogResult, isFalse);
@@ -174,7 +172,10 @@ final List<Uri> _launchedUris = [];
 final List<String> _clipboardWrites = [];
 bool _launcherReturn = true;
 
-Future<bool> _fakeLauncher(Uri uri, {LaunchMode mode = LaunchMode.externalApplication}) async {
+Future<bool> _fakeLauncher(
+  Uri uri, {
+  LaunchMode mode = LaunchMode.externalApplication,
+}) async {
   _launchedUris.add(uri);
   return _launcherReturn;
 }
@@ -183,11 +184,12 @@ Future<bool> _alwaysTrueProbe(Uri uri) async => true;
 
 bool? _dialogResult;
 
-Future<void> _pumpEpcDialog(
-    WidgetTester tester, QrPaymentEpc epc) async {
+Future<void> _pumpEpcDialog(WidgetTester tester, QrPaymentEpc epc) async {
   _dialogResult = null;
   await tester.pumpWidget(
     MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Builder(
         builder: (outer) => Scaffold(
           body: Center(

--- a/test/features/payment/presentation/widgets/unknown_qr_dialog_test.dart
+++ b/test/features/payment/presentation/widgets/unknown_qr_dialog_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/payment/presentation/widgets/unknown_qr_dialog.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('UnknownQrDialog (#725)', () {
@@ -12,8 +13,9 @@ void main() {
       expect(find.text('weird://gibberish/xyz?a=1&b=2'), findsOneWidget);
     });
 
-    testWidgets('Copy button writes raw to clipboard and pops dialog',
-        (tester) async {
+    testWidgets('Copy button writes raw to clipboard and pops dialog', (
+      tester,
+    ) async {
       final writes = <String>[];
       await _pump(
         tester,
@@ -26,28 +28,29 @@ void main() {
       expect(find.byType(UnknownQrDialog), findsNothing);
     });
 
-    testWidgets('Report button calls onShare with a report body including the raw text',
-        (tester) async {
-      String? capturedText;
-      String? capturedSubject;
-      await _pump(
-        tester,
-        raw: 'mystery://pay/abc',
-        onShare: (text, subject) async {
-          capturedText = text;
-          capturedSubject = subject;
-        },
-      );
-      await tester.tap(find.byKey(const Key('unknownQrReport')));
-      await tester.pumpAndSettle();
-      expect(capturedText, contains('mystery://pay/abc'));
-      expect(capturedText, contains('App version:'));
-      expect(capturedSubject, contains('unrecognised payment QR'));
-      expect(find.byType(UnknownQrDialog), findsNothing);
-    });
+    testWidgets(
+      'Report button calls onShare with a report body including the raw text',
+      (tester) async {
+        String? capturedText;
+        String? capturedSubject;
+        await _pump(
+          tester,
+          raw: 'mystery://pay/abc',
+          onShare: (text, subject) async {
+            capturedText = text;
+            capturedSubject = subject;
+          },
+        );
+        await tester.tap(find.byKey(const Key('unknownQrReport')));
+        await tester.pumpAndSettle();
+        expect(capturedText, contains('mystery://pay/abc'));
+        expect(capturedText, contains('App version:'));
+        expect(capturedSubject, contains('unrecognised payment QR'));
+        expect(find.byType(UnknownQrDialog), findsNothing);
+      },
+    );
 
-    testWidgets('Cancel button pops without any side effects',
-        (tester) async {
+    testWidgets('Cancel button pops without any side effects', (tester) async {
       final writes = <String>[];
       var shareCalled = false;
       await _pump(
@@ -73,6 +76,8 @@ Future<void> _pump(
 }) async {
   await tester.pumpWidget(
     MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Builder(
         builder: (ctx) => Scaffold(
           body: Center(

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -79,13 +79,14 @@ void main() {
       // tests Hive isn't initialised so the spool's default path
       // throws — point the override at a no-op recorder so log() is
       // genuinely silent here.
-      errorLogger.spoolEnqueueOverride = ({
-        required String isolateTaskName,
-        required Object error,
-        StackTrace? stack,
-        Map<String, dynamic>? contextMap,
-        DateTime? timestamp,
-      }) async {};
+      errorLogger.spoolEnqueueOverride =
+          ({
+            required String isolateTaskName,
+            required Object error,
+            StackTrace? stack,
+            Map<String, dynamic>? contextMap,
+            DateTime? timestamp,
+          }) async {};
       addTearDown(errorLogger.resetForTest);
 
       mockStorage = MockStorageRepository();
@@ -97,7 +98,9 @@ void main() {
       when(() => mockStorage.getPriceHistoryKeys()).thenReturn(['k1', 'k2']);
       when(() => mockStorage.profileCount).thenReturn(1);
       when(() => mockStorage.cacheEntryCount).thenReturn(15);
-      when(() => mockStorage.getItineraries()).thenReturn([{'id': 'r1'}]);
+      when(() => mockStorage.getItineraries()).thenReturn([
+        {'id': 'r1'},
+      ]);
       when(() => mockStorage.hasApiKey()).thenReturn(true);
       when(() => mockStorage.hasCustomApiKey()).thenReturn(true);
       when(() => mockStorage.getApiKey()).thenReturn('key');
@@ -115,10 +118,10 @@ void main() {
     });
 
     List<Object> overrides() => [
-          storageRepositoryProvider.overrideWithValue(mockStorage),
-          syncStateProvider.overrideWith(() => _DisabledSyncState()),
-          traceStorageProvider.overrideWithValue(_StubTraceStorage()),
-        ];
+      storageRepositoryProvider.overrideWithValue(mockStorage),
+      syncStateProvider.overrideWith(() => _DisabledSyncState()),
+      traceStorageProvider.overrideWithValue(_StubTraceStorage()),
+    ];
 
     testWidgets('shows local data counts', (tester) async {
       await _setTallSurface(tester);
@@ -129,8 +132,14 @@ void main() {
       );
 
       expect(find.text('5'), findsOneWidget); // favorites
-      expect(find.text('2'), findsAtLeast(1)); // ignored or alerts or price history
-      expect(find.text('1'), findsAtLeast(1)); // ratings or profiles or itineraries
+      expect(
+        find.text('2'),
+        findsAtLeast(1),
+      ); // ignored or alerts or price history
+      expect(
+        find.text('1'),
+        findsAtLeast(1),
+      ); // ratings or profiles or itineraries
       expect(find.text('15'), findsOneWidget); // cache entries
     });
 
@@ -147,8 +156,7 @@ void main() {
       // hasEvApiKey=false → No row hidden behind the #1530
       // 'Show N empty rows' toggle. Reveal it to verify the No row
       // is still present in the rendered tree.
-      await tester
-          .tap(find.byKey(const Key('privacyShowAllRowsToggle')));
+      await tester.tap(find.byKey(const Key('privacyShowAllRowsToggle')));
       await tester.pumpAndSettle();
       expect(find.text('No'), findsOneWidget);
     });
@@ -161,10 +169,7 @@ void main() {
         overrides: overrides(),
       );
 
-      expect(
-        find.textContaining('Cloud sync is disabled'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Cloud sync is disabled'), findsOneWidget);
     });
 
     testWidgets('shows sync info when sync is enabled', (tester) async {
@@ -184,8 +189,7 @@ void main() {
       expect(find.text('View server data'), findsOneWidget);
     });
 
-    testWidgets(
-        'shows the "Save error log" button labelled with the current '
+    testWidgets('shows the "Save error log" button labelled with the current '
         'trace count (#476, #2145)', (tester) async {
       await _setTallSurface(tester);
       await pumpApp(
@@ -208,15 +212,12 @@ void main() {
         find.byKey(const ValueKey('privacy-export-error-log-button')),
         findsOneWidget,
       );
-      expect(
-        find.textContaining('Save error log (0)'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Save error log (0)'), findsOneWidget);
     });
 
-    testWidgets(
-        'clear error-log button is disabled when the log is empty',
-        (tester) async {
+    testWidgets('clear error-log button is disabled when the log is empty', (
+      tester,
+    ) async {
       await _setTallSurface(tester);
       await pumpApp(
         tester,
@@ -232,37 +233,41 @@ void main() {
       final button = tester.widget<IconButton>(
         find.byKey(const ValueKey('privacy-clear-error-log-button')),
       );
-      expect(button.onPressed, isNull,
-          reason: 'nothing to clear → the reset button is disabled');
+      expect(
+        button.onPressed,
+        isNull,
+        reason: 'nothing to clear → the reset button is disabled',
+      );
     });
 
     testWidgets(
-        'tapping clear error-log clears the traces and confirms (#1971)',
-        (tester) async {
-      await _setTallSurface(tester);
-      final stub = _StubTraceStorage(stubCount: 7);
-      await pumpApp(
-        tester,
-        const PrivacyDashboardScreen(),
-        overrides: [
-          storageRepositoryProvider.overrideWithValue(mockStorage),
-          syncStateProvider.overrideWith(() => _DisabledSyncState()),
-          traceStorageProvider.overrideWithValue(stub),
-        ],
-      );
+      'tapping clear error-log clears the traces and confirms (#1971)',
+      (tester) async {
+        await _setTallSurface(tester);
+        final stub = _StubTraceStorage(stubCount: 7);
+        await pumpApp(
+          tester,
+          const PrivacyDashboardScreen(),
+          overrides: [
+            storageRepositoryProvider.overrideWithValue(mockStorage),
+            syncStateProvider.overrideWith(() => _DisabledSyncState()),
+            traceStorageProvider.overrideWithValue(stub),
+          ],
+        );
 
-      await tester.scrollUntilVisible(
-        find.byKey(const ValueKey('privacy-clear-error-log-button')),
-        50.0,
-      );
-      await tester.tap(
-        find.byKey(const ValueKey('privacy-clear-error-log-button')),
-      );
-      await tester.pumpAndSettle();
+        await tester.scrollUntilVisible(
+          find.byKey(const ValueKey('privacy-clear-error-log-button')),
+          50.0,
+        );
+        await tester.tap(
+          find.byKey(const ValueKey('privacy-clear-error-log-button')),
+        );
+        await tester.pumpAndSettle();
 
-      expect(stub.clearAllCalled, isTrue);
-      expect(find.text('Error log cleared'), findsOneWidget);
-    });
+        expect(stub.clearAllCalled, isTrue);
+        expect(find.text('Error log cleared'), findsOneWidget);
+      },
+    );
 
     testWidgets('shows export button', (tester) async {
       await _setTallSurface(tester);
@@ -287,10 +292,7 @@ void main() {
         overrides: overrides(),
       );
 
-      await tester.scrollUntilVisible(
-        find.text('Delete all data'),
-        200,
-      );
+      await tester.scrollUntilVisible(find.text('Delete all data'), 200);
       expect(find.text('Delete all data'), findsOneWidget);
     });
 
@@ -302,10 +304,7 @@ void main() {
         overrides: overrides(),
       );
 
-      await tester.scrollUntilVisible(
-        find.text('Delete all data'),
-        200,
-      );
+      await tester.scrollUntilVisible(find.text('Delete all data'), 200);
       await tester.tap(find.text('Delete all data'));
       await tester.pumpAndSettle();
 
@@ -324,10 +323,7 @@ void main() {
         overrides: overrides(),
       );
 
-      await tester.scrollUntilVisible(
-        find.text('Delete all data'),
-        200,
-      );
+      await tester.scrollUntilVisible(find.text('Delete all data'), 200);
       await tester.tap(find.text('Delete all data'));
       await tester.pumpAndSettle();
 
@@ -346,10 +342,7 @@ void main() {
         overrides: overrides(),
       );
 
-      expect(
-        find.textContaining('Your data belongs to you'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Your data belongs to you'), findsOneWidget);
     });
 
     testWidgets('shows estimated storage size', (tester) async {
@@ -380,16 +373,18 @@ void main() {
 
       void wireClipboardCapture(WidgetTester tester) {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(SystemChannels.platform,
-                (MethodCall call) async {
-          if (call.method == 'Clipboard.setData') {
-            capturedClipboard = Map<String, dynamic>.from(call.arguments as Map);
-          }
-          return null;
-        });
+            .setMockMethodCallHandler(SystemChannels.platform, (
+              MethodCall call,
+            ) async {
+              if (call.method == 'Clipboard.setData') {
+                capturedClipboard = Map<String, dynamic>.from(
+                  call.arguments as Map,
+                );
+              }
+              return null;
+            });
         addTearDown(() {
-          TestDefaultBinaryMessengerBinding
-              .instance.defaultBinaryMessenger
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
               .setMockMethodCallHandler(SystemChannels.platform, null);
         });
       }
@@ -428,89 +423,105 @@ void main() {
       }
 
       testWidgets(
-          'small JSON path writes to Clipboard.setData and skips share_plus',
-          (tester) async {
-        wireClipboardCapture(tester);
-        wireShareCapture();
-        await _setTallSurface(tester);
+        'small JSON path writes to Clipboard.setData and skips share_plus',
+        (tester) async {
+          wireClipboardCapture(tester);
+          wireShareCapture();
+          await _setTallSurface(tester);
 
-        const smallJson = '{"traceCount":1,"traces":[{"id":"a"}]}';
-        final stub = _StubTraceStorage(
-          stubCount: 1,
-          stubParsedCount: 1,
-          stubExport: smallJson,
-        );
-        await pumpApp(
-          tester,
-          const PrivacyDashboardScreen(),
-          overrides: [
-            storageRepositoryProvider.overrideWithValue(mockStorage),
-            syncStateProvider.overrideWith(() => _DisabledSyncState()),
-            traceStorageProvider.overrideWithValue(stub),
-          ],
-        );
+          const smallJson = '{"traceCount":1,"traces":[{"id":"a"}]}';
+          final stub = _StubTraceStorage(
+            stubCount: 1,
+            stubParsedCount: 1,
+            stubExport: smallJson,
+          );
+          await pumpApp(
+            tester,
+            const PrivacyDashboardScreen(),
+            overrides: [
+              storageRepositoryProvider.overrideWithValue(mockStorage),
+              syncStateProvider.overrideWith(() => _DisabledSyncState()),
+              traceStorageProvider.overrideWithValue(stub),
+            ],
+          );
 
-        await tapExportButton(tester);
+          await tapExportButton(tester);
 
-        expect(capturedClipboard, isNotNull,
-            reason: 'small payload should reach the clipboard channel');
-        expect(capturedClipboard!['text'], smallJson);
-        expect(capturedShareParams, isNull,
-            reason: 'small payload should NOT trigger share_plus');
-        // Snackbar reports byte size + entry count.
-        expect(find.textContaining('Error log copied to clipboard'),
-            findsOneWidget);
-        expect(find.textContaining('1 entries'), findsOneWidget);
-      });
-
-      testWidgets(
-          'large JSON path hands off to share_plus with a JSON file attachment',
-          (tester) async {
-        wireClipboardCapture(tester);
-        wireShareCapture();
-        await _setTallSurface(tester);
-
-        // 80 KB > 64 KB threshold.
-        final bigPayload = '{"traceCount":1,"big":"${'x' * (80 * 1024)}"}';
-        final stub = _StubTraceStorage(
-          stubCount: 1,
-          stubParsedCount: 1,
-          stubExport: bigPayload,
-        );
-        await pumpApp(
-          tester,
-          const PrivacyDashboardScreen(),
-          overrides: [
-            storageRepositoryProvider.overrideWithValue(mockStorage),
-            syncStateProvider.overrideWith(() => _DisabledSyncState()),
-            traceStorageProvider.overrideWithValue(stub),
-          ],
-        );
-
-        await tapExportButton(tester);
-
-        expect(capturedShareParams, isNotNull,
-            reason: 'payload above 64 KB threshold must use share sheet');
-        expect(capturedShareParams!.files, isNotNull);
-        expect(capturedShareParams!.files!, hasLength(1));
-        expect(
-          capturedShareParams!.files!.first.path,
-          endsWith('tankstellen-error-log.json'),
-        );
-        expect(capturedClipboard, isNull,
-            reason: 'large payload skips clipboard');
-        // Snackbar mentions "shared".
-        expect(find.textContaining('Error log shared'), findsOneWidget);
-      });
+          expect(
+            capturedClipboard,
+            isNotNull,
+            reason: 'small payload should reach the clipboard channel',
+          );
+          expect(capturedClipboard!['text'], smallJson);
+          expect(
+            capturedShareParams,
+            isNull,
+            reason: 'small payload should NOT trigger share_plus',
+          );
+          // Snackbar reports byte size + entry count.
+          expect(
+            find.textContaining('Error log copied to clipboard'),
+            findsOneWidget,
+          );
+          expect(find.textContaining('1 entries'), findsOneWidget);
+        },
+      );
 
       testWidgets(
-          'snackbar surfaces parsed-vs-unparsed split when Hive has '
+        'large JSON path hands off to share_plus with a JSON file attachment',
+        (tester) async {
+          wireClipboardCapture(tester);
+          wireShareCapture();
+          await _setTallSurface(tester);
+
+          // 80 KB > 64 KB threshold.
+          final bigPayload = '{"traceCount":1,"big":"${'x' * (80 * 1024)}"}';
+          final stub = _StubTraceStorage(
+            stubCount: 1,
+            stubParsedCount: 1,
+            stubExport: bigPayload,
+          );
+          await pumpApp(
+            tester,
+            const PrivacyDashboardScreen(),
+            overrides: [
+              storageRepositoryProvider.overrideWithValue(mockStorage),
+              syncStateProvider.overrideWith(() => _DisabledSyncState()),
+              traceStorageProvider.overrideWithValue(stub),
+            ],
+          );
+
+          await tapExportButton(tester);
+
+          expect(
+            capturedShareParams,
+            isNotNull,
+            reason: 'payload above 64 KB threshold must use share sheet',
+          );
+          expect(capturedShareParams!.files, isNotNull);
+          expect(capturedShareParams!.files!, hasLength(1));
+          expect(
+            capturedShareParams!.files!.first.path,
+            endsWith('tankstellen-error-log.json'),
+          );
+          expect(
+            capturedClipboard,
+            isNull,
+            reason: 'large payload skips clipboard',
+          );
+          // Snackbar mentions "shared".
+          expect(find.textContaining('Error log shared'), findsOneWidget);
+        },
+      );
+
+      testWidgets('snackbar surfaces parsed-vs-unparsed split when Hive has '
           'schema drift', (tester) async {
         wireClipboardCapture(tester);
         wireShareCapture();
         await _setTallSurface(tester);
 
-        const mixedJson = '{"traceCount":3,"parsedCount":1,'
+        const mixedJson =
+            '{"traceCount":3,"parsedCount":1,'
             '"unparsedCount":2,"traces":[],"unparsedRaw":[{"id":"x"}]}';
         final stub = _StubTraceStorage(
           stubCount: 3,
@@ -533,8 +544,7 @@ void main() {
         expect(capturedClipboard, isNotNull);
         // Snackbar tells the user the breakdown explicitly.
         expect(
-          find.textContaining(
-              'Error log copied (1 parsed + 2 raw entries'),
+          find.textContaining('Error log copied (1 parsed + 2 raw entries'),
           findsOneWidget,
         );
         expect(
@@ -549,49 +559,52 @@ void main() {
       // `… (1).json`. With NO share sink wired (production behaviour), the
       // file must be written exactly ONCE.
       testWidgets(
-          'large JSON path writes to Downloads exactly once (no duplicate '
-          'file — BUG 1)', (tester) async {
-        wireClipboardCapture(tester);
-        // Deliberately do NOT wire the share sink: production has none, so
-        // this exercises the real single-write path.
-        await _setTallSurface(tester);
+        'large JSON path writes to Downloads exactly once (no duplicate '
+        'file — BUG 1)',
+        (tester) async {
+          wireClipboardCapture(tester);
+          // Deliberately do NOT wire the share sink: production has none, so
+          // this exercises the real single-write path.
+          await _setTallSurface(tester);
 
-        var saveCalls = 0;
-        final savedNames = <String>[];
-        debugPublicFileExporterOverride = ({
-          required bytes,
-          required fileName,
-          required mimeType,
-        }) async {
-          saveCalls++;
-          savedNames.add(fileName);
-          return '/Downloads/$fileName';
-        };
-        addTearDown(() => debugPublicFileExporterOverride = null);
+          var saveCalls = 0;
+          final savedNames = <String>[];
+          debugPublicFileExporterOverride =
+              ({required bytes, required fileName, required mimeType}) async {
+                saveCalls++;
+                savedNames.add(fileName);
+                return '/Downloads/$fileName';
+              };
+          addTearDown(() => debugPublicFileExporterOverride = null);
 
-        final bigPayload = '{"traceCount":1,"big":"${'x' * (80 * 1024)}"}';
-        final stub = _StubTraceStorage(
-          stubCount: 1,
-          stubParsedCount: 1,
-          stubExport: bigPayload,
-        );
-        await pumpApp(
-          tester,
-          const PrivacyDashboardScreen(),
-          overrides: [
-            storageRepositoryProvider.overrideWithValue(mockStorage),
-            syncStateProvider.overrideWith(() => _DisabledSyncState()),
-            traceStorageProvider.overrideWithValue(stub),
-          ],
-        );
+          final bigPayload = '{"traceCount":1,"big":"${'x' * (80 * 1024)}"}';
+          final stub = _StubTraceStorage(
+            stubCount: 1,
+            stubParsedCount: 1,
+            stubExport: bigPayload,
+          );
+          await pumpApp(
+            tester,
+            const PrivacyDashboardScreen(),
+            overrides: [
+              storageRepositoryProvider.overrideWithValue(mockStorage),
+              syncStateProvider.overrideWith(() => _DisabledSyncState()),
+              traceStorageProvider.overrideWithValue(stub),
+            ],
+          );
 
-        await tapExportButton(tester);
+          await tapExportButton(tester);
 
-        expect(saveCalls, 1,
-            reason: 'the large error-log export must write the Downloads '
-                'file exactly once, not twice');
-        expect(savedNames, ['tankstellen-error-log.json']);
-      });
+          expect(
+            saveCalls,
+            1,
+            reason:
+                'the large error-log export must write the Downloads '
+                'file exactly once, not twice',
+          );
+          expect(savedNames, ['tankstellen-error-log.json']);
+        },
+      );
     });
   });
 }
@@ -604,10 +617,10 @@ class _DisabledSyncState extends SyncState {
 class _EnabledSyncState extends SyncState {
   @override
   SyncConfig build() => const SyncConfig(
-        enabled: true,
-        supabaseUrl: 'https://test.supabase.co',
-        supabaseAnonKey: 'test-key',
-        userId: 'user-abcdef12-3456-7890',
-        mode: SyncMode.community,
-      );
+    enabled: true,
+    supabaseUrl: 'https://test.supabase.co',
+    supabaseAnonKey: 'test-key',
+    userId: 'user-abcdef12-3456-7890',
+    mode: SyncMode.community,
+  );
 }

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -16,6 +16,7 @@ import 'package:tankstellen/features/profile/presentation/widgets/feature_manage
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 import '../../../../mocks/mocks.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for the #1373 phase-2 Feature management section on the
 /// Settings screen. The engine's `enable` still throws on a missing
@@ -29,7 +30,8 @@ import '../../../../mocks/mocks.dart';
 /// feature — available and default-on in beta, absent in production.
 FeatureManifest _manifestWithBetaOnly(Feature f) {
   final entries = Map<Feature, FeatureManifestEntry>.from(
-      FeatureManifest.defaultManifest.entries);
+    FeatureManifest.defaultManifest.entries,
+  );
   final orig = entries[f]!;
   entries[f] = FeatureManifestEntry(
     feature: f,
@@ -100,39 +102,44 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('section renders one toggle per feature (minus Conso-mode flags)',
-        (tester) async {
-      await pumpApp(tester, const ProfileScreen(), overrides: baseOverrides);
-      await openSection(tester);
+    testWidgets(
+      'section renders one toggle per feature (minus Conso-mode flags)',
+      (tester) async {
+        await pumpApp(tester, const ProfileScreen(), overrides: baseOverrides);
+        await openSection(tester);
 
-      // #1571 — three Conso-surface flags are no longer rendered as
-      // per-feature switches: `obd2TripRecording`, `manualConsumption`,
-      // and `showConsumptionTab` are now driven by the segmented
-      // control inside the Conso card. Every other Feature enum value
-      // still surfaces a SwitchListTile keyed `featureToggle_<name>`.
-      const consoModeFlags = <Feature>{
-        Feature.obd2TripRecording,
-        Feature.manualConsumption,
-        Feature.showConsumptionTab,
-      };
-      for (final f in Feature.values) {
-        if (consoModeFlags.contains(f)) {
-          expect(
-            find.byKey(Key('featureToggle_${f.name}')),
-            findsNothing,
-            reason: '${f.name} is driven by the Conso segmented control '
-                '(#1571) — it must not render as a stand-alone switch.',
-          );
-        } else {
-          expect(
-            find.byKey(Key('featureToggle_${f.name}')),
-            findsOneWidget,
-            reason: 'expected a switch for ${f.name}',
-          );
+        // #1571 — three Conso-surface flags are no longer rendered as
+        // per-feature switches: `obd2TripRecording`, `manualConsumption`,
+        // and `showConsumptionTab` are now driven by the segmented
+        // control inside the Conso card. Every other Feature enum value
+        // still surfaces a SwitchListTile keyed `featureToggle_<name>`.
+        const consoModeFlags = <Feature>{
+          Feature.obd2TripRecording,
+          Feature.manualConsumption,
+          Feature.showConsumptionTab,
+        };
+        for (final f in Feature.values) {
+          if (consoModeFlags.contains(f)) {
+            expect(
+              find.byKey(Key('featureToggle_${f.name}')),
+              findsNothing,
+              reason:
+                  '${f.name} is driven by the Conso segmented control '
+                  '(#1571) — it must not render as a stand-alone switch.',
+            );
+          } else {
+            expect(
+              find.byKey(Key('featureToggle_${f.name}')),
+              findsOneWidget,
+              reason: 'expected a switch for ${f.name}',
+            );
+          }
         }
-      }
-      expect(Feature.values.length, 32,
-          reason: '#1373 phase 1 shipped 13 features; phase 3d added '
+        expect(
+          Feature.values.length,
+          32,
+          reason:
+              '#1373 phase 1 shipped 13 features; phase 3d added '
               'autoRecord (14); phase 3c bundled showFuel + showElectric + '
               'showConsumptionTab (17); #1517 added manualConsumption + '
               'loyaltyCards (19); #1543 added tflitePricePrediction (20); '
@@ -145,225 +152,263 @@ void main() {
               'debugMode (29); #2382 added approachOverlay (30); '
               '#2569 added voiceAnnouncements (31); #2735 added '
               'addFillUpShareIntentReceipt (32). '
-              'Update the test if a new feature was added or removed.');
-    });
+              'Update the test if a new feature was added or removed.',
+        );
+      },
+    );
 
     testWidgets(
-        'toggling an unblocked feature flips its state via the provider',
-        (tester) async {
-      // Use a probe ProviderScope so we can observe the state change.
-      final container = ProviderContainer(
-        overrides: baseOverrides.cast(),
-      );
-      addTearDown(container.dispose);
+      'toggling an unblocked feature flips its state via the provider',
+      (tester) async {
+        // Use a probe ProviderScope so we can observe the state change.
+        final container = ProviderContainer(overrides: baseOverrides.cast());
+        addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(
-            home: Scaffold(
-              body: SingleChildScrollView(child: FeatureManagementSection()),
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SingleChildScrollView(child: FeatureManagementSection()),
+              ),
             ),
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
+        await tester.pumpAndSettle();
 
-      // tankSync defaults to false in the manifest; toggling it on is
-      // unblocked because it has no prerequisites.
-      expect(
-        container.read(enabledFeaturesProvider),
-        isNot(contains(Feature.tankSync)),
-      );
-      // Post-#1440 the section renders grouped cards which can push
-      // the tankSync row below the 800x600 default surface. Scroll it
-      // into view before tapping so the hit test lands on the switch.
-      final tankSyncFinder = find.byKey(const Key('featureToggle_tankSync'));
-      await tester.scrollUntilVisible(
-        tankSyncFinder,
-        100,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(tankSyncFinder);
-      // Pump the synchronous state update + the in-flight Future. We
-      // don't pumpAndSettle because the section has no animations.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        // tankSync defaults to false in the manifest; toggling it on is
+        // unblocked because it has no prerequisites.
+        expect(
+          container.read(enabledFeaturesProvider),
+          isNot(contains(Feature.tankSync)),
+        );
+        // Post-#1440 the section renders grouped cards which can push
+        // the tankSync row below the 800x600 default surface. Scroll it
+        // into view before tapping so the hit test lands on the switch.
+        final tankSyncFinder = find.byKey(const Key('featureToggle_tankSync'));
+        await tester.scrollUntilVisible(
+          tankSyncFinder,
+          100,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(tankSyncFinder);
+        // Pump the synchronous state update + the in-flight Future. We
+        // don't pumpAndSettle because the section has no animations.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      expect(
-        container.read(enabledFeaturesProvider),
-        contains(Feature.tankSync),
-      );
-    });
+        expect(
+          container.read(enabledFeaturesProvider),
+          contains(Feature.tankSync),
+        );
+      },
+    );
 
     testWidgets(
-        'enabling gamification while obd2TripRecording is OFF is blocked '
-        '(switch disabled + tooltip names the prerequisite)', (tester) async {
-      final container = ProviderContainer(
-        overrides: baseOverrides.cast(),
-      );
-      addTearDown(container.dispose);
+      'enabling gamification while obd2TripRecording is OFF is blocked '
+      '(switch disabled + tooltip names the prerequisite)',
+      (tester) async {
+        final container = ProviderContainer(overrides: baseOverrides.cast());
+        addTearDown(container.dispose);
 
-      // Defaults: gamification is ON, obd2TripRecording is OFF. To set
-      // up the blocked-enable scenario we first turn gamification off
-      // (which is allowed because no other dependent is enabled).
-      await container
-          .read(featureFlagsProvider.notifier)
-          .disable(Feature.gamification);
-      // Sanity: we are now in the state we want to test against.
-      expect(
-        container.read(enabledFeaturesProvider),
-        isNot(contains(Feature.gamification)),
-      );
-      expect(
-        container.read(enabledFeaturesProvider),
-        isNot(contains(Feature.obd2TripRecording)),
-      );
+        // Defaults: gamification is ON, obd2TripRecording is OFF. To set
+        // up the blocked-enable scenario we first turn gamification off
+        // (which is allowed because no other dependent is enabled).
+        await container
+            .read(featureFlagsProvider.notifier)
+            .disable(Feature.gamification);
+        // Sanity: we are now in the state we want to test against.
+        expect(
+          container.read(enabledFeaturesProvider),
+          isNot(contains(Feature.gamification)),
+        );
+        expect(
+          container.read(enabledFeaturesProvider),
+          isNot(contains(Feature.obd2TripRecording)),
+        );
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(
-            home: Scaffold(
-              body: SingleChildScrollView(child: FeatureManagementSection()),
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SingleChildScrollView(child: FeatureManagementSection()),
+              ),
             ),
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
+        await tester.pumpAndSettle();
 
-      // Switch must be disabled — `onChanged: null`.
-      final gamificationSwitch = tester.widget<SwitchListTile>(
-        find.byKey(const Key('featureToggle_gamification')),
-      );
-      expect(gamificationSwitch.onChanged, isNull,
-          reason: 'gamification switch must be disabled when '
-              'obd2TripRecording is OFF');
+        // Switch must be disabled — `onChanged: null`.
+        final gamificationSwitch = tester.widget<SwitchListTile>(
+          find.byKey(const Key('featureToggle_gamification')),
+        );
+        expect(
+          gamificationSwitch.onChanged,
+          isNull,
+          reason:
+              'gamification switch must be disabled when '
+              'obd2TripRecording is OFF',
+        );
 
-      // The Tooltip wrapping the disabled switch must name the
-      // missing prerequisite. The English message includes "OBD2 trip
-      // recording".
-      final tooltip = tester.widget<Tooltip>(
-        find.ancestor(
-          of: find.byKey(const Key('featureToggle_gamification')),
-          matching: find.byType(Tooltip),
-        ),
-      );
-      expect(tooltip.message, isNotNull);
-      expect(tooltip.message!, contains('OBD2 trip recording'),
-          reason: 'tooltip must name the blocking prerequisite');
-    });
+        // The Tooltip wrapping the disabled switch must name the
+        // missing prerequisite. The English message includes "OBD2 trip
+        // recording".
+        final tooltip = tester.widget<Tooltip>(
+          find.ancestor(
+            of: find.byKey(const Key('featureToggle_gamification')),
+            matching: find.byType(Tooltip),
+          ),
+        );
+        expect(tooltip.message, isNotNull);
+        expect(
+          tooltip.message!,
+          contains('OBD2 trip recording'),
+          reason: 'tooltip must name the blocking prerequisite',
+        );
+      },
+    );
 
     testWidgets(
-        'disabling obd2TripRecording via the provider while gamification is '
-        'ON succeeds — gamification switch then renders disabled-with-'
-        'tooltip (#1447 cascading-disable, #1571 segmented control)',
-        (tester) async {
-      final container = ProviderContainer(
-        overrides: baseOverrides.cast(),
-      );
-      addTearDown(container.dispose);
+      'disabling obd2TripRecording via the provider while gamification is '
+      'ON succeeds — gamification switch then renders disabled-with-'
+      'tooltip (#1447 cascading-disable, #1571 segmented control)',
+      (tester) async {
+        final container = ProviderContainer(overrides: baseOverrides.cast());
+        addTearDown(container.dispose);
 
-      await container
-          .read(featureFlagsProvider.notifier)
-          .enable(Feature.obd2TripRecording);
-      expect(
-        container.read(enabledFeaturesProvider),
-        containsAll(<Feature>[
-          Feature.obd2TripRecording,
-          Feature.gamification,
-        ]),
-      );
+        await container
+            .read(featureFlagsProvider.notifier)
+            .enable(Feature.obd2TripRecording);
+        expect(
+          container.read(enabledFeaturesProvider),
+          containsAll(<Feature>[
+            Feature.obd2TripRecording,
+            Feature.gamification,
+          ]),
+        );
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(
-            home: Scaffold(
-              body: SingleChildScrollView(child: FeatureManagementSection()),
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SingleChildScrollView(child: FeatureManagementSection()),
+              ),
             ),
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
+        await tester.pumpAndSettle();
 
-      // #1571 — `obd2TripRecording` is no longer a stand-alone switch.
-      // The user-facing path is the Conso segmented control's "Off"
-      // segment; we drive the underlying flag directly here to keep
-      // this test focused on the cascading-disable behaviour rather
-      // than the segmented control wiring (covered in
-      // `feature_management_section_grouping_test.dart`).
-      await container
-          .read(featureFlagsProvider.notifier)
-          .disable(Feature.obd2TripRecording);
-      await tester.pumpAndSettle();
+        // #1571 — `obd2TripRecording` is no longer a stand-alone switch.
+        // The user-facing path is the Conso segmented control's "Off"
+        // segment; we drive the underlying flag directly here to keep
+        // this test focused on the cascading-disable behaviour rather
+        // than the segmented control wiring (covered in
+        // `feature_management_section_grouping_test.dart`).
+        await container
+            .read(featureFlagsProvider.notifier)
+            .disable(Feature.obd2TripRecording);
+        await tester.pumpAndSettle();
 
-      expect(
-        container.read(enabledFeaturesProvider),
-        isNot(contains(Feature.obd2TripRecording)),
-      );
-      expect(
-        container.read(enabledFeaturesProvider),
-        contains(Feature.gamification),
-        reason: 'Stored child state must survive parent-disable so the '
-            'user does not lose their preference.',
-      );
+        expect(
+          container.read(enabledFeaturesProvider),
+          isNot(contains(Feature.obd2TripRecording)),
+        );
+        expect(
+          container.read(enabledFeaturesProvider),
+          contains(Feature.gamification),
+          reason:
+              'Stored child state must survive parent-disable so the '
+              'user does not lose their preference.',
+        );
 
-      final gamificationSwitchAfter = tester.widget<SwitchListTile>(
-        find.byKey(const Key('featureToggle_gamification')),
-      );
-      expect(gamificationSwitchAfter.onChanged, isNull,
-          reason: 'With parent off, the child switch must be '
+        final gamificationSwitchAfter = tester.widget<SwitchListTile>(
+          find.byKey(const Key('featureToggle_gamification')),
+        );
+        expect(
+          gamificationSwitchAfter.onChanged,
+          isNull,
+          reason:
+              'With parent off, the child switch must be '
               'effectively-disabled (non-interactive) until the user '
-              're-enables the parent.');
+              're-enables the parent.',
+        );
 
-      final tooltip = tester.widget<Tooltip>(
-        find.ancestor(
-          of: find.byKey(const Key('featureToggle_gamification')),
-          matching: find.byType(Tooltip),
-        ),
-      );
-      expect(tooltip.message, isNotNull);
-      expect(tooltip.message!, contains('OBD2 trip recording'),
-          reason: 'tooltip must point the user at the parent they need '
-              'to flip back on to make the child reachable.');
-    });
+        final tooltip = tester.widget<Tooltip>(
+          find.ancestor(
+            of: find.byKey(const Key('featureToggle_gamification')),
+            matching: find.byType(Tooltip),
+          ),
+        );
+        expect(tooltip.message, isNotNull);
+        expect(
+          tooltip.message!,
+          contains('OBD2 trip recording'),
+          reason:
+              'tooltip must point the user at the parent they need '
+              'to flip back on to make the child reachable.',
+        );
+      },
+    );
 
-    testWidgets(
-        '#1675 — a beta-only feature is hidden from the list in a '
+    testWidgets('#1675 — a beta-only feature is hidden from the list in a '
         'production build', (tester) async {
-      await pumpApp(tester, const ProfileScreen(), overrides: [
-        ...baseOverrides,
-        featureManifestProvider
-            .overrideWithValue(_manifestWithBetaOnly(Feature.fuelCalculator)),
-        buildChannelProvider.overrideWithValue(BuildChannel.production),
-      ]);
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: [
+          ...baseOverrides,
+          featureManifestProvider.overrideWithValue(
+            _manifestWithBetaOnly(Feature.fuelCalculator),
+          ),
+          buildChannelProvider.overrideWithValue(BuildChannel.production),
+        ],
+      );
       await openSection(tester);
 
-      expect(find.byKey(const Key('featureToggle_fuelCalculator')),
-          findsNothing,
-          reason: 'a beta-only feature must not render in a production '
-              'build');
+      expect(
+        find.byKey(const Key('featureToggle_fuelCalculator')),
+        findsNothing,
+        reason:
+            'a beta-only feature must not render in a production '
+            'build',
+      );
       // A channel-available feature still renders.
-      expect(find.byKey(const Key('featureToggle_priceAlerts')),
-          findsOneWidget);
+      expect(
+        find.byKey(const Key('featureToggle_priceAlerts')),
+        findsOneWidget,
+      );
     });
 
-    testWidgets(
-        '#1675 — the same feature is visible in a beta build',
-        (tester) async {
-      await pumpApp(tester, const ProfileScreen(), overrides: [
-        ...baseOverrides,
-        featureManifestProvider
-            .overrideWithValue(_manifestWithBetaOnly(Feature.fuelCalculator)),
-        buildChannelProvider.overrideWithValue(BuildChannel.beta),
-      ]);
+    testWidgets('#1675 — the same feature is visible in a beta build', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const ProfileScreen(),
+        overrides: [
+          ...baseOverrides,
+          featureManifestProvider.overrideWithValue(
+            _manifestWithBetaOnly(Feature.fuelCalculator),
+          ),
+          buildChannelProvider.overrideWithValue(BuildChannel.beta),
+        ],
+      );
       await openSection(tester);
 
-      expect(find.byKey(const Key('featureToggle_fuelCalculator')),
-          findsOneWidget,
-          reason: 'a beta-only feature must render in a beta build');
+      expect(
+        find.byKey(const Key('featureToggle_fuelCalculator')),
+        findsOneWidget,
+        reason: 'a beta-only feature must render in a beta build',
+      );
     });
   });
 }

--- a/test/features/profile/presentation/screens/theme_settings_screen_test.dart
+++ b/test/features/profile/presentation/screens/theme_settings_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/theme/theme_mode_provider.dart';
 import 'package:tankstellen/features/profile/presentation/screens/theme_settings_screen.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Test-only ThemeModeSetting that exposes a fixed `build()` value and
 /// skips the real provider's SharedPreferences load — widget tests do
@@ -27,14 +28,14 @@ class _FixedThemeMode extends ThemeModeSetting {
 
 void main() {
   group('ThemeSettingsScreen (#897)', () {
-    testWidgets('renders Scaffold + AppBar with Theme title',
-        (tester) async {
+    testWidgets('renders Scaffold + AppBar with Theme title', (tester) async {
       await pumpApp(
         tester,
         const ThemeSettingsScreen(),
         overrides: [
-          themeModeSettingProvider
-              .overrideWith(() => _FixedThemeMode(AppThemeChoice.system)),
+          themeModeSettingProvider.overrideWith(
+            () => _FixedThemeMode(AppThemeChoice.system),
+          ),
         ],
       );
 
@@ -48,8 +49,9 @@ void main() {
         tester,
         const ThemeSettingsScreen(),
         overrides: [
-          themeModeSettingProvider
-              .overrideWith(() => _FixedThemeMode(AppThemeChoice.system)),
+          themeModeSettingProvider.overrideWith(
+            () => _FixedThemeMode(AppThemeChoice.system),
+          ),
         ],
       );
 
@@ -62,29 +64,29 @@ void main() {
         find.textContaining('Match the current device appearance'),
         findsOneWidget,
       );
-      expect(
-        find.textContaining('Bright backgrounds'),
-        findsOneWidget,
-      );
-      expect(
-        find.textContaining('Dark backgrounds'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Bright backgrounds'), findsOneWidget);
+      expect(find.textContaining('Dark backgrounds'), findsOneWidget);
     });
 
-    testWidgets('tapping Light option updates ThemeModeSetting',
-        (tester) async {
+    testWidgets('tapping Light option updates ThemeModeSetting', (
+      tester,
+    ) async {
       late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            themeModeSettingProvider
-                .overrideWith(() => _FixedThemeMode(AppThemeChoice.system)),
+            themeModeSettingProvider.overrideWith(
+              () => _FixedThemeMode(AppThemeChoice.system),
+            ),
           ],
           child: Builder(
             builder: (ctx) {
               container = ProviderScope.containerOf(ctx);
-              return const MaterialApp(home: ThemeSettingsScreen());
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: ThemeSettingsScreen(),
+              );
             },
           ),
         ),
@@ -101,19 +103,23 @@ void main() {
       expect(container.read(themeModeSettingProvider), AppThemeChoice.light);
     });
 
-    testWidgets('tapping Dark option updates ThemeModeSetting',
-        (tester) async {
+    testWidgets('tapping Dark option updates ThemeModeSetting', (tester) async {
       late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            themeModeSettingProvider
-                .overrideWith(() => _FixedThemeMode(AppThemeChoice.system)),
+            themeModeSettingProvider.overrideWith(
+              () => _FixedThemeMode(AppThemeChoice.system),
+            ),
           ],
           child: Builder(
             builder: (ctx) {
               container = ProviderScope.containerOf(ctx);
-              return const MaterialApp(home: ThemeSettingsScreen());
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: ThemeSettingsScreen(),
+              );
             },
           ),
         ),
@@ -128,19 +134,25 @@ void main() {
       expect(container.read(themeModeSettingProvider), AppThemeChoice.dark);
     });
 
-    testWidgets('tapping System option from Dark resets to System',
-        (tester) async {
+    testWidgets('tapping System option from Dark resets to System', (
+      tester,
+    ) async {
       late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            themeModeSettingProvider
-                .overrideWith(() => _FixedThemeMode(AppThemeChoice.dark)),
+            themeModeSettingProvider.overrideWith(
+              () => _FixedThemeMode(AppThemeChoice.dark),
+            ),
           ],
           child: Builder(
             builder: (ctx) {
               container = ProviderScope.containerOf(ctx);
-              return const MaterialApp(home: ThemeSettingsScreen());
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: ThemeSettingsScreen(),
+              );
             },
           ),
         ),
@@ -155,21 +167,20 @@ void main() {
       expect(container.read(themeModeSettingProvider), AppThemeChoice.system);
     });
 
-    testWidgets('all interactive options meet the 48dp tap-target guideline',
-        (tester) async {
+    testWidgets('all interactive options meet the 48dp tap-target guideline', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const ThemeSettingsScreen(),
         overrides: [
-          themeModeSettingProvider
-              .overrideWith(() => _FixedThemeMode(AppThemeChoice.system)),
+          themeModeSettingProvider.overrideWith(
+            () => _FixedThemeMode(AppThemeChoice.system),
+          ),
         ],
       );
 
-      await expectLater(
-        tester,
-        meetsGuideline(androidTapTargetGuideline),
-      );
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
     });
   });
 }

--- a/test/features/profile/presentation/widgets/profile_edit_sheet_test.dart
+++ b/test/features/profile/presentation/widgets/profile_edit_sheet_test.dart
@@ -22,38 +22,41 @@ void main() {
           home: Builder(
             builder: (context) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                unawaited(showDialog<bool>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    icon: Icon(
-                      Icons.warning_amber_rounded,
-                      color: Theme.of(context).colorScheme.error,
-                      size: 48,
-                    ),
-                    title: Text(AppLocalizations.of(context)?.deleteProfileTitle ??
-                        'Delete profile?'),
-                    content: Text(
-                      AppLocalizations.of(context)?.deleteProfileBody ??
-                          'This profile and its settings will be permanently deleted. This cannot be undone.',
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context, false),
-                        child: Text(
-                            AppLocalizations.of(context)?.cancel ?? 'Cancel'),
+                unawaited(
+                  showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      icon: Icon(
+                        Icons.warning_amber_rounded,
+                        color: Theme.of(context).colorScheme.error,
+                        size: 48,
                       ),
-                      FilledButton(
-                        style: FilledButton.styleFrom(
-                          backgroundColor: Theme.of(context).colorScheme.error,
+                      title: Text(
+                        AppLocalizations.of(context).deleteProfileTitle,
+                      ),
+                      content: Text(
+                        AppLocalizations.of(context).deleteProfileBody,
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: Text(AppLocalizations.of(context).cancel),
                         ),
-                        onPressed: () => Navigator.pop(context, true),
-                        child: Text(
-                            AppLocalizations.of(context)?.deleteProfileConfirm ??
-                                'Delete profile'),
-                      ),
-                    ],
+                        FilledButton(
+                          style: FilledButton.styleFrom(
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.error,
+                          ),
+                          onPressed: () => Navigator.pop(context, true),
+                          child: Text(
+                            AppLocalizations.of(context).deleteProfileConfirm,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ));
+                );
               });
               return const Scaffold(body: SizedBox.expand());
             },
@@ -173,9 +176,7 @@ void main() {
 
     test('all 23 ARB files have deleteProfile keys', () {
       final arbDir = Directory('lib/l10n');
-      final arbFiles = arbDir.listSync().where(
-            (f) => f.path.endsWith('.arb'),
-          );
+      final arbFiles = arbDir.listSync().where((f) => f.path.endsWith('.arb'));
       for (final file in arbFiles) {
         final content = File(file.path).readAsStringSync();
         expect(
@@ -221,8 +222,9 @@ void main() {
 
       // Must NOT call onDelete directly from the delete button's onPressed.
       expect(
-        RegExp(r'onPressed:\s*\(\)\s*\{\s*widget\.onDelete!\(\)')
-            .hasMatch(source),
+        RegExp(
+          r'onPressed:\s*\(\)\s*\{\s*widget\.onDelete!\(\)',
+        ).hasMatch(source),
         isFalse,
         reason:
             'Delete button must NOT call widget.onDelete! directly from onPressed',
@@ -257,8 +259,8 @@ void main() {
 
   group('ProfileEditSheet #2551 SectionCard redesign', () {
     String mainSource() => File(
-          'lib/features/profile/presentation/widgets/profile_edit_sheet.dart',
-        ).readAsStringSync();
+      'lib/features/profile/presentation/widgets/profile_edit_sheet.dart',
+    ).readAsStringSync();
 
     test('groups every section in a SectionCard', () {
       expect(mainSource(), contains('SectionCard('));
@@ -307,11 +309,11 @@ void main() {
   // #2597 — the country picker enforces one profile per country.
   group('ProfileEditSheet one-per-country picker (#2597)', () {
     String parts2Source() => File(
-          'lib/features/profile/presentation/widgets/profile_edit_sheet_parts2.dart',
-        ).readAsStringSync();
+      'lib/features/profile/presentation/widgets/profile_edit_sheet_parts2.dart',
+    ).readAsStringSync();
     String mainSource() => File(
-          'lib/features/profile/presentation/widgets/profile_edit_sheet.dart',
-        ).readAsStringSync();
+      'lib/features/profile/presentation/widgets/profile_edit_sheet.dart',
+    ).readAsStringSync();
 
     test('_CountrySection consults isCountryTaken, excluding the edited '
         'profile', () {
@@ -332,9 +334,11 @@ void main() {
       );
     });
 
-    test('the edit sheet threads the edited profile id into _CountrySection',
-        () {
-      expect(mainSource(), contains('profileId: widget.profile.id'));
-    });
+    test(
+      'the edit sheet threads the edited profile id into _CountrySection',
+      () {
+        expect(mainSource(), contains('profileId: widget.profile.id'));
+      },
+    );
   });
 }

--- a/test/features/profile/presentation/widgets/profile_list_section_test.dart
+++ b/test/features/profile/presentation/widgets/profile_list_section_test.dart
@@ -113,8 +113,9 @@ void main() {
   });
 
   group('ProfileListSection rendering', () {
-    testWidgets('empty profiles list renders only the New Profile button',
-        (tester) async {
+    testWidgets('empty profiles list renders only the New Profile button', (
+      tester,
+    ) async {
       when(() => mockRepo.getActiveProfile()).thenReturn(null);
       when(() => mockRepo.getAllProfiles()).thenReturn(const []);
 
@@ -136,8 +137,9 @@ void main() {
       expect(find.text('New profile'), findsOneWidget);
     });
 
-    testWidgets('single active profile renders one Card with active icon',
-        (tester) async {
+    testWidgets('single active profile renders one Card with active icon', (
+      tester,
+    ) async {
       when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
       when(() => mockRepo.getAllProfiles()).thenReturn(const [_activeProfile]);
 
@@ -166,8 +168,9 @@ void main() {
       'on the inactive one',
       (tester) async {
         when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
-        when(() => mockRepo.getAllProfiles())
-            .thenReturn(const [_activeProfile, _otherProfile]);
+        when(
+          () => mockRepo.getAllProfiles(),
+        ).thenReturn(const [_activeProfile, _otherProfile]);
 
         final std = standardTestOverrides();
 
@@ -192,44 +195,55 @@ void main() {
         final ctx = tester.element(find.text('Home'));
         final theme = Theme.of(ctx);
         final cards = tester.widgetList<Card>(find.byType(Card)).toList();
-        expect(cards[0].color, theme.colorScheme.primaryContainer,
-            reason: 'Active profile card uses primaryContainer color');
-        expect(cards[1].color, isNull,
-            reason: 'Inactive profile card has no override color');
+        expect(
+          cards[0].color,
+          theme.colorScheme.primaryContainer,
+          reason: 'Active profile card uses primaryContainer color',
+        );
+        expect(
+          cards[1].color,
+          isNull,
+          reason: 'Inactive profile card has no override color',
+        );
       },
     );
 
     testWidgets(
-        'subtitle composes flag, fuel display name, radius (km), and landing screen',
-        (tester) async {
-      when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
-      when(() => mockRepo.getAllProfiles()).thenReturn(const [_activeProfile]);
+      'subtitle composes flag, fuel display name, radius (km), and landing screen',
+      (tester) async {
+        when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
+        when(
+          () => mockRepo.getAllProfiles(),
+        ).thenReturn(const [_activeProfile]);
 
-      final std = standardTestOverrides();
+        final std = standardTestOverrides();
 
-      await pumpApp(
-        tester,
-        const ProfileListSection(),
-        overrides: [
-          ...std.overrides,
-          profileRepositoryProvider.overrideWithValue(mockRepo),
-        ],
-      );
+        await pumpApp(
+          tester,
+          const ProfileListSection(),
+          overrides: [
+            ...std.overrides,
+            profileRepositoryProvider.overrideWithValue(mockRepo),
+          ],
+        );
 
-      // German flag emoji + Super E10 + 10 km + landing screen "Nearest stations".
-      expect(find.textContaining('Super E10'), findsOneWidget);
-      expect(find.textContaining('10 km'), findsOneWidget);
-      // Landing screen English label, since locale is en.
-      expect(find.textContaining('Nearest stations'), findsOneWidget);
-      // German flag is part of the subtitle for a profile with countryCode DE.
-      expect(find.textContaining('\u{1F1E9}\u{1F1EA}'), findsOneWidget);
-    });
+        // German flag emoji + Super E10 + 10 km + landing screen "Nearest stations".
+        expect(find.textContaining('Super E10'), findsOneWidget);
+        expect(find.textContaining('10 km'), findsOneWidget);
+        // Landing screen English label, since locale is en.
+        expect(find.textContaining('Nearest stations'), findsOneWidget);
+        // German flag is part of the subtitle for a profile with countryCode DE.
+        expect(find.textContaining('\u{1F1E9}\u{1F1EA}'), findsOneWidget);
+      },
+    );
 
-    testWidgets('subtitle omits the flag when countryCode is null',
-        (tester) async {
+    testWidgets('subtitle omits the flag when countryCode is null', (
+      tester,
+    ) async {
       when(() => mockRepo.getActiveProfile()).thenReturn(_profileNoCountry);
-      when(() => mockRepo.getAllProfiles())
-          .thenReturn(const [_profileNoCountry]);
+      when(
+        () => mockRepo.getAllProfiles(),
+      ).thenReturn(const [_profileNoCountry]);
 
       final std = standardTestOverrides();
 
@@ -251,7 +265,9 @@ void main() {
       expect(find.textContaining('Map'), findsOneWidget);
     });
 
-    testWidgets('edit IconButton has a non-null tooltip (a11y)', (tester) async {
+    testWidgets('edit IconButton has a non-null tooltip (a11y)', (
+      tester,
+    ) async {
       when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
       when(() => mockRepo.getAllProfiles()).thenReturn(const [_activeProfile]);
 
@@ -280,11 +296,13 @@ void main() {
   });
 
   group('ProfileListSection actions', () {
-    testWidgets('tapping Activate calls switchProfile with the inactive id',
-        (tester) async {
+    testWidgets('tapping Activate calls switchProfile with the inactive id', (
+      tester,
+    ) async {
       when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
-      when(() => mockRepo.getAllProfiles())
-          .thenReturn(const [_activeProfile, _otherProfile]);
+      when(
+        () => mockRepo.getAllProfiles(),
+      ).thenReturn(const [_activeProfile, _otherProfile]);
 
       final std = standardTestOverrides();
       final switchCalls = <String>[];
@@ -312,8 +330,9 @@ void main() {
       'Cancel and Save actions',
       (tester) async {
         when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
-        when(() => mockRepo.getAllProfiles())
-            .thenReturn(const [_activeProfile]);
+        when(
+          () => mockRepo.getAllProfiles(),
+        ).thenReturn(const [_activeProfile]);
 
         final std = standardTestOverrides();
 
@@ -323,8 +342,9 @@ void main() {
           overrides: [
             ...std.overrides,
             profileRepositoryProvider.overrideWithValue(mockRepo),
-            activeLanguageProvider
-                .overrideWith(() => _FixedActiveLanguage(AppLanguages.all.first)),
+            activeLanguageProvider.overrideWith(
+              () => _FixedActiveLanguage(AppLanguages.all.first),
+            ),
           ],
         );
 
@@ -355,43 +375,50 @@ void main() {
     // `ref.invalidate` on a dead ref. The notifier is now captured BEFORE
     // the await and the invalidate is mounted-guarded.
     testWidgets(
-        'disposing the section while switchProfile is in flight does not '
-        'throw a dead-ref StateError (#3159)', (tester) async {
-      when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
-      when(() => mockRepo.getAllProfiles())
-          .thenReturn(const [_activeProfile, _otherProfile]);
+      'disposing the section while switchProfile is in flight does not '
+      'throw a dead-ref StateError (#3159)',
+      (tester) async {
+        when(() => mockRepo.getActiveProfile()).thenReturn(_activeProfile);
+        when(
+          () => mockRepo.getAllProfiles(),
+        ).thenReturn(const [_activeProfile, _otherProfile]);
 
-      final std = standardTestOverrides();
-      final gate = Completer<void>();
+        final std = standardTestOverrides();
+        final gate = Completer<void>();
 
-      await pumpApp(
-        tester,
-        const ProfileListSection(),
-        overrides: [
-          ...std.overrides,
-          profileRepositoryProvider.overrideWithValue(mockRepo),
-          activeProfileProvider.overrideWith(
-            () => _GatedActiveProfile(_activeProfile, gate),
-          ),
-        ],
-      );
+        await pumpApp(
+          tester,
+          const ProfileListSection(),
+          overrides: [
+            ...std.overrides,
+            profileRepositoryProvider.overrideWithValue(mockRepo),
+            activeProfileProvider.overrideWith(
+              () => _GatedActiveProfile(_activeProfile, gate),
+            ),
+          ],
+        );
 
-      // Start the switch — _activateProfile is now parked on the gate.
-      await tester.tap(find.text('Activate'));
-      await tester.pump();
+        // Start the switch — _activateProfile is now parked on the gate.
+        await tester.tap(find.text('Activate'));
+        await tester.pump();
 
-      // Tear the whole tree down while the await is still pending
-      // (simulates the user leaving the screen mid-switch).
-      await tester.pumpWidget(const SizedBox.shrink());
+        // Tear the whole tree down while the await is still pending
+        // (simulates the user leaving the screen mid-switch).
+        await tester.pumpWidget(const SizedBox.shrink());
 
-      // Release the future; the continuation must not touch the dead ref.
-      gate.complete();
-      await tester.pump();
+        // Release the future; the continuation must not touch the dead ref.
+        gate.complete();
+        await tester.pump();
 
-      expect(tester.takeException(), isNull,
-          reason: 'post-await ref use on the unmounted section must be '
-              'either pre-captured or mounted-guarded');
-    });
+        expect(
+          tester.takeException(),
+          isNull,
+          reason:
+              'post-await ref use on the unmounted section must be '
+              'either pre-captured or mounted-guarded',
+        );
+      },
+    );
 
     // Note: tapping Cancel/Save inside the naming dialog reliably triggers
     // a Flutter-test-only `_FocusInheritedScope` assertion when the dialog's
@@ -404,8 +431,8 @@ void main() {
 
   group('ProfileListSection source-level regression', () {
     String readSource() => File(
-          'lib/features/profile/presentation/widgets/profile_list_section.dart',
-        ).readAsStringSync();
+      'lib/features/profile/presentation/widgets/profile_list_section.dart',
+    ).readAsStringSync();
 
     test('_createProfile bails out when the name is null or empty', () {
       final source = readSource();
@@ -413,34 +440,39 @@ void main() {
       // any repository call, so an empty Save never creates a profile.
       expect(
         source,
-        matches(RegExp(r'if\s*\(\s*name\s*==\s*null\s*\|\|\s*name\.isEmpty\s*\)\s*return')),
+        matches(
+          RegExp(
+            r'if\s*\(\s*name\s*==\s*null\s*\|\|\s*name\.isEmpty\s*\)\s*return',
+          ),
+        ),
         reason: '_createProfile must early-return on empty/null name',
       );
     });
 
-    test('_createProfile passes active country + language codes to the repo',
-        () {
-      final source = readSource();
-      // The createProfile call must thread country.code and language.code,
-      // not raw values pulled from the profile being edited or hardcoded.
-      // #2597 — the country is suppressed when already taken
-      // (`countryTaken ? null : country.code`) to hold the one-per-country
-      // invariant, so assert the free-country branch threads `country.code`.
-      expect(source, contains('repo.createProfile('));
-      expect(source, contains('country.code'));
-      expect(source, contains('languageCode: language.code'));
-    });
+    test(
+      '_createProfile passes active country + language codes to the repo',
+      () {
+        final source = readSource();
+        // The createProfile call must thread country.code and language.code,
+        // not raw values pulled from the profile being edited or hardcoded.
+        // #2597 — the country is suppressed when already taken
+        // (`countryTaken ? null : country.code`) to hold the one-per-country
+        // invariant, so assert the free-country branch threads `country.code`.
+        expect(source, contains('repo.createProfile('));
+        expect(source, contains('country.code'));
+        expect(source, contains('languageCode: language.code'));
+      },
+    );
 
     test('_editProfile gates onDelete on more than one profile existing', () {
       final source = readSource();
       // Last-profile guard: when allProfiles.length <= 1, the bottom sheet
       // is opened with onDelete: null, hiding the destructive action.
       expect(source, contains('canDelete = allProfiles.length > 1'));
-      expect(source, contains('onDelete: canDelete ?'));
+      expect(source, contains('onDelete: canDelete'));
     });
 
-    test('Activate button calls switchProfile through the active notifier',
-        () {
+    test('Activate button calls switchProfile through the active notifier', () {
       final source = readSource();
       expect(
         source,
@@ -453,9 +485,11 @@ void main() {
     test('edit IconButton wires a tooltip', () {
       final source = readSource();
       // Static-scan equivalent of the accessibility check; ProfileListSection
-      // ships with `tooltip: AppLocalizations.of(context)?.editProfile ?? ...`.
-      expect(source,
-          contains('tooltip: AppLocalizations.of(context)?.editProfile'));
+      // ships with `tooltip: AppLocalizations.of(context).editProfile`.
+      expect(
+        source,
+        contains('tooltip: AppLocalizations.of(context).editProfile'),
+      );
     });
   });
 
@@ -482,8 +516,9 @@ void main() {
         const ProfileListSection(),
         overrides: [
           ...std.overrides,
-          activeLanguageProvider
-              .overrideWith(() => _FixedActiveLanguage(AppLanguages.all.first)),
+          activeLanguageProvider.overrideWith(
+            () => _FixedActiveLanguage(AppLanguages.all.first),
+          ),
         ],
       );
     }

--- a/test/features/report/domain/entities/report_type_test.dart
+++ b/test/features/report/domain/entities/report_type_test.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/report/domain/entities/report_type.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Tests for `ReportType` enum — Refs #561.
 ///
@@ -12,12 +15,14 @@ import 'package:tankstellen/features/report/domain/entities/report_type.dart';
 ///   - `routesToGitHub` / `isTankerkoenigSupported` routing predicates
 ///   - `fuelTypeColumnValue` Supabase column mapping
 ///   - `visibleForCountry` country gating (#484)
-///   - `displayName(null)` English fallback path (l10n-free)
+///   - `displayName` English (`en` ARB) mapping
 ///
-/// `displayName(AppLocalizations)` with a real localisation delegate is
-/// covered implicitly by widget tests that pump the report screen — here
-/// we only assert the fallback branch so the unit test stays pure.
+/// `displayName` is driven with the real `en` lookup (#3162 — the
+/// nullable fallback branch no longer exists), keeping the unit test
+/// pure while asserting the canonical ARB labels.
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('apiValue', () {
     test('wrongE5 → wrongPetrolPremium', () {
       expect(ReportType.wrongE5.apiValue, 'wrongPetrolPremium');
@@ -132,16 +137,18 @@ void main() {
       });
     }
 
-    test('routesToGitHub matches needsText — metadata reports route to GitHub',
-        () {
-      for (final t in ReportType.values) {
-        expect(
-          t.routesToGitHub,
-          t.needsText,
-          reason: '$t should route to GitHub iff it needs free-text input',
-        );
-      }
-    });
+    test(
+      'routesToGitHub matches needsText — metadata reports route to GitHub',
+      () {
+        for (final t in ReportType.values) {
+          expect(
+            t.routesToGitHub,
+            t.needsText,
+            reason: '$t should route to GitHub iff it needs free-text input',
+          );
+        }
+      },
+    );
   });
 
   group('isTankerkoenigSupported', () {
@@ -167,12 +174,14 @@ void main() {
       expect(count, 5);
     });
 
-    test('extended price types (E85, E98, LPG) are NOT Tankerkoenig-supported',
-        () {
-      expect(ReportType.wrongE85.isTankerkoenigSupported, isFalse);
-      expect(ReportType.wrongE98.isTankerkoenigSupported, isFalse);
-      expect(ReportType.wrongLpg.isTankerkoenigSupported, isFalse);
-    });
+    test(
+      'extended price types (E85, E98, LPG) are NOT Tankerkoenig-supported',
+      () {
+        expect(ReportType.wrongE85.isTankerkoenigSupported, isFalse);
+        expect(ReportType.wrongE98.isTankerkoenigSupported, isFalse);
+        expect(ReportType.wrongLpg.isTankerkoenigSupported, isFalse);
+      },
+    );
   });
 
   group('fuelTypeColumnValue (Supabase mapping)', () {
@@ -209,8 +218,9 @@ void main() {
     });
 
     test('all column values are unique (no analytics aliasing)', () {
-      final values =
-          ReportType.values.map((e) => e.fuelTypeColumnValue).toSet();
+      final values = ReportType.values
+          .map((e) => e.fuelTypeColumnValue)
+          .toSet();
       expect(values.length, ReportType.values.length);
     });
   });
@@ -228,24 +238,24 @@ void main() {
     });
 
     test('IT → metadata-only', () {
-      expect(
-        ReportType.visibleForCountry('IT'),
-        const [ReportType.wrongName, ReportType.wrongAddress],
-      );
+      expect(ReportType.visibleForCountry('IT'), const [
+        ReportType.wrongName,
+        ReportType.wrongAddress,
+      ]);
     });
 
     test('ES → metadata-only', () {
-      expect(
-        ReportType.visibleForCountry('ES'),
-        const [ReportType.wrongName, ReportType.wrongAddress],
-      );
+      expect(ReportType.visibleForCountry('ES'), const [
+        ReportType.wrongName,
+        ReportType.wrongAddress,
+      ]);
     });
 
     test('empty country code → metadata-only fallback', () {
-      expect(
-        ReportType.visibleForCountry(''),
-        const [ReportType.wrongName, ReportType.wrongAddress],
-      );
+      expect(ReportType.visibleForCountry(''), const [
+        ReportType.wrongName,
+        ReportType.wrongAddress,
+      ]);
     });
 
     test('lowercase "de" does NOT match — case-sensitive ISO codes', () {
@@ -253,10 +263,10 @@ void main() {
       // lowercase value here means the caller forgot to normalise.
       // Falling back to metadata-only is the safe default (no
       // Tankerkoenig attempt against a non-DE station).
-      expect(
-        ReportType.visibleForCountry('de'),
-        const [ReportType.wrongName, ReportType.wrongAddress],
-      );
+      expect(ReportType.visibleForCountry('de'), const [
+        ReportType.wrongName,
+        ReportType.wrongAddress,
+      ]);
     });
 
     test('non-DE country list only contains GitHub-routed types', () {
@@ -267,11 +277,11 @@ void main() {
     });
   });
 
-  group('displayName (null l10n fallback)', () {
+  group('displayName (en ARB mapping)', () {
     const expected = <ReportType, String>{
-      ReportType.wrongE5: 'Prix Super E5 incorrect',
-      ReportType.wrongE10: 'Prix Super E10 incorrect',
-      ReportType.wrongDiesel: 'Prix Diesel incorrect',
+      ReportType.wrongE5: 'Wrong Super E5 price',
+      ReportType.wrongE10: 'Wrong Super E10 price',
+      ReportType.wrongDiesel: 'Wrong Diesel price',
       ReportType.wrongE85: 'Wrong E85 price',
       ReportType.wrongE98: 'Wrong Super 98 price',
       ReportType.wrongLpg: 'Wrong LPG price',
@@ -282,17 +292,17 @@ void main() {
     };
 
     for (final entry in expected.entries) {
-      test('${entry.key} fallback label', () {
-        expect(entry.key.displayName(null), entry.value);
+      test('${entry.key} en label', () {
+        expect(entry.key.displayName(l10nEn), entry.value);
       });
     }
 
-    test('every report type has a non-empty fallback label', () {
+    test('every report type has a non-empty display name', () {
       for (final t in ReportType.values) {
         expect(
-          t.displayName(null),
+          t.displayName(l10nEn),
           isNotEmpty,
-          reason: '$t returned empty fallback display name',
+          reason: '$t returned an empty display name',
         );
       }
     });
@@ -303,12 +313,12 @@ void main() {
       expect(ReportType.values.length, 10);
     });
 
-    test(
-        'needsPrice, needsText, and status bucket are mutually exclusive and '
+    test('needsPrice, needsText, and status bucket are mutually exclusive and '
         'together cover every enum value', () {
       for (final t in ReportType.values) {
         final isStatus =
-            t == ReportType.wrongStatusOpen || t == ReportType.wrongStatusClosed;
+            t == ReportType.wrongStatusOpen ||
+            t == ReportType.wrongStatusClosed;
         final bucketCount =
             (t.needsPrice ? 1 : 0) + (t.needsText ? 1 : 0) + (isStatus ? 1 : 0);
         expect(

--- a/test/features/report/presentation/screens/report_screen_test.dart
+++ b/test/features/report/presentation/screens/report_screen_test.dart
@@ -11,11 +11,15 @@ import 'package:tankstellen/features/report/presentation/screens/report_screen.d
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('ReportScreen', () {
-    testWidgets('renders Scaffold with the retitled "Report a problem"',
-        (tester) async {
+    testWidgets('renders Scaffold with the retitled "Report a problem"', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       when(() => test.mockStorage.getApiKey()).thenReturn(null);
@@ -55,7 +59,8 @@ void main() {
       final scrollable = find.byType(Scrollable).first;
       for (var i = 0; i < 20 && seen.length < ReportType.values.length; i++) {
         for (final radio in tester.widgetList<RadioListTile<ReportType>>(
-            find.byType(RadioListTile<ReportType>))) {
+          find.byType(RadioListTile<ReportType>),
+        )) {
           seen.add(radio.value);
         }
         await tester.drag(scrollable, const Offset(0, -200));
@@ -63,15 +68,20 @@ void main() {
       }
       // Final pass after the last drag.
       for (final radio in tester.widgetList<RadioListTile<ReportType>>(
-          find.byType(RadioListTile<ReportType>))) {
+        find.byType(RadioListTile<ReportType>),
+      )) {
         seen.add(radio.value);
       }
-      expect(seen, equals(ReportType.values.toSet()),
-          reason: 'all 10 report types must be rendered in the list');
+      expect(
+        seen,
+        equals(ReportType.values.toSet()),
+        reason: 'all 10 report types must be rendered in the list',
+      );
     });
 
-    testWidgets('renders send button in disabled state initially',
-        (tester) async {
+    testWidgets('renders send button in disabled state initially', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       when(() => test.mockStorage.getApiKey()).thenReturn(null);
@@ -96,11 +106,9 @@ void main() {
   });
 
   group('ReportScreen country gating (regression #484)', () {
-    testWidgets(
-        'DE without Tankerkoenig key and without TankSync → no-backend '
+    testWidgets('DE without Tankerkoenig key and without TankSync → no-backend '
         'banner shown; price/status radios disabled but name/address '
-        '(GitHub-routed, #508) stay enabled',
-        (tester) async {
+        '(GitHub-routed, #508) stay enabled', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       when(() => test.mockStorage.getApiKey()).thenReturn(null);
@@ -136,11 +144,10 @@ void main() {
       // `true`  → enabled (tappable), `false` → disabled.
       final seen = <ReportType, bool>{};
       final scrollable = find.byType(Scrollable).first;
-      for (var i = 0;
-          i < 20 && seen.length < ReportType.values.length;
-          i++) {
+      for (var i = 0; i < 20 && seen.length < ReportType.values.length; i++) {
         for (final radio in tester.widgetList<RadioListTile<ReportType>>(
-            find.byType(RadioListTile<ReportType>))) {
+          find.byType(RadioListTile<ReportType>),
+        )) {
           seen.putIfAbsent(radio.value, () => radio.enabled ?? true);
         }
         if (seen.length == ReportType.values.length) break;
@@ -161,63 +168,76 @@ void main() {
       expect(button.onPressed, isNull);
 
       for (final type in ReportType.values) {
-        expect(seen.containsKey(type), isTrue,
-            reason: '$type must be rendered in DE even without a backend');
+        expect(
+          seen.containsKey(type),
+          isTrue,
+          reason: '$type must be rendered in DE even without a backend',
+        );
         if (type.routesToGitHub) {
-          expect(seen[type], isTrue,
-              reason:
-                  '$type is GitHub-routed and must stay enabled (#508)');
+          expect(
+            seen[type],
+            isTrue,
+            reason: '$type is GitHub-routed and must stay enabled (#508)',
+          );
         } else {
-          expect(seen[type], isFalse,
-              reason:
-                  '$type needs a backend and must be disabled here');
+          expect(
+            seen[type],
+            isFalse,
+            reason: '$type needs a backend and must be disabled here',
+          );
         }
       }
     });
 
     testWidgets(
-        'FR without TankSync → no banner, only wrongName + wrongAddress '
-        'visible, both enabled (#508)',
-        (tester) async {
-      final test = standardTestOverrides(country: Countries.france);
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
-      when(() => test.mockStorage.getApiKey()).thenReturn(null);
+      'FR without TankSync → no banner, only wrongName + wrongAddress '
+      'visible, both enabled (#508)',
+      (tester) async {
+        final test = standardTestOverrides(country: Countries.france);
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+        when(() => test.mockStorage.getApiKey()).thenReturn(null);
 
-      await pumpApp(
-        tester,
-        const ReportScreen(stationId: 'test-station-1'),
-        overrides: test.overrides,
-      );
-      await tester.pumpAndSettle();
+        await pumpApp(
+          tester,
+          const ReportScreen(stationId: 'test-station-1'),
+          overrides: test.overrides,
+        );
+        await tester.pumpAndSettle();
 
-      // Outside DE, only GitHub-routed types are visible — nothing
-      // needs configuring, so the banner must NOT appear.
-      expect(
-        find.byKey(const ValueKey('report-no-backend-banner')),
-        findsNothing,
-      );
+        // Outside DE, only GitHub-routed types are visible — nothing
+        // needs configuring, so the banner must NOT appear.
+        expect(
+          find.byKey(const ValueKey('report-no-backend-banner')),
+          findsNothing,
+        );
 
-      // Exactly two radios, both GitHub-routed, both enabled.
-      final radios = tester
-          .widgetList<RadioListTile<ReportType>>(
-              find.byType(RadioListTile<ReportType>))
-          .toList();
-      expect(radios, hasLength(2));
-      expect(
-        radios.map((r) => r.value).toList(),
-        equals([ReportType.wrongName, ReportType.wrongAddress]),
-      );
-      for (final r in radios) {
-        expect(r.enabled ?? true, isTrue,
-            reason: 'GitHub-routed radios must be enabled regardless of '
-                'backend availability');
-      }
-    });
+        // Exactly two radios, both GitHub-routed, both enabled.
+        final radios = tester
+            .widgetList<RadioListTile<ReportType>>(
+              find.byType(RadioListTile<ReportType>),
+            )
+            .toList();
+        expect(radios, hasLength(2));
+        expect(
+          radios.map((r) => r.value).toList(),
+          equals([ReportType.wrongName, ReportType.wrongAddress]),
+        );
+        for (final r in radios) {
+          expect(
+            r.enabled ?? true,
+            isTrue,
+            reason:
+                'GitHub-routed radios must be enabled regardless of '
+                'backend availability',
+          );
+        }
+      },
+    );
 
-    testWidgets(
-        'FR with no sync — submit button enables when wrongAddress is '
-        'selected and text is entered, even without any backend (#508)',
-        (tester) async {
+    testWidgets('FR with no sync — submit button enables when wrongAddress is '
+        'selected and text is entered, even without any backend (#508)', (
+      tester,
+    ) async {
       final test = standardTestOverrides(country: Countries.france);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       when(() => test.mockStorage.getApiKey()).thenReturn(null);
@@ -244,38 +264,47 @@ void main() {
       await tester.pumpAndSettle();
 
       button = tester.widget<FilledButton>(find.byType(FilledButton));
-      expect(button.onPressed, isNotNull,
-          reason: 'GitHub-routed reports must work without a backend');
+      expect(
+        button.onPressed,
+        isNotNull,
+        reason: 'GitHub-routed reports must work without a backend',
+      );
     });
 
     testWidgets(
-        'DE WITH Tankerkoenig API key → banner hidden, radios enabled',
-        (tester) async {
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+      'DE WITH Tankerkoenig API key → banner hidden, radios enabled',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(true);
+        when(
+          () => test.mockStorage.getApiKey(),
+        ).thenReturn('11111111-2222-3333-4444-555555555555');
 
-      await pumpApp(
-        tester,
-        const ReportScreen(stationId: 'test-station-1'),
-        overrides: test.overrides,
-      );
+        await pumpApp(
+          tester,
+          const ReportScreen(stationId: 'test-station-1'),
+          overrides: test.overrides,
+        );
 
-      expect(
-        find.byKey(const ValueKey('report-no-backend-banner')),
-        findsNothing,
-        reason: 'DE+key must NOT show the no-backend banner',
-      );
+        expect(
+          find.byKey(const ValueKey('report-no-backend-banner')),
+          findsNothing,
+          reason: 'DE+key must NOT show the no-backend banner',
+        );
 
-      for (final radio in tester
-          .widgetList<RadioListTile<ReportType>>(
-              find.byType(RadioListTile<ReportType>))) {
-        expect(radio.enabled ?? true, isTrue,
-            reason: 'radios must be enabled when at least one backend is '
-                'available');
-      }
-    });
+        for (final radio in tester.widgetList<RadioListTile<ReportType>>(
+          find.byType(RadioListTile<ReportType>),
+        )) {
+          expect(
+            radio.enabled ?? true,
+            isTrue,
+            reason:
+                'radios must be enabled when at least one backend is '
+                'available',
+          );
+        }
+      },
+    );
   });
 
   group('ReportScreen metadata report types (#484)', () {
@@ -295,13 +324,14 @@ void main() {
       );
     }
 
-    testWidgets(
-        'selecting wrongName shows a text field, not the price field',
-        (tester) async {
+    testWidgets('selecting wrongName shows a text field, not the price field', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+      when(
+        () => test.mockStorage.getApiKey(),
+      ).thenReturn('11111111-2222-3333-4444-555555555555');
 
       await pumpApp(
         tester,
@@ -323,13 +353,14 @@ void main() {
       expect(find.text('Correct price (e.g. 1.459)'), findsNothing);
     });
 
-    testWidgets(
-        'selecting wrongAddress shows the correction text field',
-        (tester) async {
+    testWidgets('selecting wrongAddress shows the correction text field', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+      when(
+        () => test.mockStorage.getApiKey(),
+      ).thenReturn('11111111-2222-3333-4444-555555555555');
 
       await pumpApp(
         tester,
@@ -349,38 +380,41 @@ void main() {
     });
 
     testWidgets(
-        'selecting wrongE85 shows the price field (extended fuel type)',
-        (tester) async {
+      'selecting wrongE85 shows the price field (extended fuel type)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(true);
+        when(
+          () => test.mockStorage.getApiKey(),
+        ).thenReturn('11111111-2222-3333-4444-555555555555');
+
+        await pumpApp(
+          tester,
+          const ReportScreen(stationId: 'test-station-1'),
+          overrides: test.overrides,
+        );
+        await tester.pumpAndSettle();
+
+        await scrollToRadio(tester, 'Wrong E85 price');
+        await tester.tap(find.text('Wrong E85 price'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Correct price (e.g. 1.459)'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('report-correction-text-field')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('submit stays disabled for wrongName until text is entered', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
-
-      await pumpApp(
-        tester,
-        const ReportScreen(stationId: 'test-station-1'),
-        overrides: test.overrides,
-      );
-      await tester.pumpAndSettle();
-
-      await scrollToRadio(tester, 'Wrong E85 price');
-      await tester.tap(find.text('Wrong E85 price'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Correct price (e.g. 1.459)'), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('report-correction-text-field')),
-        findsNothing,
-      );
-    });
-
-    testWidgets(
-        'submit stays disabled for wrongName until text is entered',
-        (tester) async {
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+      when(
+        () => test.mockStorage.getApiKey(),
+      ).thenReturn('11111111-2222-3333-4444-555555555555');
 
       await pumpApp(
         tester,
@@ -397,8 +431,11 @@ void main() {
       await scrollToButton(tester);
 
       var button = tester.widget<FilledButton>(find.byType(FilledButton));
-      expect(button.onPressed, isNull,
-          reason: 'submit must stay disabled until correction is typed');
+      expect(
+        button.onPressed,
+        isNull,
+        reason: 'submit must stay disabled until correction is typed',
+      );
 
       await tester.enterText(
         find.byKey(const ValueKey('report-correction-text-field')),
@@ -408,18 +445,21 @@ void main() {
 
       await scrollToButton(tester);
       button = tester.widget<FilledButton>(find.byType(FilledButton));
-      expect(button.onPressed, isNotNull,
-          reason: 'submit must enable once correction text is present');
+      expect(
+        button.onPressed,
+        isNotNull,
+        reason: 'submit must enable once correction text is present',
+      );
     });
   });
 
   group('ReportScreen country-gated visibility (#508)', () {
-    testWidgets(
-        'DE — all 10 report types are rendered', (tester) async {
+    testWidgets('DE — all 10 report types are rendered', (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+      when(
+        () => test.mockStorage.getApiKey(),
+      ).thenReturn('11111111-2222-3333-4444-555555555555');
 
       await pumpApp(
         tester,
@@ -430,11 +470,10 @@ void main() {
 
       final seen = <ReportType>{};
       final scrollable = find.byType(Scrollable).first;
-      for (var i = 0;
-          i < 20 && seen.length < ReportType.values.length;
-          i++) {
+      for (var i = 0; i < 20 && seen.length < ReportType.values.length; i++) {
         for (final radio in tester.widgetList<RadioListTile<ReportType>>(
-            find.byType(RadioListTile<ReportType>))) {
+          find.byType(RadioListTile<ReportType>),
+        )) {
           seen.add(radio.value);
         }
         await tester.drag(scrollable, const Offset(0, -200));
@@ -443,8 +482,9 @@ void main() {
       expect(seen, equals(ReportType.values.toSet()));
     });
 
-    testWidgets('FR — only wrongName + wrongAddress are rendered',
-        (tester) async {
+    testWidgets('FR — only wrongName + wrongAddress are rendered', (
+      tester,
+    ) async {
       final test = standardTestOverrides(country: Countries.france);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       when(() => test.mockStorage.getApiKey()).thenReturn(null);
@@ -458,7 +498,8 @@ void main() {
 
       final values = tester
           .widgetList<RadioListTile<ReportType>>(
-              find.byType(RadioListTile<ReportType>))
+            find.byType(RadioListTile<ReportType>),
+          )
           .map((r) => r.value)
           .toList();
       expect(
@@ -468,10 +509,7 @@ void main() {
     });
 
     test('visibleForCountry returns all types for DE, last 2 for FR/GB', () {
-      expect(
-        ReportType.visibleForCountry('DE'),
-        equals(ReportType.values),
-      );
+      expect(ReportType.visibleForCountry('DE'), equals(ReportType.values));
       expect(
         ReportType.visibleForCountry('FR'),
         equals(const [ReportType.wrongName, ReportType.wrongAddress]),
@@ -484,109 +522,109 @@ void main() {
 
     test('routesToGitHub covers exactly wrongName + wrongAddress', () {
       for (final t in ReportType.values) {
-        expect(t.routesToGitHub, t == ReportType.wrongName || t == ReportType.wrongAddress,
-            reason: '$t routesToGitHub is wrong');
+        expect(
+          t.routesToGitHub,
+          t == ReportType.wrongName || t == ReportType.wrongAddress,
+          reason: '$t routesToGitHub is wrong',
+        );
       }
     });
   });
 
   group('ReportScreen GitHub routing (#508)', () {
     testWidgets(
-        'wrongAddress on FR hands off to ErrorReporter with populated payload',
-        (tester) async {
-      ErrorReportPayload? captured;
-      final reporter = ErrorReporter(launcher: (uri) async => true);
+      'wrongAddress on FR hands off to ErrorReporter with populated payload',
+      (tester) async {
+        ErrorReportPayload? captured;
+        final reporter = ErrorReporter(launcher: (uri) async => true);
 
-      final test = standardTestOverrides(country: Countries.france);
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
-      when(() => test.mockStorage.getApiKey()).thenReturn(null);
+        final test = standardTestOverrides(country: Countries.france);
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+        when(() => test.mockStorage.getApiKey()).thenReturn(null);
 
-      // A wrapped reporter that records the payload on reportError and
-      // then delegates (with consent skipped) to the real one.
-      final recording = _RecordingReporter((p) => captured = p);
+        // A wrapped reporter that records the payload on reportError and
+        // then delegates (with consent skipped) to the real one.
+        final recording = _RecordingReporter((p) => captured = p);
 
-      await pumpApp(
-        tester,
-        ReportScreen(
-          stationId: 'station-42',
-          reporter: recording,
-        ),
-        overrides: test.overrides,
-      );
-      await tester.pumpAndSettle();
+        await pumpApp(
+          tester,
+          ReportScreen(stationId: 'station-42', reporter: recording),
+          overrides: test.overrides,
+        );
+        await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Wrong address'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.text('Wrong address'));
+        await tester.pumpAndSettle();
 
-      await tester.enterText(
-        find.byKey(const ValueKey('report-correction-text-field')),
-        '42 rue de la République',
-      );
-      await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('report-correction-text-field')),
+          '42 rue de la République',
+        );
+        await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FilledButton));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byType(FilledButton));
+        await tester.pumpAndSettle();
 
-      expect(captured, isNotNull, reason: 'reporter must be invoked');
-      expect(captured!.countryCode, 'FR');
-      expect(captured!.errorType, 'WrongMetadataReport');
-      expect(captured!.errorMessage, contains('station-42'));
-      expect(captured!.errorMessage, contains('42 rue de la République'));
-      expect(captured!.sourceLabel, isNotNull);
+        expect(captured, isNotNull, reason: 'reporter must be invoked');
+        expect(captured!.countryCode, 'FR');
+        expect(captured!.errorType, 'WrongMetadataReport');
+        expect(captured!.errorMessage, contains('station-42'));
+        expect(captured!.errorMessage, contains('42 rue de la République'));
+        expect(captured!.sourceLabel, isNotNull);
 
-      // Silence the unused-field lint on `reporter`.
-      expect(reporter, isA<ErrorReporter>());
-    });
+        // Silence the unused-field lint on `reporter`.
+        expect(reporter, isA<ErrorReporter>());
+      },
+    );
 
     testWidgets(
-        'wrongName on DE still routes to GitHub (not to Tankerkoenig)',
-        (tester) async {
-      ErrorReportPayload? captured;
-      final recording = _RecordingReporter((p) => captured = p);
+      'wrongName on DE still routes to GitHub (not to Tankerkoenig)',
+      (tester) async {
+        ErrorReportPayload? captured;
+        final recording = _RecordingReporter((p) => captured = p);
 
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(true);
-      when(() => test.mockStorage.getApiKey())
-          .thenReturn('11111111-2222-3333-4444-555555555555');
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(true);
+        when(
+          () => test.mockStorage.getApiKey(),
+        ).thenReturn('11111111-2222-3333-4444-555555555555');
 
-      await pumpApp(
-        tester,
-        ReportScreen(
-          stationId: 'station-99',
-          reporter: recording,
-        ),
-        overrides: test.overrides,
-      );
-      await tester.pumpAndSettle();
+        await pumpApp(
+          tester,
+          ReportScreen(stationId: 'station-99', reporter: recording),
+          overrides: test.overrides,
+        );
+        await tester.pumpAndSettle();
 
-      await tester.scrollUntilVisible(
-        find.text('Wrong station name'),
-        120,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.tap(find.text('Wrong station name'));
-      await tester.pumpAndSettle();
+        await tester.scrollUntilVisible(
+          find.text('Wrong station name'),
+          120,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.tap(find.text('Wrong station name'));
+        await tester.pumpAndSettle();
 
-      await tester.enterText(
-        find.byKey(const ValueKey('report-correction-text-field')),
-        'Shell Castelnau',
-      );
-      await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('report-correction-text-field')),
+          'Shell Castelnau',
+        );
+        await tester.pumpAndSettle();
 
-      await tester.scrollUntilVisible(
-        find.byType(FilledButton),
-        120,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.tap(find.byType(FilledButton));
-      await tester.pumpAndSettle();
+        await tester.scrollUntilVisible(
+          find.byType(FilledButton),
+          120,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.tap(find.byType(FilledButton));
+        await tester.pumpAndSettle();
 
-      expect(captured, isNotNull);
-      expect(captured!.countryCode, 'DE');
-      expect(captured!.errorType, 'WrongMetadataReport');
-      expect(captured!.errorMessage, contains('station-99'));
-      expect(captured!.errorMessage, contains('Shell Castelnau'));
-    });
+        expect(captured, isNotNull);
+        expect(captured!.countryCode, 'DE');
+        expect(captured!.errorType, 'WrongMetadataReport');
+        expect(captured!.errorMessage, contains('station-99'));
+        expect(captured!.errorMessage, contains('Shell Castelnau'));
+      },
+    );
   });
 
   group('ReportType enum (#484)', () {
@@ -598,8 +636,7 @@ void main() {
       expect(ReportType.wrongE98.fuelTypeColumnValue, 'e98');
       expect(ReportType.wrongLpg.fuelTypeColumnValue, 'lpg');
       expect(ReportType.wrongStatusOpen.fuelTypeColumnValue, 'status_open');
-      expect(
-          ReportType.wrongStatusClosed.fuelTypeColumnValue, 'status_closed');
+      expect(ReportType.wrongStatusClosed.fuelTypeColumnValue, 'status_closed');
       expect(ReportType.wrongName.fuelTypeColumnValue, 'name');
       expect(ReportType.wrongAddress.fuelTypeColumnValue, 'address');
     });
@@ -619,16 +656,18 @@ void main() {
       expect(ReportType.wrongAddress.isTankerkoenigSupported, isFalse);
     });
 
-    test('needsPrice / needsText are mutually exclusive and exhaustive',
-        () {
+    test('needsPrice / needsText are mutually exclusive and exhaustive', () {
       for (final type in ReportType.values) {
-        expect(type.needsPrice && type.needsText, isFalse,
-            reason: '$type cannot be both price and text');
+        expect(
+          type.needsPrice && type.needsText,
+          isFalse,
+          reason: '$type cannot be both price and text',
+        );
       }
       // Sanity — every type has a non-empty display name (French
       // fallback is always present).
       for (final type in ReportType.values) {
-        expect(type.displayName(null), isNotEmpty);
+        expect(type.displayName(l10nEn), isNotEmpty);
       }
     });
   });
@@ -638,8 +677,7 @@ void main() {
 /// `reportError` to record the payload — skipping both the consent
 /// dialog and the real browser launcher.
 class _RecordingReporter extends ErrorReporter {
-  _RecordingReporter(this.onReport)
-      : super(launcher: _noopLauncher);
+  _RecordingReporter(this.onReport) : super(launcher: _noopLauncher);
 
   final void Function(ErrorReportPayload) onReport;
 

--- a/test/features/search/presentation/screens/search_criteria_screen_test.dart
+++ b/test/features/search/presentation/screens/search_criteria_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:tankstellen/features/search/providers/search_screen_ui_provider.
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// ActiveProfile stub that records updates in-memory for test assertions.
 class _FakeActiveProfile extends ActiveProfile {
@@ -38,40 +39,51 @@ class _FakeActiveProfile extends ActiveProfile {
 
 void main() {
   group('SearchCriteriaScreen', () {
-    testWidgets('renders form: LocationInput, FuelTypeSelector, slider, button',
-        (tester) async {
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    testWidgets(
+      'renders form: LocationInput, FuelTypeSelector, slider, button',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
-      await pumpApp(
-        tester,
-        const SearchCriteriaScreen(),
-        overrides: [
-          ...test.overrides,
-          selectedFuelTypeOverride(FuelType.e10),
-          searchRadiusOverride(8),
-          userPositionNullOverride(),
-        ],
-      );
+        await pumpApp(
+          tester,
+          const SearchCriteriaScreen(),
+          overrides: [
+            ...test.overrides,
+            selectedFuelTypeOverride(FuelType.e10),
+            searchRadiusOverride(8),
+            userPositionNullOverride(),
+          ],
+        );
 
-      expect(find.byType(LocationInput), findsOneWidget);
-      expect(find.byType(FuelTypeSelector), findsOneWidget);
-      expect(find.byType(Slider), findsOneWidget);
-      // #2131 — the inline "Search" CTA moved to the central FAB in
-      // the shell bar; the criteria screen no longer renders its own
-      // submit button.
-      expect(find.byKey(const ValueKey('criteria-search-button')),
-          findsNothing);
-      expect(find.byKey(const ValueKey('criteria-mode-toggle')),
-          findsOneWidget);
-      expect(find.byKey(const ValueKey('criteria-open-only-toggle')),
-          findsOneWidget);
-      expect(find.byKey(const ValueKey('criteria-save-defaults-button')),
-          findsOneWidget);
-    });
+        expect(find.byType(LocationInput), findsOneWidget);
+        expect(find.byType(FuelTypeSelector), findsOneWidget);
+        expect(find.byType(Slider), findsOneWidget);
+        // #2131 — the inline "Search" CTA moved to the central FAB in
+        // the shell bar; the criteria screen no longer renders its own
+        // submit button.
+        expect(
+          find.byKey(const ValueKey('criteria-search-button')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('criteria-mode-toggle')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('criteria-open-only-toggle')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('criteria-save-defaults-button')),
+          findsOneWidget,
+        );
+      },
+    );
 
-    testWidgets('mode toggle switches from LocationInput to RouteInput',
-        (tester) async {
+    testWidgets('mode toggle switches from LocationInput to RouteInput', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -109,10 +121,16 @@ void main() {
             searchRadiusOverride(8),
             userPositionNullOverride(),
           ].cast(),
-          child: Consumer(builder: (context, ref, _) {
-            container = ProviderScope.containerOf(context);
-            return const MaterialApp(home: SearchCriteriaScreen());
-          }),
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context);
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: SearchCriteriaScreen(),
+              );
+            },
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -120,8 +138,7 @@ void main() {
       container.read(openOnlyFilterProvider.notifier).set(false);
       expect(container.read(openOnlyFilterProvider), isFalse);
 
-      final toggle =
-          find.byKey(const ValueKey('criteria-open-only-toggle'));
+      final toggle = find.byKey(const ValueKey('criteria-open-only-toggle'));
       await tester.ensureVisible(toggle);
       await tester.pump();
       await tester.tap(toggle);
@@ -143,10 +160,16 @@ void main() {
             searchRadiusOverride(8),
             userPositionNullOverride(),
           ].cast(),
-          child: Consumer(builder: (context, ref, _) {
-            container = ProviderScope.containerOf(context);
-            return const MaterialApp(home: SearchCriteriaScreen());
-          }),
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context);
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: SearchCriteriaScreen(),
+              );
+            },
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -175,19 +198,18 @@ void main() {
       expect(container.read(selectedAmenitiesProvider), isEmpty);
     });
 
-    testWidgets(
-        'save-as-defaults button updates the active profile', (tester) async {
+    testWidgets('save-as-defaults button updates the active profile', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
       // #1792 — open-only, amenities and brands have no UserProfile
       // field; they persist device-locally via putSetting.
-      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
-          .thenAnswer((_) async {});
+      when(
+        () => test.mockStorage.putSetting(any(), any<dynamic>()),
+      ).thenAnswer((_) async {});
 
-      const initialProfile = UserProfile(
-        id: 'p1',
-        name: 'Standard',
-      );
+      const initialProfile = UserProfile(id: 'p1', name: 'Standard');
       final fake = _FakeActiveProfile(initialProfile);
 
       // Pre-select shop amenity via the provider override container.
@@ -199,11 +221,7 @@ void main() {
         activeProfileProvider.overrideWith(() => fake),
       ];
 
-      await pumpApp(
-        tester,
-        const SearchCriteriaScreen(),
-        overrides: overrides,
-      );
+      await pumpApp(tester, const SearchCriteriaScreen(), overrides: overrides);
 
       // Select the "Air" amenity chip so we can assert it gets persisted.
       final airChip = find.byKey(const ValueKey('criteria-amenity-airPump'));
@@ -212,8 +230,9 @@ void main() {
       await tester.tap(airChip);
       await tester.pump();
 
-      final saveBtn =
-          find.byKey(const ValueKey('criteria-save-defaults-button'));
+      final saveBtn = find.byKey(
+        const ValueKey('criteria-save-defaults-button'),
+      );
       await tester.ensureVisible(saveBtn);
       await tester.pump();
       await tester.tap(saveBtn);
@@ -227,48 +246,52 @@ void main() {
 
       // #1792 — the amenity set has no profile field; it persists
       // device-locally instead of on the profile.
-      verify(() => test.mockStorage.putSetting(
-            StorageKeys.defaultAmenities,
-            [StationAmenity.airPump.name],
-          )).called(1);
+      verify(
+        () => test.mockStorage.putSetting(StorageKeys.defaultAmenities, [
+          StationAmenity.airPump.name,
+        ]),
+      ).called(1);
     });
 
     testWidgets(
-        '#2592 — save-as-defaults persists route params in route mode',
-        (tester) async {
-      final test = standardTestOverrides();
-      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
-      when(() => test.mockStorage.putSetting(any(), any<dynamic>()))
-          .thenAnswer((_) async {});
+      '#2592 — save-as-defaults persists route params in route mode',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+        when(
+          () => test.mockStorage.putSetting(any(), any<dynamic>()),
+        ).thenAnswer((_) async {});
 
-      const initialProfile = UserProfile(id: 'p1', name: 'Standard');
-      final fake = _FakeActiveProfile(initialProfile);
+        const initialProfile = UserProfile(id: 'p1', name: 'Standard');
+        final fake = _FakeActiveProfile(initialProfile);
 
-      await pumpApp(
-        tester,
-        const SearchCriteriaScreen(),
-        overrides: [
-          ...test.overrides,
-          selectedFuelTypeOverride(FuelType.diesel),
-          searchRadiusOverride(15),
-          userPositionNullOverride(),
-          activeSearchModeOverride(SearchMode.route),
-          routeSegmentSearchParamOverride(250),
-          activeProfileProvider.overrideWith(() => fake),
-        ],
-      );
+        await pumpApp(
+          tester,
+          const SearchCriteriaScreen(),
+          overrides: [
+            ...test.overrides,
+            selectedFuelTypeOverride(FuelType.diesel),
+            searchRadiusOverride(15),
+            userPositionNullOverride(),
+            activeSearchModeOverride(SearchMode.route),
+            routeSegmentSearchParamOverride(250),
+            activeProfileProvider.overrideWith(() => fake),
+          ],
+        );
 
-      final saveBtn =
-          find.byKey(const ValueKey('criteria-save-defaults-button'));
-      await tester.ensureVisible(saveBtn);
-      await tester.pump();
-      await tester.tap(saveBtn);
-      await tester.pump();
+        final saveBtn = find.byKey(
+          const ValueKey('criteria-save-defaults-button'),
+        );
+        await tester.ensureVisible(saveBtn);
+        await tester.pump();
+        await tester.tap(saveBtn);
+        await tester.pump();
 
-      expect(fake.updates, hasLength(1));
-      // Route mode persists the route-segment override onto the profile.
-      expect(fake.updates.single.routeSegmentKm, 250);
-    });
+        expect(fake.updates, hasLength(1));
+        // Route mode persists the route-segment override onto the profile.
+        expect(fake.updates.single.routeSegmentKm, 250);
+      },
+    );
 
     testWidgets('has a close (X) button that pops the route', (tester) async {
       final test = standardTestOverrides();
@@ -305,8 +328,9 @@ void main() {
       expect(find.byType(SearchCriteriaScreen), findsNothing);
     });
 
-    testWidgets('#2131 — registers a SearchFabAction on mount (nearby mode)',
-        (tester) async {
+    testWidgets('#2131 — registers a SearchFabAction on mount (nearby mode)', (
+      tester,
+    ) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
@@ -319,18 +343,26 @@ void main() {
             searchRadiusOverride(8),
             userPositionNullOverride(),
           ].cast(),
-          child: Consumer(builder: (context, ref, _) {
-            container = ProviderScope.containerOf(context);
-            return const MaterialApp(home: SearchCriteriaScreen());
-          }),
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context);
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: SearchCriteriaScreen(),
+              );
+            },
+          ),
         ),
       );
       await tester.pumpAndSettle();
 
-      final action =
-          container.read(searchFabActionControllerProvider);
-      expect(action, isNotNull,
-          reason: 'Criteria screen must publish a FAB action on mount.');
+      final action = container.read(searchFabActionControllerProvider);
+      expect(
+        action,
+        isNotNull,
+        reason: 'Criteria screen must publish a FAB action on mount.',
+      );
       // Nearby mode is the default — FAB enabled, search icon.
       expect(action!.icon, Icons.search);
       expect(action.enabled, isTrue);
@@ -355,8 +387,7 @@ void main() {
     });
 
     group('#522 compaction + l10n', () {
-      testWidgets(
-          'FR locale shows the localised location placeholder '
+      testWidgets('FR locale shows the localised location placeholder '
           '(not "Location search field")', (tester) async {
         final test = standardTestOverrides();
         when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -381,8 +412,7 @@ void main() {
         expect(find.text('Adresse, code postal ou ville'), findsOneWidget);
       });
 
-      testWidgets(
-          'FR locale renders the HelpBanner with the translated '
+      testWidgets('FR locale renders the HelpBanner with the translated '
           '"Compris" dismiss button', (tester) async {
         final test = standardTestOverrides();
         when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -406,8 +436,7 @@ void main() {
         expect(find.text('Got it'), findsNothing);
       });
 
-      testWidgets(
-          'form renders without a vertical overflow at the S23 Ultra '
+      testWidgets('form renders without a vertical overflow at the S23 Ultra '
           'surface size and 1x text scale', (tester) async {
         // #522 acceptance: every filter control fits above the fold.
         await tester.binding.setSurfaceSize(const Size(412, 915));
@@ -437,4 +466,3 @@ void main() {
     });
   });
 }
-

--- a/test/features/search/presentation/widgets/amenity_filter_wrap_test.dart
+++ b/test/features/search/presentation/widgets/amenity_filter_wrap_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/domain/station_amenity.dart';
 import 'package:tankstellen/features/search/presentation/widgets/amenity_filter_wrap.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('AmenityFilterWrap', () {
@@ -15,11 +16,10 @@ void main() {
     }) {
       return tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: AmenityFilterWrap(
-              selected: selected,
-              onToggle: onToggle,
-            ),
+            body: AmenityFilterWrap(selected: selected, onToggle: onToggle),
           ),
         ),
       );
@@ -44,14 +44,11 @@ void main() {
       expect(selectedCount, 2);
     });
 
-    testWidgets('tapping a chip invokes onToggle with that amenity',
-        (tester) async {
+    testWidgets('tapping a chip invokes onToggle with that amenity', (
+      tester,
+    ) async {
       StationAmenity? captured;
-      await pumpWrap(
-        tester,
-        selected: const {},
-        onToggle: (a) => captured = a,
-      );
+      await pumpWrap(tester, selected: const {}, onToggle: (a) => captured = a);
       await tester.tap(find.text('Shop'));
       await tester.pump();
       expect(captured, StationAmenity.shop);

--- a/test/features/search/presentation/widgets/brand_filter_chips_test.dart
+++ b/test/features/search/presentation/widgets/brand_filter_chips_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/features/search/presentation/widgets/brand_filter_ch
 import 'package:tankstellen/features/search/providers/brand_filter_provider.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for [BrandFilterChips] that pin the gaps the existing
 /// `brand_filter_test.dart` and `brand_filter_chip_counts_test.dart`
@@ -17,7 +18,7 @@ import '../../../../helpers/pump_app.dart';
 ///
 /// - tap on "All" calls `selectedBrandsProvider.notifier.clear()`,
 /// - tap on "No highway" toggles `excludeHighwayStationsProvider`,
-/// - tap on "Autoroute" toggles `'Autoroute'` in `selectedBrandsProvider`,
+/// - tap on the "Highway" chip toggles `'Autoroute'` in `selectedBrandsProvider`,
 /// - the "All" chip is selected by default when `selectedBrands` is empty,
 /// - a chip whose label matches a selected brand renders `selected: true`,
 /// - sort order: major brands by count descending, then `Others` last,
@@ -28,25 +29,20 @@ import '../../../../helpers/pump_app.dart';
 /// 100% — every `onSelected` branch is exercised, plus the static
 /// `extractGroupedBrands` ordering contract.
 
-Station _s(
-  String id,
-  String brand, {
-  String stationType = 'R',
-}) =>
-    Station(
-      id: id,
-      name: id,
-      brand: brand,
-      street: 'Rue Test',
-      houseNumber: '1',
-      postCode: '34120',
-      place: 'Test',
-      lat: 43.0,
-      lng: 3.0,
-      dist: 1.0,
-      isOpen: true,
-      stationType: stationType,
-    );
+Station _s(String id, String brand, {String stationType = 'R'}) => Station(
+  id: id,
+  name: id,
+  brand: brand,
+  street: 'Rue Test',
+  houseNumber: '1',
+  postCode: '34120',
+  place: 'Test',
+  lat: 43.0,
+  lng: 3.0,
+  dist: 1.0,
+  isOpen: true,
+  stationType: stationType,
+);
 
 void main() {
   group('BrandFilterChips — empty / minimal renders', () {
@@ -61,30 +57,28 @@ void main() {
     testWidgets(
       'no highway stations → No highway and Autoroute chips are absent',
       (tester) async {
-        final stations = [
-          _s('a', 'Total'),
-          _s('b', 'Esso'),
-        ];
+        final stations = [_s('a', 'Total'), _s('b', 'Esso')];
         await pumpApp(tester, BrandFilterChips(stations: stations));
         expect(find.text('No highway'), findsNothing);
-        expect(find.text('Autoroute'), findsNothing);
+        expect(find.text('Highway'), findsNothing);
       },
     );
   });
 
   group('BrandFilterChips — initial state', () {
-    testWidgets(
-      'All chip is selected by default (selectedBrands is empty)',
-      (tester) async {
-        final stations = [_s('a', 'Total'), _s('b', 'Esso')];
-        await pumpApp(tester, BrandFilterChips(stations: stations));
+    testWidgets('All chip is selected by default (selectedBrands is empty)', (
+      tester,
+    ) async {
+      final stations = [_s('a', 'Total'), _s('b', 'Esso')];
+      await pumpApp(tester, BrandFilterChips(stations: stations));
 
-        final allChip = tester.widget<ChoiceChip>(find.byType(ChoiceChip));
-        expect(allChip.selected, isTrue,
-            reason:
-                'When selectedBrands is empty the All chip is the active state');
-      },
-    );
+      final allChip = tester.widget<ChoiceChip>(find.byType(ChoiceChip));
+      expect(
+        allChip.selected,
+        isTrue,
+        reason: 'When selectedBrands is empty the All chip is the active state',
+      );
+    });
 
     testWidgets(
       'a brand chip whose label is selected renders with selected: true',
@@ -99,6 +93,8 @@ void main() {
               ),
             ],
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(body: BrandFilterChips(stations: stations)),
             ),
           ),
@@ -107,8 +103,11 @@ void main() {
 
         // The "TotalEnergies (1)" chip should be selected; "All" should NOT.
         final allChip = tester.widget<ChoiceChip>(find.byType(ChoiceChip));
-        expect(allChip.selected, isFalse,
-            reason: 'All chip is unselected once a brand is chosen');
+        expect(
+          allChip.selected,
+          isFalse,
+          reason: 'All chip is unselected once a brand is chosen',
+        );
 
         final totalChip = tester.widget<FilterChip>(
           find.ancestor(
@@ -122,68 +121,76 @@ void main() {
   });
 
   group('BrandFilterChips — tap interactions', () {
-    testWidgets(
-      'tapping All calls selectedBrandsProvider.notifier.clear()',
-      (tester) async {
-        final stations = [_s('a', 'Total'), _s('b', 'Esso')];
-        final container = ProviderContainer();
-        addTearDown(container.dispose);
+    testWidgets('tapping All calls selectedBrandsProvider.notifier.clear()', (
+      tester,
+    ) async {
+      final stations = [_s('a', 'Total'), _s('b', 'Esso')];
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-        // Start with a non-empty selection so clear() is observable.
-        container.read(selectedBrandsProvider.notifier).toggle('TotalEnergies');
-        expect(container.read(selectedBrandsProvider), {'TotalEnergies'});
+      // Start with a non-empty selection so clear() is observable.
+      container.read(selectedBrandsProvider.notifier).toggle('TotalEnergies');
+      expect(container.read(selectedBrandsProvider), {'TotalEnergies'});
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: MaterialApp(
-              home: Scaffold(body: BrandFilterChips(stations: stations)),
-            ),
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: BrandFilterChips(stations: stations)),
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('All'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('All'));
+      await tester.pumpAndSettle();
 
-        expect(container.read(selectedBrandsProvider), isEmpty,
-            reason: 'Tapping All must clear the selection');
-      },
-    );
+      expect(
+        container.read(selectedBrandsProvider),
+        isEmpty,
+        reason: 'Tapping All must clear the selection',
+      );
+    });
 
-    testWidgets(
-      'tapping No highway toggles excludeHighwayStationsProvider',
-      (tester) async {
-        final stations = [
-          _s('a', 'Total'),
-          _s('hwy', 'Total', stationType: 'A'),
-        ];
-        final container = ProviderContainer();
-        addTearDown(container.dispose);
+    testWidgets('tapping No highway toggles excludeHighwayStationsProvider', (
+      tester,
+    ) async {
+      final stations = [_s('a', 'Total'), _s('hwy', 'Total', stationType: 'A')];
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-        expect(container.read(excludeHighwayStationsProvider), isFalse);
+      expect(container.read(excludeHighwayStationsProvider), isFalse);
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: MaterialApp(
-              home: Scaffold(body: BrandFilterChips(stations: stations)),
-            ),
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: BrandFilterChips(stations: stations)),
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('No highway'));
-        await tester.pumpAndSettle();
-        expect(container.read(excludeHighwayStationsProvider), isTrue,
-            reason: 'First tap on No highway flips the flag on');
+      await tester.tap(find.text('No highway'));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(excludeHighwayStationsProvider),
+        isTrue,
+        reason: 'First tap on No highway flips the flag on',
+      );
 
-        await tester.tap(find.text('No highway'));
-        await tester.pumpAndSettle();
-        expect(container.read(excludeHighwayStationsProvider), isFalse,
-            reason: 'Second tap toggles back off');
-      },
-    );
+      await tester.tap(find.text('No highway'));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(excludeHighwayStationsProvider),
+        isFalse,
+        reason: 'Second tap toggles back off',
+      );
+    });
 
     testWidgets(
       'tapping Autoroute toggles "Autoroute" membership in selectedBrands',
@@ -199,6 +206,8 @@ void main() {
           UncontrolledProviderScope(
             container: container,
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(body: BrandFilterChips(stations: stations)),
             ),
           ),
@@ -207,15 +216,21 @@ void main() {
 
         expect(container.read(selectedBrandsProvider), isEmpty);
 
-        await tester.tap(find.text('Autoroute'));
+        await tester.tap(find.text('Highway'));
         await tester.pumpAndSettle();
-        expect(container.read(selectedBrandsProvider), {'Autoroute'},
-            reason: 'First tap adds Autoroute to the selection');
+        expect(
+          container.read(selectedBrandsProvider),
+          {'Autoroute'},
+          reason: 'First tap adds Autoroute to the selection',
+        );
 
-        await tester.tap(find.text('Autoroute'));
+        await tester.tap(find.text('Highway'));
         await tester.pumpAndSettle();
-        expect(container.read(selectedBrandsProvider), isEmpty,
-            reason: 'Second tap removes Autoroute again');
+        expect(
+          container.read(selectedBrandsProvider),
+          isEmpty,
+          reason: 'Second tap removes Autoroute again',
+        );
       },
     );
 
@@ -230,6 +245,8 @@ void main() {
           UncontrolledProviderScope(
             container: container,
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(body: BrandFilterChips(stations: stations)),
             ),
           ),
@@ -260,18 +277,24 @@ void main() {
           UncontrolledProviderScope(
             container: container,
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(body: BrandFilterChips(stations: stations)),
             ),
           ),
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Autoroute'));
+        await tester.tap(find.text('Highway'));
         await tester.pumpAndSettle();
 
-        expect(container.read(excludeHighwayStationsProvider), isFalse,
-            reason: 'Autoroute chip writes to selectedBrands, not the highway '
-                'exclusion flag — the two filters live on different providers');
+        expect(
+          container.read(excludeHighwayStationsProvider),
+          isFalse,
+          reason:
+              'Autoroute chip writes to selectedBrands, not the highway '
+              'exclusion flag — the two filters live on different providers',
+        );
       },
     );
   });
@@ -304,13 +327,21 @@ void main() {
             return (counts[b] ?? 0).compareTo(counts[a] ?? 0);
           });
 
-        expect(sorted.last, BrandRegistry.othersLabel,
-            reason: 'Others is always last, even when its count is highest');
-        expect(sorted.first, 'TotalEnergies',
-            reason: 'Major brands sorted by count desc — TotalEnergies has 3');
-        expect(sorted.indexOf('TotalEnergies'),
-            lessThan(sorted.indexOf('Esso')),
-            reason: 'count 3 must rank before count 2');
+        expect(
+          sorted.last,
+          BrandRegistry.othersLabel,
+          reason: 'Others is always last, even when its count is highest',
+        );
+        expect(
+          sorted.first,
+          'TotalEnergies',
+          reason: 'Major brands sorted by count desc — TotalEnergies has 3',
+        );
+        expect(
+          sorted.indexOf('TotalEnergies'),
+          lessThan(sorted.indexOf('Esso')),
+          reason: 'count 3 must rank before count 2',
+        );
       },
     );
   });

--- a/test/features/search/presentation/widgets/ev_connector_chips_test.dart
+++ b/test/features/search/presentation/widgets/ev_connector_chips_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/features/search/presentation/widgets/ev_connector_chips.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('EvConnectorChips', () {
@@ -15,6 +16,8 @@ void main() {
     }) {
       return tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: EvConnectorChips(
               connectors: connectors,

--- a/test/features/search/presentation/widgets/route_planning_controls_test.dart
+++ b/test/features/search/presentation/widgets/route_planning_controls_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/features/route_search/providers/route_search_params_provider.dart';
 import 'package:tankstellen/features/search/presentation/widgets/route_planning_controls.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// #2592 — the route-planning controls render three sliders defaulted from
 /// the active profile and write the per-search override providers on drag.
@@ -21,22 +22,27 @@ class _FixedProfile extends ActiveProfile {
 
 void main() {
   group('RoutePlanningControls (#2592)', () {
-    testWidgets('renders three sliders defaulted from the profile',
-        (tester) async {
+    testWidgets('renders three sliders defaulted from the profile', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             activeProfileProvider.overrideWith(
-              () => _FixedProfile(const UserProfile(
-                id: 'p',
-                name: 'P',
-                routeSegmentKm: 200,
-                routeDetourBudgetKm: 8,
-                minRouteSavingPerLiter: 0.05,
-              )),
+              () => _FixedProfile(
+                const UserProfile(
+                  id: 'p',
+                  name: 'P',
+                  routeSegmentKm: 200,
+                  routeDetourBudgetKm: 8,
+                  minRouteSavingPerLiter: 0.05,
+                ),
+              ),
             ),
           ],
           child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: RoutePlanningControls()),
           ),
         ),
@@ -51,26 +57,29 @@ void main() {
       expect(find.text('0.05 €/L'), findsWidgets);
     });
 
-    testWidgets('dragging the segment slider updates the provider',
-        (tester) async {
+    testWidgets('dragging the segment slider updates the provider', (
+      tester,
+    ) async {
       late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             activeProfileProvider.overrideWith(
-              () => _FixedProfile(const UserProfile(
-                id: 'p',
-                name: 'P',
-                routeSegmentKm: 50,
-              )),
+              () => _FixedProfile(
+                const UserProfile(id: 'p', name: 'P', routeSegmentKm: 50),
+              ),
             ),
           ],
-          child: Consumer(builder: (context, ref, _) {
-            container = ProviderScope.containerOf(context);
-            return const MaterialApp(
-              home: Scaffold(body: RoutePlanningControls()),
-            );
-          }),
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context);
+              return const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(body: RoutePlanningControls()),
+              );
+            },
+          ),
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/search/presentation/widgets/search_mode_toggle_test.dart
+++ b/test/features/search/presentation/widgets/search_mode_toggle_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/domain/search_mode.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_mode_toggle.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('SearchModeToggle', () {
@@ -15,6 +16,8 @@ void main() {
     }) {
       return tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SearchModeToggle(mode: mode, onChanged: onChanged),
           ),
@@ -22,52 +25,47 @@ void main() {
       );
     }
 
-    testWidgets('renders both Nearby and Along route segments',
-        (tester) async {
-      await pumpToggle(
-        tester,
-        mode: SearchMode.nearby,
-        onChanged: (_) {},
-      );
-      expect(find.text('Nearby'), findsOneWidget);
-      expect(find.text('Along route'), findsOneWidget);
+    testWidgets('renders both Nearby and Along route segments', (tester) async {
+      await pumpToggle(tester, mode: SearchMode.nearby, onChanged: (_) {});
+      expect(find.text('Nearby stations'), findsOneWidget);
+      expect(find.text('Search along route'), findsOneWidget);
     });
 
-    testWidgets('selecting the route segment invokes onChanged(route)',
-        (tester) async {
+    testWidgets('selecting the route segment invokes onChanged(route)', (
+      tester,
+    ) async {
       SearchMode? captured;
       await pumpToggle(
         tester,
         mode: SearchMode.nearby,
         onChanged: (m) => captured = m,
       );
-      await tester.tap(find.text('Along route'));
+      await tester.tap(find.text('Search along route'));
       await tester.pumpAndSettle();
       expect(captured, SearchMode.route);
     });
 
-    testWidgets('selecting the nearby segment invokes onChanged(nearby)',
-        (tester) async {
+    testWidgets('selecting the nearby segment invokes onChanged(nearby)', (
+      tester,
+    ) async {
       SearchMode? captured;
       await pumpToggle(
         tester,
         mode: SearchMode.route,
         onChanged: (m) => captured = m,
       );
-      await tester.tap(find.text('Nearby'));
+      await tester.tap(find.text('Nearby stations'));
       await tester.pumpAndSettle();
       expect(captured, SearchMode.nearby);
     });
 
-    testWidgets('initial mode is reflected in the segmented button selection',
-        (tester) async {
-      await pumpToggle(
-        tester,
-        mode: SearchMode.route,
-        onChanged: (_) {},
+    testWidgets('initial mode is reflected in the segmented button selection', (
+      tester,
+    ) async {
+      await pumpToggle(tester, mode: SearchMode.route, onChanged: (_) {});
+      final button = tester.widget<SegmentedButton<SearchMode>>(
+        find.byType(SegmentedButton<SearchMode>),
       );
-      final button =
-          tester.widget<SegmentedButton<SearchMode>>(find.byType(SegmentedButton<SearchMode>));
       expect(button.selected, {SearchMode.route});
     });
   });

--- a/test/features/search/presentation/widgets/search_radius_slider_test.dart
+++ b/test/features/search/presentation/widgets/search_radius_slider_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_radius_slider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('SearchRadiusSlider', () {
@@ -16,6 +17,8 @@ void main() {
     }) {
       return tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SearchRadiusSlider(
               radiusKm: radius,
@@ -28,8 +31,9 @@ void main() {
       );
     }
 
-    testWidgets('renders the rounded radius value with km suffix',
-        (tester) async {
+    testWidgets('renders the rounded radius value with km suffix', (
+      tester,
+    ) async {
       await pumpSlider(tester, radius: 10.4, onChanged: (_) {});
       // Title row + slider label both render the rounded value.
       expect(find.text('10 km'), findsWidgets);
@@ -48,20 +52,25 @@ void main() {
       expect(slider.value, 1);
     });
 
-    testWidgets('uses (max - min) divisions so each integer km is a tick',
-        (tester) async {
-      await pumpSlider(tester, radius: 5, minKm: 1, maxKm: 10, onChanged: (_) {});
+    testWidgets('uses (max - min) divisions so each integer km is a tick', (
+      tester,
+    ) async {
+      await pumpSlider(
+        tester,
+        radius: 5,
+        minKm: 1,
+        maxKm: 10,
+        onChanged: (_) {},
+      );
       final slider = tester.widget<Slider>(find.byType(Slider));
       expect(slider.divisions, 9);
     });
 
-    testWidgets('forwards onChanged when the slider is dragged', (tester) async {
+    testWidgets('forwards onChanged when the slider is dragged', (
+      tester,
+    ) async {
       double? captured;
-      await pumpSlider(
-        tester,
-        radius: 10,
-        onChanged: (v) => captured = v,
-      );
+      await pumpSlider(tester, radius: 10, onChanged: (v) => captured = v);
       // Tap halfway across the slider track. tester.drag is the closest we
       // can get without geometry — assert just that *something* is forwarded.
       await tester.tap(find.byType(Slider));

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -17,6 +17,7 @@ import 'package:tankstellen/features/search/presentation/widgets/station_card.da
 
 import '../../../../helpers/pump_app.dart';
 import '../../../../fixtures/stations.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('StationCard', () {
@@ -40,8 +41,7 @@ void main() {
       expect(find.textContaining('10115'), findsOneWidget);
     });
 
-    testWidgets(
-        'brand-less CRE station shows full name as title and NO orphan '
+    testWidgets('brand-less CRE station shows full name as title and NO orphan '
         'comma in the address line (#2704)', (tester) async {
       // #2704 — Mexican CRE stations carry no brand and no address: the
       // service sets brand:'' and mirrors the full company name into both
@@ -68,8 +68,11 @@ void main() {
         const StationCard(station: mxStation, selectedFuelType: FuelType.e5),
       );
 
-      expect(find.text('TRENOGAS SA DE CV'), findsOneWidget,
-          reason: 'full company name is the card title');
+      expect(
+        find.text('TRENOGAS SA DE CV'),
+        findsOneWidget,
+        reason: 'full company name is the card title',
+      );
       // The address line collapses to '' (postCode + place both empty);
       // there must be no orphan comma anywhere on the card.
       expect(find.text(', '), findsNothing);
@@ -332,50 +335,52 @@ void main() {
     });
 
     testWidgets(
-        '#2622 — favourite star is hoisted OUT of the price row but keeps '
-        'its 32x32 tap target', (tester) async {
-      await pumpApp(
-        tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-          isFavorite: true,
-        ),
-      );
+      '#2622 — favourite star is hoisted OUT of the price row but keeps '
+      'its 32x32 tap target',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: testStation,
+            selectedFuelType: FuelType.e10,
+            isFavorite: true,
+          ),
+        );
 
-      // The favourite icon is still rendered and 22px (compact).
-      final favIcon = find.byWidgetPredicate(
-        (widget) =>
-            widget is Icon &&
-            widget.icon == Icons.star &&
-            widget.color == Colors.amber,
-      );
-      expect(favIcon, findsOneWidget);
+        // The favourite icon is still rendered and 22px (compact).
+        final favIcon = find.byWidgetPredicate(
+          (widget) =>
+              widget is Icon &&
+              widget.icon == Icons.star &&
+              widget.color == Colors.amber,
+        );
+        expect(favIcon, findsOneWidget);
 
-      // The favourite IconButton retains its compact 32x32 tap target even
-      // after being relocated to the card's top-right (#2622).
-      final sizedBox = find.ancestor(
-        of: find.byIcon(Icons.star),
-        matching: find.byWidgetPredicate(
-          (w) => w is SizedBox && w.width == 32 && w.height == 32,
-        ),
-      );
-      expect(sizedBox, findsOneWidget);
+        // The favourite IconButton retains its compact 32x32 tap target even
+        // after being relocated to the card's top-right (#2622).
+        final sizedBox = find.ancestor(
+          of: find.byIcon(Icons.star),
+          matching: find.byWidgetPredicate(
+            (w) => w is SizedBox && w.width == 32 && w.height == 32,
+          ),
+        );
+        expect(sizedBox, findsOneWidget);
 
-      // The star now sits ABOVE the price headline (own line), not on the
-      // same baseline as the price RichText.
-      final starTop = tester.getTopLeft(find.byIcon(Icons.star)).dy;
-      final priceTop =
-          tester.getTopLeft(find.byType(RichText).last).dy;
-      expect(
-        starTop,
-        lessThan(priceTop),
-        reason: 'favourite star is hoisted above the price row (#2622)',
-      );
-    });
+        // The star now sits ABOVE the price headline (own line), not on the
+        // same baseline as the price RichText.
+        final starTop = tester.getTopLeft(find.byIcon(Icons.star)).dy;
+        final priceTop = tester.getTopLeft(find.byType(RichText).last).dy;
+        expect(
+          starTop,
+          lessThan(priceTop),
+          reason: 'favourite star is hoisted above the price row (#2622)',
+        );
+      },
+    );
 
-    testWidgets('#2622 — favourite star still toggles when tapped after move',
-        (tester) async {
+    testWidgets('#2622 — favourite star still toggles when tapped after move', (
+      tester,
+    ) async {
       var favTapped = false;
       await pumpApp(
         tester,
@@ -392,61 +397,64 @@ void main() {
     });
 
     testWidgets(
-        '#2622 — Cheapest badge precedes the price in the widget tree',
-        (tester) async {
-      await pumpApp(
-        tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-          isCheapest: true,
-        ),
-      );
+      '#2622 — Cheapest badge precedes the price in the widget tree',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: testStation,
+            selectedFuelType: FuelType.e10,
+            isCheapest: true,
+          ),
+        );
 
-      // The "Cheapest" badge must sit visually ABOVE the price headline so
-      // it anchors the stop before the eye reaches the number (#2622).
-      final cheapest = find.text('Cheapest');
-      expect(cheapest, findsOneWidget);
+        // The "Cheapest" badge must sit visually ABOVE the price headline so
+        // it anchors the stop before the eye reaches the number (#2622).
+        final cheapest = find.text('Cheapest');
+        expect(cheapest, findsOneWidget);
 
-      final cheapestTop = tester.getTopLeft(cheapest).dy;
-      final priceTop = tester.getTopLeft(find.byType(RichText).last).dy;
-      expect(
-        cheapestTop,
-        lessThan(priceTop),
-        reason: 'Cheapest badge must be promoted above the price (#2622)',
-      );
-    });
+        final cheapestTop = tester.getTopLeft(cheapest).dy;
+        final priceTop = tester.getTopLeft(find.byType(RichText).last).dy;
+        expect(
+          cheapestTop,
+          lessThan(priceTop),
+          reason: 'Cheapest badge must be promoted above the price (#2622)',
+        );
+      },
+    );
 
     testWidgets(
-        '#2622 — last-updated timestamp reads as "Updated {time}", not a '
-        'bare code', (tester) async {
-      const updatedStation = Station(
-        id: 'updated-test',
-        name: 'Test Station',
-        brand: 'TEST',
-        street: 'Teststr.',
-        postCode: '12345',
-        place: 'Teststadt',
-        lat: 52.0,
-        lng: 13.0,
-        dist: 1.0,
-        e10: 1.799,
-        isOpen: true,
-        updatedAt: '10:30',
-      );
+      '#2622 — last-updated timestamp reads as "Updated {time}", not a '
+      'bare code',
+      (tester) async {
+        const updatedStation = Station(
+          id: 'updated-test',
+          name: 'Test Station',
+          brand: 'TEST',
+          street: 'Teststr.',
+          postCode: '12345',
+          place: 'Teststadt',
+          lat: 52.0,
+          lng: 13.0,
+          dist: 1.0,
+          e10: 1.799,
+          isOpen: true,
+          updatedAt: '10:30',
+        );
 
-      await pumpApp(
-        tester,
-        const StationCard(
-          station: updatedStation,
-          selectedFuelType: FuelType.e10,
-        ),
-      );
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: updatedStation,
+            selectedFuelType: FuelType.e10,
+          ),
+        );
 
-      expect(find.textContaining('Updated 10:30'), findsOneWidget);
-      // The bare timestamp on its own must not appear.
-      expect(find.text('10:30'), findsNothing);
-    });
+        expect(find.textContaining('Updated 10:30'), findsOneWidget);
+        // The bare timestamp on its own must not appear.
+        expect(find.text('10:30'), findsNothing);
+      },
+    );
 
     testWidgets('renders amenity chips on single horizontal line', (
       tester,
@@ -1140,6 +1148,8 @@ void main() {
       testWidgets('card uses elevation 1 in dark mode', (tester) async {
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             theme: ThemeData.dark(),
             home: const Scaffold(
               body: StationCard(
@@ -1230,38 +1240,32 @@ void main() {
       },
     );
 
-    testWidgets(
-      '#2926 — an unbranded station WITH a real name shows that name '
-      '(not the localized fallback)',
-      (tester) async {
-        // Mexican CRE stations carry no brand but a real company name; that
-        // name must stay the title — the "Unbranded station" fallback is only
-        // for the no-brand AND no-name case.
-        const namedStation = Station(
-          id: 'mx-named',
-          name: 'TRENOGAS SA DE CV',
-          brand: '',
-          street: 'CALLE 5',
-          postCode: '11700',
-          place: 'CDMX',
-          lat: 19.43,
-          lng: -99.13,
-          e5: 22.95,
-          isOpen: true,
-        );
+    testWidgets('#2926 — an unbranded station WITH a real name shows that name '
+        '(not the localized fallback)', (tester) async {
+      // Mexican CRE stations carry no brand but a real company name; that
+      // name must stay the title — the "Unbranded station" fallback is only
+      // for the no-brand AND no-name case.
+      const namedStation = Station(
+        id: 'mx-named',
+        name: 'TRENOGAS SA DE CV',
+        brand: '',
+        street: 'CALLE 5',
+        postCode: '11700',
+        place: 'CDMX',
+        lat: 19.43,
+        lng: -99.13,
+        e5: 22.95,
+        isOpen: true,
+      );
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: namedStation,
-            selectedFuelType: FuelType.e5,
-          ),
-        );
+      await pumpApp(
+        tester,
+        const StationCard(station: namedStation, selectedFuelType: FuelType.e5),
+      );
 
-        expect(find.text('TRENOGAS SA DE CV'), findsOneWidget);
-        expect(find.text('Unbranded station'), findsNothing);
-      },
-    );
+      expect(find.text('TRENOGAS SA DE CV'), findsOneWidget);
+      expect(find.text('Unbranded station'), findsNothing);
+    });
   });
 
   group('StationCardShell composition (#2493)', () {
@@ -1362,8 +1366,9 @@ void main() {
       isOpen: true,
     );
 
-    testWidgets('no bar when closenessRadiusMeters is null (regular list)',
-        (tester) async {
+    testWidgets('no bar when closenessRadiusMeters is null (regular list)', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const StationCard(
@@ -1374,8 +1379,9 @@ void main() {
       expect(find.byType(ProximityFillBar), findsNothing);
     });
 
-    testWidgets('renders the bar in radar mode at the expected fraction',
-        (tester) async {
+    testWidgets('renders the bar in radar mode at the expected fraction', (
+      tester,
+    ) async {
       // 0.2 km station scaled to a 1 km search radius → 80% full.
       await pumpApp(
         tester,
@@ -1389,8 +1395,11 @@ void main() {
       final bar = tester.widget<ProximityFillBar>(
         find.byType(ProximityFillBar),
       );
-      expect(bar.distanceMeters, closeTo(200, 1e-9),
-          reason: 'station.dist (km) → metres for the bar');
+      expect(
+        bar.distanceMeters,
+        closeTo(200, 1e-9),
+        reason: 'station.dist (km) → metres for the bar',
+      );
       expect(bar.radiusMeters, 1000);
       expect(
         ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!),
@@ -1398,8 +1407,9 @@ void main() {
       );
     });
 
-    testWidgets('a far station scales to near-empty against the search radius',
-        (tester) async {
+    testWidgets('a far station scales to near-empty against the search radius', (
+      tester,
+    ) async {
       // 6.2 km exceeds the 1 km trip geo-fence but reads as RELATIVE closeness
       // against the wider search radius (10 km) → ~0.38, not pinned to empty.
       const farStation = Station(

--- a/test/features/setup/presentation/widgets/api_key_input_section_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_input_section_test.dart
@@ -35,6 +35,8 @@ const _germanyNoUrl = CountryConfig(
 );
 
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('ApiKeyInputSection', () {
     Future<void> pumpSection(
       WidgetTester tester, {
@@ -59,7 +61,7 @@ void main() {
                 country: country,
                 controller: ctrl,
                 formatValid: formatValid,
-                l10n: null,
+                l10n: l10nEn,
               ),
             ),
           ),
@@ -67,8 +69,9 @@ void main() {
       );
     }
 
-    testWidgets('shows no validation indicator when format state is null',
-        (tester) async {
+    testWidgets('shows no validation indicator when format state is null', (
+      tester,
+    ) async {
       await pumpSection(tester, formatValid: null);
       expect(find.byIcon(Icons.check_circle), findsNothing);
       expect(find.byIcon(Icons.error_outline), findsNothing);
@@ -83,8 +86,9 @@ void main() {
       );
     });
 
-    testWidgets('shows red error icon and error text when format is invalid',
-        (tester) async {
+    testWidgets('shows red error icon and error text when format is invalid', (
+      tester,
+    ) async {
       await pumpSection(tester, formatValid: false);
       final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
       expect(
@@ -97,35 +101,36 @@ void main() {
       );
     });
 
-    testWidgets('renders the registration button when a URL is configured',
-        (tester) async {
+    testWidgets('renders the registration button when a URL is configured', (
+      tester,
+    ) async {
       await pumpSection(tester, formatValid: null);
       expect(find.text('Tankerkoenig Registration'), findsOneWidget);
       expect(find.byIcon(Icons.open_in_new), findsOneWidget);
     });
 
-    testWidgets('omits the registration button when no URL is configured',
-        (tester) async {
+    testWidgets('omits the registration button when no URL is configured', (
+      tester,
+    ) async {
       await pumpSection(tester, formatValid: null, country: _germanyNoUrl);
       expect(find.text('Tankerkoenig Registration'), findsNothing);
       expect(find.byIcon(Icons.open_in_new), findsNothing);
     });
 
-    testWidgets('routes typed text into the supplied controller',
-        (tester) async {
+    testWidgets('routes typed text into the supplied controller', (
+      tester,
+    ) async {
       final controller = TextEditingController();
       await pumpSection(tester, formatValid: null, controller: controller);
       await tester.enterText(find.byType(TextField), 'abc-123');
       expect(controller.text, 'abc-123');
     });
 
-    testWidgets('renders the terms-of-use disclaimer with provider name',
-        (tester) async {
+    testWidgets('renders the terms-of-use disclaimer with provider name', (
+      tester,
+    ) async {
       await pumpSection(tester, formatValid: null);
-      expect(
-        find.textContaining('Tankerkoenig'),
-        findsAtLeast(1),
-      );
+      expect(find.textContaining('Tankerkoenig'), findsAtLeast(1));
       expect(
         find.textContaining('Data redistribution is prohibited.'),
         findsOneWidget,

--- a/test/features/setup/presentation/widgets/country_info_card_test.dart
+++ b/test/features/setup/presentation/widgets/country_info_card_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/country_info_card.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/country_status_badge.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 const _germany = CountryConfig(
   code: 'DE',
@@ -37,22 +38,24 @@ void main() {
     Future<void> pumpCard(WidgetTester tester, CountryConfig country) {
       return tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: CountryInfoCard(country: country),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: CountryInfoCard(country: country)),
         ),
       );
     }
 
-    testWidgets('renders the country name and the data-source line',
-        (tester) async {
+    testWidgets('renders the country name and the data-source line', (
+      tester,
+    ) async {
       await pumpCard(tester, _germany);
       expect(find.text('Deutschland'), findsOneWidget);
       expect(find.text('Data: Tankerkoenig'), findsOneWidget);
     });
 
-    testWidgets('renders "Data: Demo" when no apiProvider is configured',
-        (tester) async {
+    testWidgets('renders "Data: Demo" when no apiProvider is configured', (
+      tester,
+    ) async {
       await pumpCard(tester, _demoCountry);
       expect(find.text('Data: Demo'), findsOneWidget);
     });
@@ -62,28 +65,29 @@ void main() {
       expect(find.text('Fuel types: e5, e10, diesel'), findsOneWidget);
     });
 
-    testWidgets('embeds a CountryStatusBadge for the API-key requirement',
-        (tester) async {
+    testWidgets('embeds a CountryStatusBadge for the API-key requirement', (
+      tester,
+    ) async {
       await pumpCard(tester, _germany);
       expect(find.byType(CountryStatusBadge), findsOneWidget);
     });
 
     testWidgets(
-        'wraps the whole card in a Semantics envelope so screen readers '
-        'announce one sentence instead of every detail twice',
-        (tester) async {
-      await pumpCard(tester, _germany);
-      // The combined semantics label includes the API-key requirement and
-      // the fuel-types list — match a substring so this stays robust to
-      // tweaks elsewhere in the sentence.
-      final sem = find.bySemanticsLabel(
-        RegExp(r'Deutschland.*API key required.*e5, e10, diesel'),
-      );
-      expect(sem, findsAtLeast(1));
-    });
+      'wraps the whole card in a Semantics envelope so screen readers '
+      'announce one sentence instead of every detail twice',
+      (tester) async {
+        await pumpCard(tester, _germany);
+        // The combined semantics label includes the API-key requirement and
+        // the fuel-types list — match a substring so this stays robust to
+        // tweaks elsewhere in the sentence.
+        final sem = find.bySemanticsLabel(
+          RegExp(r'Deutschland.*API key required.*e5, e10, diesel'),
+        );
+        expect(sem, findsAtLeast(1));
+      },
+    );
 
-    testWidgets(
-        'wraps the visual flag/title/fuels in ExcludeSemantics so they '
+    testWidgets('wraps the visual flag/title/fuels in ExcludeSemantics so they '
         "don't double up with the parent Semantics label", (tester) async {
       await pumpCard(tester, _germany);
       expect(find.byType(ExcludeSemantics), findsAtLeast(3));

--- a/test/features/setup/presentation/widgets/onboarding_navigation_buttons_test.dart
+++ b/test/features/setup/presentation/widgets/onboarding_navigation_buttons_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/onboarding_navigation_buttons.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('OnboardingNavigationButtons', () {
@@ -19,6 +20,8 @@ void main() {
     }) {
       return tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: OnboardingNavigationButtons(
               currentStep: currentStep,
@@ -45,8 +48,7 @@ void main() {
       expect(find.text('Back'), findsOneWidget);
     });
 
-    testWidgets('hides Skip button when step is not skippable',
-        (tester) async {
+    testWidgets('hides Skip button when step is not skippable', (tester) async {
       await pumpButtons(tester, currentStep: 1, isSkippable: false);
       expect(find.text('Skip'), findsNothing);
     });
@@ -56,16 +58,18 @@ void main() {
       expect(find.text('Skip'), findsOneWidget);
     });
 
-    testWidgets('shows "Get started" + check icon on the last step',
-        (tester) async {
+    testWidgets('shows "Get started" + check icon on the last step', (
+      tester,
+    ) async {
       await pumpButtons(tester, currentStep: 3, isLastStep: true);
       expect(find.text('Get started'), findsOneWidget);
       expect(find.byIcon(Icons.check), findsOneWidget);
       expect(find.byIcon(Icons.arrow_forward), findsNothing);
     });
 
-    testWidgets('shows "Next" + arrow icon on intermediate steps',
-        (tester) async {
+    testWidgets('shows "Next" + arrow icon on intermediate steps', (
+      tester,
+    ) async {
       await pumpButtons(tester, currentStep: 1, isLastStep: false);
       expect(find.text('Next'), findsOneWidget);
       expect(find.byIcon(Icons.arrow_forward), findsOneWidget);

--- a/test/features/station_detail/presentation/widgets/station_rating_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_rating_section_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/widgets/star_rating.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('StationRatingSection content', () {
@@ -15,6 +16,8 @@ void main() {
     testWidgets('StarRating renders with no rating', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: StarRating(rating: null, onRatingChanged: (_) {}),
           ),
@@ -28,9 +31,9 @@ void main() {
     testWidgets('StarRating renders with a rating value', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: StarRating(rating: 3, onRatingChanged: (_) {}),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: StarRating(rating: 3, onRatingChanged: (_) {})),
         ),
       );
 

--- a/test/features/station_detail/presentation/widgets/station_status_row_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_status_row_test.dart
@@ -8,12 +8,14 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/domain/station.dart';
 import 'package:tankstellen/features/search/providers/station_rating_provider.dart';
 import 'package:tankstellen/features/station_detail/presentation/widgets/station_status_row.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 ServiceResult<dynamic> _result({DateTime? fetchedAt}) {
   return ServiceResult(
     data: const Object(),
     source: ServiceSource.tankerkoenigApi,
-    fetchedAt: fetchedAt ?? DateTime.now().subtract(const Duration(seconds: 10)),
+    fetchedAt:
+        fetchedAt ?? DateTime.now().subtract(const Duration(seconds: 10)),
   );
 }
 
@@ -58,10 +60,13 @@ void main() {
       return tester.pumpWidget(
         ProviderScope(
           overrides: [
-            stationRatingsProvider
-                .overrideWith(() => _FakeStationRatings(ratings)),
+            stationRatingsProvider.overrideWith(
+              () => _FakeStationRatings(ratings),
+            ),
           ],
           child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: StationStatusRow(
                 station: station,
@@ -74,8 +79,9 @@ void main() {
       );
     }
 
-    testWidgets('renders the open status text when station is open',
-        (tester) async {
+    testWidgets('renders the open status text when station is open', (
+      tester,
+    ) async {
       await pumpRow(
         tester,
         station: _station(isOpen: true),
@@ -84,8 +90,9 @@ void main() {
       expect(find.textContaining('Open —'), findsOneWidget);
     });
 
-    testWidgets('renders the closed status text when station is closed',
-        (tester) async {
+    testWidgets('renders the closed status text when station is closed', (
+      tester,
+    ) async {
       await pumpRow(
         tester,
         station: _station(isOpen: false),

--- a/test/features/sync/data/auth_error_mapper_test.dart
+++ b/test/features/sync/data/auth_error_mapper_test.dart
@@ -3,66 +3,85 @@
 
 import 'dart:io';
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/sync/data/auth_error_mapper.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   group('friendlyAuthError', () {
     test('maps SocketException to no-network message', () {
       const e = SocketException(
-          "Failed host lookup: 'klelxnkzrxlpzuddhpfg.supabase.co' (errno = 7)");
-      expect(friendlyAuthError(e, null),
-          'No network connection. Try again later.');
+        "Failed host lookup: 'klelxnkzrxlpzuddhpfg.supabase.co' (errno = 7)",
+      );
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'No network connection. Try again later.',
+      );
     });
 
     test('maps AuthRetryableFetchException string to no-network message', () {
       final e = Exception(
-          'AuthRetryableFetchException(message: ClientException with SocketException: Failed host lookup, statusCode: null)');
-      expect(friendlyAuthError(e, null),
-          'No network connection. Try again later.');
+        'AuthRetryableFetchException(message: ClientException with SocketException: Failed host lookup, statusCode: null)',
+      );
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'No network connection. Try again later.',
+      );
     });
 
     test('maps invalid_credentials to credentials message', () {
       final e = Exception('AuthException: invalid_credentials');
-      expect(friendlyAuthError(e, null),
-          'Invalid email or password. Check your credentials.');
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'Invalid email or password. Check your credentials.',
+      );
     });
 
     test('maps user_already_exists to already-registered message', () {
       final e = Exception('AuthException: user_already_exists');
-      expect(friendlyAuthError(e, null),
-          'This email is already registered. Try signing in instead.');
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'This email is already registered. Try signing in instead.',
+      );
     });
 
     test('maps already registered (alternate phrasing) to same message', () {
       final e = Exception('user already registered');
-      expect(friendlyAuthError(e, null),
-          'This email is already registered. Try signing in instead.');
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'This email is already registered. Try signing in instead.',
+      );
     });
 
     test('maps email_not_confirmed to confirmation message', () {
       final e = Exception('AuthException: email_not_confirmed');
-      expect(friendlyAuthError(e, null),
-          'Please check your email and confirm your account first.');
+      expect(
+        friendlyAuthError(e, l10nEn),
+        'Please check your email and confirm your account first.',
+      );
     });
 
     test('falls back to generic message for unknown exceptions', () {
       final e = Exception('something unexpected went wrong');
-      expect(friendlyAuthError(e, null),
-          'Sign-in failed. Please try again.');
+      expect(friendlyAuthError(e, l10nEn), 'Sign-in failed. Please try again.');
     });
 
     test('never leaks the supabase URL', () {
       const e = SocketException(
-          "Failed host lookup: 'klelxnkzrxlpzuddhpfg.supabase.co' (errno = 7)");
-      final msg = friendlyAuthError(e, null);
+        "Failed host lookup: 'klelxnkzrxlpzuddhpfg.supabase.co' (errno = 7)",
+      );
+      final msg = friendlyAuthError(e, l10nEn);
       expect(msg.contains('supabase'), isFalse);
       expect(msg.contains('klelxnkzrxlpzuddhpfg'), isFalse);
     });
 
     test('never leaks the exception type name', () {
       final e = Exception('AuthRetryableFetchException(...)');
-      final msg = friendlyAuthError(e, null);
+      final msg = friendlyAuthError(e, l10nEn);
       expect(msg.contains('Exception'), isFalse);
       expect(msg.contains('AuthRetryableFetchException'), isFalse);
     });

--- a/test/features/sync/presentation/widgets/auth_form_widget_test.dart
+++ b/test/features/sync/presentation/widgets/auth_form_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/auth_form_widget.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   Future<void> pumpForm(
@@ -16,15 +17,18 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SingleChildScrollView(
               child: AuthFormWidget(
-                onSubmit: ({
-                  required bool isEmail,
-                  String? email,
-                  String? password,
-                  required bool isSignUp,
-                }) async {},
+                onSubmit:
+                    ({
+                      required bool isEmail,
+                      String? email,
+                      String? password,
+                      required bool isSignUp,
+                    }) async {},
                 isLoading: isLoading,
                 error: error,
               ),
@@ -45,10 +49,15 @@ void main() {
     testWidgets('default mode is Anonymous — no email fields', (tester) async {
       await pumpForm(tester);
       expect(find.text('Email'), findsOneWidget); // In segmented button
-      expect(find.widgetWithText(TextField, 'Email'), findsNothing); // No input field
+      expect(
+        find.widgetWithText(TextField, 'Email'),
+        findsNothing,
+      ); // No input field
     });
 
-    testWidgets('tapping Email shows email and password fields', (tester) async {
+    testWidgets('tapping Email shows email and password fields', (
+      tester,
+    ) async {
       await pumpForm(tester);
       await tester.tap(find.text('Email'));
       await tester.pumpAndSettle();
@@ -60,7 +69,10 @@ void main() {
       await pumpForm(tester);
       await tester.tap(find.text('Email'));
       await tester.pumpAndSettle();
-      expect(find.widgetWithText(TextField, 'Confirm password'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'Confirm password'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('toggle to sign-in hides confirm password', (tester) async {
@@ -96,22 +108,27 @@ void main() {
     });
 
     group('password length validation (#198)', () {
-      testWidgets('sign-in accepts passwords shorter than 6 characters', (tester) async {
+      testWidgets('sign-in accepts passwords shorter than 6 characters', (
+        tester,
+      ) async {
         bool submitCalled = false;
         await tester.pumpWidget(
           ProviderScope(
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(
                 body: SingleChildScrollView(
                   child: AuthFormWidget(
-                    onSubmit: ({
-                      required bool isEmail,
-                      String? email,
-                      String? password,
-                      required bool isSignUp,
-                    }) async {
-                      submitCalled = true;
-                    },
+                    onSubmit:
+                        ({
+                          required bool isEmail,
+                          String? email,
+                          String? password,
+                          required bool isSignUp,
+                        }) async {
+                          submitCalled = true;
+                        },
                   ),
                 ),
               ),
@@ -128,8 +145,14 @@ void main() {
         await tester.pumpAndSettle();
 
         // Enter email and short password
-        await tester.enterText(find.widgetWithText(TextField, 'Email'), 'test@example.com');
-        await tester.enterText(find.widgetWithText(TextField, 'Password'), 'abc');
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Email'),
+          'test@example.com',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Password'),
+          'abc',
+        );
 
         // Submit
         await tester.tap(find.text('Sign in & connect'));
@@ -139,22 +162,27 @@ void main() {
         expect(submitCalled, isTrue);
       });
 
-      testWidgets('sign-up rejects passwords shorter than 6 characters', (tester) async {
+      testWidgets('sign-up rejects passwords shorter than 6 characters', (
+        tester,
+      ) async {
         bool submitCalled = false;
         await tester.pumpWidget(
           ProviderScope(
             child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(
                 body: SingleChildScrollView(
                   child: AuthFormWidget(
-                    onSubmit: ({
-                      required bool isEmail,
-                      String? email,
-                      String? password,
-                      required bool isSignUp,
-                    }) async {
-                      submitCalled = true;
-                    },
+                    onSubmit:
+                        ({
+                          required bool isEmail,
+                          String? email,
+                          String? password,
+                          required bool isSignUp,
+                        }) async {
+                          submitCalled = true;
+                        },
                   ),
                 ),
               ),
@@ -167,9 +195,18 @@ void main() {
         await tester.pumpAndSettle();
 
         // Enter email and short password
-        await tester.enterText(find.widgetWithText(TextField, 'Email'), 'test@example.com');
-        await tester.enterText(find.widgetWithText(TextField, 'Password'), 'abc');
-        await tester.enterText(find.widgetWithText(TextField, 'Confirm password'), 'abc');
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Email'),
+          'test@example.com',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Password'),
+          'abc',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Confirm password'),
+          'abc',
+        );
 
         // Submit
         await tester.tap(find.text('Create account & connect'));

--- a/test/features/sync/presentation/widgets/link_device_how_it_works_card_test.dart
+++ b/test/features/sync/presentation/widgets/link_device_how_it_works_card_test.dart
@@ -4,15 +4,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/link_device_how_it_works_card.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('LinkDeviceHowItWorksCard', () {
     Future<void> pumpCard(WidgetTester tester) {
       return tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(
-            body: LinkDeviceHowItWorksCard(),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: LinkDeviceHowItWorksCard()),
         ),
       );
     }
@@ -25,18 +26,9 @@ void main() {
 
     testWidgets('renders the step-by-step body text', (tester) async {
       await pumpCard(tester);
-      expect(
-        find.textContaining('On Device A'),
-        findsOneWidget,
-      );
-      expect(
-        find.textContaining('On Device B'),
-        findsOneWidget,
-      );
-      expect(
-        find.textContaining('Import data'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('On Device A'), findsOneWidget);
+      expect(find.textContaining('On Device B'), findsOneWidget);
+      expect(find.textContaining('Import data'), findsOneWidget);
     });
 
     testWidgets('renders inside a Card', (tester) async {

--- a/test/features/sync/presentation/widgets/link_device_import_card_test.dart
+++ b/test/features/sync/presentation/widgets/link_device_import_card_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/link_device_import_card.dart';
 import 'package:tankstellen/features/sync/providers/link_device_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 class _FakeLinkDeviceController extends LinkDeviceController {
   _FakeLinkDeviceController(this._initial);
@@ -33,10 +34,13 @@ void main() {
       return tester.pumpWidget(
         ProviderScope(
           overrides: [
-            linkDeviceControllerProvider
-                .overrideWith(() => _FakeLinkDeviceController(state)),
+            linkDeviceControllerProvider.overrideWith(
+              () => _FakeLinkDeviceController(state),
+            ),
           ],
           child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: LinkDeviceImportCard(codeController: codeController),
             ),
@@ -54,15 +58,17 @@ void main() {
       );
     });
 
-    testWidgets('Import button is disabled when the code field is empty',
-        (tester) async {
+    testWidgets('Import button is disabled when the code field is empty', (
+      tester,
+    ) async {
       await pumpCard(tester);
       final button = tester.widget<FilledButton>(find.byType(FilledButton));
       expect(button.onPressed, isNull);
     });
 
-    testWidgets('Import button enables once the code field has text',
-        (tester) async {
+    testWidgets('Import button enables once the code field has text', (
+      tester,
+    ) async {
       await pumpCard(tester);
       codeController.text = 'abc-123';
       await tester.pump();
@@ -70,23 +76,19 @@ void main() {
       expect(button.onPressed, isNotNull);
     });
 
-    testWidgets('Shows a spinner inside the button while linking',
-        (tester) async {
-      await pumpCard(
-        tester,
-        state: const LinkDeviceState(isLinking: true),
-      );
+    testWidgets('Shows a spinner inside the button while linking', (
+      tester,
+    ) async {
+      await pumpCard(tester, state: const LinkDeviceState(isLinking: true));
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byIcon(Icons.sync), findsNothing);
     });
 
-    testWidgets('Disables the button while linking even when text is present',
-        (tester) async {
+    testWidgets('Disables the button while linking even when text is present', (
+      tester,
+    ) async {
       codeController.text = 'abc-123';
-      await pumpCard(
-        tester,
-        state: const LinkDeviceState(isLinking: true),
-      );
+      await pumpCard(tester, state: const LinkDeviceState(isLinking: true));
       final button = tester.widget<FilledButton>(find.byType(FilledButton));
       expect(button.onPressed, isNull);
     });
@@ -102,9 +104,7 @@ void main() {
     testWidgets('Renders a red result message on error', (tester) async {
       await pumpCard(
         tester,
-        state: const LinkDeviceState(
-          result: 'Link failed',
-        ),
+        state: const LinkDeviceState(result: 'Link failed'),
       );
       expect(find.text('Link failed'), findsOneWidget);
     });

--- a/test/features/sync/presentation/widgets/link_device_this_device_card_test.dart
+++ b/test/features/sync/presentation/widgets/link_device_this_device_card_test.dart
@@ -5,15 +5,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/link_device_this_device_card.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('LinkDeviceThisDeviceCard', () {
     Future<void> pumpCard(WidgetTester tester, {String? myId}) {
       return tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: LinkDeviceThisDeviceCard(myId: myId),
-          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: LinkDeviceThisDeviceCard(myId: myId)),
         ),
       );
     }
@@ -29,8 +30,7 @@ void main() {
       expect(find.text('Not connected'), findsOneWidget);
     });
 
-    testWidgets('shows the copy button when myId is non-null',
-        (tester) async {
+    testWidgets('shows the copy button when myId is non-null', (tester) async {
       await pumpCard(tester, myId: 'abc-123');
       expect(find.byIcon(Icons.copy), findsOneWidget);
     });
@@ -40,20 +40,20 @@ void main() {
       expect(find.byIcon(Icons.copy), findsNothing);
     });
 
-    testWidgets('tapping the copy button writes the id to the clipboard',
-        (tester) async {
+    testWidgets('tapping the copy button writes the id to the clipboard', (
+      tester,
+    ) async {
       // Mock the clipboard channel because flutter_test doesn't ship a
       // platform implementation.
       String? captured;
-      TestDefaultBinaryMessengerBinding
-          .instance.defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-        if (call.method == 'Clipboard.setData') {
-          final args = call.arguments as Map;
-          captured = args['text'] as String?;
-        }
-        return null;
-      });
+            if (call.method == 'Clipboard.setData') {
+              final args = call.arguments as Map;
+              captured = args['text'] as String?;
+            }
+            return null;
+          });
 
       await pumpCard(tester, myId: 'copy-me-please');
       await tester.tap(find.byIcon(Icons.copy));
@@ -61,8 +61,7 @@ void main() {
 
       expect(captured, 'copy-me-please');
 
-      TestDefaultBinaryMessengerBinding
-          .instance.defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
   });

--- a/test/features/sync/presentation/widgets/qr_scanner_screen_test.dart
+++ b/test/features/sync/presentation/widgets/qr_scanner_screen_test.dart
@@ -7,17 +7,20 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:tankstellen/core/permissions/camera_permissions.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/qr_scanner_screen.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('QrScannerTorchButton (#721 subset)', () {
-    testWidgets('hidden when the platform reports torch unavailable',
-        (tester) async {
+    testWidgets('hidden when the platform reports torch unavailable', (
+      tester,
+    ) async {
       await _pumpButton(tester, TorchState.unavailable);
       expect(find.byKey(const Key('qrScannerTorchToggle')), findsNothing);
     });
 
-    testWidgets('off state: flash_off icon + "Turn flash on" tooltip',
-        (tester) async {
+    testWidgets('off state: flash_off icon + "Turn flash on" tooltip', (
+      tester,
+    ) async {
       await _pumpButton(tester, TorchState.off);
       final btn = find.byKey(const Key('qrScannerTorchToggle'));
       expect(btn, findsOneWidget);
@@ -25,8 +28,9 @@ void main() {
       expect(find.byIcon(Icons.flash_off), findsOneWidget);
     });
 
-    testWidgets('on state: flash_on icon + "Turn flash off" tooltip',
-        (tester) async {
+    testWidgets('on state: flash_on icon + "Turn flash off" tooltip', (
+      tester,
+    ) async {
       await _pumpButton(tester, TorchState.on);
       final btn = find.byKey(const Key('qrScannerTorchToggle'));
       expect(tester.widget<IconButton>(btn).tooltip, 'Turn flash off');
@@ -35,26 +39,22 @@ void main() {
 
     testWidgets('tapping the button calls onToggle', (tester) async {
       var calls = 0;
-      await _pumpButton(
-        tester,
-        TorchState.off,
-        onToggle: () async => calls++,
-      );
+      await _pumpButton(tester, TorchState.off, onToggle: () async => calls++);
       await tester.tap(find.byKey(const Key('qrScannerTorchToggle')));
       await tester.pump();
       expect(calls, 1);
     });
 
-    testWidgets('rebuilds when the notifier emits a new torch state',
-        (tester) async {
+    testWidgets('rebuilds when the notifier emits a new torch state', (
+      tester,
+    ) async {
       final notifier = _TorchStateNotifier(TorchState.off);
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: QrScannerTorchButton(
-              state: notifier,
-              onToggle: () async {},
-            ),
+            body: QrScannerTorchButton(state: notifier, onToggle: () async {}),
           ),
         ),
       );
@@ -77,6 +77,8 @@ Future<void> _pumpButton(
   final notifier = _TorchStateNotifier(torch);
   await tester.pumpWidget(
     MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: QrScannerTorchButton(
           state: notifier,
@@ -121,9 +123,13 @@ void _registerQrScannerFlowTests() {
       final perms = _FakeCameraPermissions(
         currentState: CameraPermissionState.permanentlyDenied,
       );
-      await tester.pumpWidget(MaterialApp(
-        home: QrScannerScreen(permissions: perms),
-      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: QrScannerScreen(permissions: perms),
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(
@@ -142,9 +148,13 @@ void _registerQrScannerFlowTests() {
         currentState: CameraPermissionState.denied,
         requestResult: CameraPermissionState.denied,
       );
-      await tester.pumpWidget(MaterialApp(
-        home: QrScannerScreen(permissions: perms),
-      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: QrScannerScreen(permissions: perms),
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('qrScannerDenied')), findsOneWidget);
@@ -157,15 +167,20 @@ void _registerQrScannerFlowTests() {
 
     testWidgets('denied + re-prompt granted clears the error state — '
         'the user who changes their mind and grants on the second '
-        'ask should land on the scanner, not get stuck on the CTA',
-        (tester) async {
+        'ask should land on the scanner, not get stuck on the CTA', (
+      tester,
+    ) async {
       final perms = _FakeCameraPermissions(
         currentState: CameraPermissionState.denied,
         requestResult: CameraPermissionState.granted,
       );
-      await tester.pumpWidget(MaterialApp(
-        home: QrScannerScreen(permissions: perms),
-      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: QrScannerScreen(permissions: perms),
+        ),
+      );
       // Intentionally don't settle — MobileScanner will start
       // initialising and fail in the test harness. We only want
       // to verify the denied CTA is no longer shown.
@@ -185,16 +200,16 @@ class _TorchStateNotifier extends ValueNotifier<MobileScannerState> {
   }
 
   static MobileScannerState _state(TorchState torch) => MobileScannerState(
-        availableCameras: 1,
-        cameraDirection: CameraFacing.back,
-        cameraLensType: CameraLensType.wide,
-        deviceOrientation: DeviceOrientation.portraitUp,
-        isInitialized: true,
-        isStarting: false,
-        isRunning: true,
-        size: Size.zero,
-        torchState: torch,
-        zoomScale: 1,
-        error: null,
-      );
+    availableCameras: 1,
+    cameraDirection: CameraFacing.back,
+    cameraLensType: CameraLensType.wide,
+    deviceOrientation: DeviceOrientation.portraitUp,
+    isInitialized: true,
+    isStarting: false,
+    isRunning: true,
+    size: Size.zero,
+    torchState: torch,
+    zoomScale: 1,
+    error: null,
+  );
 }

--- a/test/features/sync/presentation/widgets/sync_mode_step_test.dart
+++ b/test/features/sync/presentation/widgets/sync_mode_step_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/sync_mode_step.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('SyncModeStep', () {
@@ -15,6 +16,8 @@ void main() {
     }) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SyncModeStep(
               onSelectMode: onSelectMode,
@@ -25,13 +28,10 @@ void main() {
       );
     }
 
-    testWidgets('renders three sync mode cards + stay-offline button',
-        (tester) async {
-      await pumpStep(
-        tester,
-        onSelectMode: (_) {},
-        onStayOffline: () {},
-      );
+    testWidgets('renders three sync mode cards + stay-offline button', (
+      tester,
+    ) async {
+      await pumpStep(tester, onSelectMode: (_) {}, onStayOffline: () {});
 
       expect(find.text('Sparkilo Community'), findsOneWidget);
       expect(find.text('Private Database'), findsOneWidget);
@@ -39,8 +39,9 @@ void main() {
       expect(find.text('Stay offline'), findsOneWidget);
     });
 
-    testWidgets('tapping community card invokes onSelectMode(community)',
-        (tester) async {
+    testWidgets('tapping community card invokes onSelectMode(community)', (
+      tester,
+    ) async {
       SyncMode? captured;
       await pumpStep(
         tester,
@@ -54,8 +55,9 @@ void main() {
       expect(captured, SyncMode.community);
     });
 
-    testWidgets('tapping private card invokes onSelectMode(private)',
-        (tester) async {
+    testWidgets('tapping private card invokes onSelectMode(private)', (
+      tester,
+    ) async {
       SyncMode? captured;
       await pumpStep(
         tester,
@@ -69,8 +71,9 @@ void main() {
       expect(captured, SyncMode.private);
     });
 
-    testWidgets('tapping join card invokes onSelectMode(joinExisting)',
-        (tester) async {
+    testWidgets('tapping join card invokes onSelectMode(joinExisting)', (
+      tester,
+    ) async {
       SyncMode? captured;
       await pumpStep(
         tester,

--- a/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
+++ b/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
@@ -3,6 +3,8 @@
 
 import 'dart:io';
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/notifications/notification_service.dart';
@@ -10,6 +12,7 @@ import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
 import 'package:tankstellen/features/vehicle/domain/services/service_reminder_evaluator.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Local fake that mirrors `test/core/notifications/notification_service_test.dart`.
 /// Duplicated on purpose so this test file stays self-contained and
@@ -51,6 +54,8 @@ class _FakeNotificationService implements NotificationService {
 }
 
 void main() {
+  final AppLocalizations l10nEn = lookupAppLocalizations(const Locale('en'));
+
   late Directory tempDir;
   late Box<String> box;
   late ServiceReminderRepository repo;
@@ -67,6 +72,7 @@ void main() {
     evaluator = ServiceReminderEvaluator(
       repository: repo,
       notifications: notifications,
+      messages: ServiceReminderMessages.fromL10n(l10nEn),
     );
   });
 
@@ -96,15 +102,9 @@ void main() {
       expect(fired, hasLength(1));
       expect(notifications.serviceReminders, hasLength(1));
       expect(notifications.serviceReminders.first.title, 'Service due');
-      // Default-English fallback: "{label} is due — {kmOver} km past the interval."
-      expect(
-        notifications.serviceReminders.first.body,
-        contains('Oil change'),
-      );
-      expect(
-        notifications.serviceReminders.first.body,
-        contains('200'),
-      );
+      // en ARB copy: "{label} is due — {kmOver} km past the interval."
+      expect(notifications.serviceReminders.first.body, contains('Oil change'));
+      expect(notifications.serviceReminders.first.body, contains('200'));
     });
 
     test('does not fire before the threshold', () async {
@@ -136,10 +136,7 @@ void main() {
         ),
       );
 
-      await evaluator.evaluate(
-        vehicleId: 'v-1',
-        currentOdometerKm: 15001,
-      );
+      await evaluator.evaluate(vehicleId: 'v-1', currentOdometerKm: 15001);
 
       expect(repo.getById('r-1')!.pendingAcknowledgment, isTrue);
     });
@@ -154,16 +151,10 @@ void main() {
         ),
       );
 
-      await evaluator.evaluate(
-        vehicleId: 'v-1',
-        currentOdometerKm: 15200,
-      );
+      await evaluator.evaluate(vehicleId: 'v-1', currentOdometerKm: 15200);
       // Second fill-up further past the threshold — the reminder is
       // still pending, so no new notification fires.
-      await evaluator.evaluate(
-        vehicleId: 'v-1',
-        currentOdometerKm: 15500,
-      );
+      await evaluator.evaluate(vehicleId: 'v-1', currentOdometerKm: 15500);
 
       expect(notifications.serviceReminders, hasLength(1));
     });
@@ -178,10 +169,7 @@ void main() {
       await repo.save(reminder);
       await repo.markDone('r-1', 15000);
 
-      await evaluator.evaluate(
-        vehicleId: 'v-1',
-        currentOdometerKm: 20000,
-      );
+      await evaluator.evaluate(vehicleId: 'v-1', currentOdometerKm: 20000);
 
       expect(notifications.serviceReminders, isEmpty);
     });

--- a/test/features/vehicle/presentation/widgets/vehicle_ev_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_ev_section_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/widgets/vehicle_ev_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('VehicleEvSection', () {
@@ -36,6 +37,8 @@ void main() {
     }) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SingleChildScrollView(
               child: VehicleEvSection(
@@ -53,8 +56,9 @@ void main() {
       );
     }
 
-    testWidgets('renders all four numeric inputs + connector chips',
-        (tester) async {
+    testWidgets('renders all four numeric inputs + connector chips', (
+      tester,
+    ) async {
       await pumpSection(tester);
       // 4 numeric fields: battery, max kw, min soc, max soc
       expect(find.byType(TextFormField), findsNWidgets(4));
@@ -65,8 +69,9 @@ void main() {
       );
     });
 
-    testWidgets('initial controller values populate the fields',
-        (tester) async {
+    testWidgets('initial controller values populate the fields', (
+      tester,
+    ) async {
       await pumpSection(tester);
       expect(find.text('75'), findsOneWidget);
       expect(find.text('250'), findsOneWidget);
@@ -74,20 +79,23 @@ void main() {
       expect(find.text('80'), findsOneWidget);
     });
 
-    testWidgets('tapping an unselected connector chip invokes onToggleConnector',
-        (tester) async {
-      ConnectorType? captured;
-      // Pick a connector that is NOT preselected.
-      final unselected = ConnectorType.values
-          .firstWhere((c) => !connectors.contains(c));
+    testWidgets(
+      'tapping an unselected connector chip invokes onToggleConnector',
+      (tester) async {
+        ConnectorType? captured;
+        // Pick a connector that is NOT preselected.
+        final unselected = ConnectorType.values.firstWhere(
+          (c) => !connectors.contains(c),
+        );
 
-      await pumpSection(tester, onToggle: (c) => captured = c);
+        await pumpSection(tester, onToggle: (c) => captured = c);
 
-      await tester.tap(find.text(unselected.label));
-      await tester.pump();
+        await tester.tap(find.text(unselected.label));
+        await tester.pump();
 
-      expect(captured, unselected);
-    });
+        expect(captured, unselected);
+      },
+    );
 
     testWidgets('selected connectors render in selected state', (tester) async {
       await pumpSection(tester);
@@ -101,8 +109,9 @@ void main() {
       expect(chip.selected, isTrue);
     });
 
-    testWidgets('numberValidator is wired to the battery + max kw fields',
-        (tester) async {
+    testWidgets('numberValidator is wired to the battery + max kw fields', (
+      tester,
+    ) async {
       var calls = 0;
       await pumpSection(
         tester,
@@ -117,8 +126,11 @@ void main() {
           .widgetList<TextFormField>(find.byType(TextFormField))
           .where((f) => f.validator != null)
           .toList();
-      expect(fields, hasLength(2),
-          reason: 'battery + max charging power should both be validated');
+      expect(
+        fields,
+        hasLength(2),
+        reason: 'battery + max charging power should both be validated',
+      );
       for (final f in fields) {
         f.validator!('1.5');
       }

--- a/test/features/vehicle/presentation/widgets/vin_info_sheet_test.dart
+++ b/test/features/vehicle/presentation/widgets/vin_info_sheet_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/vehicle/presentation/widgets/vin_info_sheet.dart';
 
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for [VinInfoSheet] (#895 / #561 zero-coverage backlog).
 ///
@@ -36,8 +37,7 @@ void main() {
       expect(find.text('Where to find it'), findsOneWidget);
     });
 
-    testWidgets('renders the dismiss button labeled "Got it"',
-        (tester) async {
+    testWidgets('renders the dismiss button labeled "Got it"', (tester) async {
       await pumpApp(tester, const VinInfoSheet());
 
       expect(find.widgetWithText(FilledButton, 'Got it'), findsOneWidget);
@@ -47,13 +47,16 @@ void main() {
       await pumpApp(tester, const VinInfoSheet());
 
       final safeArea = tester.widget<SafeArea>(find.byType(SafeArea).first);
-      expect(safeArea.top, isFalse,
-          reason: 'top:false avoids double-padding when the sheet '
-              'opens above a transparent system status bar.');
+      expect(
+        safeArea.top,
+        isFalse,
+        reason:
+            'top:false avoids double-padding when the sheet '
+            'opens above a transparent system status bar.',
+      );
     });
 
-    testWidgets('caps maxHeight at 85% of the screen height',
-        (tester) async {
+    testWidgets('caps maxHeight at 85% of the screen height', (tester) async {
       // Force a known viewport so the cap is deterministic.
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1;
@@ -72,12 +75,19 @@ void main() {
           .widgetList<ConstrainedBox>(find.byType(ConstrainedBox))
           .where((b) => b.constraints.maxHeight.isFinite)
           .toList();
-      expect(boxes, isNotEmpty,
-          reason: 'VinInfoSheet must wrap its body in a finite-height '
-              'ConstrainedBox so long copy scrolls instead of '
-              'spilling past the top of the screen.');
-      expect(boxes.first.constraints.maxHeight, closeTo(800 * 0.85, 0.01),
-          reason: 'The sheet caps height at 85% of the viewport.');
+      expect(
+        boxes,
+        isNotEmpty,
+        reason:
+            'VinInfoSheet must wrap its body in a finite-height '
+            'ConstrainedBox so long copy scrolls instead of '
+            'spilling past the top of the screen.',
+      );
+      expect(
+        boxes.first.constraints.maxHeight,
+        closeTo(800 * 0.85, 0.01),
+        reason: 'The sheet caps height at 85% of the viewport.',
+      );
     });
 
     testWidgets('long body uses a SingleChildScrollView', (tester) async {
@@ -91,6 +101,8 @@ void main() {
       (tester) async {
         await tester.pumpWidget(
           MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: Builder(
                 builder: (context) => Center(
@@ -118,9 +130,13 @@ void main() {
         final sheetFinder = find.byType(BottomSheet);
         expect(sheetFinder, findsOneWidget);
         final sheet = tester.widget<BottomSheet>(sheetFinder);
-        expect(sheet.showDragHandle, isTrue,
-            reason: 'show() must request a drag handle so users can '
-                'pull the sheet down.');
+        expect(
+          sheet.showDragHandle,
+          isTrue,
+          reason:
+              'show() must request a drag handle so users can '
+              'pull the sheet down.',
+        );
         expect(sheet.enableDrag, isTrue);
       },
     );

--- a/test/features/widget/presentation/widget_help_section_test.dart
+++ b/test/features/widget/presentation/widget_help_section_test.dart
@@ -21,13 +21,14 @@ class _StubActiveProfile extends ActiveProfile {
 }
 
 void main() {
-  testWidgets('WidgetHelpSection renders the home-screen widget help (#1806)',
-      (tester) async {
+  testWidgets('WidgetHelpSection renders the home-screen widget help (#1806)', (
+    tester,
+  ) async {
     await pumpApp(tester, const WidgetHelpSection());
 
     final l = AppLocalizations.of(
       tester.element(find.byType(WidgetHelpSection)),
-    )!;
+    );
     expect(find.text(l.widgetHelpIntro), findsOneWidget);
     expect(find.text(l.widgetHelpAdd), findsOneWidget);
     expect(find.text(l.widgetHelpTap), findsOneWidget);
@@ -37,30 +38,31 @@ void main() {
   });
 
   testWidgets(
-      '#2106 — active profile swaps the Reconfigure hint for the colour + '
-      'variant defaults editor', (tester) async {
-    const profile = UserProfile(
-      id: 'p1',
-      name: 'Test',
-    );
-    await pumpApp(
-      tester,
-      const WidgetHelpSection(),
-      overrides: [
-        activeProfileProvider.overrideWith(() => _StubActiveProfile(profile)),
-      ],
-    );
+    '#2106 — active profile swaps the Reconfigure hint for the colour + '
+    'variant defaults editor',
+    (tester) async {
+      const profile = UserProfile(id: 'p1', name: 'Test');
+      await pumpApp(
+        tester,
+        const WidgetHelpSection(),
+        overrides: [
+          activeProfileProvider.overrideWith(() => _StubActiveProfile(profile)),
+        ],
+      );
 
-    final l = AppLocalizations.of(
-      tester.element(find.byType(WidgetHelpSection)),
-    )!;
-    // Legacy hint is suppressed — the editor took its place.
-    expect(find.text(l.widgetHelpConfigure), findsNothing);
-    expect(find.text(l.widgetDefaultsApplyToAllHint), findsOneWidget);
-    expect(find.text(l.widgetDefaultsColorLabel), findsOneWidget);
-    expect(find.text(l.widgetDefaultsVariantLabel), findsOneWidget);
-    expect(find.byKey(const Key('widget_color_scheme_dropdown')),
-        findsOneWidget);
-    expect(find.byKey(const Key('widget_variant_segmented')), findsOneWidget);
-  });
+      final l = AppLocalizations.of(
+        tester.element(find.byType(WidgetHelpSection)),
+      );
+      // Legacy hint is suppressed — the editor took its place.
+      expect(find.text(l.widgetHelpConfigure), findsNothing);
+      expect(find.text(l.widgetDefaultsApplyToAllHint), findsOneWidget);
+      expect(find.text(l.widgetDefaultsColorLabel), findsOneWidget);
+      expect(find.text(l.widgetDefaultsVariantLabel), findsOneWidget);
+      expect(
+        find.byKey(const Key('widget_color_scheme_dropdown')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('widget_variant_segmented')), findsOneWidget);
+    },
+  );
 }

--- a/test/lint/no_hardcoded_ui_strings_test.dart
+++ b/test/lint/no_hardcoded_ui_strings_test.dart
@@ -26,19 +26,25 @@ import 'package:flutter_test/flutter_test.dart';
 /// `SnackBar` content and `AppBar` titles are `Text(...)` widgets, so
 /// the `Text(` sink already covers them.
 ///
+/// ## The l10n-fallback pattern (#3162 — gate closed)
+///
+/// `l10n.yaml` sets `nullable-getter: false`, so
+/// `AppLocalizations.of(context)` is non-nullable and the historical
+/// `l10n?.key ?? 'English fallback'` convention is dead code — all
+/// ~708 fallback literals were removed with it. A dedicated sink keeps
+/// the pattern at **zero**: any `l10n.key ?? 'prose'` (or `l?.key`,
+/// `loc.key`, … — with or without arguments) is a violation. Code that
+/// genuinely runs without a `BuildContext` (background isolates, TTS,
+/// notifications) resolves a non-null instance via
+/// `lookupAppLocalizations(locale)` (the #2766 pattern) instead of
+/// falling back to a literal.
+///
 /// ## What is NOT flagged (precision)
 ///
-/// The literal must sit *immediately* after the sink (modulo `const`
-/// and whitespace). That single anchor rules out the bulk of false
-/// positives for free:
+/// For the widget sinks the literal must sit *immediately* after the
+/// sink (modulo `const` and whitespace). That single anchor rules out
+/// the bulk of false positives for free:
 ///
-///   * the intentional fallback pattern `Text(l?.key ?? 'fallback')` /
-///     `Semantics(label: l10n?.key ?? 'fallback')` — a localized
-///     `l10n?…` expression precedes the literal, so the literal is no
-///     longer the first quote after the sink and never matches. This is
-///     the project-wide convention (every `l10n?.x ?? 'English'`); the
-///     `?? 'fallback'` literal is a documented blind spot, intentional
-///     because the primary value is always localized;
 ///   * string interpolation `Text('$count items')` — a `$` inside the
 ///     literal disqualifies it;
 ///   * pure interpolation `Semantics(label: '$a · $b')` that composes
@@ -95,6 +101,19 @@ void main() {
       r'Semantics\(\s*(?:[A-Za-z][A-Za-z0-9]*:\s*[A-Za-z0-9.]+,\s*)*'
       'label:\\s*$quoted',
     ),
+    // #3162 — the l10n-fallback blind spot, closed. `nullable-getter:
+    // false` makes `AppLocalizations.of(context)` non-nullable, so a
+    // `l10n.key ?? 'English fallback'` (let alone `l10n?.key`) is a
+    // duplicated English string that silently drifts from the ARB.
+    // Matches a member access on the conventional localization
+    // identifiers (`l10n`, `l`, `loc`, `localizations`), optionally
+    // with arguments, null-coalesced into a quoted literal — across
+    // newlines (`\s*` spans the wrap).
+    RegExp(
+      r'\b(?:l10n|l|loc|localizations)\??\.[a-zA-Z][a-zA-Z0-9_]*'
+      r'(?:\([^()]*\))?\s*\?\?\s*'
+      '$quoted',
+    ),
   ];
 
   // A ternary *then*-branch that is a bare string literal, sitting
@@ -106,8 +125,8 @@ void main() {
   //
   // The negative lookbehind `(?<!\?)` excludes the null-coalescing
   // operator `?? 'fallback'` (a single `?` is a ternary; a double `??`
-  // is the intentional localized-fallback convention and is NOT a
-  // violation). The trailing `:` confirms it is the `then` arm of a
+  // is handled by the dedicated #3162 fallback sink above, not this
+  // ternary detector). The trailing `:` confirms it is the `then` arm of a
   // conditional rather than a bare expression. The interpolation-context
   // guard below rules out top-level ternaries that are not inside a
   // `${…}` block.


### PR DESCRIPTION
## l10n nullable-getter:false + the ~1,600 hardcoded English fallback literals eliminated

The HARD-RULE-#1 blind spot, from the (closed) lint epic #3158:

- `AppLocalizations.of(context)` is now **non-nullable** (nullable-getter flip + regenerated bindings), so every `l10n?.key ?? 'English prose'` fallback became dead — all ~1,600 lib sites swept to plain key access. The `no_hardcoded_ui_strings` gate gains a dedicated `l10n.key ?? 'prose'` sink locked at **0**, CI-fatal.
- Genuine null-context paths (background isolates, pre-localization widgets) use the sanctioned `lookupAppLocalizations` pattern (#2766); the gpx exporter keeps its documented nullable param.
- **Real bug fixed along the way**: service-reminder notifications were always English — the localized message bundle is now injected at the vehicle provider (`ServiceReminderMessages.fromL10n` watching `activeLanguageProvider`, so a language switch rebuilds the evaluator); 1 new ARB key fanned to all 23 locales.
- The sweep's own confirmation run caught two ratchet regressions in its first design (boundary +1, file_length +63) — fixed with the injection redesign at zero baseline cost; the ratchets work.
- Rebased over the five movers (typed routes / obd2 / alerts / phases / shell): 20 conflicts resolved as typed-route + swept-l10n unions, validated to zero-flag analyze.

Closes #3162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
