### PR TITLE
feat(android-auto): live in-car GPS via CarContext.requestPermissions (#2990)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -303,7 +303,13 @@ fdroidExcludedConfigs.forEach { configName ->
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
-    implementation("androidx.car.app:app:1.4.0")
+    // Android Auto v2 PHASE-3 (#2990) — 1.7.0 (≥ the 1.7.0-rc01 the issue
+    // requires) stabilises the in-car location-permission flow
+    // (CarContext.requestPermissions) the live in-car GPS slice relies on.
+    // Phase-1 deliberately stayed on 1.4.0. androidx.car.app is a plain
+    // androidx artifact (GMS-free), so the fdroid flavor is unaffected — the
+    // car components are only registered in the play source-set manifest.
+    implementation("androidx.car.app:app:1.7.0")
     // #2412 / #2413 — BootReceiver + the widget-refresh trigger enqueue a
     // WorkManager one-off directly (androidx.work.*). The workmanager plugin
     // pulls work-runtime in as `implementation`, which Gradle does not expose
@@ -316,7 +322,7 @@ dependencies {
     // (MenuScreen/SearchScreen/RadarScreen) drive androidx.car.app's
     // ScreenController under Robolectric, so they need a real CarContext +
     // merged Android resources.
-    testImplementation("androidx.car.app:app-testing:1.4.0")
+    testImplementation("androidx.car.app:app-testing:1.7.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.12.2")
     testImplementation("androidx.test:core:1.6.1")

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarSession.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarSession.kt
@@ -9,6 +9,7 @@ import androidx.car.app.Session
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import de.tankstellen.tankstellen.car.CarDataBridge
+import de.tankstellen.tankstellen.car.CarLocationSource
 import de.tankstellen.tankstellen.car.MenuScreen
 
 /**
@@ -23,8 +24,14 @@ import de.tankstellen.tankstellen.car.MenuScreen
  * on Session DESTROYED, via a [DefaultLifecycleObserver] on the session
  * lifecycle. The engine therefore lives ONLY for the duration of the bound car
  * connection — never in a started / foreground service — preserving the #1498
- * FGS-avoidance. The Search screen fetches live through it; Radar stays on the
- * v1 SharedPreferences snapshot this slice (slice 2 wires its live fetch).
+ * FGS-avoidance. Both Search and Radar fetch live through it.
+ *
+ * ## Live in-car GPS lifecycle (v2 PHASE-3 / slice 4, #2990)
+ * The session also owns [CarLocationSource]: started on Session CREATED
+ * (which primes the location permission IN-CAR via
+ * `CarContext.requestPermissions` when it isn't already granted) and stopped
+ * on Session DESTROYED — location runs ONLY while an Auto session is active,
+ * still with zero foreground services.
  */
 class TankstellenCarSession : Session() {
     init {
@@ -32,9 +39,11 @@ class TankstellenCarSession : Session() {
             override fun onCreate(owner: LifecycleOwner) {
                 // carContext is available once the session is created.
                 CarDataBridge.create(carContext)
+                CarLocationSource.start(carContext)
             }
 
             override fun onDestroy(owner: LifecycleOwner) {
+                CarLocationSource.stop()
                 CarDataBridge.destroy()
             }
         })

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
@@ -99,6 +99,17 @@ object CarDataBridge : CarLiveSource {
     // i18n-ignore: protocol sentinel, not user-facing text.
     private const val NO_GPS = "no_gps"
 
+    /** Live in-car fix argument keys (v2 phase-3 slice 4, #2990) — the Dart
+     *  `CarDataService.liveFixFromArgs` counterpart. */
+    // i18n-ignore: protocol tokens, not user-facing text.
+    private const val ARG_LAT = "lat"
+    // i18n-ignore: protocol token, not user-facing text.
+    private const val ARG_LNG = "lng"
+    // i18n-ignore: protocol token, not user-facing text.
+    private const val ARG_ACCURACY_M = "accuracyM"
+    // i18n-ignore: protocol token, not user-facing text.
+    private const val ARG_AGE_MS = "ageMs"
+
     /**
      * Hard ceiling on a single fetch round-trip (engine spin-up + Dart work +
      * channel reply). Kept above the Dart side's own 7 s fetch timeout so the
@@ -212,7 +223,21 @@ object CarDataBridge : CarLiveSource {
         val timeout = Runnable { finish(null) }
         mainHandler.postDelayed(timeout, FETCH_TIMEOUT_MS)
 
-        ch.invokeMethod(method, null, object : MethodChannel.Result {
+        // Live in-car fix (v2 phase-3 slice 4, #2990): when CarLocationSource
+        // has one, attach it so the Dart producer searches around the LIVE
+        // position; null args keep the phase-1 persisted-fix behaviour (the
+        // offline / permission-denied fallback).
+        val fix = CarLocationSource.latestFix
+        val args: Map<String, Any>? = fix?.let {
+            mapOf(
+                ARG_LAT to it.latitude,
+                ARG_LNG to it.longitude,
+                ARG_ACCURACY_M to it.accuracy.toDouble(),
+                ARG_AGE_MS to (System.currentTimeMillis() - it.time),
+            )
+        }
+
+        ch.invokeMethod(method, args, object : MethodChannel.Result {
             override fun success(result: Any?) {
                 mainHandler.removeCallbacks(timeout)
                 val json = result as? String

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarLocationSource.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarLocationSource.kt
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.car
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Build
+import android.os.Looper
+import androidx.car.app.CarContext
+import androidx.core.content.ContextCompat
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * The narrow fix-update surface [StationListScreen] subscribes to, so a
+ * Robolectric test can substitute a fake (the real [CarLocationSource] is a
+ * process singleton wrapping the platform [LocationManager]).
+ */
+interface CarFixUpdates {
+    /** Subscribe to significant live-fix updates (main-thread delivery). */
+    fun addListener(listener: (Location) -> Unit)
+
+    /** Unsubscribe; a never-added listener is a no-op. */
+    fun removeListener(listener: (Location) -> Unit)
+}
+
+/**
+ * Android Auto v2 — PHASE-3 / slice 4 (#2990 / epic #2946): the LIVE in-car
+ * GPS source.
+ *
+ * Phase-1 (#2947) deliberately fed the car screens from the PERSISTED
+ * last-known phone fix (`StorageKeys.userPositionLat/Lng`), which goes stale on
+ * Automotive OS (no phone process refreshing it) and for a driver who paired
+ * the head unit but never opened the phone app. This object acquires a live
+ * fix INSIDE the bound `CarAppService`/Session instead:
+ *
+ *  - [start] is called from the Session lifecycle `onCreate` and [stop] from
+ *    `onDestroy`, so location runs ONLY while an Auto session is active —
+ *    never in a started / foreground service (preserves the #1498
+ *    FGS-avoidance: a bound car app shown on the head unit counts as
+ *    "in use" for the while-in-use location permission).
+ *  - If `ACCESS_FINE_LOCATION` is already granted (the phone app's normal
+ *    grant), updates begin immediately — no prompt. Otherwise the permission
+ *    is primed IN-CAR via [CarContext.requestPermissions] (stabilised by
+ *    androidx.car.app 1.7.0, the reason for the #2990 bump): the host renders
+ *    the grant flow (on-phone for projected Android Auto, on-head-unit for
+ *    Automotive OS), at most ONCE per session. A denial simply leaves the
+ *    persisted-fix fallback in charge.
+ *  - The platform [LocationManager] is used directly (fused provider on
+ *    API 31+, else GPS/network) — never a GMS client, so nothing here would
+ *    trip `scripts/audit_no_gms.sh` even though this class compiles into both
+ *    flavors (only the play manifest registers the car service).
+ *
+ * The freshest fix is exposed as [latestFix]; [CarDataBridge] attaches it to
+ * every fetch over the EXISTING `tankstellen/car_data` channel so the Dart
+ * `CarDataService` searches around the live position (and refreshes the
+ * persisted fix as the fallback). Screens subscribe via [CarFixUpdates] and
+ * are notified on the FIRST fix and after a significant move, so a cold-start
+ * `no_gps` empty-state heals itself the moment a fix arrives.
+ *
+ * Never throws: every platform call is guarded — a location fault degrades to
+ * the persisted-fix fallback, never crashes the car session.
+ */
+object CarLocationSource : CarFixUpdates {
+
+    /** Notify subscribed screens only after moving this far (re-fetch cost). */
+    private const val SIGNIFICANT_MOVE_M = 250f
+
+    /** Update cadence requested from the platform provider. */
+    private const val MIN_TIME_MS = 15_000L
+    private const val MIN_DISTANCE_M = 100f
+
+    /** Max age for a seed `getLastKnownLocation` fix to be considered live. */
+    private const val MAX_SEED_AGE_MS = 10L * 60L * 1000L
+
+    private val listeners = CopyOnWriteArrayList<(Location) -> Unit>()
+
+    /** The freshest in-car fix, or null when none was acquired (yet). */
+    @Volatile
+    var latestFix: Location? = null
+        private set
+
+    private var locationManager: LocationManager? = null
+    private var updatesActive = false
+    private var sessionActive = false
+    private var promptedThisSession = false
+    private var lastNotifiedFix: Location? = null
+
+    private val locationListener = LocationListener { location -> onFix(location) }
+
+    /**
+     * Begin acquiring the in-car fix. Idempotent. Call from Session `onCreate`.
+     *
+     * Respects the existing permission state: an already-granted location
+     * permission starts updates silently; a missing one is primed in-car via
+     * [CarContext.requestPermissions] at most once per session.
+     */
+    @Synchronized
+    fun start(carContext: CarContext) {
+        sessionActive = true
+        if (updatesActive) return
+        if (hasLocationPermission(carContext)) {
+            beginUpdates(carContext)
+            return
+        }
+        if (promptedThisSession) return
+        promptedThisSession = true
+        try {
+            carContext.requestPermissions(
+                listOf(Manifest.permission.ACCESS_FINE_LOCATION),
+            ) { granted, _ ->
+                if (granted.contains(Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    beginUpdates(carContext)
+                }
+                // Denied → persisted-fix fallback stays in charge; no re-prompt
+                // this session.
+            }
+        } catch (e: Exception) {
+            // A host that can't render the grant flow must never crash the
+            // session — the persisted-fix fallback applies.
+        }
+    }
+
+    /**
+     * Stop updates and clear state. Idempotent. Call from Session `onDestroy`
+     * so no location request outlives the car connection.
+     */
+    @Synchronized
+    fun stop() {
+        sessionActive = false
+        promptedThisSession = false
+        try {
+            locationManager?.removeUpdates(locationListener)
+        } catch (_: Exception) {
+            // Best-effort teardown.
+        }
+        locationManager = null
+        updatesActive = false
+        latestFix = null
+        lastNotifiedFix = null
+        listeners.clear()
+    }
+
+    override fun addListener(listener: (Location) -> Unit) {
+        listeners.addIfAbsent(listener)
+    }
+
+    override fun removeListener(listener: (Location) -> Unit) {
+        listeners.remove(listener)
+    }
+
+    /**
+     * Request platform location updates on the main looper. May run from the
+     * permission-grant callback, so it re-checks the session is still alive.
+     */
+    @Synchronized
+    private fun beginUpdates(carContext: CarContext) {
+        if (updatesActive || !sessionActive) return
+        try {
+            val lm = carContext.applicationContext
+                .getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+                ?: return
+            val provider = pickProvider(lm, fineGranted(carContext)) ?: return
+            seedFromLastKnown(lm)
+            lm.requestLocationUpdates(
+                provider,
+                MIN_TIME_MS,
+                MIN_DISTANCE_M,
+                locationListener,
+                Looper.getMainLooper(),
+            )
+            locationManager = lm
+            updatesActive = true
+        } catch (e: Exception) {
+            // SecurityException (revoked between check and request) or any
+            // provider fault → persisted-fix fallback, never a crash.
+        }
+    }
+
+    /**
+     * Best available platform provider: fused (API 31+) → GPS → network. A
+     * coarse-only grant skips GPS (which needs fine).
+     */
+    private fun pickProvider(lm: LocationManager, fine: Boolean): String? {
+        val candidates = buildList {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                add(LocationManager.FUSED_PROVIDER)
+            }
+            if (fine) add(LocationManager.GPS_PROVIDER)
+            add(LocationManager.NETWORK_PROVIDER)
+        }
+        return candidates.firstOrNull { provider ->
+            try {
+                lm.allProviders.contains(provider) && lm.isProviderEnabled(provider)
+            } catch (_: Exception) {
+                false
+            }
+        }
+    }
+
+    /** Seed [latestFix] from a recent last-known fix so the first fetch can
+     *  already carry a live-ish position while the first real fix arrives. */
+    private fun seedFromLastKnown(lm: LocationManager) {
+        if (latestFix != null) return
+        val now = System.currentTimeMillis()
+        val best = lm.allProviders
+            .mapNotNull { provider ->
+                try {
+                    lm.getLastKnownLocation(provider)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+            .filter { now - it.time <= MAX_SEED_AGE_MS }
+            .maxByOrNull { it.time }
+        if (best != null) latestFix = best
+    }
+
+    /** A new platform fix: remember it; notify screens on the first fix and
+     *  after every significant move (delivered on the main looper). */
+    private fun onFix(location: Location) {
+        latestFix = location
+        val last = lastNotifiedFix
+        if (last != null && location.distanceTo(last) < SIGNIFICANT_MOVE_M) return
+        lastNotifiedFix = location
+        for (listener in listeners) {
+            try {
+                listener(location)
+            } catch (_: Exception) {
+                // One faulty subscriber must not starve the rest.
+            }
+        }
+    }
+
+    private fun hasLocationPermission(context: Context): Boolean =
+        fineGranted(context) ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+
+    private fun fineGranted(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+}

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
@@ -3,6 +3,7 @@
 
 package de.tankstellen.tankstellen.car
 
+import android.location.Location
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.model.Action
@@ -17,6 +18,8 @@ import androidx.car.app.model.PlaceListMapTemplate
 import androidx.car.app.model.PlaceMarker
 import androidx.car.app.model.Row
 import androidx.car.app.model.Template
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 
 /**
  * Android Auto base car screen that renders a station list as a
@@ -73,6 +76,13 @@ abstract class StationListScreen(carContext: CarContext) : Screen(carContext) {
     protected open val liveSource: CarLiveSource = CarDataBridge
 
     /**
+     * The live in-car fix feed (v2 phase-3 slice 4, #2990). Defaults to the
+     * real [CarLocationSource]; overridable so a Robolectric test can inject a
+     * fake (the real source wraps the platform LocationManager).
+     */
+    protected open val fixUpdates: CarFixUpdates = CarLocationSource
+
+    /**
      * The latest LIVE list, or null before any live result has arrived. When
      * non-null it takes precedence over the snapshot in [onGetTemplate].
      * Mutated only on the main thread (the bridge callback), then [invalidate].
@@ -81,6 +91,31 @@ abstract class StationListScreen(carContext: CarContext) : Screen(carContext) {
 
     /** True once a live fetch has completed (success OR fault). */
     private var liveAttempted = false
+
+    /**
+     * A first (or significantly-moved) live in-car fix arrived (#2990):
+     * re-arm the fetch and invalidate so the next render searches around the
+     * fresh position — this is what heals a cold-start `no_gps` empty-state
+     * the moment the in-car GPS locks. Delivered on the main thread.
+     */
+    private val fixListener: (Location) -> Unit = {
+        liveAttempted = false
+        invalidate()
+    }
+
+    init {
+        // Subscribe to live-fix updates only while this screen is visible and
+        // only when it actually fetches live data.
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                if (liveFetchEnabled) fixUpdates.addListener(fixListener)
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                fixUpdates.removeListener(fixListener)
+            }
+        })
+    }
 
     override fun onGetTemplate(): Template {
         val snapshot = CarStation.read(carContext, prefsKey)

--- a/android/app/src/play/AndroidManifest.xml
+++ b/android/app/src/play/AndroidManifest.xml
@@ -20,15 +20,19 @@
          Why this ships WITHOUT the #1498 "Foreground Service Use" form:
          A POI CarAppService rendering PlaceListMapTemplate is a BOUND service.
          The Android Auto / Automotive host binds it through the car-app
-         framework; it does NOT start itself as a foreground service, and it
-         reads its station data from SharedPreferences (written by the Flutter
-         app), so it accesses no runtime location in the car process. Per
-         Google's POI manifest example (the car-app-library-fundamentals
-         codelab on developer.android.com) the service carries NO
-         android:permission and the app declares NO FOREGROUND_SERVICE
-         permission for it. Host trust is enforced in code by
-         TankstellenCarAppService.createHostValidator(), not a manifest
-         bind-permission (androidx.car.app 1.4.0 defines no BIND permission).
+         framework; it does NOT start itself as a foreground service. Since
+         v2 phase-3 (#2990) the session DOES acquire live while-in-use
+         location (CarLocationSource, platform LocationManager) — which needs
+         no FGS either: a bound car app displayed on the head unit counts as
+         "in use", per Google's car-app location guidance (the places /
+         navigation samples request ACCESS_FINE_LOCATION via
+         CarContext.requestPermissions and use LocationManager in the bound
+         Session). Per Google's POI manifest example (the
+         car-app-library-fundamentals codelab on developer.android.com) the
+         service carries NO android:permission and the app declares NO
+         FOREGROUND_SERVICE permission for it. Host trust is enforced in code
+         by TankstellenCarAppService.createHostValidator(), not a manifest
+         bind-permission (androidx.car.app defines no BIND permission).
 
          The FOREGROUND_SERVICE permissions stay stripped with
          tools:node="remove" in the MAIN manifest (androidx.work:work-runtime

--- a/lib/features/car/car_data_service.dart
+++ b/lib/features/car/car_data_service.dart
@@ -16,12 +16,12 @@ import '../../core/data/storage_repository.dart';
 import '../../core/logging/error_logger.dart';
 import '../../core/services/country_service_registry.dart';
 import '../../core/storage/hive_storage.dart';
-import '../../core/storage/storage_keys.dart';
-import '../../core/utils/geo_utils.dart' show isUsableCoord;
 import '../../core/domain/search_params.dart';
-import '../../core/domain/fuel_type.dart';
 import '../../core/domain/station.dart';
 import '../widget/data/car_station_data.dart';
+import 'car_fix_store.dart';
+
+export 'car_fix_store.dart' show kNoGpsMarker;
 
 /// Android Auto v2 — PHASE-1 (#2947 / epic #2946): the headless Flutter entry
 /// point the native [CarDataBridge] runs to fetch LIVE in-car Search AND Radar
@@ -41,11 +41,18 @@ import '../widget/data/car_station_data.dart';
 /// radar shape); they differ ONLY in the snapshot key refreshed
 /// ([CarStationData.searchKey] / [CarStationData.radarKey]).
 ///
-/// ## Persisted-fix GPS only (never a live lock)
-/// The contract (#2947) is the persisted last-known fix the nearest-widget
+/// ## Live in-car fix first, persisted fix as the fallback (#2990, phase-3)
+/// Phase-1 (#2947) used ONLY the persisted last-known fix the nearest-widget
 /// builder reads — `StorageKeys.userPositionLat/Lng` with the #2872
-/// [isUsableCoord] guard. No live GPS in the car process in phase-1 (that + the
-/// `requestPermissions` flow is a later phase), so this never blocks; an absent
+/// [isUsableCoord] guard — which goes stale on Automotive OS / when the phone
+/// app was never opened. Phase-3 slice 4 (#2990) has the native
+/// `CarLocationSource` acquire a LIVE fix inside the bound session (in-car
+/// permission priming via `CarContext.requestPermissions`, androidx.car.app
+/// 1.7.0) and attach it as `{lat,lng,accuracyM,ageMs}` arguments on the SAME
+/// fetch methods. A usable live fix wins and is persisted back (source `car`)
+/// so the fallback — and the nearest widget — stay fresh; absent / poisoned
+/// args fall back to the persisted fix exactly as before (the offline /
+/// permission-denied path). Neither path ever blocks on a GPS lock; an absent
 /// / poisoned fix returns [kNoGpsMarker] and the screen keeps its snapshot.
 ///
 /// ## Live fetch path — bulk-country-correct + never throws
@@ -84,11 +91,9 @@ const String kCarMethodFetchRadar = 'fetchRadar';
 // i18n-ignore: protocol token, not user-facing text.
 const String kCarMethodGetUserLocation = 'getUserLocation';
 
-/// Sentinel the entry point returns (in place of a JSON list) when there is
-/// no usable persisted GPS fix — the native screen keeps its snapshot /
-/// shows the `car_empty_no_gps` message rather than blanking.
-// i18n-ignore: protocol sentinel, not user-facing text.
-const String kNoGpsMarker = 'no_gps';
+// kNoGpsMarker (the "no usable GPS fix" protocol sentinel) lives in
+// car_fix_store.dart since #2990 and is re-exported below so this file stays
+// the single import for the channel contract.
 
 /// Hard ceiling on the live fetch's own work, independent of the native
 /// bridge's own timeout. Keeps a slow provider from holding the engine open.
@@ -107,9 +112,9 @@ void carDataMain() {
   channel.setMethodCallHandler((call) async {
     switch (call.method) {
       case kCarMethodFetchSearch:
-        return service.fetchSearch();
+        return service.fetchSearch(args: call.arguments);
       case kCarMethodFetchRadar:
-        return service.fetchRadar();
+        return service.fetchRadar(args: call.arguments);
       case kCarMethodGetUserLocation:
         return service.getUserLocation();
       default:
@@ -175,23 +180,33 @@ class CarDataService {
       HomeWidget.saveWidgetData(key, value);
 
   /// Handle [kCarMethodFetchSearch] — see [_fetch]; refreshes
-  /// [CarStationData.searchKey]. Never throws.
-  Future<String> fetchSearch() =>
-      _fetch(CarStationData.searchKey, 'fetchSearch');
+  /// [CarStationData.searchKey]. [args] is the optional live in-car fix the
+  /// native bridge attaches, parsed by [carLiveFixFromArgs] (#2990). Never
+  /// throws.
+  Future<String> fetchSearch({Object? args}) =>
+      _fetch(CarStationData.searchKey, 'fetchSearch',
+          liveFix: carLiveFixFromArgs(args));
 
   /// Handle [kCarMethodFetchRadar] (v2 phase-1 slice 2, #2947) — the SAME live
   /// producer as [fetchSearch] (nearest priced stations within the active radius,
   /// distance-sorted + capped — the v1 in-app radar shape), refreshing
-  /// [CarStationData.radarKey] instead. Never throws.
-  Future<String> fetchRadar() =>
-      _fetch(CarStationData.radarKey, 'fetchRadar');
+  /// [CarStationData.radarKey] instead. [args] is the optional live in-car fix
+  /// the native bridge attaches, parsed by [carLiveFixFromArgs] (#2990). Never
+  /// throws.
+  Future<String> fetchRadar({Object? args}) =>
+      _fetch(CarStationData.radarKey, 'fetchRadar',
+          liveFix: carLiveFixFromArgs(args));
 
   /// Shared Hive-lock + isolate-init wrapper behind [fetchSearch] / [fetchRadar]:
   /// open Hive under the isolate lock, load the API key, run [_resolveJson] for
   /// [snapshotKey] ([where] tags the error-log context), and ALWAYS close the
   /// boxes in `finally`. Never throws — any fault returns [kNoGpsMarker] so the
   /// screen degrades to its snapshot / empty-state.
-  Future<String> _fetch(String snapshotKey, String where) async {
+  Future<String> _fetch(
+    String snapshotKey,
+    String where, {
+    ({double lat, double lng})? liveFix,
+  }) async {
     HiveIsolateLock? lock;
     try {
       lock = await HiveIsolateLock.create();
@@ -203,7 +218,8 @@ class CarDataService {
       await HiveStorage.initInIsolate();
       await HiveStorage.loadApiKey();
       final storage = HiveStorage();
-      return await _resolveJson(storage, snapshotKey, apiKey: storage.getApiKey())
+      return await _resolveJson(storage, snapshotKey,
+              apiKey: storage.getApiKey(), liveFix: liveFix)
           .timeout(_fetchTimeout, onTimeout: () => kNoGpsMarker);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
@@ -230,7 +246,7 @@ class CarDataService {
       lock = await HiveIsolateLock.create();
       if (!await lock.acquire()) return const {'source': kNoGpsMarker};
       await HiveStorage.initInIsolate();
-      return readUserLocation(HiveStorage());
+      return readCarUserLocation(HiveStorage());
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'CarDataService.getUserLocation',
@@ -252,8 +268,10 @@ class CarDataService {
   Future<String> resolveSearchJson(
     StorageRepository storage, {
     String? apiKey,
+    ({double lat, double lng})? liveFix,
   }) =>
-      _resolveJson(storage, CarStationData.searchKey, apiKey: apiKey);
+      _resolveJson(storage, CarStationData.searchKey,
+          apiKey: apiKey, liveFix: liveFix);
 
   /// Pure resolution of the live Radar JSON — see [_resolveJson]. Identical
   /// producer to [resolveSearchJson] (same fix + country + profile radius/fuel +
@@ -264,13 +282,19 @@ class CarDataService {
   Future<String> resolveRadarJson(
     StorageRepository storage, {
     String? apiKey,
+    ({double lat, double lng})? liveFix,
   }) =>
-      _resolveJson(storage, CarStationData.radarKey, apiKey: apiKey);
+      _resolveJson(storage, CarStationData.radarKey,
+          apiKey: apiKey, liveFix: liveFix);
 
-  /// Pure resolution used by both the live handlers and the unit tests: read
-  /// the persisted fix (with the #2872 guard), resolve the active country +
+  /// Pure resolution used by both the live handlers and the unit tests: take
+  /// the live in-car fix when one was attached (#2990), else read the
+  /// persisted fix (with the #2872 guard); resolve the active country +
   /// profile, run a LIVE radius [CountryAlertStrategy.searchArea], encode with
   /// [CarStationData.encode], and refresh [snapshotKey] on a non-empty result.
+  /// A live fix is also persisted back (source `car`, best-effort) so the
+  /// persisted fallback — and everything else that reads it, e.g. the nearest
+  /// widget — stays fresh while driving.
   /// Returns [kNoGpsMarker] when no usable fix exists; an empty `[]` when the
   /// fix is good but the search returned nothing or faulted (the screen keeps
   /// its snapshot). Never throws.
@@ -278,15 +302,20 @@ class CarDataService {
     StorageRepository storage,
     String snapshotKey, {
     String? apiKey,
+    ({double lat, double lng})? liveFix,
   }) async {
-    final fix = _persistedFix(storage);
+    final fix = liveFix ?? readPersistedCarFix(storage);
     if (fix == null) return kNoGpsMarker;
+
+    if (liveFix != null) {
+      await persistCarFix(storage, liveFix);
+    }
 
     final country = CountryServiceRegistry.countryForLatLng(fix.lat, fix.lng) ??
         (storage.getSetting('active_country_code') as String?) ??
         'DE';
 
-    final profile = _activeProfile(storage);
+    final profile = activeCarProfile(storage);
     final budget = ProviderRequestBudget(storage);
     final strategy = _strategyFactory(
       country,
@@ -334,70 +363,4 @@ class CarDataService {
     return json;
   }
 
-  /// The `{lat,lng,source,updatedAtMs}` location payload, or `{source:no_gps}`.
-  @visibleForTesting
-  Map<String, dynamic> readUserLocation(StorageRepository storage) {
-    final fix = _persistedFix(storage);
-    if (fix == null) return const {'source': kNoGpsMarker};
-    return <String, dynamic>{
-      'lat': fix.lat,
-      'lng': fix.lng,
-      'source': (storage.getSetting(StorageKeys.userPositionSource) as String?) ??
-          'persisted',
-      'updatedAtMs': _updatedAtMs(storage),
-    };
-  }
-
-  /// Read the persisted fix the same way the nearest-widget builder does, then
-  /// apply the #2872 [isUsableCoord] guard so a `(0,0)` / one-axis / NaN fix is
-  /// rejected (returns null → the caller emits [kNoGpsMarker]).
-  ({double lat, double lng})? _persistedFix(StorageRepository storage) {
-    final lat =
-        (storage.getSetting(StorageKeys.userPositionLat) as num?)?.toDouble();
-    final lng =
-        (storage.getSetting(StorageKeys.userPositionLng) as num?)?.toDouble();
-    if (lat == null || lng == null) return null;
-    if (!isUsableCoord(lat, lng)) return null;
-    return (lat: lat, lng: lng);
-  }
-
-  int? _updatedAtMs(StorageRepository storage) {
-    final raw = storage.getSetting(StorageKeys.userPositionTimestamp);
-    if (raw is int) return raw;
-    if (raw is num) return raw.toInt();
-    if (raw is String) {
-      final parsed = DateTime.tryParse(raw);
-      if (parsed != null) return parsed.millisecondsSinceEpoch;
-      return int.tryParse(raw);
-    }
-    return null;
-  }
-
-  /// Active-profile radius + fuel, mirroring the nearest-widget builder's
-  /// `_activeProfile` (default 10 km / E10 when no profile is set).
-  _CarProfile _activeProfile(StorageRepository storage) {
-    final id = storage.getActiveProfileId();
-    if (id == null) return const _CarProfile();
-    final raw = storage.getProfile(id);
-    if (raw == null) return const _CarProfile();
-    final radius = (raw['defaultSearchRadius'] as num?)?.toDouble() ?? 10.0;
-    FuelType fuel = FuelType.e10;
-    final key = raw['preferredFuelType']?.toString();
-    if (key != null) {
-      try {
-        fuel = FuelType.fromString(key);
-      // #3164 — kept: preference validation; unknown fuel key falls back.
-      } catch (e, st) { // ignore: unused_catch_stack
-        debugPrint('CarDataService: unknown preferred fuel "$key": $e');
-      }
-    }
-    return _CarProfile(radiusKm: radius, fuelType: fuel);
-  }
-}
-
-/// Active-profile snapshot for one car fetch.
-class _CarProfile {
-  final double radiusKm;
-  final FuelType fuelType;
-  const _CarProfile({this.radiusKm = 10.0, this.fuelType = FuelType.e10});
 }

--- a/lib/features/car/car_fix_store.dart
+++ b/lib/features/car/car_fix_store.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../core/data/storage_repository.dart';
+import '../../core/domain/fuel_type.dart';
+import '../../core/logging/error_logger.dart';
+import '../../core/storage/storage_keys.dart';
+import '../../core/utils/geo_utils.dart' show isUsableCoord;
+
+/// Android Auto fix + profile storage helpers behind `CarDataService`
+/// (extracted in #2990 to keep `car_data_service.dart` under the #1680 file
+/// budget): reading the persisted last-known fix, parsing/persisting the LIVE
+/// in-car fix the native `CarLocationSource` attaches to a fetch, and the
+/// active-profile radius/fuel snapshot. Everything here is pure or
+/// best-effort and never throws into the headless engine.
+
+/// Sentinel the entry point returns (in place of a JSON list) when there is
+/// no usable GPS fix — the native screen keeps its snapshot / shows the
+/// `car_empty_no_gps` message rather than blanking. (Lives here, next to the
+/// fix readers; re-exported by `car_data_service.dart`, the channel contract.)
+// i18n-ignore: protocol sentinel, not user-facing text.
+const String kNoGpsMarker = 'no_gps';
+
+/// Parse the live in-car fix the native `CarLocationSource`/`CarDataBridge`
+/// attaches to a fetch (#2990): a `{lat,lng,...}` map. Returns null — i.e.
+/// the persisted-fix fallback — for absent / malformed args or a fix the
+/// #2872 [isUsableCoord] guard rejects. Never throws.
+({double lat, double lng})? carLiveFixFromArgs(Object? args) {
+  if (args is! Map) return null;
+  final rawLat = args['lat'];
+  final rawLng = args['lng'];
+  // `is!` (not a cast) so a hostile / corrupted payload degrades to the
+  // fallback instead of throwing into the headless engine.
+  if (rawLat is! num || rawLng is! num) return null;
+  final lat = rawLat.toDouble();
+  final lng = rawLng.toDouble();
+  if (!isUsableCoord(lat, lng)) return null;
+  return (lat: lat, lng: lng);
+}
+
+/// Read the persisted fix the same way the nearest-widget builder does, then
+/// apply the #2872 [isUsableCoord] guard so a `(0,0)` / one-axis / NaN fix is
+/// rejected (returns null → the caller emits the `no_gps` marker).
+({double lat, double lng})? readPersistedCarFix(StorageRepository storage) {
+  final lat =
+      (storage.getSetting(StorageKeys.userPositionLat) as num?)?.toDouble();
+  final lng =
+      (storage.getSetting(StorageKeys.userPositionLng) as num?)?.toDouble();
+  if (lat == null || lng == null) return null;
+  if (!isUsableCoord(lat, lng)) return null;
+  return (lat: lat, lng: lng);
+}
+
+/// Persist the live in-car fix as the new last-known position (#2990) —
+/// the same keys `UserPositionNotifier._persist` writes, with source `car` —
+/// so the persisted fallback (and everything else that reads it, e.g. the
+/// nearest widget) stays fresh while driving.
+/// Best-effort: a storage fault never fails the fetch.
+Future<void> persistCarFix(
+  StorageRepository storage,
+  ({double lat, double lng}) fix,
+) async {
+  try {
+    await storage.putSetting(StorageKeys.userPositionLat, fix.lat);
+    await storage.putSetting(StorageKeys.userPositionLng, fix.lng);
+    await storage.putSetting(
+      StorageKeys.userPositionTimestamp,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    // i18n-ignore: position-source tag, not user-facing text.
+    await storage.putSetting(StorageKeys.userPositionSource, 'car');
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      'where': 'persistCarFix',
+    }));
+  }
+}
+
+/// The `{lat,lng,source,updatedAtMs}` location payload, or `{source:no_gps}`.
+Map<String, dynamic> readCarUserLocation(StorageRepository storage) {
+  final fix = readPersistedCarFix(storage);
+  if (fix == null) return const {'source': kNoGpsMarker};
+  return <String, dynamic>{
+    'lat': fix.lat,
+    'lng': fix.lng,
+    'source': (storage.getSetting(StorageKeys.userPositionSource) as String?) ??
+        'persisted',
+    'updatedAtMs': _updatedAtMs(storage),
+  };
+}
+
+int? _updatedAtMs(StorageRepository storage) {
+  final raw = storage.getSetting(StorageKeys.userPositionTimestamp);
+  if (raw is int) return raw;
+  if (raw is num) return raw.toInt();
+  if (raw is String) {
+    final parsed = DateTime.tryParse(raw);
+    if (parsed != null) return parsed.millisecondsSinceEpoch;
+    return int.tryParse(raw);
+  }
+  return null;
+}
+
+/// Active-profile radius + fuel, mirroring the nearest-widget builder's
+/// `_activeProfile` (default 10 km / E10 when no profile is set).
+CarProfile activeCarProfile(StorageRepository storage) {
+  final id = storage.getActiveProfileId();
+  if (id == null) return const CarProfile();
+  final raw = storage.getProfile(id);
+  if (raw == null) return const CarProfile();
+  final radius = (raw['defaultSearchRadius'] as num?)?.toDouble() ?? 10.0;
+  FuelType fuel = FuelType.e10;
+  final key = raw['preferredFuelType']?.toString();
+  if (key != null) {
+    try {
+      fuel = FuelType.fromString(key);
+    // #3164 — kept: preference validation; unknown fuel key falls back.
+    } catch (e, st) { // ignore: unused_catch_stack
+      debugPrint('activeCarProfile: unknown preferred fuel "$key": $e');
+    }
+  }
+  return CarProfile(radiusKm: radius, fuelType: fuel);
+}
+
+/// Active-profile snapshot for one car fetch.
+class CarProfile {
+  final double radiusKm;
+  final FuelType fuelType;
+  const CarProfile({this.radiusKm = 10.0, this.fuelType = FuelType.e10});
+}

--- a/test/features/car/car_data_service_test.dart
+++ b/test/features/car/car_data_service_test.dart
@@ -20,6 +20,7 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/features/car/car_data_service.dart';
+import 'package:tankstellen/features/car/car_fix_store.dart';
 import 'package:tankstellen/core/domain/search_params.dart';
 import 'package:tankstellen/core/domain/station.dart';
 
@@ -191,8 +192,7 @@ void main() {
 
     test('getUserLocation returns no_gps when the fix is poisoned', () {
       final storage = FakeStorageRepository();
-      final service = CarDataService();
-      expect(service.readUserLocation(storage), {'source': kNoGpsMarker});
+      expect(readCarUserLocation(storage), {'source': kNoGpsMarker});
     });
   });
 
@@ -220,7 +220,7 @@ void main() {
       unawaited(storage.inner.putSetting(StorageKeys.userPositionLat, 48.8566));
       unawaited(storage.inner.putSetting(StorageKeys.userPositionLng, 2.3522));
       unawaited(storage.inner.putSetting(StorageKeys.userPositionSource, 'gps'));
-      final loc = CarDataService().readUserLocation(storage);
+      final loc = readCarUserLocation(storage);
       expect(loc['lat'], 48.8566);
       expect(loc['lng'], 2.3522);
       expect(loc['source'], 'gps');
@@ -400,6 +400,113 @@ void main() {
       expect(byId['de-1']!['address'], 'Hauptstr. 1, 10115 Berlin');
       // No street → city only, no orphan comma (#2704 collapsing).
       expect(byId['de-2']!['address'], '10117 Berlin');
+    });
+  });
+
+  // ── v2 PHASE-3 SLICE 4 (#2990) — LIVE in-car fix over the same channel ─────
+
+  group('live in-car fix (#2990) — wins over the persisted fix', () {
+    test('a stale persisted fix is overridden + persisted back as source car',
+        () async {
+      final storage = FakeStorageRepository();
+      // Stale persisted fix far away (Hamburg) — phase-1 would search there.
+      await storage.putSetting(StorageKeys.userPositionLat, 53.5511);
+      await storage.putSetting(StorageKeys.userPositionLng, 9.9937);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      // Stations exist only around BERLIN, where the car actually is.
+      final deDataset = _RecordedDataset(
+        ServiceSource.tankerkoenigApi,
+        [
+          _row('de-1', 'Aral', 52.521, 13.401, e10: 1.799),
+          _row('de-2', 'Shell', 52.516, 13.420, e10: 1.829),
+        ],
+      );
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', deDataset),
+        writeSnapshot: (_, _) async {},
+      );
+
+      final json = await service.resolveSearchJson(
+        storage,
+        apiKey: 'k',
+        liveFix: (lat: 52.52, lng: 13.405),
+      );
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      // Searched around the LIVE Berlin fix, not the stale Hamburg one.
+      expect(rows.map((r) => r['id']).toSet(), {'de-1', 'de-2'},
+          reason: 'the live in-car fix must drive the radius search');
+
+      // The live fix refreshed the persisted fallback (source `car`).
+      expect(storage.getSetting(StorageKeys.userPositionLat), 52.52);
+      expect(storage.getSetting(StorageKeys.userPositionLng), 13.405);
+      expect(storage.getSetting(StorageKeys.userPositionSource), 'car');
+      expect(storage.getSetting(StorageKeys.userPositionTimestamp), isNotNull);
+    });
+
+    test('cold start: NO persisted fix + a live fix → priced list (not no_gps)',
+        () async {
+      final storage = FakeStorageRepository();
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi,
+          [_row('de-1', 'Aral', 52.521, 13.401, e10: 1.799)],
+        )),
+        writeSnapshot: (_, _) async {},
+      );
+
+      // The Automotive-OS / never-opened-phone-app scenario the issue fixes:
+      // no persisted fix exists, but the in-car GPS has one.
+      final json = await service.resolveRadarJson(
+        storage,
+        apiKey: 'k',
+        liveFix: (lat: 52.52, lng: 13.405),
+      );
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+      expect(rows.map((r) => r['id']), ['de-1']);
+    });
+
+    test('carLiveFixFromArgs — parses the bridge payload, guards bad fixes',
+        () {
+      // The native CarDataBridge payload shape.
+      expect(
+        carLiveFixFromArgs(
+            {'lat': 52.52, 'lng': 13.405, 'accuracyM': 12.0, 'ageMs': 900}),
+        (lat: 52.52, lng: 13.405),
+      );
+      // Absent / malformed args → persisted-fix fallback.
+      expect(carLiveFixFromArgs(null), isNull);
+      expect(carLiveFixFromArgs('garbage'), isNull);
+      expect(carLiveFixFromArgs({'lat': 52.52}), isNull);
+      // A degenerate (0,0) live fix is rejected by the #2872 guard.
+      expect(carLiveFixFromArgs({'lat': 0.0, 'lng': 0.0}), isNull);
+    });
+
+    test('a poisoned live fix falls back to the persisted fix', () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi,
+          [_row('de-1', 'Aral', 52.521, 13.401, e10: 1.799)],
+        )),
+        writeSnapshot: (_, _) async {},
+      );
+
+      final json = await service.resolveSearchJson(
+        storage,
+        apiKey: 'k',
+        // The guard rejects (0,0) → null → the persisted Berlin fix applies.
+        liveFix: carLiveFixFromArgs({'lat': 0.0, 'lng': 0.0}),
+      );
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+      expect(rows.map((r) => r['id']), ['de-1']);
+      // The persisted source tag must NOT be clobbered to `car` on fallback.
+      expect(storage.getSetting(StorageKeys.userPositionSource), isNot('car'));
     });
   });
 }

--- a/test/features/car/car_fix_store_test.dart
+++ b/test/features/car/car_fix_store_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/car/car_fix_store.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+/// Android Auto v2 PHASE-3 (#2990) — fault-injection coverage for the
+/// never-throws contract of `car_fix_store.dart` (#2349/#1103): every helper
+/// the headless car engine calls must return normally when its dependency
+/// faults, because a throw would crash the OS-spawned engine.
+void main() {
+  group('persistCarFix — never throws (#2349 fault injection)', () {
+    test('a throwing storage write completes normally (best-effort persist)',
+        () async {
+      final storage = _WriteFaultStorage();
+      await expectLater(
+        persistCarFix(storage, (lat: 52.52, lng: 13.405)),
+        completes,
+        reason: 'a storage fault must never fail the car fetch',
+      );
+    });
+
+    test('a healthy storage gets the UserPositionNotifier-shaped keys',
+        () async {
+      final storage = FakeStorageRepository();
+      await persistCarFix(storage, (lat: 52.52, lng: 13.405));
+      expect(storage.getSetting(StorageKeys.userPositionLat), 52.52);
+      expect(storage.getSetting(StorageKeys.userPositionLng), 13.405);
+      expect(storage.getSetting(StorageKeys.userPositionSource), 'car');
+      expect(storage.getSetting(StorageKeys.userPositionTimestamp), isA<int>());
+    });
+  });
+
+  group('readers — degrade to null / no_gps, never throw', () {
+    test('carLiveFixFromArgs returns normally on every malformed payload', () {
+      expect(() => carLiveFixFromArgs(null), returnsNormally);
+      expect(() => carLiveFixFromArgs(42), returnsNormally);
+      expect(() => carLiveFixFromArgs({'lat': 'NaNish', 'lng': true}),
+          returnsNormally);
+      expect(carLiveFixFromArgs({'lat': 'NaNish', 'lng': true}), isNull);
+    });
+
+    test('readPersistedCarFix rejects a poisoned (0,0) fix (#2872 guard)',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 0.0);
+      await storage.putSetting(StorageKeys.userPositionLng, 0.0);
+      expect(readPersistedCarFix(storage), isNull);
+    });
+
+    test('readCarUserLocation degrades a string timestamp, never throws', () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 48.8566);
+      await storage.putSetting(StorageKeys.userPositionLng, 2.3522);
+      await storage.putSetting(
+          StorageKeys.userPositionTimestamp, 'not-a-date-or-int');
+      final loc = readCarUserLocation(storage);
+      expect(loc['lat'], 48.8566);
+      expect(loc['updatedAtMs'], isNull);
+    });
+  });
+
+  group('activeCarProfile — unknown fuel key falls back, never throws', () {
+    test('an unparseable preferredFuelType degrades to the E10 default',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.saveProfile('p1', {
+        'id': 'p1',
+        'name': 'Default',
+        'defaultSearchRadius': 7.0,
+        'preferredFuelType': 'kryptonite',
+      });
+      await storage.setActiveProfileId('p1');
+
+      late CarProfile profile;
+      expect(() => profile = activeCarProfile(storage), returnsNormally);
+      expect(profile.radiusKm, 7.0);
+      // FuelType.fromString maps unknown keys to FuelType.all (its own
+      // fallback) rather than throwing — the radius must still apply.
+      expect(profile.fuelType, FuelType.all);
+    });
+  });
+}
+
+/// Fault seam: a [FakeStorageRepository] whose setting writes throw — drives
+/// the `persistCarFix` best-effort contract.
+class _WriteFaultStorage extends FakeStorageRepository {
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    throw StateError('injected storage fault');
+  }
+}


### PR DESCRIPTION
## Android Auto: live in-car GPS via CarContext.requestPermissions

Fixes the Automotive-OS / phone-idle staleness: the in-car screens no longer depend on the phone-side persisted fix.

- `androidx.car.app` 1.4.0 → 1.7.0 (plain androidx artifact; fdroid flavor untouched; bound service — zero FGS, the #1498 audit posture is intact).
- New session-scoped `CarLocationSource` (platform LocationManager only — fused on API 31+, no GMS client, never-throws) started on session create, stopped on destroy; in-car permission priming via `CarContext.requestPermissions` at most once per session, host-rendered, denial degrades to the persisted-fix fallback.
- Every car fetch attaches the live fix over the existing `tankstellen/car_data` channel (no new channels); a usable live fix wins over the persisted one and is persisted back, so the cold-start `no_gps` empty state heals on first lock (screen re-arms on first fix / ≥250 m moves).
- Dart side decomposed under the 400-line budget (`car_fix_store.dart`); the new #2349 fault test caught a real crash (unguarded `as num?` on a corrupted payload — now `is!`-guarded).

Validated: analyze clean, lint + 26 car tests green, `flutter build apk --debug --flavor play` ✓, Robolectric car-screen tests pass on 1.7.0. Physical head-unit verification points listed in the issue close-out.

Closes #2990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
