### PR TITLE
fix(obd2): framing-aware Mode 09 VIN parse — correct VIN on multi-frame replies (#3278, #3279)

### DIFF
--- a/lib/features/obd2/data/elm327_parsers.dart
+++ b/lib/features/obd2/data/elm327_parsers.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'elm327_vin_parser.dart';
+
 /// ELM327 response parsers — pure string→value decoders for Mode 01,
 /// Mode 09 and Mode 22 responses.
 ///
@@ -459,47 +461,13 @@ class Elm327Parsers {
     }
   }
 
-  /// Parse the ASCII VIN from a Mode 09 PID 02 response. ELM frames
-  /// the 17-byte VIN across 4–5 CAN frames, each prefixed with the
-  /// 3-byte header `49 02 NN` (where NN is a frame counter).
+  /// Parse the ASCII VIN from a Mode 09 PID 02 response.
   ///
-  /// We concatenate the hex payload and decode as ASCII, skipping:
-  /// - frame-header bytes (0x49 'I' — not a valid VIN char anyway,
-  ///   VIN excludes I/O/Q to avoid confusion with 1/0);
-  /// - padding zeros;
-  /// - any other non-printable byte.
-  ///
-  /// Returns the last 17 printable characters, which is the VIN for
-  /// well-formed responses. Returns null on NO DATA or < 17 chars. (#719)
-  /// NB: real multiline responses leak ISO-TP line-number digits into the
-  /// charset, so a framing-aware parse is tracked with the VIN fallback #3278.
-  static String? parseVin(String raw) {
-    final clean = cleanResponse(raw);
-    if (clean == null) return null;
-    final tokens =
-        clean.split(RegExp(r'\s+')).where((s) => s.isNotEmpty).toList();
-    final chars = <int>[];
-    for (final token in tokens) {
-      final byte = int.tryParse(token, radix: 16);
-      if (byte == null) continue;
-      // Digits 0-9.
-      if (byte >= 0x30 && byte <= 0x39) {
-        chars.add(byte);
-        continue;
-      }
-      // Upper-case letters A-Z, except I/O/Q (reserved — the 'I' that
-      // appears in frame headers is excluded by this rule).
-      if (byte >= 0x41 &&
-          byte <= 0x5A &&
-          byte != 0x49 &&
-          byte != 0x4F &&
-          byte != 0x51) {
-        chars.add(byte);
-      }
-    }
-    if (chars.length < 17) return null;
-    return String.fromCharCodes(chars.sublist(chars.length - 17));
-  }
+  /// #3278/#3279 — delegates to the framing-aware [Elm327VinParser], which
+  /// correctly handles the real multi-frame `49 02 NN` framing (the old "last
+  /// 17 chars" heuristic returned a wrong-but-plausible VIN on multiline
+  /// replies). Returns null on NO DATA or fewer than 17 VIN characters.
+  static String? parseVin(String raw) => Elm327VinParser.parse(raw);
 
   static List<int>? _parseMode22Body(
     String raw,

--- a/lib/features/obd2/data/elm327_vin_parser.dart
+++ b/lib/features/obd2/data/elm327_vin_parser.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Framing-aware decoder for the Mode 09 PID 02 (`0902`) VIN response (#3278).
+///
+/// Extracted from `Elm327Parsers` (#3279) so the VIN framing — which is genuinely
+/// different from the single-line Mode 01 decoders — lives in one focused,
+/// testable place, and so its VIN-safe cleaner does not share `Elm327Parsers`'
+/// `cleanResponse` (that one anchors the string on the first `41`, which would
+/// corrupt a VIN whose second character is `A` = 0x41, e.g. an Audi `WA1…`).
+///
+/// ## Why a framing-aware parse
+///
+/// A real ELM327 VIN reply is multi-frame, e.g. a captured Peugeot 308:
+///
+/// ```
+/// 014
+/// 0: 49 02 01 56 46 33
+/// 1: 4C 43 42 4D 42 32 43
+/// 2: 53 32 36 31 38 39 32
+/// 3: 33 39 00 00 00 00 00
+/// ```
+///
+/// The first line is the ISO-TP length, each line carries an `N:` index prefix
+/// (unparseable as hex → dropped), the `49 02 01` is the mode/PID echo + item
+/// count, then the **17 VIN bytes**, then padding. A naive "take the last 17
+/// printable chars" heuristic returns the WRONG 17 here (it slides past the
+/// genuine VIN into the trailing `39` + padding), yielding a plausible but
+/// incorrect VIN that mis-selects the OEM PID table.
+///
+/// This parser instead anchors on the `49 02` echo, then takes the FIRST 17
+/// VIN-charset bytes that follow (skipping the item-count byte, any padding and
+/// the per-frame echoes), which is the real VIN. With no echo present it falls
+/// back to the first 17 VIN-charset bytes from the start.
+class Elm327VinParser {
+  const Elm327VinParser._();
+
+  /// Decode the VIN, or null on NO DATA / fewer than 17 VIN characters.
+  static String? parse(String raw) {
+    final cleaned = _clean(raw);
+    if (cleaned == null) return null;
+
+    final bytes = <int>[];
+    for (final token in cleaned.split(RegExp(r'\s+'))) {
+      if (token.isEmpty) continue;
+      final b = int.tryParse(token, radix: 16);
+      // Keep only real single bytes; an `N:` line prefix / stray token parses
+      // to null and is dropped, as is anything outside 0x00–0xFF.
+      if (b != null && b >= 0 && b <= 0xFF) bytes.add(b);
+    }
+
+    // Anchor past the `49 02` (Mode 09 / PID 02) echo when present, so the
+    // item-count byte + any pre-VIN framing are skipped; otherwise scan from 0.
+    var start = 0;
+    for (var i = 0; i + 1 < bytes.length; i++) {
+      if (bytes[i] == 0x49 && bytes[i + 1] == 0x02) {
+        start = i + 2;
+        break;
+      }
+    }
+
+    // Take the FIRST 17 VIN-charset bytes from the anchor — the count byte,
+    // padding zeros and per-frame echoes are not VIN chars, so they're skipped.
+    final chars = <int>[];
+    for (var i = start; i < bytes.length && chars.length < 17; i++) {
+      if (_isVinChar(bytes[i])) chars.add(bytes[i]);
+    }
+    if (chars.length < 17) return null;
+    return String.fromCharCodes(chars);
+  }
+
+  /// VIN-safe cleaner: strips the prompt + CR/LF and rejects the error / no-data
+  /// sentinels, WITHOUT the `41`-anchoring [Elm327Parsers.cleanResponse] does
+  /// (Mode 09 responses begin `49`, and a VIN byte can legitimately be `0x41`).
+  static String? _clean(String raw) {
+    final cleaned = raw
+        .replaceAll('>', '')
+        .replaceAll('\r', ' ')
+        .replaceAll('\n', ' ')
+        .trim();
+    if (cleaned.isEmpty ||
+        cleaned.contains('NO DATA') ||
+        cleaned.contains('UNABLE TO CONNECT') ||
+        cleaned.contains('ERROR') ||
+        cleaned.contains('?')) {
+      return null;
+    }
+    return cleaned;
+  }
+
+  /// A VIN character: digit 0-9 or A-Z excluding I/O/Q (reserved by VIN rules
+  /// to avoid confusion with 1/0; `49`='I' is also the Mode 09 echo byte).
+  static bool _isVinChar(int b) {
+    if (b >= 0x30 && b <= 0x39) return true; // 0-9
+    return b >= 0x41 &&
+        b <= 0x5A &&
+        b != 0x49 && // I
+        b != 0x4F && // O
+        b != 0x51; // Q
+  }
+}

--- a/test/features/obd2/data/elm327_parsers_test.dart
+++ b/test/features/obd2/data/elm327_parsers_test.dart
@@ -941,11 +941,15 @@ void main() {
       expect(Elm327Parsers.parseVin('NO DATA'), isNull);
     });
 
-    test('returns LAST 17 chars when more than 17 valid chars present', () {
-      // 20 valid chars - parser keeps the trailing 17.
-      const tail = 'WVWZZZ1KZ8W123456';
-      final extraThenVin = hex('AAA$tail');
-      expect(Elm327Parsers.parseVin(extraThenVin), tail);
+    test('takes the FIRST 17 VIN bytes after the 49 02 echo, ignoring trailing '
+        'padding (#3278 — not the old wrong "last 17")', () {
+      // The real multi-frame case: the VIN is the 17 bytes right after the
+      // `49 02 01` echo; the trailing bytes (`39` + padding) are NOT part of
+      // it. The old last-17 heuristic slid past the VIN into that tail and
+      // returned a wrong-but-plausible 17 chars.
+      const vin = 'WVWZZZ1KZ8W123456';
+      final response = '49 02 01 ${hex(vin)} 39 00 00 00 00';
+      expect(Elm327Parsers.parseVin(response), vin);
     });
   });
 

--- a/test/features/obd2/data/elm327_vin_parser_test.dart
+++ b/test/features/obd2/data/elm327_vin_parser_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/elm327_vin_parser.dart';
+
+/// #3278 — the framing-aware Mode 09 VIN decoder. These pin the EXACT decoded
+/// VIN (not just its length), which is what catches the real multiline bug the
+/// old "last 17 chars" heuristic masked.
+void main() {
+  String hex(String s) => s.codeUnits
+      .map((c) => c.toRadixString(16).padLeft(2, '0').toUpperCase())
+      .join(' ');
+
+  group('Elm327VinParser.parse', () {
+    test('decodes the EXACT VIN from a real Peugeot 308 multi-frame response',
+        () {
+      // Captured from a real Peugeot 308 (2014). The old last-17 heuristic
+      // returned "3LCBMB2CS26189239" (wrong — slid into the trailing 39 +
+      // padding); the correct VIN is the 17 bytes right after `49 02 01`.
+      const response = '014\r\n0: 49 02 01 56 46 33\r\n'
+          '1: 4C 43 42 4D 42 32 43\r\n'
+          '2: 53 32 36 31 38 39 32\r\n'
+          '3: 33 39 00 00 00 00 00\r\n>';
+      expect(Elm327VinParser.parse(response), 'VF3LCBMB2CS261892');
+    });
+
+    test('single-frame response after the 49 02 01 echo', () {
+      const vin = 'WVWZZZ1KZ8W123456';
+      expect(Elm327VinParser.parse('49 02 01 ${hex(vin)}>'), vin);
+    });
+
+    test('decodes a VIN whose 2nd byte is 0x41 (A) — the old 41-anchored '
+        'cleaner would have truncated it', () {
+      // An Audi-style WA1… VIN: byte 2 is 0x41. Elm327Parsers.cleanResponse
+      // anchors on the first "41" and would drop the leading "57" (W); the
+      // VIN-safe cleaner here keeps the whole frame.
+      const vin = 'WA1ABCDEFGH123456'; // 17 chars, no I/O/Q
+      expect(Elm327VinParser.parse('49 02 01 ${hex(vin)}>'), vin);
+    });
+
+    test('ignores trailing padding after the 17 VIN bytes', () {
+      const vin = 'JH4KA8260MC123456';
+      expect(
+        Elm327VinParser.parse('49 02 01 ${hex(vin)} 00 00 00 00>'),
+        vin,
+      );
+    });
+
+    test('returns null on NO DATA', () {
+      expect(Elm327VinParser.parse('NO DATA\r\n>'), isNull);
+    });
+
+    test('returns null when fewer than 17 VIN chars follow the echo', () {
+      expect(Elm327VinParser.parse('49 02 01 41 42 43 44 45>'), isNull);
+    });
+
+    test('skips I/O/Q and non-VIN bytes between echo and VIN', () {
+      const vin = '12345678901234567';
+      expect(
+        Elm327VinParser.parse('49 02 01 40 4F 51 ${hex(vin)}>'),
+        vin,
+      );
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -417,12 +417,13 @@ void main() {
     // ambient-air (0x46) temps. All trivial decoders reusing the existing
     // `_parseFuelTrim` / `_parse1BytePercent` / `_parseModeOneBody`
     // plumbing. Decomposition tracked separately by #2187/#2188.
-    // #3275 — re-grandfathered 538 → 551: the `_plausibleOdometerKm` gate on
-    // the four odometer parsers (rejects a saturated/garbage frame before it
-    // corrupts downstream distance/fuel math). bumps→3 ⇒ decomposition is now
-    // mandatory and tracked by #3279 (split the Mode 22 manufacturer slice).
+    // #3275 — bumped 538 → 551 for the `_plausibleOdometerKm` odometer gate.
+    // #3278/#3279 — ratcheted DOWN 551 → 519: the Mode 09 VIN decoder was
+    // extracted to `elm327_vin_parser.dart` (a framing-aware parse that fixes
+    // the multiline wrong-VIN bug). First slice of the #3279 decomposition;
+    // the Mode 22 manufacturer slice is still pending there.
     'lib/features/obd2/data/elm327_parsers.dart': (
-      lines: 551,
+      lines: 519,
       bumps: 3,
       decompositionIssue: 3279,
     ),


### PR DESCRIPTION
## What & why

The Mode 09 VIN decoder took the **last 17** valid characters of the response. On a real multi-frame reply that's wrong: the VIN is the 17 bytes right after the `49 02 01` echo, and the trailing bytes (a stray data byte + ISO-TP padding) aren't part of it — so last-17 slid past the VIN and returned a *plausible but incorrect* VIN, which mis-selects the OEM PID table.

A captured **Peugeot 308** multi-frame response decoded to `3LCBMB2CS26189239` instead of the correct `VF3LCBMB2CS261892`. The existing test only asserted length 17, so the bug was masked (this is exactly how I found it: my earlier #3275 "exactly 17" attempt broke the fixture, revealing the parse was never correct).

## Change
- New **`Elm327VinParser`** (framing-aware): anchors on the `49 02` echo, then takes the **first 17 VIN-charset bytes** after it (skipping the item-count byte, padding and per-frame echoes). Uses a **VIN-safe cleaner** that does *not* `41`-anchor like `Elm327Parsers.cleanResponse` — that would truncate a VIN whose 2nd byte is `0x41` (`'A'`, e.g. an Audi `WA1…`).
- `Elm327Parsers.parseVin` now **delegates** to it, so all callers/tests are unchanged.
- First slice of the **#3279** parser decomposition: `elm327_parsers.dart` ratchets **down** 551 → 519; the file-length snapshot is updated accordingly.

## Tests
New `elm327_vin_parser_test.dart` pins the **exact** decoded VIN — the real Peugeot fixture, the `WA1…`/`0x41` case the old cleaner corrupted, trailing-padding, NO DATA, and `<17`. The parser-suite VIN test that asserted the old "last 17" heuristic is rewritten to the correct framing-aware contract. Full local gates green.

## Scope / follow-ups (kept open)
- **#3278** — the UDS `22 F1 90` / WWHOBD service-22 VIN fallback for European cars that don't implement Mode 09 remains to be implemented; this PR fixes the Mode 09 *parse* correctness it depends on.
- **#3279** — the Mode 22 manufacturer-odometer slice is still to be extracted.

Advances #3278 and #3279.
