### PR TITLE
test(net): pin ISRG Root YR into the nightly trust store — the 2026 LE rotation broke Denmark's TLS verify (#3115 #3222)

### DIFF
--- a/test/core/services/api_connectivity_test.dart
+++ b/test/core/services/api_connectivity_test.dart
@@ -214,6 +214,11 @@ void main() {
     });
 
     test('Denmark — OK API is reachable and returns stations', () async {
+      // #3115/#3222 — this endpoint rotated onto Let's Encrypt's new ISRG
+      // Root YR hierarchy on 2026-06-09 and the runner's stale CA bundle
+      // failed the handshake nightly; `retryingDio` now anchors the pinned
+      // Root YR (see network_retry.dart) so it verifies like a current
+      // platform store.
       final response = await dio.get<dynamic>(
         'https://mobility-prices.ok.dk/api/v1/fuel-prices',
       );

--- a/test/helpers/network_retry.dart
+++ b/test/helpers/network_retry.dart
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:flutter_test/flutter_test.dart' show TestFailure;
 
 /// Bounded retry for the `network`-tagged nightly suite (#3096).
@@ -22,7 +25,79 @@ bool _isTransient(DioException e) =>
     e.type == DioExceptionType.receiveTimeout ||
     e.type == DioExceptionType.sendTimeout ||
     e.type == DioExceptionType.connectionError ||
+    // TLS handshake blips (#3115/#3222): during an upstream certificate
+    // rotation, load-balancer backends can briefly serve inconsistent /
+    // incomplete chains. A retry draws again; a PERSISTENTLY broken TLS
+    // endpoint still exhausts the bounded retries and fails hard.
+    e.error is HandshakeException ||
     (e.response?.statusCode != null && e.response!.statusCode! >= 500);
+
+/// ISRG "Root YR" — Let's Encrypt's 2026 root, embedded as an EXTRA trust
+/// anchor for the nightly network suite (#3115/#3222).
+///
+/// On 2026-06-09 the Denmark OK endpoint (`mobility-prices.ok.dk`) renewed
+/// onto the new Let's Encrypt `YR1` intermediate, and the nightly Linux
+/// runner started failing its handshake with `CERTIFICATE_VERIFY_FAILED:
+/// unable to get local issuer certificate`: the Ubuntu image's
+/// `ca-certificates` bundle predates ISRG Root YR, dart:io/BoringSSL does no
+/// AIA chasing (unlike macOS/iOS), and during the rotation window the server
+/// did not yet serve the `Root YR ← ISRG Root X1` cross-sign that would have
+/// bridged the gap. Trusting the genuine Root YR root — which current
+/// platform stores ship — makes the suite verify exactly like an up-to-date
+/// device, WITHOUT weakening any real signal: an expired / revoked /
+/// wrong-host certificate still fails.
+///
+/// Provenance (verified 2026-06-11 against the live mobility-prices.ok.dk
+/// chain — the SPKI matches the served `Root YR by X1` cross-sign and this
+/// root verifies the served `YR1` intermediate):
+///   - source: https://letsencrypt.org/certs/gen-y/root-yr.pem
+///   - subject: C=US, O=ISRG, CN=Root YR (self-signed)
+///   - validity: 2025-09-03 → 2045-09-02
+///   - SPKI SHA-256:
+///     7e4e8838a8add6295de7ae3b047d3aba3488ab95db0a0aa56d897a00d8618bcf
+///
+/// Remove once GitHub's ubuntu-latest `ca-certificates` ships ISRG Root YR.
+const String _isrgRootYrPem = '''
+-----BEGIN CERTIFICATE-----
+MIIFKTCCAxGgAwIBAgIRAOxGNJNgz0sP+KmC2Tqpyj0wDQYJKoZIhvcNAQELBQAw
+LjELMAkGA1UEBhMCVVMxDTALBgNVBAoTBElTUkcxEDAOBgNVBAMTB1Jvb3QgWVIw
+HhcNMjUwOTAzMDAwMDAwWhcNNDUwOTAyMjM1OTU5WjAuMQswCQYDVQQGEwJVUzEN
+MAsGA1UEChMESVNSRzEQMA4GA1UEAxMHUm9vdCBZUjCCAiIwDQYJKoZIhvcNAQEB
+BQADggIPADCCAgoCggIBANvGJnN78CTJdWL3+eGfsLN5TrNBJs+VH9hRXqRbwxu9
+sGNiB0BD1fcOxbSUQCJIM1xE13Db+5Cw1w0s0EBYsvuIP/6joF0w8cuImbgR1OGg
+YbSQ4OpzI+DG8SGuTlcE873OCS+kh3srlo6vl43M5OJg4Aeo1sfHp6kTJDoIiFBN
+JAY+OKfX/FUvYKuhjT+no49lmqmupSBI5PkBQiqrEGtWU5uxU/cQWHGu8jSjFBzn
+ZqvbNPLMXMLFxCb3WTfrJBXXjqvWG+v4bjzxjjeAtOlU7qarRDvNOyAuQYLln904
+M+faKx8hnLCpJ15ZqaEgcNlY+9MMWcC5yvL2A2j3l9+2buggZX+dOE91zYmIdawT
+vSZuVvlbRrAlLxIB6pwMBjneXCjYQ8+3BCCjssbSNpZU3hTcBDdhfAlEDlYr6pEa
+tnMdmDT5BqnKC92bd0EhM1fbLHioLccLCuievT8ZkPhZrq7Mii7gNXAcUEAR8+lz
+Yal+9zTg7C5DALyVOeG/CqfRAMn1KSHCR0NSA6P8tn/mGRlnCct5rtVCLnVySVpU
+6H1qGg3DgTOuskf8eahTMiYbI5ezPJmO5ertalskQ1utp74+eDy92PI4ftHKTbq9
+IWhH4YZKh3WnJEIt+oQvlYZbY8tpEroKrFB6PFGzrJIDRyts4HqvuH52RFj2zv/B
+AgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
+DgQWBBTe51tg0CJtQCh9Pw0B/qS1UrRRlDANBgkqhkiG9w0BAQsFAAOCAgEAWHnf
+713Bdkq7t5yN2dNIgQakUb94X9WuyhMEHHkgx4oDpSUlnG0w4g94MoqaEUE31ZjR
+LU7L5LD1g9ujFHTQu8AD215AHMVQFbm6j8hQxdXHAzDajFNQnOlDJrLjzIx176oy
+AjvUtejZx2NNmdb5fd0WGVGsCdoAJ3N8ozo7ajE8t6vfxStZb4BQ9WYJGHUDrv2N
+i5tJF6CNiPnlzs3BUfECRbE4JSk+jvy8+VoGiFE8qsH/j78x2fjgQhAQFV7P7Zxy
+dBTZ1wEkNpZNW2qnaK1SKBLa+xf6E06YRIq5uaI+HWH8SY1y5VbRgzq40EKg3yxP
+06fz+uYAUIFJoLNfhwRCc3Q6pQVuMX3yAjHAes4gk4moGcLQ5p7HAh39yeylZc1J
+41sx/jKwLIkPE6Rr1Nf4pxdsxf9SA4yOEiAkDgq04DVxn8hgYFdUtBCuiuVC2heA
+EiqVEa+8QZjuw8Gj0EbHXcRd1nInvGqRS1o9Is7YBdQN57X1AYveGBNNqjICSb7c
+awuw1EawTDrs13VUlJVEsbQ0/O/1aaV73mCdOQ8azqL2KTv1Ewu1xbquE2S+kdQU
+To9TUwat3wUA6cwXh1EfpS/3fJ0aGah5hdpRyoCLDlsSn8tkrjMfFFX0viC+GxHc
+sI1ANRYvqSFC2X1VRZfDg+wD6E21BccmifG4yWc=
+-----END CERTIFICATE-----
+''';
+
+/// System trust roots + the pinned [_isrgRootYrPem] (#3115/#3222).
+///
+/// Used by [retryingDio] so the nightly network suite validates upstream TLS
+/// the way an UP-TO-DATE platform store does, instead of the runner image's
+/// (potentially months-old) `ca-certificates` bundle.
+SecurityContext networkTestSecurityContext() =>
+    SecurityContext(withTrustedRoots: true)
+      ..setTrustedCertificatesBytes(utf8.encode(_isrgRootYrPem));
 
 class _RetryInterceptor extends Interceptor {
   _RetryInterceptor(this._dio, {this.maxRetries = 2});
@@ -52,6 +127,9 @@ class _RetryInterceptor extends Interceptor {
 /// Drop-in for `Dio(BaseOptions(...))` in the live network tests.
 Dio retryingDio(BaseOptions options, {int maxRetries = 2}) {
   final dio = Dio(options);
+  dio.httpClientAdapter = IOHttpClientAdapter(
+    createHttpClient: () => HttpClient(context: networkTestSecurityContext()),
+  );
   dio.interceptors.add(_RetryInterceptor(dio, maxRetries: maxRetries));
   return dio;
 }

--- a/test/helpers/network_retry_test.dart
+++ b/test/helpers/network_retry_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'network_retry.dart';
+
+/// Regression tests for the nightly-network retry helper (#3096), extended
+/// for the #3115/#3222 TLS-trust hardening (Denmark OK rotated onto the new
+/// ISRG Root YR hierarchy and the runner's stale CA bundle failed the
+/// handshake every night). No `network` tag — everything here is offline.
+void main() {
+  group('networkTestSecurityContext (#3115/#3222)', () {
+    test('embedded ISRG Root YR PEM parses into a SecurityContext', () {
+      // setTrustedCertificatesBytes throws a TlsException on a corrupt /
+      // truncated PEM, so this guards the embedded certificate bytes.
+      expect(networkTestSecurityContext, returnsNormally);
+    });
+  });
+
+  group('transient-error classification (#3096, #3115/#3222)', () {
+    DioException handshakeFailure() => DioException(
+          requestOptions: RequestOptions(path: '/probe'),
+          error: const HandshakeException(
+            'Handshake error in client (CERTIFICATE_VERIFY_FAILED)',
+          ),
+        );
+
+    test('a TLS handshake blip is retried and can self-heal', () async {
+      var calls = 0;
+      final result = await retryNetwork<int>(
+        () async {
+          calls++;
+          if (calls < 2) throw handshakeFailure();
+          return 42;
+        },
+        baseDelay: Duration.zero,
+      );
+      expect(result, 42);
+      expect(calls, 2);
+    });
+
+    test('a PERSISTENT handshake failure still fails after bounded retries',
+        () async {
+      var calls = 0;
+      await expectLater(
+        retryNetwork<int>(
+          () async {
+            calls++;
+            throw handshakeFailure();
+          },
+          attempts: 3,
+          baseDelay: Duration.zero,
+        ),
+        throwsA(isA<DioException>()),
+      );
+      expect(calls, 3);
+    });
+
+    test('a non-transient 4xx is NOT retried (contract break fails fast)',
+        () async {
+      var calls = 0;
+      await expectLater(
+        retryNetwork<int>(
+          () async {
+            calls++;
+            throw DioException(
+              requestOptions: RequestOptions(path: '/probe'),
+              type: DioExceptionType.badResponse,
+              response: Response<void>(
+                requestOptions: RequestOptions(path: '/probe'),
+                statusCode: 404,
+              ),
+            );
+          },
+          baseDelay: Duration.zero,
+        ),
+        throwsA(isA<DioException>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('a real assertion (TestFailure) is never retried', () async {
+      var calls = 0;
+      await expectLater(
+        retryNetwork<int>(
+          () async {
+            calls++;
+            fail('upstream contract changed');
+          },
+          baseDelay: Duration.zero,
+        ),
+        throwsA(isA<TestFailure>()),
+      );
+      expect(calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Nightly TLS flake — ISRG Root YR pinned into the network-test trust store

Both nightly-flaky reports (#3115, #3222) were one test: Denmark's OK API, failing `CERTIFICATE_VERIFY_FAILED` on ubuntu-latest since the host renewed onto Let's Encrypt's new 2026 hierarchy (leaf ← YR1 ← ISRG Root YR) on 2026-06-09 — the runner's ca-certificates predates ISRG Root YR, dart:io does no AIA fetching, and the cross-sign wasn't served during the rotation window. Verified down to SPKI hashes and reproduced both failure and fix with openssl.

- `retryingDio` now trusts platform roots + the pinned, provenance-documented ISRG Root YR (expired/revoked/wrong-host still fail hard); `HandshakeException` classified transient for the existing bounded retries.
- New offline regression suite guards the PEM integrity + retry classification; Denmark live test 20/20 locally; a dispatched nightly-flaky run came back green and auto-closed both issues.

Refs #3115, #3222 (closed by the green run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
