### PR TITLE
feat(radar): unify on one live-distance framework — live, efficient, fast-starting on-search radar (#3267, #3255, #3254, #3256)

### DIFF
--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -123,6 +123,49 @@ LocationSettings approachLocationSettings({TargetPlatform? platform}) {
   }
 }
 
+/// #3267 — the [LocationSettings] for the **on-search** Fuel Station Radar's
+/// live position stream, the foreground sibling of [approachLocationSettings].
+///
+/// The on-search radar is an affordance the user is actively looking at —
+/// never a backgrounded trip — so unlike the recorder/approach profiles this
+/// one does **not** request background updates or a foreground service. It is
+/// the light profile:
+///
+///   * `medium` accuracy — cell/wifi-assisted, the same ~100 m the #3116 fast
+///     first fix uses; ample for a km-scale radar and far cheaper than the
+///     satellite lock the user would otherwise wait on;
+///   * `distanceFilter: 25` m — only re-emit (and re-rank) after a meaningful
+///     move, so a parked/idle user doesn't spin the CPU re-ranking identical
+///     fixes while a moving one still ticks the distance down smoothly;
+///   * iOS `pauseLocationUpdatesAutomatically: false` — the #3112 lesson: a
+///     bare `LocationSettings` lets CoreLocation auto-pause the stream when it
+///     thinks the user stopped, freezing the live distance. Updates keep
+///     flowing while the radar is on, but `allowBackgroundLocationUpdates`
+///     stays off (foreground-only).
+LocationSettings radarSearchLocationSettings({TargetPlatform? platform}) {
+  switch (platform ?? defaultTargetPlatform) {
+    case TargetPlatform.iOS:
+      return AppleSettings(
+        accuracy: LocationAccuracy.medium,
+        activityType: ActivityType.otherNavigation,
+        pauseLocationUpdatesAutomatically: false,
+        allowBackgroundLocationUpdates: false,
+        distanceFilter: 25,
+      );
+    case TargetPlatform.android:
+      return AndroidSettings(
+        accuracy: LocationAccuracy.medium,
+        distanceFilter: 25,
+        intervalDuration: const Duration(seconds: 3),
+      );
+    default:
+      return const LocationSettings(
+        accuracy: LocationAccuracy.medium,
+        distanceFilter: 25,
+      );
+  }
+}
+
 LocationSettings recordingLocationSettings({
   required AppLocalizations l10n,
   TargetPlatform? platform,

--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -90,8 +90,9 @@ class ApproachDetector {
     double lat,
     double lng,
     double radiusKm,
-    String fuelType,
-  ) _fetchStations;
+    String fuelType, {
+    double? headingDegrees,
+  }) _fetchStations;
   final ApproachDetectorConfig _config;
   final StreamController<ApproachState> _out =
       StreamController<ApproachState>.broadcast();
@@ -111,8 +112,9 @@ class ApproachDetector {
       double lat,
       double lng,
       double radiusKm,
-      String fuelType,
-    ) fetchStations,
+      String fuelType, {
+      double? headingDegrees,
+    }) fetchStations,
     required ApproachDetectorConfig config,
   })  : _gps = gpsStream,
         _fetchStations = fetchStations,
@@ -244,6 +246,10 @@ class ApproachDetector {
         gps.longitude,
         _config.radiusMeters / 1000.0,
         _config.fuelTypeApiValue,
+        // #3256 — thread the live heading so the corridor cache prefetches the
+        // tile ahead before the driver crosses into it (a standstill/first-fix
+        // sentinel maps to null = no prefetch).
+        headingDegrees: geo.sanitizedHeading(gps.heading),
       );
       final inRadius = stations
           .map((s) => (

--- a/lib/core/services/radar/radar_in_radius_cache.dart
+++ b/lib/core/services/radar/radar_in_radius_cache.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../domain/station.dart';
+
+/// One direct in-radius station search — the caller supplies this, routed
+/// through the per-service rate-limited chain. Returns the search rows (already
+/// fuel-filtered + distance-sorted by the chain); `const []` on any failure.
+typedef InRadiusFetch = Future<List<Station>> Function(
+  double lat,
+  double lng,
+  double radiusKm,
+);
+
+/// Movement + time gate for the radar's **direct in-radius merge** (#3254).
+///
+/// ## Why this exists
+///
+/// The corridor cache (tier-1) is built from a polled-source search that is
+/// row-capped with no distance ordering, so in a dense area the genuinely-
+/// nearest forecourt can be truncated out. Both the on-search radar (#2806)
+/// and the swipe page-set (#2965) therefore merge a DIRECT in-radius
+/// `searchStations` to guarantee the result is a superset of the regular
+/// search. But that direct search bypasses the corridor/JIT tiers and hits the
+/// chain on **every** call. The radar re-evaluates on every GPS fix
+/// (`ApproachPolling` emits a fresh object per poll, 5.6–30 s while driving;
+/// the live on-search radar re-ranks on every fix too), and the chain's cache
+/// key rounds to ≈111 m cells — so a moving car produces a new key almost every
+/// fix → a real network call every fix. The rate limiter QUEUES rather than
+/// drops (DE 60 s, AT/PT/SI/CL 1 h minInterval), so arrivals at 2–10/min behind
+/// a 1/min drain build an unbounded backlog: corridor refreshes, the imminent
+/// JIT price and the user's own searches all stall behind it, and the backlog
+/// keeps burning quota after the trip ends.
+///
+/// ## The gate
+///
+/// Cache the last in-radius result and re-issue the search ONLY when the fix
+/// has moved into a new ≈111 m cell **and** the provider's `minInterval` has
+/// elapsed since the last fetch. So a standstill never re-fetches, and a moving
+/// car issues at most one in-radius search per `minInterval` — a bounded queue.
+/// Inside the gate the cached merge is returned with zero network. A failed
+/// fetch degrades to the last good merge (or empty), never breaking the
+/// surface. The radius is part of the cache cell so a radius change re-fetches.
+///
+/// Mirrors [JitPriceCache]'s injection seams (`fetch`, `now`) so it is unit-
+/// testable without a Riverpod container or a real clock.
+class RadarInRadiusCache {
+  /// Decimal places the cell key rounds the fix to. 3 ⇒ ≈111 m — matches the
+  /// chain's own search cache-key rounding, so a fix that wouldn't change the
+  /// upstream cache key never forces a fresh search here either.
+  static const int cellDecimals = 3;
+
+  final InRadiusFetch _fetch;
+  final Duration Function() _minInterval;
+  final DateTime Function() _now;
+
+  String? _cellKey;
+  DateTime? _fetchedAt;
+  List<Station> _cached = const [];
+
+  RadarInRadiusCache({
+    required InRadiusFetch fetch,
+    required Duration Function() minInterval,
+    DateTime Function()? now,
+  })  : _fetch = fetch,
+        _minInterval = minInterval,
+        _now = now ?? DateTime.now;
+
+  /// The in-radius rows around ([lat], [lng]) at [radiusKm] — freshly fetched
+  /// only when the movement+time gate opens, otherwise the cached merge.
+  Future<List<Station>> stationsNear(
+    double lat,
+    double lng,
+    double radiusKm,
+  ) async {
+    final cell = _cell(lat, lng, radiusKm);
+    final fetchedAt = _fetchedAt;
+    // After the first fetch, re-fetch ONLY when we've moved into a new cell AND
+    // the provider's minInterval has elapsed (#3254). Otherwise reuse — a
+    // standstill, a sub-cell jitter, or a too-soon move all return the cached
+    // merge with zero network.
+    if (fetchedAt != null) {
+      if (cell == _cellKey) return _cached;
+      Duration interval;
+      try {
+        interval = _minInterval();
+      } on Object {
+        // Can't resolve the cadence (e.g. no active-country graph in a
+        // harness) — be conservative and reuse rather than risk hammering.
+        return _cached;
+      }
+      if (_now().difference(fetchedAt) < interval) return _cached;
+    }
+    try {
+      final data = await _fetch(lat, lng, radiusKm);
+      _cached = data;
+      _cellKey = cell;
+      _fetchedAt = _now();
+      return _cached;
+    } on Object {
+      // Degrade to the last good merge — a transient fetch failure must never
+      // collapse the surface to "no stations".
+      return _cached;
+    }
+  }
+
+  String _cell(double lat, double lng, double radiusKm) =>
+      '$radiusKm:${lat.toStringAsFixed(cellDecimals)},'
+      '${lng.toStringAsFixed(cellDecimals)}';
+}

--- a/lib/core/services/radar/radar_in_radius_cache_provider.dart
+++ b/lib/core/services/radar/radar_in_radius_cache_provider.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../country/country_provider.dart';
+import '../../domain/fuel_type.dart';
+import '../../domain/search_params.dart';
+import '../../domain/station.dart';
+import '../country_service_registry.dart';
+import 'radar_in_radius_cache.dart';
+import '../service_providers.dart';
+
+part 'radar_in_radius_cache_provider.g.dart';
+
+/// The shared, movement+time-gated in-radius merge cache (#3254) used by the
+/// radar surfaces that re-evaluate on every GPS fix — the swipe page-set
+/// ([radarCandidateList]) and the live on-search radar.
+///
+/// keepAlive so the gate's last-fetch position/time survives the per-fix
+/// rebuilds of those providers; the country's `minInterval` is read live so a
+/// country switch picks up the new published cadence. The fetch is fuel-
+/// agnostic (`FuelType.all`) — the chain returns every fuel's price per row, so
+/// one cached merge serves any selected fuel and a fuel change never forces a
+/// re-fetch; [RadarRanking] applies the per-fuel filter downstream.
+@Riverpod(keepAlive: true)
+RadarInRadiusCache radarInRadiusCache(Ref ref) {
+  final svc = ref.read(stationServiceProvider);
+  return RadarInRadiusCache(
+    fetch: (lat, lng, radiusKm) async {
+      try {
+        final result = await svc.searchStations(
+          SearchParams(
+            lat: lat,
+            lng: lng,
+            radiusKm: radiusKm,
+            fuelType: FuelType.all,
+            sortBy: SortBy.distance,
+          ),
+        );
+        return result.data;
+      } on Object {
+        return const <Station>[];
+      }
+    },
+    minInterval: () {
+      final code = ref.read(activeCountryProvider).code;
+      return CountryServiceRegistry.policyFor(code)?.minInterval ??
+          const Duration(seconds: 60);
+    },
+  );
+}

--- a/lib/core/services/radar/radar_in_radius_cache_provider.g.dart
+++ b/lib/core/services/radar/radar_in_radius_cache_provider.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'radar_in_radius_cache_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The shared, movement+time-gated in-radius merge cache (#3254) used by the
+/// radar surfaces that re-evaluate on every GPS fix — the swipe page-set
+/// ([radarCandidateList]) and the live on-search radar.
+///
+/// keepAlive so the gate's last-fetch position/time survives the per-fix
+/// rebuilds of those providers; the country's `minInterval` is read live so a
+/// country switch picks up the new published cadence. The fetch is fuel-
+/// agnostic (`FuelType.all`) — the chain returns every fuel's price per row, so
+/// one cached merge serves any selected fuel and a fuel change never forces a
+/// re-fetch; [RadarRanking] applies the per-fuel filter downstream.
+
+@ProviderFor(radarInRadiusCache)
+final radarInRadiusCacheProvider = RadarInRadiusCacheProvider._();
+
+/// The shared, movement+time-gated in-radius merge cache (#3254) used by the
+/// radar surfaces that re-evaluate on every GPS fix — the swipe page-set
+/// ([radarCandidateList]) and the live on-search radar.
+///
+/// keepAlive so the gate's last-fetch position/time survives the per-fix
+/// rebuilds of those providers; the country's `minInterval` is read live so a
+/// country switch picks up the new published cadence. The fetch is fuel-
+/// agnostic (`FuelType.all`) — the chain returns every fuel's price per row, so
+/// one cached merge serves any selected fuel and a fuel change never forces a
+/// re-fetch; [RadarRanking] applies the per-fuel filter downstream.
+
+final class RadarInRadiusCacheProvider
+    extends
+        $FunctionalProvider<
+          RadarInRadiusCache,
+          RadarInRadiusCache,
+          RadarInRadiusCache
+        >
+    with $Provider<RadarInRadiusCache> {
+  /// The shared, movement+time-gated in-radius merge cache (#3254) used by the
+  /// radar surfaces that re-evaluate on every GPS fix — the swipe page-set
+  /// ([radarCandidateList]) and the live on-search radar.
+  ///
+  /// keepAlive so the gate's last-fetch position/time survives the per-fix
+  /// rebuilds of those providers; the country's `minInterval` is read live so a
+  /// country switch picks up the new published cadence. The fetch is fuel-
+  /// agnostic (`FuelType.all`) — the chain returns every fuel's price per row, so
+  /// one cached merge serves any selected fuel and a fuel change never forces a
+  /// re-fetch; [RadarRanking] applies the per-fuel filter downstream.
+  RadarInRadiusCacheProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'radarInRadiusCacheProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$radarInRadiusCacheHash();
+
+  @$internal
+  @override
+  $ProviderElement<RadarInRadiusCache> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RadarInRadiusCache create(Ref ref) {
+    return radarInRadiusCache(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RadarInRadiusCache value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RadarInRadiusCache>(value),
+    );
+  }
+}
+
+String _$radarInRadiusCacheHash() =>
+    r'382244a11b25abd4db677d606231b88322a288fb';

--- a/lib/core/services/radar/radar_ranking.dart
+++ b/lib/core/services/radar/radar_ranking.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../domain/fuel_type.dart';
+import '../../domain/station.dart';
+import '../mixins/station_service_helpers.dart';
+import '../../utils/geo_utils.dart' as geo;
+import '../../utils/station_extensions.dart';
+
+/// The single distance-ranking authority shared by every radar surface (#3267).
+///
+/// The on-search radar ([radar_search_provider]), the trip-screen single
+/// nearest lookup ([nearest_station_radar_provider]) and the swipe page-set
+/// ([radar_candidate_list_provider]) all need the SAME four steps:
+///
+///   1. **Dedup by id** — when a wide corridor slice is merged with a direct
+///      in-radius fetch (#2806/#2965), the in-radius row must win (it carries
+///      the freshest per-fuel price). The merge passes corridor rows first and
+///      in-radius rows last, so "last write wins" is the contract.
+///   2. **Fuel-filter** — drop forecourts that don't sell the selected fuel so
+///      the surface never shows a `--` price (#2926/#2583).
+///   3. **Live distance stamp** — recompute `Station.dist` (km) from the
+///      CURRENT GPS fix, not the value frozen at corridor-fetch time, so the
+///      distance caption + closeness bar move as the driver approaches
+///      (#2808/#3092/#3267).
+///   4. **Distance sort** — nearest first.
+///
+/// Pulling the copy-pasted body of those three providers into one helper is the
+/// "one framework for both" the radar unification (#3267) asks for: change the
+/// ranking once and every surface — search list, PiP tile, swipe card — moves
+/// together, and the live re-stamp on each GPS fix is identical everywhere.
+class RadarRanking {
+  const RadarRanking._();
+
+  /// Dedup [stations] by id (last wins), fuel-filter for [fuel], re-stamp each
+  /// row's live distance (km) from ([lat], [lng]) and return them distance-
+  /// sorted (nearest first).
+  ///
+  /// [requirePrice] picks the fuel-filter:
+  ///
+  ///  - `false` (the on-search radar) applies the SHARED hard-fuel filter
+  ///    [StationServiceHelpers.filterByFuel] — identical to the regular search,
+  ///    so the radar list is a consistent superset of it. `FuelType.all` and
+  ///    the unpriced fuels (electric/hydrogen) keep every station.
+  ///  - `true` (the trip nearest / swipe page-set) keeps ONLY stations that
+  ///    carry a usable (`> 0`) price for [fuel] — the driver must be able to
+  ///    price-compare the target, so a `--` row never becomes the locked
+  ///    station or a swipe page (#2583). The trip surfaces always resolve a
+  ///    concrete priced fuel, where this coincides with the shared filter; the
+  ///    flag only diverges for `all`/EV, which those surfaces never pass.
+  static List<Station> rank(
+    Iterable<Station> stations, {
+    required double lat,
+    required double lng,
+    required FuelType fuel,
+    bool requirePrice = false,
+  }) {
+    // 1. Dedup by id — last write wins (the in-radius merge row beats the
+    // corridor row it follows).
+    final byId = <String, Station>{};
+    for (final s in stations) {
+      byId[s.id] = s;
+    }
+
+    // 2. Fuel-filter.
+    final Iterable<Station> filtered = requirePrice
+        ? byId.values.where((s) {
+            final price = s.priceFor(fuel);
+            return price != null && price > 0;
+          })
+        : StationServiceHelpers.filterByFuel(
+            byId.values.toList(growable: false),
+            fuel,
+          );
+
+    // 3. Live distance stamp + 4. distance sort.
+    return [
+      for (final s in filtered)
+        s.copyWith(dist: geo.distanceMeters(lat, lng, s.lat, s.lng) / 1000.0),
+    ]..sort((a, b) => a.dist.compareTo(b.dist));
+  }
+
+  /// The single nearest station of [rank] with `requirePrice: true`, or `null`
+  /// when nothing in [stations] is priced for [fuel]. The trip-screen nearest
+  /// lookup ([nearest_station_radar_provider]) surfaces exactly this.
+  static Station? nearestPriced(
+    Iterable<Station> stations, {
+    required double lat,
+    required double lng,
+    required FuelType fuel,
+  }) {
+    final ranked = rank(
+      stations,
+      lat: lat,
+      lng: lng,
+      fuel: fuel,
+      requirePrice: true,
+    );
+    return ranked.isEmpty ? null : ranked.first;
+  }
+}

--- a/lib/core/utils/geo_utils.dart
+++ b/lib/core/utils/geo_utils.dart
@@ -77,6 +77,20 @@ double distanceMeters(double lat1, double lng1, double lat2, double lng2) {
   return earthRadiusMeters * 2 * atan2(sqrt(a), sqrt(1 - a));
 }
 
+/// A GPS heading sanitized for the corridor tile-ahead prefetch (#3256).
+///
+/// `geolocator` reports `Position.heading` as degrees clockwise from true
+/// north, but emits a sentinel (a negative value or `NaN`) when the device
+/// can't resolve a course — typically at a standstill, or on the very first
+/// fix. The corridor cache prefetches the tile ahead ONLY when handed a
+/// non-null heading, so a sentinel must map to `null` (skip the prefetch)
+/// rather than a bogus due-north/southward bearing that prefetches the wrong
+/// neighbouring tile. A valid value is normalised into `[0, 360)`.
+double? sanitizedHeading(double? heading) {
+  if (heading == null || !heading.isFinite || heading < 0) return null;
+  return heading % 360;
+}
+
 /// Computes how far along a polyline a given point is (in km from start).
 ///
 /// Walks the polyline segments, accumulating distance. Returns the cumulative

--- a/lib/features/approach/providers/approach_state_provider.dart
+++ b/lib/features/approach/providers/approach_state_provider.dart
@@ -94,16 +94,19 @@ Stream<ApproachState> approachState(Ref ref) {
       // bare high-accuracy settings (unchanged).
       locationSettings: approachLocationSettings(),
     ),
-    fetchStations: (lat, lng, radiusKm, fuelTypeApiValue) async {
+    fetchStations: (lat, lng, radiusKm, fuelTypeApiValue,
+        {double? headingDegrees}) async {
       try {
         // Cached corridor locations (tier-1) + JIT price for the imminent
         // station(s) (tier-3). Zero network when the tile is already cached
-        // and no imminent station needs a price refresh.
+        // and no imminent station needs a price refresh. #3256 — forward the
+        // detector's live heading so the corridor prefetches the tile ahead.
         return await radar.fetchStations(
           lat,
           lng,
           radiusKm,
           fuelTypeApiValue,
+          headingDegrees: headingDegrees,
         );
       } on Object catch (e, st) {
         // #2297 — the detector treats this as "no stations in radius" and

--- a/lib/features/approach/providers/approach_state_provider.g.dart
+++ b/lib/features/approach/providers/approach_state_provider.g.dart
@@ -116,4 +116,4 @@ final class ApproachStateProvider
   }
 }
 
-String _$approachStateHash() => r'fed767cd9a11d53969b45939edfe210c30829ccb';
+String _$approachStateHash() => r'9990af423c55172fa0f7187093104f8c052ea4e7';

--- a/lib/features/approach/providers/nearest_station_radar_provider.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.dart
@@ -1,15 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:collection/collection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/domain/station.dart';
 import '../../../core/services/approach_detector.dart';
 import '../../../core/utils/geo_utils.dart' as geo;
-import '../../../core/utils/station_extensions.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
-import '../../../core/domain/station.dart';
+import '../../../core/services/radar/radar_ranking.dart';
 import 'effective_approach_state_provider.dart';
 import 'fuel_station_radar_provider.dart';
 
@@ -75,36 +74,21 @@ Future<Station?> nearestStationRadar(Ref ref) async {
       gps.longitude,
       profile.approachRadiusKm,
       fuel.apiValue,
+      // #3256 — thread the live heading so the corridor cache prefetches the
+      // tile ahead; a standstill/first-fix sentinel maps to null (no prefetch).
+      headingDegrees: geo.sanitizedHeading(gps.heading),
     );
-    // The corridor set is cached in fetch order, not distance order — sort
-    // by distance from the live fix, then surface the nearest station that
-    // actually carries a price for the effective fuel (a non-null, positive
-    // [priceFor]) so the card never shows a `--` price the driver can't
-    // compare (#2583). `null` when none in range is priced.
-    final sorted = stations.toList(growable: false)
-      ..sort((a, b) => geo
-          .distanceMeters(gps.latitude, gps.longitude, a.lat, a.lng)
-          .compareTo(
-            geo.distanceMeters(gps.latitude, gps.longitude, b.lat, b.lng),
-          ));
-    final nearest = sorted.firstWhereOrNull((s) {
-      final price = s.priceFor(fuel);
-      return price != null && price > 0;
-    });
-    if (nearest == null) return null;
-    // #2808 — re-stamp the LIVE distance (km) from the current fix. The
-    // corridor station carries a `dist` frozen at the corridor-fetch centre
-    // (stamped once at parse time), so without this the PiP proximity bar +
-    // distance caption never move as the driver approaches. Mirrors the
-    // on-search radar (radar_search_provider.dart).
-    final distKm = geo.distanceMeters(
-          gps.latitude,
-          gps.longitude,
-          nearest.lat,
-          nearest.lng,
-        ) /
-        1000.0;
-    return nearest.copyWith(dist: distKm);
+    // #3267 — the single distance-ranking authority: dedup, drop forecourts
+    // unpriced for the effective fuel (#2583), re-stamp the LIVE distance off
+    // the current fix (#2808 — the corridor `dist` is frozen at fetch time so
+    // without this the PiP bar + caption never move) and return the nearest.
+    // `null` when nothing in range is priced.
+    return RadarRanking.nearestPriced(
+      stations,
+      lat: gps.latitude,
+      lng: gps.longitude,
+      fuel: fuel,
+    );
   } on Object {
     // Radar / chain failure — treat as "no station nearby". The provider
     // re-runs on the next approach-state tick.

--- a/lib/features/approach/providers/nearest_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.g.dart
@@ -151,4 +151,4 @@ final class NearestStationRadarProvider
 }
 
 String _$nearestStationRadarHash() =>
-    r'ef42198fcc6ac6493b83d4148eaa21a3f97b0ed1';
+    r'bbae8635d6a1623b5895d1d964503f35fcf96023';

--- a/lib/features/approach/providers/radar_candidate_list_provider.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.dart
@@ -3,17 +3,15 @@
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/domain/station.dart';
 import '../../../core/services/approach_detector.dart';
-import '../../../core/services/service_providers.dart';
 import '../../../core/utils/geo_utils.dart' as geo;
-import '../../../core/utils/station_extensions.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
-import '../../../core/domain/search_params.dart';
-import '../../../core/domain/fuel_type.dart';
-import '../../../core/domain/station.dart';
+import '../../../core/services/radar/radar_ranking.dart';
 import 'effective_approach_state_provider.dart';
 import 'fuel_station_radar_provider.dart';
+import '../../../core/services/radar/radar_in_radius_cache_provider.dart';
 
 part 'radar_candidate_list_provider.g.dart';
 
@@ -89,98 +87,45 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
     // Cache-first corridor (tier-1) + JIT price for the imminent station(s)
     // (tier-3), at the user's default radar radius — the same envelope the
     // in-radius detector polls with. Zero network on a warm tile / a
-    // bulk-file country.
+    // bulk-file country. #3256 — thread the live heading so the cache
+    // prefetches the tile ahead before the driver crosses into it.
     final corridor = await radar.fetchStations(
       gps.latitude,
       gps.longitude,
       profile.approachRadiusKm,
       fuel.apiValue,
+      headingDegrees: geo.sanitizedHeading(gps.heading),
     );
 
     // #2965 — merge a DIRECT in-radius search so the candidate set is always a
     // SUPERSET of the in-radius search (mirrors the on-search radar's #2806
-    // rescue). The corridor's polled source is row-capped with no distance
-    // ordering, so in a dense area the genuinely-nearest forecourt can be
-    // truncated out and this card would show "no station nearby" while a priced
-    // station is metres away. Best-effort: corridor-only on failure.
-    final inRadius = await _inRadiusStations(
-      ref,
-      gps.latitude,
-      gps.longitude,
-      profile.approachRadiusKm,
-      fuel,
-    );
+    // rescue): the corridor's polled source is row-capped with no distance
+    // ordering, so a dense area can truncate out the genuinely-nearest
+    // forecourt. #3254 — this merge is now movement+time-gated, so it issues
+    // at most one chain search per the provider's minInterval (not one per
+    // poll), and reuses its cached merge in between — bounding the rate-limit
+    // queue a moving car used to flood.
+    final inRadius = await ref.read(radarInRadiusCacheProvider).stationsNear(
+          gps.latitude,
+          gps.longitude,
+          profile.approachRadiusKm,
+        );
 
-    // Dedup by id, the in-radius row winning — it carries the freshest per-fuel
-    // price/distance. Then keep only stations the driver can actually price-
-    // compare (a non-null, positive [priceFor] for the effective fuel) so a
-    // swipe never lands on a `--` price row (#2583), and distance-sort from the
-    // live fix (the corridor is cached in fetch order, not distance order).
-    final byId = <String, Station>{
-      for (final s in corridor) s.id: s,
-      for (final s in inRadius) s.id: s,
-    };
-    final priced = byId.values
-        .where((s) {
-          final price = s.priceFor(fuel);
-          return price != null && price > 0;
-        })
-        .toList(growable: false)
-      ..sort((a, b) => geo
-          .distanceMeters(gps.latitude, gps.longitude, a.lat, a.lng)
-          .compareTo(
-            geo.distanceMeters(gps.latitude, gps.longitude, b.lat, b.lng),
-          ));
-    // #2808 — re-stamp each row's LIVE distance (km) from the current fix.
-    // The corridor stations carry a `dist` frozen at the corridor-fetch
-    // centre, so without this the swipe-card proximity bar + caption never
-    // move as the driver approaches. Mirrors the on-search radar.
-    return [
-      for (final s in priced)
-        s.copyWith(
-          dist: geo.distanceMeters(
-                gps.latitude,
-                gps.longitude,
-                s.lat,
-                s.lng,
-              ) /
-              1000.0,
-        ),
-    ];
+    // #3267 — the single distance-ranking authority: dedup (the in-radius row
+    // wins — freshest per-fuel price/distance), keep only stations priced for
+    // the effective fuel so a swipe never lands on a `--` row (#2583), live-
+    // stamp each row's distance off the current fix (#2808 — the corridor
+    // `dist` is frozen at fetch time) and distance-sort nearest-first.
+    return RadarRanking.rank(
+      [...corridor, ...inRadius],
+      lat: gps.latitude,
+      lng: gps.longitude,
+      fuel: fuel,
+      requirePrice: true,
+    );
   } on Object {
     // Radar / chain failure — treat as "no stations nearby". The provider
     // re-runs on the next approach-state tick.
     return const [];
-  }
-}
-
-/// A direct in-radius station fetch around the live fix (#2965), mirroring the
-/// regular search + the on-search radar's `_inRadiusStations`, so the candidate
-/// list is a superset of the in-radius search and a dense-corridor row cap can
-/// never truncate out the genuinely-nearest forecourt.
-///
-/// **Never throws.** Returns `const []` on any failure (offline, rate-limit, a
-/// service that doesn't support geo search) so the candidate list degrades to
-/// its cached corridor rather than collapsing the card.
-Future<List<Station>> _inRadiusStations(
-  Ref ref,
-  double lat,
-  double lng,
-  double radiusKm,
-  FuelType fuel,
-) async {
-  try {
-    final result = await ref.read(stationServiceProvider).searchStations(
-          SearchParams(
-            lat: lat,
-            lng: lng,
-            radiusKm: radiusKm,
-            fuelType: fuel,
-            sortBy: SortBy.distance,
-          ),
-        );
-    return result.data;
-  } on Object {
-    return const <Station>[];
   }
 }

--- a/lib/features/approach/providers/radar_candidate_list_provider.g.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.g.dart
@@ -210,4 +210,4 @@ final class RadarCandidateListProvider
 }
 
 String _$radarCandidateListHash() =>
-    r'ba7871184e8eca320d6ffd2949658d0e707c51f1';
+    r'319e230c75f4669b9c98ef2a7e935f1361a44d46';

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -65,7 +65,15 @@ class SearchResultsContent extends ConsumerWidget {
           // distinct from the loading shimmer and the error banner, so the
           // user knows the scan FINISHED and found nothing — not that it's
           // still searching (the old bare "0 stations" + blank was ambiguous).
+          // #3267 — but while a fresh fix is still resolving ([locating]) an
+          // empty provisional scan is NOT "found nothing"; show the acquiring
+          // state so the empty result doesn't flicker in before the live fix.
           if (stations.isEmpty) {
+            if (radar.locating) {
+              return _RadarLocatingState(
+                message: l10n.radarAcquiringLocation,
+              );
+            }
             return _RadarEmptyState(
               onRetry: () => ref.read(radarSearchProvider.notifier).runRadar(),
             );
@@ -75,12 +83,24 @@ class SearchResultsContent extends ConsumerWidget {
             source: ServiceSource.cache,
             fetchedAt: DateTime.now(),
           );
-          return SearchResultsList(
+          final list = SearchResultsList(
             result: radarResult,
             onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
           );
+          // #3267 — while painting from the last-known position, a thin banner
+          // tells the user the spot is being refreshed (instead of silently
+          // showing stale-position distances), and clears once the live fix
+          // lands and the list re-ranks.
+          if (!radar.locating) return list;
+          return Column(
+            children: [
+              _RadarUpdatingBanner(message: l10n.radarUpdatingLocation),
+              Expanded(child: list),
+            ],
+          );
         },
-        loading: () => const ShimmerStationList(),
+        loading: () =>
+            _RadarLocatingState(message: l10n.radarAcquiringLocation),
         error: (error, stackTrace) => ServiceChainErrorWidget(
           error: error,
           onRetry: () => ref.read(radarSearchProvider.notifier).runRadar(),
@@ -178,6 +198,85 @@ class _RadarEmptyState extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// #3267 — the on-search radar's "acquiring the first GPS fix" state: a centred
+/// spinner + caption shown when the radar is active but has no position yet to
+/// scan around (a fresh install, or a cold first fix with no last-known point).
+/// Visually distinct from the empty state (scan finished, found nothing) so the
+/// user knows the radar is still warming up, not done.
+class _RadarLocatingState extends StatelessWidget {
+  const _RadarLocatingState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              width: 28,
+              height: 28,
+              child: CircularProgressIndicator(strokeWidth: 3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// #3267 — a thin banner above the radar results while a fresh GPS fix is still
+/// resolving. The list below is painted from the last-known position (so the
+/// user sees results instantly), and this strip signals the spot is being
+/// refreshed; it clears once the live fix lands and the list re-ranks.
+class _RadarUpdatingBanner extends StatelessWidget {
+  const _RadarUpdatingBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      color: theme.colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text(
+              message,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -4,29 +4,34 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:geolocator/geolocator.dart' show Position;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/error/exceptions.dart';
-import '../../../core/location/user_position_provider.dart';
-import '../../../core/services/mixins/station_service_helpers.dart';
-import '../../../core/services/service_providers.dart';
-import '../../../core/utils/geo_utils.dart' as geo;
-import '../../approach/providers/fuel_station_radar_provider.dart';
-import '../../widget/data/car_station_writer.dart';
-import '../../../core/domain/search_params.dart';
-import '../../../core/domain/fuel_type.dart';
 import '../../../core/domain/station.dart';
+import '../../../core/error/exceptions.dart';
+import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/location/recording_location_settings.dart'
+    show radarSearchLocationSettings;
+import '../../../core/location/user_position_provider.dart';
+import '../../../core/logging/error_logger.dart';
+import '../../../core/utils/geo_utils.dart' as geo;
+import '../../../core/services/radar/radar_ranking.dart';
+import '../../approach/providers/fuel_station_radar_provider.dart';
+import '../../../core/services/radar/radar_in_radius_cache_provider.dart';
+import '../../widget/data/car_station_writer.dart';
 import 'search_filters_provider.dart';
 
 part 'radar_search_provider.g.dart';
 
-/// State of the on-search Fuel Station Radar (#2659 / #2674).
+/// State of the on-search Fuel Station Radar (#2659 / #2674 / #3267).
 ///
-/// Holds whether the radar is the active result source ([active]) plus the
-/// `AsyncValue` of the distance-sorted, priced station list it produced.
+/// Holds whether the radar is the active result source ([active]), whether a
+/// fresh GPS fix is still being acquired ([locating]) and the `AsyncValue` of
+/// the distance-sorted, priced station list it produced.
 class RadarSearchState {
   const RadarSearchState({
     required this.active,
+    this.locating = false,
     required this.stations,
   });
 
@@ -34,43 +39,83 @@ class RadarSearchState {
   /// the radar stations instead of the regular `searchStateProvider` results.
   final bool active;
 
+  /// `true` while a fresh GPS fix is in flight (#3267). The radar paints
+  /// instantly from the last-known position and flips this off once the live
+  /// fix lands, so the UI can show an "updating your location" affordance
+  /// instead of a blank, blocked screen during the cold fix.
+  final bool locating;
+
   /// The radar's distance-sorted, priced station list (loading/data/error).
   final AsyncValue<List<Station>> stations;
 
   static const RadarSearchState idle = RadarSearchState(
     active: false,
+    locating: false,
     stations: AsyncData<List<Station>>(<Station>[]),
   );
 
   RadarSearchState copyWith({
     bool? active,
+    bool? locating,
     AsyncValue<List<Station>>? stations,
   }) =>
       RadarSearchState(
         active: active ?? this.active,
+        locating: locating ?? this.locating,
         stations: stations ?? this.stations,
       );
 }
 
-/// The on-search Fuel Station Radar (#2659).
+/// The on-search Fuel Station Radar (#2659 / #3267).
 ///
-/// A one-shot radar fetch around the user's CURRENT position
-/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
-/// the trip-only shared GPS stream), surfaced in the search results list like
-/// a regular search. It reuses the #2661 radar data layer
-/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
-/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
-/// in-radius fetch so the result is always a superset of the regular search
-/// (#2806).
+/// A **live** radar around the user's current position, surfaced in the search
+/// results list like a regular search. Unlike its one-shot predecessor, it
+/// subscribes to a foreground GPS stream ([radarSearchLocationSettings]) while
+/// active and re-stamps each station's distance on every fix, so the distance
+/// captions + the closeness bars tick down as the driver approaches — the SAME
+/// live-distance behaviour the trip radar gets from the approach detector. The
+/// distance/dedup/fuel-filter/sort is the shared [RadarRanking] authority, so
+/// both surfaces rank identically (#3267).
 ///
-/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
-/// approach detector: those only fire while a trip records (gated on
-/// `ApproachPolling`). This provider runs on demand from the search screen, with
-/// no geofence polling and no second `ApproachDetector` / `PipController`.
+/// It reuses the #2661 radar data layer ([fuelStationRadarProvider]) — the
+/// tier-1 corridor location cache (1 h) + tier-3 JIT price cache (5 min) — for
+/// the wide net, and merges a direct in-radius fetch so the result is always a
+/// superset of the regular search (#2806). That in-radius merge runs through
+/// the shared, movement+time-gated [radarInRadiusCacheProvider] (#3254), so a
+/// moving user re-queries the chain at most once per the provider's
+/// `minInterval` instead of once per fix; between fetches the distance still
+/// updates live off the cached set with **zero** network.
+///
+/// ### Fast, non-blocking init (#3267)
+///
+/// On [runRadar] the radar paints immediately from the persisted last-known
+/// position (corridor-only, [locating] = true) so the user never stares at a
+/// blank screen through the cold GPS fix, then re-scans authoritatively once
+/// the fresh fix lands. The GPS subscription and the corridor fetch progress
+/// concurrently rather than strictly serially.
 @riverpod
 class RadarSearch extends _$RadarSearch {
+  /// The live GPS subscription, open only while the radar is active. Cancelled
+  /// on [dismiss] and on provider dispose.
+  StreamSubscription<Position>? _gpsSub;
+
+  /// The most recent raw (un-ranked) station set from the last fetch — corridor
+  /// + the gated in-radius merge. Re-ranked against each new GPS fix WITHOUT a
+  /// network call, so the distance/order update live between gated re-fetches.
+  List<Station> _lastRaw = const [];
+
+  /// The most recent live fix, kept for its heading (corridor tile-ahead
+  /// prefetch, #3256).
+  Position? _lastFix;
+
   @override
-  RadarSearchState build() => RadarSearchState.idle;
+  RadarSearchState build() {
+    ref.onDispose(() {
+      unawaited(_gpsSub?.cancel());
+      _gpsSub = null;
+    });
+    return RadarSearchState.idle;
+  }
 
   /// Android Auto v1 (#2948) — mirrors each radar run into the
   /// `car_radar_json` SharedPreferences key the native car Radar screen
@@ -79,153 +124,203 @@ class RadarSearch extends _$RadarSearch {
   @visibleForTesting
   CarStationWriter carWriter = const CarStationWriter();
 
-  /// Run the radar around the user's CURRENT position. No-op (leaves the radar
-  /// inactive) when no position is known yet — the user must search / locate at
-  /// least once so we have somewhere to scan around.
+  /// Run the radar around the user's current position and keep it live.
+  ///
+  /// Paints instantly from the persisted last-known position, subscribes to the
+  /// live GPS stream, then re-scans around the fresh fix. Surfaces an actionable
+  /// error only when there is NO position to scan around at all (#3042).
   Future<void> runRadar() async {
-    // #2806 — refresh the live GPS fix first, exactly as the regular search
-    // does (search_provider_orchestration.dart). The radar used to reuse the
-    // PERSISTED [userPositionProvider] with no refresh, so after any movement
-    // it scanned a location minutes behind the user — surfacing a far-away
-    // band and dropping the nearby stations the in-radius search shows.
-    // Best-effort: keep the persisted position if the fix is denied / times
-    // out, so an offline / permission-less run still scans the last spot.
+    // Subscribe to live GPS first so a fix that lands during the initial scans
+    // already drives a re-rank. Idempotent + test-safe (a platform-less stream
+    // is swallowed, keeping the radar usable off the persisted/refreshed fix).
+    _subscribeGps();
+
+    // #3267 — instant first paint from the last-known position (corridor-only,
+    // no in-radius merge yet) so the user sees something immediately while the
+    // fresh fix resolves, rather than a blank, blocked screen.
+    final persisted = ref.read(userPositionProvider);
+    if (persisted != null) {
+      state = state.copyWith(active: true, locating: true);
+      await _scan(
+        persisted.lat,
+        persisted.lng,
+        withInRadiusMerge: false,
+        silent: false,
+      );
+    } else {
+      state = state.copyWith(
+        active: true,
+        locating: true,
+        stations: const AsyncLoading<List<Station>>(),
+      );
+    }
+
+    // #2806 — refresh the live GPS fix, exactly as the regular search does, so
+    // the authoritative scan is around the user's CURRENT spot, not a position
+    // minutes behind them. Best-effort: keep the persisted point if the fix is
+    // denied / times out, so an offline run still scans the last spot.
     Object? gpsError;
     StackTrace? gpsStack;
     try {
       await ref.read(userPositionProvider.notifier).updateFromGps();
     } catch (e, st) {
-      // #3042 — remember WHY the refresh failed. We still fall back to the
-      // persisted position below (offline resilience, #2806), but if there
-      // is no position at all the radar must surface this instead of
-      // silently going idle.
       gpsError = e;
       gpsStack = st;
     }
 
     final pos = ref.read(userPositionProvider);
     if (pos == null) {
-      // #3042 — no position to scan around (e.g. a fresh install where the
-      // user denied location). This used to set [RadarSearchState.idle] and
-      // return, so the radar flipped on then off with ZERO feedback. Surface
-      // the underlying location failure as an error state so
-      // SearchResultsContent renders an actionable banner (grant / open
-      // settings / search by postal code) instead of an empty list.
+      // #3042 — no position to scan around (fresh install, denied location).
+      // Surface the underlying failure as an error so SearchResultsContent
+      // renders an actionable banner instead of an empty / silent list.
       state = RadarSearchState(
         active: true,
+        locating: false,
         stations: AsyncError<List<Station>>(
-          // English diagnostic per the exceptions.dart contract (#2316) — NOT
-          // user-facing. ServiceChainErrorWidget renders LocationException via
-          // ErrorLocalizer → the translated `errorLocation` / `locationDenied`
-          // ARB strings, so the user always sees localized text, never this.
           gpsError ??
-              const LocationException(
-                message: 'Location permission denied.',
-              ),
+              const LocationException(message: 'Location permission denied.'),
           gpsStack ?? StackTrace.current,
         ),
       );
       return;
     }
 
-    final radiusKm = ref.read(searchRadiusProvider);
-    final fuel = ref.read(selectedFuelTypeProvider);
-
-    state = state.copyWith(
-      active: true,
-      stations: const AsyncLoading<List<Station>>(),
+    // Authoritative scan around the fresh fix, with the in-radius superset
+    // merge. Clears `locating` — the user is now seeing their real surroundings.
+    state = state.copyWith(locating: false);
+    await _scan(
+      pos.lat,
+      pos.lng,
+      withInRadiusMerge: true,
+      heading: geo.sanitizedHeading(_lastFix?.heading),
+      silent: false,
     );
+  }
 
+  /// Open the live GPS subscription if it isn't already. Never throws — a
+  /// platform-less stream (unit tests, a device with location off) is logged
+  /// and swallowed, leaving the radar live off the persisted / refreshed fix.
+  void _subscribeGps() {
+    if (_gpsSub != null) return;
     try {
-      final radar = ref.read(fuelStationRadarProvider);
-      final raw = await radar.fetchStations(
-        pos.lat,
-        pos.lng,
-        radiusKm,
-        fuel.apiValue,
+      final stream = ref
+          .read(geolocatorWrapperProvider)
+          .getPositionStream(locationSettings: radarSearchLocationSettings());
+      _gpsSub = stream.listen(
+        _onFix,
+        onError: (Object e, StackTrace st) {
+          // A mid-run permission revoke / OS location kill: keep the last
+          // results, just stop ticking. Leave a breadcrumb (#2297 style).
+          unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+            'where': 'RadarSearch GPS stream error',
+          }));
+        },
+        cancelOnError: false,
       );
-
-      // #2806 — the wide corridor is fetched with a hard row cap (60 km /
-      // limit 50, un-distance-ordered), so in a dense area its returned slice
-      // can MISS the closest forecourts, leaving the radar excluding stations
-      // the regular search shows. Merge a direct in-radius fetch so the radar
-      // is always a SUPERSET of the in-radius search around the same position
-      // (the user's stated expectation). Best-effort: corridor-only if the
-      // in-radius fetch fails.
-      final nearby = await _inRadiusStations(pos, radiusKm, fuel);
-
-      // Dedup by id (the in-radius row wins — it carries the freshest per-fuel
-      // price) and stamp each station's distance (km) from the user.
-      final byId = <String, Station>{};
-      for (final s in [...raw, ...nearby]) {
-        final distKm =
-            geo.distanceMeters(pos.lat, pos.lng, s.lat, s.lng) / 1000.0;
-        final withDist = s.copyWith(dist: distKm);
-        byId[withDist.id] = withDist;
-      }
-
-      // #2926 — apply the SAME shared hard-fuel-filter the regular search runs
-      // (StationServiceChain.searchStations → StationServiceHelpers.filterByFuel)
-      // so the radar surfaces exactly the stations that sell the selected fuel —
-      // never a `--` row — and its result set is identical to the in-radius
-      // search for the same position + radius + fuel. `FuelType.all` keeps every
-      // station. Then distance-sort, like the regular search list.
-      final priced = StationServiceHelpers.filterByFuel(
-        byId.values.toList(),
-        fuel,
-      ).toList()
-        ..sort((a, b) => a.dist.compareTo(b.dist));
-
-      // #2948 — publish the radar list to the Android Auto Radar screen.
-      // Never throws (CarStationWriter swallows write faults).
-      unawaited(carWriter.writeRadar(priced, fuel));
-
-      state = state.copyWith(
-        active: true,
-        stations: AsyncData<List<Station>>(priced),
-      );
-    } catch (e, st) {
-      state = state.copyWith(
-        active: true,
-        stations: AsyncError<List<Station>>(e, st),
-      );
+    } on Object catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'RadarSearch GPS subscribe',
+      }));
     }
   }
 
-  /// A direct in-radius station fetch around [pos], mirroring the regular
-  /// search, so [runRadar] can guarantee the radar list is a superset of it
-  /// (#2806). Returns `[]` on any failure so the radar degrades to its cached
-  /// corridor rather than erroring.
-  Future<List<Station>> _inRadiusStations(
-    UserPositionData pos,
-    double radiusKm,
-    FuelType fuel,
-  ) async {
+  /// Handle a live GPS fix while the radar is active: re-rank the cached set
+  /// against the new position immediately (zero network) so the distance ticks
+  /// down, then trigger a gated re-fetch in the background.
+  void _onFix(Position p) {
+    _lastFix = p;
+    if (!state.active) return;
+    // 1. Immediate, network-free re-rank off the cached raw set so the distance
+    //    captions + closeness bars move on every fix.
+    _republish(p.latitude, p.longitude);
+    // 2. Background gated re-fetch — the corridor is cache-served inside a tile
+    //    and the in-radius merge is movement+time-gated (#3254), so this is
+    //    mostly free and never re-queries more than necessary. Silent: a
+    //    transient failure must not clobber the live results with an error.
+    unawaited(_scan(
+      p.latitude,
+      p.longitude,
+      withInRadiusMerge: true,
+      heading: geo.sanitizedHeading(p.heading),
+      silent: true,
+    ));
+  }
+
+  /// Fetch the corridor (+ optional gated in-radius merge) around ([lat],
+  /// [lng]), rank it with the shared authority, and publish.
+  Future<void> _scan(
+    double lat,
+    double lng, {
+    required bool withInRadiusMerge,
+    double? heading,
+    required bool silent,
+  }) async {
+    final radiusKm = ref.read(searchRadiusProvider);
+    final fuel = ref.read(selectedFuelTypeProvider);
     try {
-      final result = await ref.read(stationServiceProvider).searchStations(
-            SearchParams(
-              lat: pos.lat,
-              lng: pos.lng,
-              radiusKm: radiusKm,
-              fuelType: fuel,
-              sortBy: SortBy.distance,
-            ),
-          );
-      return result.data;
-    } on Object {
-      return const <Station>[];
+      final radar = ref.read(fuelStationRadarProvider);
+      final corridor = await radar.fetchStations(
+        lat,
+        lng,
+        radiusKm,
+        fuel.apiValue,
+        headingDegrees: heading,
+      );
+
+      // #2806 — the wide corridor is row-capped + un-distance-ordered, so it can
+      // miss the closest forecourts. Merge a direct in-radius fetch so the radar
+      // is always a SUPERSET of the in-radius search. #3254 — through the shared
+      // movement+time gate, so a moving user re-queries at most once per
+      // minInterval. Skipped on the provisional first paint (corridor-only).
+      final nearby = withInRadiusMerge
+          ? await ref.read(radarInRadiusCacheProvider).stationsNear(
+                lat,
+                lng,
+                radiusKm,
+              )
+          : const <Station>[];
+
+      _lastRaw = [...corridor, ...nearby];
+      final ranked = RadarRanking.rank(_lastRaw, lat: lat, lng: lng, fuel: fuel);
+
+      // #2948 — publish to the Android Auto Radar screen (swallows write faults).
+      unawaited(carWriter.writeRadar(ranked, fuel));
+
+      state = state.copyWith(stations: AsyncData<List<Station>>(ranked));
+    } catch (e, st) {
+      // On a background (live) refresh, keep the last good results; only an
+      // explicit (initial / retry) scan surfaces the error.
+      if (!silent) {
+        state = state.copyWith(stations: AsyncError<List<Station>>(e, st));
+      }
     }
+  }
+
+  /// Re-rank the cached raw set against ([lat], [lng]) and publish — no network.
+  void _republish(double lat, double lng) {
+    if (_lastRaw.isEmpty) return;
+    final fuel = ref.read(selectedFuelTypeProvider);
+    final ranked = RadarRanking.rank(_lastRaw, lat: lat, lng: lng, fuel: fuel);
+    unawaited(carWriter.writeRadar(ranked, fuel));
+    state = state.copyWith(stations: AsyncData<List<Station>>(ranked));
   }
 
   /// Dismiss the radar result and hand the results list back to the regular
-  /// `searchStateProvider`.
+  /// `searchStateProvider`. Cancels the live GPS subscription.
   void dismiss() {
+    unawaited(_gpsSub?.cancel());
+    _gpsSub = null;
+    _lastRaw = const [];
+    _lastFix = null;
     state = RadarSearchState.idle;
   }
 }
 
 /// The nearest priced radar station, or null. Feeds the small-window PiP tile
-/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP. Now
+/// carries the LIVE distance (the list it reads is re-stamped on every GPS
+/// fix), so the tile's distance + closeness bar move as the user approaches —
+/// fixing the frozen-snapshot distance #3255 flagged.
 @riverpod
 Station? radarSearchNearest(Ref ref) {
   final radar = ref.watch(radarSearchProvider);

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -8,57 +8,93 @@ part of 'radar_search_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// The on-search Fuel Station Radar (#2659).
+/// The on-search Fuel Station Radar (#2659 / #3267).
 ///
-/// A one-shot radar fetch around the user's CURRENT position
-/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
-/// the trip-only shared GPS stream), surfaced in the search results list like
-/// a regular search. It reuses the #2661 radar data layer
-/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
-/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
-/// in-radius fetch so the result is always a superset of the regular search
-/// (#2806).
+/// A **live** radar around the user's current position, surfaced in the search
+/// results list like a regular search. Unlike its one-shot predecessor, it
+/// subscribes to a foreground GPS stream ([radarSearchLocationSettings]) while
+/// active and re-stamps each station's distance on every fix, so the distance
+/// captions + the closeness bars tick down as the driver approaches — the SAME
+/// live-distance behaviour the trip radar gets from the approach detector. The
+/// distance/dedup/fuel-filter/sort is the shared [RadarRanking] authority, so
+/// both surfaces rank identically (#3267).
 ///
-/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
-/// approach detector: those only fire while a trip records (gated on
-/// `ApproachPolling`). This provider runs on demand from the search screen, with
-/// no geofence polling and no second `ApproachDetector` / `PipController`.
+/// It reuses the #2661 radar data layer ([fuelStationRadarProvider]) — the
+/// tier-1 corridor location cache (1 h) + tier-3 JIT price cache (5 min) — for
+/// the wide net, and merges a direct in-radius fetch so the result is always a
+/// superset of the regular search (#2806). That in-radius merge runs through
+/// the shared, movement+time-gated [radarInRadiusCacheProvider] (#3254), so a
+/// moving user re-queries the chain at most once per the provider's
+/// `minInterval` instead of once per fix; between fetches the distance still
+/// updates live off the cached set with **zero** network.
+///
+/// ### Fast, non-blocking init (#3267)
+///
+/// On [runRadar] the radar paints immediately from the persisted last-known
+/// position (corridor-only, [locating] = true) so the user never stares at a
+/// blank screen through the cold GPS fix, then re-scans authoritatively once
+/// the fresh fix lands. The GPS subscription and the corridor fetch progress
+/// concurrently rather than strictly serially.
 
 @ProviderFor(RadarSearch)
 final radarSearchProvider = RadarSearchProvider._();
 
-/// The on-search Fuel Station Radar (#2659).
+/// The on-search Fuel Station Radar (#2659 / #3267).
 ///
-/// A one-shot radar fetch around the user's CURRENT position
-/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
-/// the trip-only shared GPS stream), surfaced in the search results list like
-/// a regular search. It reuses the #2661 radar data layer
-/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
-/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
-/// in-radius fetch so the result is always a superset of the regular search
-/// (#2806).
+/// A **live** radar around the user's current position, surfaced in the search
+/// results list like a regular search. Unlike its one-shot predecessor, it
+/// subscribes to a foreground GPS stream ([radarSearchLocationSettings]) while
+/// active and re-stamps each station's distance on every fix, so the distance
+/// captions + the closeness bars tick down as the driver approaches — the SAME
+/// live-distance behaviour the trip radar gets from the approach detector. The
+/// distance/dedup/fuel-filter/sort is the shared [RadarRanking] authority, so
+/// both surfaces rank identically (#3267).
 ///
-/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
-/// approach detector: those only fire while a trip records (gated on
-/// `ApproachPolling`). This provider runs on demand from the search screen, with
-/// no geofence polling and no second `ApproachDetector` / `PipController`.
+/// It reuses the #2661 radar data layer ([fuelStationRadarProvider]) — the
+/// tier-1 corridor location cache (1 h) + tier-3 JIT price cache (5 min) — for
+/// the wide net, and merges a direct in-radius fetch so the result is always a
+/// superset of the regular search (#2806). That in-radius merge runs through
+/// the shared, movement+time-gated [radarInRadiusCacheProvider] (#3254), so a
+/// moving user re-queries the chain at most once per the provider's
+/// `minInterval` instead of once per fix; between fetches the distance still
+/// updates live off the cached set with **zero** network.
+///
+/// ### Fast, non-blocking init (#3267)
+///
+/// On [runRadar] the radar paints immediately from the persisted last-known
+/// position (corridor-only, [locating] = true) so the user never stares at a
+/// blank screen through the cold GPS fix, then re-scans authoritatively once
+/// the fresh fix lands. The GPS subscription and the corridor fetch progress
+/// concurrently rather than strictly serially.
 final class RadarSearchProvider
     extends $NotifierProvider<RadarSearch, RadarSearchState> {
-  /// The on-search Fuel Station Radar (#2659).
+  /// The on-search Fuel Station Radar (#2659 / #3267).
   ///
-  /// A one-shot radar fetch around the user's CURRENT position
-  /// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
-  /// the trip-only shared GPS stream), surfaced in the search results list like
-  /// a regular search. It reuses the #2661 radar data layer
-  /// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
-  /// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
-  /// in-radius fetch so the result is always a superset of the regular search
-  /// (#2806).
+  /// A **live** radar around the user's current position, surfaced in the search
+  /// results list like a regular search. Unlike its one-shot predecessor, it
+  /// subscribes to a foreground GPS stream ([radarSearchLocationSettings]) while
+  /// active and re-stamps each station's distance on every fix, so the distance
+  /// captions + the closeness bars tick down as the driver approaches — the SAME
+  /// live-distance behaviour the trip radar gets from the approach detector. The
+  /// distance/dedup/fuel-filter/sort is the shared [RadarRanking] authority, so
+  /// both surfaces rank identically (#3267).
   ///
-  /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
-  /// approach detector: those only fire while a trip records (gated on
-  /// `ApproachPolling`). This provider runs on demand from the search screen, with
-  /// no geofence polling and no second `ApproachDetector` / `PipController`.
+  /// It reuses the #2661 radar data layer ([fuelStationRadarProvider]) — the
+  /// tier-1 corridor location cache (1 h) + tier-3 JIT price cache (5 min) — for
+  /// the wide net, and merges a direct in-radius fetch so the result is always a
+  /// superset of the regular search (#2806). That in-radius merge runs through
+  /// the shared, movement+time-gated [radarInRadiusCacheProvider] (#3254), so a
+  /// moving user re-queries the chain at most once per the provider's
+  /// `minInterval` instead of once per fix; between fetches the distance still
+  /// updates live off the cached set with **zero** network.
+  ///
+  /// ### Fast, non-blocking init (#3267)
+  ///
+  /// On [runRadar] the radar paints immediately from the persisted last-known
+  /// position (corridor-only, [locating] = true) so the user never stares at a
+  /// blank screen through the cold GPS fix, then re-scans authoritatively once
+  /// the fresh fix lands. The GPS subscription and the corridor fetch progress
+  /// concurrently rather than strictly serially.
   RadarSearchProvider._()
     : super(
         from: null,
@@ -86,23 +122,35 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'f6256739953e784dee6b94ea5f0b55f8ce6592c9';
+String _$radarSearchHash() => r'55f444f30916d2a36f7c4691ec522b8b568a7f59';
 
-/// The on-search Fuel Station Radar (#2659).
+/// The on-search Fuel Station Radar (#2659 / #3267).
 ///
-/// A one-shot radar fetch around the user's CURRENT position
-/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
-/// the trip-only shared GPS stream), surfaced in the search results list like
-/// a regular search. It reuses the #2661 radar data layer
-/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
-/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
-/// in-radius fetch so the result is always a superset of the regular search
-/// (#2806).
+/// A **live** radar around the user's current position, surfaced in the search
+/// results list like a regular search. Unlike its one-shot predecessor, it
+/// subscribes to a foreground GPS stream ([radarSearchLocationSettings]) while
+/// active and re-stamps each station's distance on every fix, so the distance
+/// captions + the closeness bars tick down as the driver approaches — the SAME
+/// live-distance behaviour the trip radar gets from the approach detector. The
+/// distance/dedup/fuel-filter/sort is the shared [RadarRanking] authority, so
+/// both surfaces rank identically (#3267).
 ///
-/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
-/// approach detector: those only fire while a trip records (gated on
-/// `ApproachPolling`). This provider runs on demand from the search screen, with
-/// no geofence polling and no second `ApproachDetector` / `PipController`.
+/// It reuses the #2661 radar data layer ([fuelStationRadarProvider]) — the
+/// tier-1 corridor location cache (1 h) + tier-3 JIT price cache (5 min) — for
+/// the wide net, and merges a direct in-radius fetch so the result is always a
+/// superset of the regular search (#2806). That in-radius merge runs through
+/// the shared, movement+time-gated [radarInRadiusCacheProvider] (#3254), so a
+/// moving user re-queries the chain at most once per the provider's
+/// `minInterval` instead of once per fix; between fetches the distance still
+/// updates live off the cached set with **zero** network.
+///
+/// ### Fast, non-blocking init (#3267)
+///
+/// On [runRadar] the radar paints immediately from the persisted last-known
+/// position (corridor-only, [locating] = true) so the user never stares at a
+/// blank screen through the cold GPS fix, then re-scans authoritatively once
+/// the fresh fix lands. The GPS subscription and the corridor fetch progress
+/// concurrently rather than strictly serially.
 
 abstract class _$RadarSearch extends $Notifier<RadarSearchState> {
   RadarSearchState build();
@@ -123,19 +171,28 @@ abstract class _$RadarSearch extends $Notifier<RadarSearchState> {
 }
 
 /// The nearest priced radar station, or null. Feeds the small-window PiP tile
-/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP. Now
+/// carries the LIVE distance (the list it reads is re-stamped on every GPS
+/// fix), so the tile's distance + closeness bar move as the user approaches —
+/// fixing the frozen-snapshot distance #3255 flagged.
 
 @ProviderFor(radarSearchNearest)
 final radarSearchNearestProvider = RadarSearchNearestProvider._();
 
 /// The nearest priced radar station, or null. Feeds the small-window PiP tile
-/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP. Now
+/// carries the LIVE distance (the list it reads is re-stamped on every GPS
+/// fix), so the tile's distance + closeness bar move as the user approaches —
+/// fixing the frozen-snapshot distance #3255 flagged.
 
 final class RadarSearchNearestProvider
     extends $FunctionalProvider<Station?, Station?, Station?>
     with $Provider<Station?> {
   /// The nearest priced radar station, or null. Feeds the small-window PiP tile
-  /// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+  /// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP. Now
+  /// carries the LIVE distance (the list it reads is re-stamped on every GPS
+  /// fix), so the tile's distance + closeness bar move as the user approaches —
+  /// fixing the frozen-snapshot distance #3255 flagged.
   RadarSearchNearestProvider._()
     : super(
         from: null,

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -30,5 +30,13 @@
   "fuelStationRadarResultBadge": "Tankstellen-Radar-Ergebnis",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
+  },
+  "radarAcquiringLocation": "Standort wird ermittelt…",
+  "@radarAcquiringLocation": {
+    "description": "Status shown while the on-search Fuel Station Radar acquires the first GPS fix and has no last-known position to scan around yet (#3267)."
+  },
+  "radarUpdatingLocation": "Standort wird aktualisiert…",
+  "@radarUpdatingLocation": {
+    "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
   }
 }

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -30,5 +30,13 @@
   "fuelStationRadarResultBadge": "Fuel Station Radar result",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "description": "Status shown while the on-search Fuel Station Radar acquires the first GPS fix and has no last-known position to scan around yet (#3267)."
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3440,6 +3440,14 @@
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
   },
+  "radarAcquiringLocation": "Standort wird ermittelt…",
+  "@radarAcquiringLocation": {
+    "description": "Status shown while the on-search Fuel Station Radar acquires the first GPS fix and has no last-known position to scan around yet (#3267)."
+  },
+  "radarUpdatingLocation": "Standort wird aktualisiert…",
+  "@radarUpdatingLocation": {
+    "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
+  },
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7041,6 +7041,14 @@
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
   },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "description": "Status shown while the on-search Fuel Station Radar acquires the first GPS fix and has no last-known position to scan around yet (#3267)."
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -2131,6 +2131,8 @@
   "fuelStationRadarStart": "⟦Šŧářŧ ƒúéł šŧáŧîóñ řáđář ·········⟧",
   "stopRadar": "⟦Šŧóƥ řáđář ····⟧",
   "fuelStationRadarResultBadge": "⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧",
+  "radarAcquiringLocation": "⟦Ƒîñđîñǧ ýóúř łóçáŧîóñ… ·········⟧",
+  "radarUpdatingLocation": "⟦Úƥđáŧîñǧ ýóúř łóçáŧîóñ… ·········⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",
   "tripRecordingPinSemanticOff": "⟦Ƥîñ řéçóřđîñǧ ƒóřɱ ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4885,5 +4885,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13012,6 +13012,18 @@ abstract class AppLocalizations {
   /// **'Fuel Station Radar result'**
   String get fuelStationRadarResultBadge;
 
+  /// Status shown while the on-search Fuel Station Radar acquires the first GPS fix and has no last-known position to scan around yet (#3267).
+  ///
+  /// In en, this message translates to:
+  /// **'Finding your location…'**
+  String get radarAcquiringLocation;
+
+  /// Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267).
+  ///
+  /// In en, this message translates to:
+  /// **'Updating your location…'**
+  String get radarUpdatingLocation;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7533,6 +7533,12 @@ class AppLocalizationsBg extends AppLocalizations {
       'Резултат от радара за бензиностанции';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Закачането задържа екрана включен — изразходва повече батерия';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7482,6 +7482,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Výsledek Radaru čerpacích stanic';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Připnutí udržuje obrazovku zapnutou — spotřebuje více baterie';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7470,6 +7470,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Tankstationsradar-resultat';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fastgørelse holder skærmen tændt — bruger mere batteri';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7516,6 +7516,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Tankstellen-Radar-Ergebnis';
 
   @override
+  String get radarAcquiringLocation => 'Standort wird ermittelt…';
+
+  @override
+  String get radarUpdatingLocation => 'Standort wird aktualisiert…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7535,6 +7535,12 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αποτέλεσμα Ραντάρ Πρατηρίου Καυσίμων';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Η καρφίτσωση κρατά την οθόνη αναμμένη — χρησιμοποιεί περισσότερη μπαταρία';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7434,6 +7434,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 
@@ -15421,6 +15427,12 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get fuelStationRadarResultBadge =>
       '⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧';
+
+  @override
+  String get radarAcquiringLocation => '⟦Ƒîñđîñǧ ýóúř łóçáŧîóñ… ·········⟧';
+
+  @override
+  String get radarUpdatingLocation => '⟦Úƥđáŧîñǧ ýóúř łóçáŧîóñ… ·········⟧';
 
   @override
   String get tripRecordingPinTooltip =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7523,6 +7523,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Resultado del Radar de gasolineras';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fijar mantiene la pantalla encendida: consume más batería';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7464,6 +7464,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Tankla radari tulemus';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kinnitamine hoiab ekraani peal — kasutab rohkem akut';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7471,6 +7471,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Asematutkan tulos';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kiinnittäminen pitää näytön päällä — kuluttaa enemmän akkua';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7549,6 +7549,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Résultat du radar de stations-service';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'L\'épinglage garde l\'écran allumé — consomme plus de batterie';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7496,6 +7496,12 @@ class AppLocalizationsHr extends AppLocalizations {
       'Rezultat radara benzinskih postaja';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prikačivanje drži ekran uključenim — troši više baterije';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7516,6 +7516,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Töltőállomás-radar eredménye';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'A rögzítés bekapcsolva tartja a képernyőt — több akkumulátort használ';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7512,6 +7512,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Risultato radar stazioni di servizio';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fissare mantiene lo schermo acceso — consuma più batteria';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7509,6 +7509,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Degalinių radaro rezultatas';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prisegimas palaiko ekraną įjungtą — naudoja daugiau baterijos';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7515,6 +7515,12 @@ class AppLocalizationsLv extends AppLocalizations {
       'Degvielas staciju radara rezultāts';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Piespraušana patur ekrānu ieslēgtu — patērē vairāk akumulatora';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7466,6 +7466,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Bensinstasjonradar-resultat';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Festing holder skjermen på – bruker mer batteri';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7495,6 +7495,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Tankstation Radar-resultaat';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Vastpinnen houdt het scherm aan — verbruikt meer batterij';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7501,6 +7501,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Wynik radaru stacji paliw';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Przypięcie utrzymuje ekran włączony — zużywa więcej baterii';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7527,6 +7527,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'Resultado do Radar de Postos de Combustível';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixar mantém o ecrã ligado — usa mais bateria';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7523,6 +7523,12 @@ class AppLocalizationsRo extends AppLocalizations {
       'Rezultat Radar stații de carburant';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixarea menține ecranul aprins — consumă mai multă baterie';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7499,6 +7499,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Výsledok radaru čerpacích staníc';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pripnutie udržuje obrazovku zapnutú — vyčerpáva viac batérie';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7478,6 +7478,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Rezultat radarja bencinski servis';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Priklepanje ohranja zaslon vklopljen — porablja več baterije';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7466,6 +7466,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fuelStationRadarResultBadge => 'Bensinmack-radarresultat';
 
   @override
+  String get radarAcquiringLocation => 'Finding your location…';
+
+  @override
+  String get radarUpdatingLocation => 'Updating your location…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Nålning håller skärmen på – förbrukar mer batteri';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4782,5 +4782,15 @@
         "example": "Oil change"
       }
     }
+  },
+  "radarAcquiringLocation": "Finding your location…",
+  "@radarAcquiringLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "radarUpdatingLocation": "Updating your location…",
+  "@radarUpdatingLocation": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/services/approach_detector_test.dart
+++ b/test/core/services/approach_detector_test.dart
@@ -118,7 +118,7 @@ void main() {
     });
 
     Future<void> setUpDetector({
-      required Future<List<Station>> Function(double, double, double, String)
+      required Future<List<Station>> Function(double, double, double, String, {double? headingDegrees})
           fetch,
       ApproachPriceMode priceMode = ApproachPriceMode.nearest,
     }) async {
@@ -137,7 +137,7 @@ void main() {
     }
 
     test('first GPS emit transitions Idle → Polling', () async {
-      await setUpDetector(fetch: (_, _, _, _) async => []);
+      await setUpDetector(fetch: (_, _, _, _, {headingDegrees}) async => []);
       gps.add(_pos(48.0, 2.0, speedMps: 25));
       await Future<void>.delayed(Duration.zero);
       expect(emitted, isNotEmpty);
@@ -146,7 +146,7 @@ void main() {
 
     test('nearest mode locks onto the first station crossed', () async {
       var callCount = 0;
-      Future<List<Station>> fetch(double lat, double lng, double r, String _) async {
+      Future<List<Station>> fetch(double lat, double lng, double r, String _, {double? headingDegrees}) async {
         callCount++;
         return [
           _station(id: 'A', lat: lat, lng: lng), // exactly on us — 0 m
@@ -180,7 +180,7 @@ void main() {
       final gps = StreamController<Position>.broadcast();
       final det = ApproachDetector(
         gpsStream: gps.stream,
-        fetchStations: (_, _, _, _) async => const <Station>[],
+        fetchStations: (_, _, _, _, {headingDegrees}) async => const <Station>[],
         config: const ApproachDetectorConfig(
           radiusMeters: 1000,
           priceMode: ApproachPriceMode.nearest,
@@ -236,7 +236,7 @@ void main() {
         final gps = StreamController<Position>.broadcast();
         final det = ApproachDetector(
           gpsStream: gps.stream,
-          fetchStations: (_, _, _, _) async => stations,
+          fetchStations: (_, _, _, _, {headingDegrees}) async => stations,
           config: const ApproachDetectorConfig(
             radiusMeters: 1000,
             priceMode: ApproachPriceMode.cheapestInRadius,
@@ -286,7 +286,7 @@ void main() {
         final gps = StreamController<Position>.broadcast();
         final det = ApproachDetector(
           gpsStream: gps.stream,
-          fetchStations: (_, _, _, _) async => stations,
+          fetchStations: (_, _, _, _, {headingDegrees}) async => stations,
           config: const ApproachDetectorConfig(
             radiusMeters: 1000,
             priceMode: ApproachPriceMode.nearest,
@@ -324,7 +324,7 @@ void main() {
         final gps = StreamController<Position>.broadcast();
         final det = ApproachDetector(
           gpsStream: gps.stream,
-          fetchStations: (_, _, _, _) async => stations,
+          fetchStations: (_, _, _, _, {headingDegrees}) async => stations,
           config: const ApproachDetectorConfig(
             radiusMeters: 1000,
             priceMode: ApproachPriceMode.nearest,
@@ -367,7 +367,7 @@ void main() {
         final gps = StreamController<Position>.broadcast();
         final det = ApproachDetector(
           gpsStream: gps.stream,
-          fetchStations: (_, _, _, _) async {
+          fetchStations: (_, _, _, _, {headingDegrees}) async {
             fetchCount++;
             return [station];
           },

--- a/test/core/services/radar/radar_in_radius_cache_test.dart
+++ b/test/core/services/radar/radar_in_radius_cache_test.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/radar/radar_in_radius_cache.dart';
+
+/// #3254 — the movement+time gate that stops the radar's direct in-radius merge
+/// from flooding the rate-limit queue. Driven against injected fetch/clock
+/// seams so the gate logic is pinned deterministically, no container/real GPS.
+Station _s(String id, double lat, double lng) => Station(
+      id: id,
+      name: id,
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: lat,
+      lng: lng,
+      e10: 1.5,
+      isOpen: true,
+    );
+
+void main() {
+  group('RadarInRadiusCache gate', () {
+    late int calls;
+    late DateTime clock;
+    late RadarInRadiusCache cache;
+
+    RadarInRadiusCache build({Duration minInterval = const Duration(minutes: 5)}) {
+      calls = 0;
+      clock = DateTime(2026, 1, 1, 12);
+      return RadarInRadiusCache(
+        fetch: (lat, lng, r) async {
+          calls++;
+          return [_s('S', lat, lng)];
+        },
+        minInterval: () => minInterval,
+        now: () => clock,
+      );
+    }
+
+    setUp(() => cache = build());
+
+    test('first call always fetches', () async {
+      final out = await cache.stationsNear(48.0, 2.0, 10);
+      expect(calls, 1);
+      expect(out, hasLength(1));
+    });
+
+    test('a standstill (same cell) never re-fetches, even past minInterval',
+        () async {
+      await cache.stationsNear(48.0, 2.0, 10);
+      clock = clock.add(const Duration(minutes: 30));
+      await cache.stationsNear(48.0001, 2.0, 10); // rounds to the same cell
+      expect(calls, 1, reason: 'same ~111 m cell reuses the cached merge');
+    });
+
+    test('moving to a new cell before minInterval reuses (no flood)', () async {
+      await cache.stationsNear(48.0, 2.0, 10);
+      clock = clock.add(const Duration(minutes: 1)); // < 5 min
+      await cache.stationsNear(48.05, 2.0, 10); // new cell, too soon
+      expect(calls, 1, reason: 'gate holds until minInterval elapses');
+    });
+
+    test('refetches only after moving to a new cell AND minInterval elapsed',
+        () async {
+      await cache.stationsNear(48.0, 2.0, 10);
+      clock = clock.add(const Duration(minutes: 6)); // >= 5 min
+      final out = await cache.stationsNear(48.05, 2.0, 10); // new cell
+      expect(calls, 2, reason: 'moved beyond the cell AND past minInterval');
+      expect(out.single.lat, 48.05, reason: 'fresh fetch around the new fix');
+    });
+
+    test('a moving drive issues at most one fetch per minInterval window',
+        () async {
+      // Simulate a steady drive: a new cell every "minute", minInterval 5 min.
+      cache = build(minInterval: const Duration(minutes: 5));
+      for (var i = 0; i < 12; i++) {
+        clock = clock.add(const Duration(minutes: 1));
+        await cache.stationsNear(48.0 + i * 0.01, 2.0, 10);
+      }
+      // 12 min of driving (+ the initial fetch) ⇒ initial + 2 windows ≈ 3.
+      expect(calls, lessThanOrEqualTo(3),
+          reason: 'bounded: ~1 chain search per minInterval, not per fix');
+    });
+
+    test('degrades to the last good merge on a fetch failure', () async {
+      var fail = false;
+      clock = DateTime(2026, 1, 1, 12);
+      final c = RadarInRadiusCache(
+        fetch: (lat, lng, r) async {
+          if (fail) throw StateError('offline');
+          return [_s('OK', lat, lng)];
+        },
+        minInterval: () => const Duration(minutes: 5),
+        now: () => clock,
+      );
+      final first = await c.stationsNear(48.0, 2.0, 10);
+      expect(first.single.id, 'OK');
+      fail = true;
+      clock = clock.add(const Duration(minutes: 10));
+      final second = await c.stationsNear(48.5, 2.0, 10); // new cell + elapsed
+      expect(second.single.id, 'OK',
+          reason: 'a failed refetch keeps the last good merge, never empties');
+    });
+
+    test('reuses the cache when the minInterval resolver throws', () async {
+      clock = DateTime(2026, 1, 1, 12);
+      final c = RadarInRadiusCache(
+        fetch: (lat, lng, r) async => [_s('S', lat, lng)],
+        minInterval: () => throw StateError('no country graph'),
+        now: () => clock,
+      );
+      await c.stationsNear(48.0, 2.0, 10); // first call fetches (no gate yet)
+      clock = clock.add(const Duration(hours: 1));
+      final out = await c.stationsNear(48.5, 2.0, 10); // gate can't resolve
+      expect(out, hasLength(1),
+          reason: 'unknown cadence ⇒ conservative reuse, never throws');
+    });
+  });
+}

--- a/test/core/services/radar/radar_ranking_test.dart
+++ b/test/core/services/radar/radar_ranking_test.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/utils/station_extensions.dart';
+import 'package:tankstellen/core/services/radar/radar_ranking.dart';
+
+/// #3267 — the single distance-ranking authority shared by every radar surface.
+/// These pin the four guarantees the three providers used to each re-implement:
+/// dedup (last wins), fuel-filter, live distance stamp, distance sort.
+Station _s(String id, double lat, double lng, {double? e10, double? e85}) =>
+    Station(
+      id: id,
+      name: id,
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: lat,
+      lng: lng,
+      e10: e10,
+      e85: e85,
+      isOpen: true,
+    );
+
+void main() {
+  group('RadarRanking.rank', () {
+    test('stamps live distance from the given point and sorts nearest-first',
+        () {
+      final out = RadarRanking.rank(
+        [
+          _s('FAR', 48.03, 2.0, e10: 1.8),
+          _s('NEAR', 48.0, 2.0, e10: 1.6),
+          _s('MID', 48.01, 2.0, e10: 1.7),
+        ],
+        lat: 48.0,
+        lng: 2.0,
+        fuel: FuelType.e10,
+      );
+      expect(out.map((s) => s.id), ['NEAR', 'MID', 'FAR']);
+      expect(out.first.dist, lessThan(0.1));
+      expect(out.last.dist, greaterThan(2.0));
+    });
+
+    test('dedups by id — the LATER (in-radius merge) row wins', () {
+      final out = RadarRanking.rank(
+        [
+          _s('DUP', 48.0, 2.0, e10: 1.999), // corridor (first)
+          _s('DUP', 48.0, 2.0, e10: 1.659), // in-radius (last) wins
+        ],
+        lat: 48.0,
+        lng: 2.0,
+        fuel: FuelType.e10,
+      );
+      expect(out, hasLength(1));
+      expect(out.single.priceFor(FuelType.e10), 1.659);
+    });
+
+    test('default (requirePrice: false) uses the shared hard-fuel filter', () {
+      final out = RadarRanking.rank(
+        [
+          _s('SELLS', 48.0, 2.0, e85: 0.84, e10: 1.77),
+          _s('E10_ONLY', 48.01, 2.0, e10: 1.75), // no E85 → dropped
+        ],
+        lat: 48.0,
+        lng: 2.0,
+        fuel: FuelType.e85,
+      );
+      expect(out.map((s) => s.id), ['SELLS']);
+    });
+
+    test('FuelType.all keeps every station (requirePrice: false)', () {
+      final out = RadarRanking.rank(
+        [_s('A', 48.0, 2.0, e10: 1.5), _s('B', 48.01, 2.0)],
+        lat: 48.0,
+        lng: 2.0,
+        fuel: FuelType.all,
+      );
+      expect(out.map((s) => s.id).toSet(), {'A', 'B'});
+    });
+
+    test('requirePrice: true drops rows unpriced for the fuel', () {
+      final out = RadarRanking.rank(
+        [
+          _s('PRICED', 48.0, 2.0, e10: 1.6),
+          _s('UNPRICED', 48.001, 2.0), // no price → dropped
+        ],
+        lat: 48.0,
+        lng: 2.0,
+        fuel: FuelType.e10,
+        requirePrice: true,
+      );
+      expect(out.map((s) => s.id), ['PRICED']);
+    });
+
+    test('nearestPriced returns the closest priced station, else null', () {
+      final stations = [
+        _s('UNPRICED_NEAR', 48.0, 2.0), // closest but unpriced
+        _s('PRICED_FAR', 48.02, 2.0, e10: 1.7),
+      ];
+      expect(
+        RadarRanking.nearestPriced(stations, lat: 48.0, lng: 2.0, fuel: FuelType.e10)
+            ?.id,
+        'PRICED_FAR',
+      );
+      expect(
+        RadarRanking.nearestPriced(
+          [_s('NONE', 48.0, 2.0)],
+          lat: 48.0,
+          lng: 2.0,
+          fuel: FuelType.e10,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/search/radar_search_provider_test.dart
+++ b/test/features/search/radar_search_provider_test.dart
@@ -1,10 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/mixins/station_service_helpers.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
@@ -133,11 +137,16 @@ class _FakeStationService implements StationService {
   final List<Station> _inRadius;
   final bool throws;
 
+  /// How many direct in-radius searches the radar issued — the #3254 gate
+  /// assertion checks this stays bounded as the user moves.
+  int searchCalls = 0;
+
   @override
   Future<ServiceResult<List<Station>>> searchStations(
     SearchParams params, {
     CancelToken? cancelToken,
   }) async {
+    searchCalls++;
     if (throws) throw StateError('in-radius fetch failed');
     return ServiceResult(
       data: _inRadius,
@@ -157,6 +166,42 @@ class _FakeStationService implements StationService {
       throw UnimplementedError();
 }
 
+/// A [GeolocatorWrapper] whose live position stream the test drives by hand —
+/// the on-search radar now subscribes to it for live distance re-stamping
+/// (#3267). Default-empty so the existing one-shot assertions are unaffected.
+class _FakeGeolocator extends GeolocatorWrapper {
+  _FakeGeolocator(this.controller);
+  final StreamController<Position> controller;
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) =>
+      controller.stream;
+}
+
+/// A [GeolocatorWrapper] whose position stream THROWS synchronously on
+/// subscribe — models a platform-less / location-off device. The on-search
+/// radar's `_subscribeGps` documents a never-throws contract: it must swallow
+/// this and keep the radar usable off the persisted / refreshed fix (#3267).
+class _ThrowingGeolocator extends GeolocatorWrapper {
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) =>
+      throw StateError('no platform location stream');
+}
+
+/// A real-shaped [Position] for the live GPS stream.
+Position _pos(double lat, double lng, {double heading = 90}) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime.now(),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: heading,
+      headingAccuracy: 0,
+      speed: 0,
+      speedAccuracy: 0,
+    );
+
 ProviderContainer _container({
   required ({double lat, double lng})? position,
   required List<Station> corridor,
@@ -166,6 +211,8 @@ ProviderContainer _container({
   ({double lat, double lng})? refreshTo,
   FuelType fuel = FuelType.e10,
   double radiusKm = 10.0,
+  StreamController<Position>? gps,
+  _FakeStationService? service,
 }) =>
     ProviderContainer(
       overrides: [
@@ -181,7 +228,13 @@ ProviderContainer _container({
         searchRadiusProvider.overrideWith(() => _FixedRadius(radiusKm)),
         fuelStationRadarProvider.overrideWithValue(_recordedRadar(corridor)),
         stationServiceProvider.overrideWithValue(
-          _FakeStationService(inRadius, throws: inRadiusThrows),
+          service ?? _FakeStationService(inRadius, throws: inRadiusThrows),
+        ),
+        // The on-search radar subscribes to the live GPS stream (#3267).
+        // A broadcast controller the test can push fixes into; default-empty
+        // (never emits) for the one-shot assertions.
+        geolocatorWrapperProvider.overrideWithValue(
+          _FakeGeolocator(gps ?? StreamController<Position>.broadcast()),
         ),
       ],
     );
@@ -427,6 +480,123 @@ void main() {
       // where NEAR is ~130 km away and would sort after FAR1.
       expect(list.first.id, 'NEAR');
       expect(list.first.dist, lessThan(0.1));
+    });
+  });
+
+  group('RadarSearch — live distance updates (#3267)', () {
+    test(
+        'a live GPS fix re-stamps distance closer as the user approaches '
+        '(no longer a frozen one-shot)', () async {
+      // One station ~5.5 km north of the user's start. As the user drives
+      // toward it the live stream must re-stamp the distance DOWN — the core
+      // bug: the on-search radar used to stamp distance once and freeze it.
+      final gps = StreamController<Position>.broadcast();
+      addTearDown(gps.close);
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [_station('AHEAD', 48.05, 2.0, e10: 1.65)],
+        gps: gps,
+      );
+      addTearDown(container.dispose);
+      // Keep the autoDispose provider alive across pumps, as the search screen
+      // does by watching it (else it disposes between reads and resets to idle).
+      addTearDown(container.listen(radarSearchProvider, (_, _) {}).close);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+      final startDist =
+          container.read(radarSearchProvider).stations.value!.first.dist;
+      expect(startDist, greaterThan(5.0),
+          reason: 'AHEAD starts ~5.5 km away');
+
+      // Drive halfway toward it.
+      gps.add(_pos(48.025, 2.0));
+      await pumpEventQueue();
+
+      final midDist =
+          container.read(radarSearchProvider).stations.value!.first.dist;
+      expect(midDist, lessThan(startDist),
+          reason: 'distance ticks DOWN on a live fix, not frozen');
+      expect(midDist, greaterThan(2.0));
+
+      // Arrive next to it.
+      gps.add(_pos(48.05, 2.0));
+      await pumpEventQueue();
+
+      final endDist =
+          container.read(radarSearchProvider).stations.value!.first.dist;
+      expect(endDist, lessThan(0.2),
+          reason: 'at the station the live distance is ~0');
+      // The derived PiP-tile nearest carries the SAME live distance (#3255).
+      expect(container.read(radarSearchNearestProvider)!.dist, lessThan(0.2));
+    });
+
+    test(
+        'live re-rank between fixes issues NO extra in-radius chain search '
+        'while inside the cache cell (#3254 gate)', () async {
+      final gps = StreamController<Position>.broadcast();
+      addTearDown(gps.close);
+      final service = _FakeStationService(const []);
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [_station('AHEAD', 48.05, 2.0, e10: 1.65)],
+        service: service,
+        gps: gps,
+      );
+      addTearDown(container.dispose);
+      addTearDown(container.listen(radarSearchProvider, (_, _) {}).close);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+      final afterRun = service.searchCalls;
+      expect(afterRun, 1, reason: 'one authoritative in-radius search on run');
+
+      // Several sub-cell jitters (<111 m) — the live distance still updates off
+      // the cached set, but NOT one chain search per fix.
+      for (final dLat in [0.0001, 0.0002, 0.0003, 0.0004]) {
+        gps.add(_pos(48.0 + dLat, 2.0));
+        await pumpEventQueue();
+      }
+      expect(service.searchCalls, afterRun,
+          reason: 'in-cell fixes reuse the gated merge — no new chain search');
+    });
+
+    test(
+        '_subscribeGps never throws — a platform-less position stream is '
+        'swallowed and the radar still scans (#3267 never-throws contract)',
+        () async {
+      final container = ProviderContainer(overrides: [
+        userPositionProvider
+            .overrideWith(() => _FixedUserPosition(48.0, 2.0)),
+        selectedFuelTypeProvider.overrideWith(() => _FixedFuelType(FuelType.e10)),
+        searchRadiusProvider.overrideWith(() => _FixedRadius(10.0)),
+        fuelStationRadarProvider.overrideWithValue(
+          _recordedRadar([_station('NEAR', 48.0, 2.0, e10: 1.5)]),
+        ),
+        stationServiceProvider
+            .overrideWithValue(_FakeStationService(const [])),
+        // The GPS stream throws on subscribe — the fault injected here.
+        geolocatorWrapperProvider.overrideWithValue(_ThrowingGeolocator()),
+      ]);
+      addTearDown(container.dispose);
+
+      // The throwing stream must NOT propagate out of runRadar.
+      await expectLater(
+        container.read(radarSearchProvider.notifier).runRadar(),
+        completes,
+      );
+      // …and the radar still scanned off the persisted / refreshed fix.
+      expect(container.read(radarSearchProvider).stations.value, isNotEmpty);
+    });
+
+    test('locating flips false once the fresh fix lands', () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [_station('NEAR', 48.0, 2.0, e10: 1.5)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+      expect(container.read(radarSearchProvider).locating, isFalse,
+          reason: 'authoritative scan around the fresh fix clears locating');
     });
   });
 }


### PR DESCRIPTION
## What & why

The fuel-station radar lives on two surfaces — the **search page** and **trip recording**. They share the data layer but diverged on the live-distance path, and the search-page surface was broken for the user's core expectation: *as you drive toward a station, the distance must tick down*.

The on-search radar was a **one-shot scan** — it refreshed GPS once, stamped `Station.dist` once, and never subscribed to GPS again. So the distance and the closeness bar froze at scan time (scanning a position that could be tens of minutes stale, e.g. "GPS (41 min)"), and never moved while approaching. This PR unifies both surfaces on one live-distance framework and makes the search radar live, efficient and fast to start.

## Changes (one commit per issue)

**`feat(radar)` — unify on one live-distance framework + live, fast on-search radar (#3267, closes #3255)**
- **`RadarRanking`** (`core/services/radar/`) — the single dedup → fuel-filter → live-distance-stamp → distance-sort authority. The on-search radar, the trip nearest lookup and the swipe page-set all delegate to it, so every surface ranks identically and the live re-stamp is defined once.
- The on-search radar now **subscribes to a foreground GPS stream** while active and re-ranks the cached set on every fix with **zero network**, so distance/closeness tick down live — the same behaviour the trip radar gets from the approach detector. This also fixes the frozen `radarSearchNearest` distance the no-trip PiP tile showed (**#3255**).
- **Fast, non-blocking init**: paints instantly from the last-known position behind a localized "Updating your location…" banner, then re-scans authoritatively when the fresh fix lands; an acquiring state covers the cold first fix instead of a blank screen.

**`fix(radar)` — movement+time-gate the in-radius merge (#3254)**
- The direct in-radius superset merge used to hit the chain on *every* GPS fix, flooding the per-service rate-limit queue (DE 60 s, AT/PT/SI/CL 1 h) into an unbounded backlog. New `RadarInRadiusCache` re-queries only after moving into a new ~111 m cell **and** `minInterval` elapsed; otherwise it reuses the cached merge. A standstill never re-fetches; a moving car issues ≤1 search per `minInterval`.

**`fix(radar)` — thread live heading so corridor tile-ahead prefetch fires (#3256)**
- All production callers omitted `headingDegrees`, so the #2283 prefetch was green in CI yet inert. Adds `geo.sanitizedHeading()` and threads the live heading through every caller (incl. the approach-detector poll path).

## Efficiency (the "data service queried no more than necessary" ask)
- Live re-rank on each fix is **in-memory only** (no network).
- The in-radius chain search is movement+time gated (#3254).
- Corridor stays cache-served inside a tile; heading prefetch (#3256) avoids the blocking mid-drive fetch.

## Tests
- `radar_ranking_test`, `radar_in_radius_cache_test` (the #3254 gate AC: ≤1 search per `minInterval`, standstill never re-fetches, degrade-on-failure), live-distance + in-cell-gate + never-throws tests in `radar_search_provider_test`, updated detector tests. Full radar/approach/search/l10n/lint suites green locally.

Closes #3267, #3255, #3254, #3256.
