### PR TITLE
feat(obd2): VIN fallback via UDS 22 F1 90 for European cars without Mode 09 (#3278)

### DIFF
--- a/lib/features/obd2/data/elm327_commands.dart
+++ b/lib/features/obd2/data/elm327_commands.dart
@@ -308,6 +308,11 @@ class Elm327Commands {
   /// support the standard PID A6 (#719).
   static const vinCommand = '0902\r';
 
+  /// UDS ReadDataByIdentifier for the VIN (ISO 14229 DID F190), the European
+  /// fallback for ECUs that don't implement the J1979 Mode 09 VIN service
+  /// (#3278). Response: `62 F1 90 <17 ASCII bytes>`.
+  static const vinCommandUds = '22F190\r';
+
   /// Manufacturer odometer PID catalog, keyed by coarse brand. Each
   /// entry is the full "22 XX YY" command and the byte-length class
   /// its response follows (#719).

--- a/lib/features/obd2/data/elm327_protocol.dart
+++ b/lib/features/obd2/data/elm327_protocol.dart
@@ -26,6 +26,7 @@ library;
 
 import 'elm327_commands.dart';
 import 'elm327_parsers.dart';
+import 'elm327_vin_parser.dart';
 
 export 'elm327_commands.dart';
 export 'elm327_parsers.dart';
@@ -94,6 +95,7 @@ class Elm327Protocol {
   static const ambientAirTempCommand = Elm327Commands.ambientAirTempCommand;
   static const fuelTypeCommand = Elm327Commands.fuelTypeCommand;
   static const vinCommand = Elm327Commands.vinCommand;
+  static const vinCommandUds = Elm327Commands.vinCommandUds;
   static const mfgOdometerCatalog = Elm327Commands.mfgOdometerCatalog;
 
   // ---------------------------------------------------------------------------
@@ -213,6 +215,9 @@ class Elm327Protocol {
       );
 
   static String? parseVin(String raw) => Elm327Parsers.parseVin(raw);
+  // Routed straight to the VIN parser (not via Elm327Parsers) to keep the
+  // line-capped parser file unchanged — #3279.
+  static String? parseVinUds(String raw) => Elm327VinParser.parseUds(raw);
 
   static String? parseFuelType(String raw) =>
       Elm327Parsers.parseFuelType(raw);

--- a/lib/features/obd2/data/elm327_vin_parser.dart
+++ b/lib/features/obd2/data/elm327_vin_parser.dart
@@ -35,8 +35,24 @@
 class Elm327VinParser {
   const Elm327VinParser._();
 
-  /// Decode the VIN, or null on NO DATA / fewer than 17 VIN characters.
-  static String? parse(String raw) {
+  /// The Mode 09 PID 02 (`0902`, J1979) response echo: `49 02`.
+  static const List<int> _mode09Echo = [0x49, 0x02];
+
+  /// The UDS ReadDataByIdentifier (`22 F1 90`, ISO 14229) response echo:
+  /// `62 F1 90` — the European fallback for ECUs without J1979 Mode 09 (#3278).
+  static const List<int> _udsEcho = [0x62, 0xF1, 0x90];
+
+  /// Decode a Mode 09 PID 02 (`0902`) VIN, or null on NO DATA / < 17 chars.
+  static String? parse(String raw) => _decode(raw, _mode09Echo);
+
+  /// Decode a UDS `22 F1 90` VIN response (`62 F1 90 <17 ASCII>`), or null
+  /// (#3278) — the fallback for European ECUs that don't implement Mode 09.
+  static String? parseUds(String raw) => _decode(raw, _udsEcho);
+
+  /// Decode the VIN by anchoring past the response [echo], then taking the
+  /// FIRST 17 VIN-charset bytes that follow (skipping any count byte, padding
+  /// and per-frame echoes). Returns null on NO DATA / fewer than 17 chars.
+  static String? _decode(String raw, List<int> echo) {
     final cleaned = _clean(raw);
     if (cleaned == null) return null;
 
@@ -49,14 +65,16 @@ class Elm327VinParser {
       if (b != null && b >= 0 && b <= 0xFF) bytes.add(b);
     }
 
-    // Anchor past the `49 02` (Mode 09 / PID 02) echo when present, so the
-    // item-count byte + any pre-VIN framing are skipped; otherwise scan from 0.
+    // Anchor past the response echo when present, so the item-count byte + any
+    // pre-VIN framing are skipped; otherwise scan from the start.
     var start = 0;
-    for (var i = 0; i + 1 < bytes.length; i++) {
-      if (bytes[i] == 0x49 && bytes[i + 1] == 0x02) {
-        start = i + 2;
-        break;
+    outer:
+    for (var i = 0; i + echo.length <= bytes.length; i++) {
+      for (var j = 0; j < echo.length; j++) {
+        if (bytes[i + j] != echo[j]) continue outer;
       }
+      start = i + echo.length;
+      break;
     }
 
     // Take the FIRST 17 VIN-charset bytes from the anchor — the count byte,

--- a/lib/features/vehicle/data/obd2_vin_reader.dart
+++ b/lib/features/vehicle/data/obd2_vin_reader.dart
@@ -28,8 +28,9 @@ class ObdVinResult {
 
 /// Why an [Obd2VinReader.read] call failed (#1162).
 enum ObdVinFailureReason {
-  /// ELM responded with `NO DATA` / `?` / empty — the ECU does not
-  /// implement Mode 09 PID 02. Most pre-2005 vehicles fall here.
+  /// ELM responded with `NO DATA` / `?` / empty — the ECU implements
+  /// neither the J1979 Mode 09 PID 02 nor the UDS `22 F1 90` VIN service
+  /// (#3278). Most pre-2005 vehicles fall here.
   unsupported,
 
   /// Bytes came back but [Elm327Protocol.parseVin] could not decode a
@@ -84,17 +85,47 @@ class Obd2VinReader {
   /// [ErrorLayer.background] so issues are diagnosable; never throws
   /// to the caller.
   Future<ObdVinResult> read() async {
+    // J1979 Mode 09 PID 02 first.
+    final primary = await _attempt(
+      Elm327Protocol.vinCommand,
+      Elm327Protocol.parseVin,
+    );
+    if (primary.isSuccess) return primary;
+
+    // #3278 — UDS 22 F1 90 (ISO 14229) fallback. Many European ECUs (e.g.
+    // Fiat) don't implement the standard Mode 09 VIN service but answer the
+    // UDS DID. Only fall back when the ECU actually ANSWERED no/odd VIN
+    // (unsupported / malformed) — a timeout or io means the link itself is
+    // unhealthy, so a second command would just pile onto a bad connection.
+    if (primary.failure == ObdVinFailureReason.unsupported ||
+        primary.failure == ObdVinFailureReason.malformed) {
+      final fallback = await _attempt(
+        Elm327Protocol.vinCommandUds,
+        Elm327Protocol.parseVinUds,
+      );
+      if (fallback.isSuccess) return fallback;
+    }
+
+    // Neither path resolved a VIN — surface the primary (Mode 09) reason,
+    // the more informative classification for the UI.
+    return primary;
+  }
+
+  /// Send one VIN [command] and decode it with [parse]. Never throws — every
+  /// error path returns a typed [ObdVinResult.failure].
+  Future<ObdVinResult> _attempt(
+    String command,
+    String? Function(String raw) parse,
+  ) async {
     try {
-      final raw = await service
-          .sendCommand(Elm327Protocol.vinCommand)
-          .timeout(timeout);
-      final parsed = Elm327Protocol.parseVin(raw);
+      final raw = await service.sendCommand(command).timeout(timeout);
+      final parsed = parse(raw);
       if (parsed != null && parsed.isNotEmpty) {
         return ObdVinResult.success(parsed);
       }
-      // parseVin returns null on NO DATA / ? / empty cleaned response
-      // and on bytes-but-fewer-than-17-printable-chars. Distinguish:
-      //   - empty / NO DATA / ? → unsupported (pre-2005 ECU)
+      // parse() returns null on NO DATA / ? / empty cleaned response and on
+      // bytes-but-fewer-than-17-printable-chars. Distinguish:
+      //   - empty / NO DATA / ? → unsupported (ECU lacks this VIN service)
       //   - anything else → malformed (frame corruption)
       if (_looksUnsupported(raw)) {
         return const ObdVinResult.failure(ObdVinFailureReason.unsupported);
@@ -105,7 +136,7 @@ class Obd2VinReader {
         ErrorLayer.background,
         e,
         st,
-        context: const {'op': 'obd2VinReader.read', 'reason': 'timeout'},
+        context: {'op': 'obd2VinReader.read', 'reason': 'timeout', 'cmd': command},
       );
       return const ObdVinResult.failure(ObdVinFailureReason.timeout);
     } catch (e, st) {
@@ -113,7 +144,7 @@ class Obd2VinReader {
         ErrorLayer.background,
         e,
         st,
-        context: const {'op': 'obd2VinReader.read', 'reason': 'io'},
+        context: {'op': 'obd2VinReader.read', 'reason': 'io', 'cmd': command},
       );
       return const ObdVinResult.failure(ObdVinFailureReason.io);
     }

--- a/test/features/obd2/data/elm327_vin_parser_test.dart
+++ b/test/features/obd2/data/elm327_vin_parser_test.dart
@@ -63,4 +63,33 @@ void main() {
       );
     });
   });
+
+  group('Elm327VinParser.parseUds (22 F1 90)', () {
+    test('decodes the VIN after the 62 F1 90 echo (#3278)', () {
+      // ISO 14229 ReadDataByIdentifier response: `62 F1 90 <17 ASCII>`.
+      const vin = 'ZFA31200003456789'; // Fiat-style, 17 chars, no I/O/Q
+      expect(Elm327VinParser.parseUds('62 F1 90 ${hex(vin)}>'), vin);
+    });
+
+    test('decodes a multi-frame UDS response with trailing padding', () {
+      const vin = 'ZFA31200003456789';
+      const response = '014\r\n0: 62 F1 90 5A 46 41\r\n'
+          '1: 33 31 32 30 30 30 30\r\n'
+          '2: 33 34 35 36 37 38 39\r\n'
+          '3: 00 00 00 00 00 00 00\r\n>';
+      expect(Elm327VinParser.parseUds(response), vin);
+    });
+
+    test('returns null on NO DATA (ECU lacks the UDS DID too)', () {
+      expect(Elm327VinParser.parseUds('NO DATA\r\n>'), isNull);
+    });
+
+    test('a Mode 09 (49 02) response is NOT matched by the UDS echo', () {
+      // Guards the anchor: the UDS parser must not accidentally decode a
+      // Mode 09 reply (no 62 F1 90 echo) — it scans from 0 and would need 17
+      // VIN chars; here the 49 02 echo bytes are non-VIN so it still works,
+      // but a too-short one returns null.
+      expect(Elm327VinParser.parseUds('62 F1 90 41 42 43>'), isNull);
+    });
+  });
 }

--- a/test/features/vehicle/data/obd2_vin_reader_test.dart
+++ b/test/features/vehicle/data/obd2_vin_reader_test.dart
@@ -24,6 +24,11 @@ import 'package:tankstellen/features/vehicle/data/obd2_vin_reader.dart';
 ///   4. timeout — sendCommand future doesn't resolve before [timeout].
 ///   5. io — any other thrown error propagates as
 ///      [ObdVinFailureReason.io].
+/// Encode an ASCII string as space-separated hex bytes (for VIN fixtures).
+String _hexBytes(String s) => s.codeUnits
+    .map((c) => c.toRadixString(16).padLeft(2, '0').toUpperCase())
+    .join(' ');
+
 void main() {
   // Wire the global errorLogger to an in-memory recorder so the
   // failure-path branches don't try to spool through Hive (which is
@@ -57,10 +62,31 @@ void main() {
       final result = await reader.read();
 
       expect(result.isSuccess, isTrue);
-      // `parseVin` returns the last 17 printable characters — exactly
-      // the VIN encoded in the fake response.
-      expect(result.vin, hasLength(17));
+      // #3278 — the framing-aware parser decodes the EXACT VIN (the old
+      // last-17 heuristic returned the wrong 17 chars here: 3LCBMB2CS26189239).
+      expect(result.vin, 'VF3LCBMB2CS261892');
       expect(result.failure, isNull);
+    });
+
+    test(
+        'falls back to UDS 22 F1 90 when Mode 09 returns NO DATA — decodes the '
+        'VIN many European ECUs only expose via UDS (#3278)', () async {
+      // The fake answers NO DATA to anything but the UDS command, so Mode 09
+      // (0902) misses and the reader must fall back to 22 F1 90.
+      const vin = 'ZFA31200003456789'; // Fiat-style, 17 chars, no I/O/Q
+      final udsResponse = '62 F1 90 ${_hexBytes(vin)}>';
+      final transport = _FakeTransport.forCommand(
+        Elm327Protocol.vinCommandUds,
+        udsResponse,
+      );
+      final reader = Obd2VinReader(service: Obd2Service(transport));
+      await transport.connect();
+
+      final result = await reader.read();
+
+      expect(result.isSuccess, isTrue,
+          reason: 'the UDS fallback resolved the VIN Mode 09 could not');
+      expect(result.vin, vin);
     });
 
     test(


### PR DESCRIPTION
## What & why

Mode 09 PID 02 (`0902`) is the US-mandated **J1979** VIN service; many **European** manufacturers (e.g. Fiat) don't implement it, so the VIN read returned `unsupported` and the app never resolved a VIN → no OEM PID table, untagged trip. (Maintainer confirmed pulling Fiat VINs via UDS `22 F1 90`.)

## Change
Add a **UDS ReadDataByIdentifier** fallback (ISO 14229 DID F190): `22 F1 90` → `62 F1 90 <17 ASCII>`.
- `Elm327VinParser` generalised to anchor on a configurable response echo — `parse()` = Mode 09 (`49 02`), `parseUds()` = UDS (`62 F1 90`) — sharing the same framing-aware "first 17 VIN-charset bytes after the echo" logic (multi-frame + padding handled identically).
- New `22F190` command + `Elm327Protocol.{vinCommandUds, parseVinUds}` facade.
- `Obd2VinReader.read()` tries Mode 09 first, then falls back to UDS **only when the ECU actually answered** no/odd VIN (unsupported/malformed) — a timeout/io means the link is unhealthy, so it won't pile a second command onto a bad connection.

## Tests
UDS parse (single + multi-frame, NO DATA, too-short), the reader fallback when `0902` returns NO DATA, and the Mode 09 path now asserts the **exact** VIN. Full local gates green.

## Scope
WWHOBD service-22 (`22 F8 02`) was deliberately left out — no real fixture to validate against (avoids a false-green fake); UDS `F190` is the field-confirmed path. Can be a follow-up if a real WWHOBD capture surfaces.

Closes #3278.
