### PR TITLE
fix(obd2): a successful/pairing retry supersedes a prior channel-open transient in the connect trace (#3243)

### DIFF
--- a/lib/features/obd2/data/obd2_connect_trace_handle.dart
+++ b/lib/features/obd2/data/obd2_connect_trace_handle.dart
@@ -146,15 +146,44 @@ class Obd2ConnectTraceHandle {
   /// log it before the trace finalises.
   String? get adapterName => _root._adapterName;
 
-  /// Stamp the terminal [outcome] — FIRST-TERMINAL-WINS (#2969 correction 3).
-  /// A second call (a fallback's own outcome) is IGNORED for the primary
-  /// outcome; record fallback progress via [addStep] instead. This is
-  /// load-bearing: `_connectByMacDirect` swallows the BLE 4 s timeout and
-  /// silently re-runs `scan()`, so without first-wins the real wrong-transport
-  /// `gattTimeout` would be overwritten by the fallback's `scanEmpty`.
+  /// Channel-open transients the #3179 transport retry loop retries. A later
+  /// terminal may supersede one of these (#3243) — see [setOutcome].
+  static const Set<Obd2ConnectOutcome> _retriedTransients = {
+    Obd2ConnectOutcome.gattTimeout,
+    Obd2ConnectOutcome.gatt133,
+    Obd2ConnectOutcome.serviceNotFound,
+    Obd2ConnectOutcome.rfcommOpenFail,
+  };
+
+  /// Stamp the terminal [outcome] — FIRST-TERMINAL-WINS (#2969 correction 3),
+  /// with two upgrade exceptions (#3243).
+  ///
+  /// A second call (a fallback's own outcome) is normally IGNORED; record
+  /// fallback progress via [addStep] instead. This is load-bearing:
+  /// `_connectByMacDirect` swallows the BLE 4 s timeout and silently re-runs
+  /// `scan()`, so without first-wins the real wrong-transport `gattTimeout`
+  /// would be overwritten by the fallback's `scanEmpty`.
+  ///
+  /// #3243 — but the #3179 transport loop RETRIES the channel-open transients
+  /// ([_retriedTransients]): attempt-1 stamps e.g. `gattTimeout` first, then
+  /// attempt-2 resolves. Two upgrades therefore override a prior transient:
+  ///  - a later `success` — the connect ultimately worked (exporting the
+  ///    transient for a WORKING connect was the bug); and
+  ///  - a later `pairingRequired` — so attempt-2's bond-window signal isn't
+  ///    masked by attempt-1's transient, and the caller surfaces the actionable
+  ///    "power-cycle within 5 min" guidance instead of a scan-fallback re-dial.
+  /// The `gattTimeout`-vs-`scanEmpty` first-wins is preserved (`scanEmpty` is
+  /// not an upgrade outcome).
   void setOutcome(Obd2ConnectOutcome outcome, {String? failureDetail}) {
     final root = _root;
-    if (root._outcome != null) return;
+    final prior = root._outcome;
+    if (prior != null) {
+      final upgrades = prior != Obd2ConnectOutcome.success &&
+          (outcome == Obd2ConnectOutcome.success ||
+              (outcome == Obd2ConnectOutcome.pairingRequired &&
+                  _retriedTransients.contains(prior)));
+      if (!upgrades) return;
+    }
     root._outcome = outcome;
     root._failureDetail = failureDetail;
   }

--- a/test/features/obd2/data/obd2_connect_trace_log_test.dart
+++ b/test/features/obd2/data/obd2_connect_trace_log_test.dart
@@ -76,6 +76,61 @@ void main() {
       expect(trace.failureDetail, 'timed out');
     });
 
+    test('#3243 a later SUCCESS upgrades a prior retried transient '
+        '(fail-once-then-succeed exports success)', () {
+      final h = Obd2ConnectTraceLog.beginTrace(
+        origin: Obd2ConnectOrigin.firstConnect,
+        mac: 'AA:BB:CC:DD:EE:FF',
+        requestedTransport: Obd2ConnectTransport.ble,
+      );
+      // Attempt 1 hits a channel-open transient the #3179 loop retries.
+      h.setOutcome(Obd2ConnectOutcome.gattTimeout, failureDetail: 'timed out');
+      // Attempt 2 connects — the trace must export success, not the transient.
+      h.setOutcome(Obd2ConnectOutcome.success);
+      Obd2ConnectTraceLog.endTrace(h);
+
+      expect(Obd2ConnectTraceLog.snapshot().single.outcome,
+          Obd2ConnectOutcome.success);
+    });
+
+    test('#3243 a later pairingRequired upgrades a prior retried transient '
+        '(the bond-window signal is not masked)', () {
+      final h = Obd2ConnectTraceLog.beginTrace(
+        origin: Obd2ConnectOrigin.firstConnect,
+        mac: 'AA:BB:CC:DD:EE:FF',
+        requestedTransport: Obd2ConnectTransport.ble,
+      );
+      h.setOutcome(Obd2ConnectOutcome.gatt133, failureDetail: '133');
+      h.setOutcome(Obd2ConnectOutcome.pairingRequired);
+      Obd2ConnectTraceLog.endTrace(h);
+
+      expect(Obd2ConnectTraceLog.snapshot().single.outcome,
+          Obd2ConnectOutcome.pairingRequired);
+    });
+
+    test('#3243 pairingRequired does NOT supersede a non-retried terminal '
+        '(scanEmpty first-wins preserved)', () {
+      final h = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      h.setOutcome(Obd2ConnectOutcome.scanEmpty);
+      h.setOutcome(Obd2ConnectOutcome.pairingRequired);
+      Obd2ConnectTraceLog.endTrace(h);
+
+      expect(Obd2ConnectTraceLog.snapshot().single.outcome,
+          Obd2ConnectOutcome.scanEmpty);
+    });
+
+    test('#3243 a real success is never overwritten by a later failure', () {
+      final h = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      h.setOutcome(Obd2ConnectOutcome.success);
+      h.setOutcome(Obd2ConnectOutcome.gattTimeout);
+      Obd2ConnectTraceLog.endTrace(h);
+
+      expect(Obd2ConnectTraceLog.snapshot().single.outcome,
+          Obd2ConnectOutcome.success);
+    });
+
     test('setOutcomeFromError classifies + keeps the raw toString detail', () {
       final h = Obd2ConnectTraceLog.beginTrace(
           origin: Obd2ConnectOrigin.liveReconnect);


### PR DESCRIPTION
## What & why

`stampOpenFailure` stamps the connect trace's terminal outcome **first-wins**, but the #3179 transport loop **retries** exactly those channel-open transients (`gattTimeout` / `gatt133` / `serviceNotFound` / `rfcommOpenFail`). So:
- **(a)** attempt-1-fails / attempt-2-succeeds exported the *transient* outcome for a **working** connect; and
- **(b)** attempt-1-recoverable + attempt-2-pairing left the trace stuck on the transient, so `_openAndInit`'s `trace.outcome == pairingRequired` gate missed → generic unresponsive error → scan fallback re-dialled the un-bonded CX, **burning its 5-minute bond window** and showing the wrong guidance. (The connect error is swallowed to a bool there, so the gate keys off the trace outcome — hence fixing the outcome accounting is the fix.)

## Change
`setOutcome` now allows two upgrades over a prior **retried transient**: a later `success` (the connect ultimately worked) and a later `pairingRequired` (so the bond-window signal isn't masked). First-wins is otherwise preserved — notably the `gattTimeout`-vs-`scanEmpty` `_connectByMacDirect` case (`scanEmpty` isn't an upgrade), and a real `success` is never overwritten by a later failure.

## Tests
4 new cases on `setOutcome`: fail-once-then-succeed → success; transient-then-pairing → pairing; scanEmpty-then-pairing → scanEmpty (first-wins preserved); success-then-failure → success. Existing first-wins + supervisor suites green.

Closes #3243.