### PR TITLE
refactor(obd2): extract Mode 22 parsers from elm327_parsers (#3279) + hotfix the #3243 success-over-ignitionOff regression

### DIFF
--- a/lib/features/obd2/data/elm327_decode_util.dart
+++ b/lib/features/obd2/data/elm327_decode_util.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Low-level ELM327 decode helpers shared by the Mode 01/09 parsers
+/// ([Elm327Parsers]) and the Mode 22 manufacturer parsers
+/// ([Elm327Mode22Parsers]) — extracted (#3279) so neither parser file owns
+/// the other, and the decomposition leaves a single definition of each.
+library;
+
+/// Parse a space-separated hex-byte string ("41 0C 1A F8") into a list of
+/// byte values, dropping any token that isn't valid hex.
+List<int> parseElmHexBytes(String hex) => hex
+    .split(RegExp(r'\s+'))
+    .where((s) => s.isNotEmpty)
+    .map((s) => int.tryParse(s, radix: 16))
+    .whereType<int>()
+    .toList();
+
+/// The largest odometer reading treated as real (#3275): no production car
+/// reaches 2,000,000 km, so a higher value is a saturated/garbage frame, and 0
+/// is a no-data sentinel — both must be rejected before they corrupt the
+/// downstream distance/fuel math.
+const double maxPlausibleOdometerKm = 2000000.0;
+
+/// Whether [km] is a plausible odometer reading (#3275).
+bool isPlausibleOdometerKm(double km) =>
+    km.isFinite && km > 0 && km <= maxPlausibleOdometerKm;

--- a/lib/features/obd2/data/elm327_mode22_parsers.dart
+++ b/lib/features/obd2/data/elm327_mode22_parsers.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'elm327_decode_util.dart';
+
+/// Mode 22 manufacturer-specific odometer parsers (#719), extracted from
+/// [Elm327Parsers] (#3279) so the OBD-mode decoders live in focused files.
+///
+/// Standard Mode 01 PID A6 odometer support is rare; most OEMs expose the
+/// odometer behind a brand-specific Mode 22 PID (`22 PH PL` → `62 PH PL …`).
+/// Each parser validates the `62` echo + the expected PID bytes and applies
+/// the shared [isPlausibleOdometerKm] gate so a saturated/garbage frame never
+/// becomes a reading.
+class Elm327Mode22Parsers {
+  const Elm327Mode22Parsers._();
+
+  /// Parse a 3-byte (big-endian, km) manufacturer odometer — used by
+  /// VW group (22 22 03), BMW (22 30 16), Renault (22 21 02), etc.
+  /// Expected response: `62 PH PL A B C` → km = (A*65536)+(B*256)+C.
+  /// Returns null on NO DATA, a PID-echo mismatch, or an implausible value.
+  static double? parseMfgOdometer3Byte(
+    String raw, {
+    required int expectedPidHi,
+    required int expectedPidLo,
+  }) {
+    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
+        minBytes: 6);
+    if (bytes == null) return null;
+    final km = ((bytes[3] << 16) | (bytes[4] << 8) | bytes[5]).toDouble();
+    return isPlausibleOdometerKm(km) ? km : null; // #3275
+  }
+
+  /// Parse a 2-byte (big-endian, km) manufacturer odometer — used by
+  /// Mercedes (22 F1 5B), PSA (22 D1 01). Expected response:
+  /// `62 PH PL A B` → km = (A*256)+B. (#719)
+  static double? parseMfgOdometer2Byte(
+    String raw, {
+    required int expectedPidHi,
+    required int expectedPidLo,
+  }) {
+    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
+        minBytes: 5);
+    if (bytes == null) return null;
+    final km = ((bytes[3] << 8) | bytes[4]).toDouble();
+    return isPlausibleOdometerKm(km) ? km : null; // #3275
+  }
+
+  /// Parse a Ford-style 2-byte miles-times-10 odometer (22 40 4D).
+  /// Response: `62 40 4D A B` → miles_x10 = (A*256)+B. The raw value
+  /// is miles × 10, so divide by 10 before converting to km. (#719)
+  static double? parseMfgOdometerMilesTimes10(
+    String raw, {
+    required int expectedPidHi,
+    required int expectedPidLo,
+  }) {
+    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
+        minBytes: 5);
+    if (bytes == null) return null;
+    final milesTimes10 = (bytes[3] << 8) | bytes[4];
+    final km = (milesTimes10 / 10.0) * 1.609344;
+    return isPlausibleOdometerKm(km) ? km : null; // #3275
+  }
+
+  static List<int>? _parseMode22Body(
+    String raw,
+    int expectedPidHi,
+    int expectedPidLo, {
+    required int minBytes,
+  }) {
+    final clean = cleanResponse22(raw);
+    if (clean == null) return null;
+    final bytes = parseElmHexBytes(clean);
+    if (bytes.length < minBytes) return null;
+    if (bytes[0] != 0x62 ||
+        bytes[1] != expectedPidHi ||
+        bytes[2] != expectedPidLo) {
+      return null;
+    }
+    return bytes;
+  }
+
+  /// Mode 22 response cleaner. Same as `Elm327Parsers.cleanResponse` but
+  /// anchors on the "62" Mode 22 echo instead of "41".
+  static String? cleanResponse22(String raw) {
+    final cleaned = raw
+        .replaceAll('>', '')
+        .replaceAll('\r', ' ')
+        .replaceAll('\n', ' ')
+        .trim();
+    if (cleaned.isEmpty ||
+        cleaned.contains('NO DATA') ||
+        cleaned.contains('UNABLE TO CONNECT') ||
+        cleaned.contains('ERROR') ||
+        cleaned.contains('?')) {
+      return null;
+    }
+    final idx = cleaned.indexOf('62');
+    if (idx >= 0) return cleaned.substring(idx).trim();
+    return cleaned;
+  }
+}

--- a/lib/features/obd2/data/elm327_parsers.dart
+++ b/lib/features/obd2/data/elm327_parsers.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'elm327_decode_util.dart';
 import 'elm327_vin_parser.dart';
 
 /// ELM327 response parsers — pure string→value decoders for Mode 01,
@@ -86,7 +87,7 @@ class Elm327Parsers {
     final clean = cleanResponse(raw);
     if (clean == null) return null;
 
-    final bytes = _parseHexBytes(clean);
+    final bytes = parseElmHexBytes(clean);
     if (bytes.length < 3 || bytes[0] != 0x41 || bytes[1] != 0x0D) return null;
 
     return bytes[2]; // Speed in km/h (0-255)
@@ -98,7 +99,7 @@ class Elm327Parsers {
     final clean = cleanResponse(raw);
     if (clean == null) return null;
 
-    final bytes = _parseHexBytes(clean);
+    final bytes = parseElmHexBytes(clean);
     if (bytes.length < 4 || bytes[0] != 0x41 || bytes[1] != 0x0C) return null;
 
     return ((bytes[2] * 256) + bytes[3]) / 4.0;
@@ -110,17 +111,11 @@ class Elm327Parsers {
     final clean = cleanResponse(raw);
     if (clean == null) return null;
 
-    final bytes = _parseHexBytes(clean);
+    final bytes = parseElmHexBytes(clean);
     if (bytes.length < 4 || bytes[0] != 0x41 || bytes[1] != 0x31) return null;
 
     return (bytes[2] * 256) + bytes[3];
   }
-
-  /// #3275 — only (0, 2,000,000] km is a real odometer; a 0 sentinel or a
-  /// saturated frame (~429M km) must not corrupt downstream distance/fuel math.
-  static const double _maxPlausibleOdometerKm = 2000000.0;
-  static bool _plausibleOdometerKm(double km) =>
-      km.isFinite && km > 0 && km <= _maxPlausibleOdometerKm;
 
   /// Parse odometer from Mode 01 PID A6 response.
   /// Response format: "41 A6 XX YY ZZ WW" where odometer = value / 10 km.
@@ -128,12 +123,12 @@ class Elm327Parsers {
     final clean = cleanResponse(raw);
     if (clean == null) return null;
 
-    final bytes = _parseHexBytes(clean);
+    final bytes = parseElmHexBytes(clean);
     if (bytes.length < 6 || bytes[0] != 0x41 || bytes[1] != 0xA6) return null;
 
     final value = (bytes[2] << 24) | (bytes[3] << 16) | (bytes[4] << 8) | bytes[5];
     final km = value / 10.0; // Odometer in km (1/10 km resolution)
-    return _plausibleOdometerKm(km) ? km : null;
+    return isPlausibleOdometerKm(km) ? km : null;
   }
 
   /// Parse calculated engine load from Mode 01 PID 04 response (#717).
@@ -353,57 +348,10 @@ class Elm327Parsers {
   }) {
     final clean = cleanResponse(raw);
     if (clean == null) return null;
-    final bytes = _parseHexBytes(clean);
+    final bytes = parseElmHexBytes(clean);
     if (bytes.length < minBytes) return null;
     if (bytes[0] != 0x41 || bytes[1] != expectedPid) return null;
     return bytes;
-  }
-
-  /// Parse a 3-byte (big-endian, km) manufacturer odometer — used by
-  /// VW group (22 22 03), BMW (22 30 16), Renault (22 21 02), etc.
-  /// Expected response: `62 PH PL A B C` → km = (A*65536)+(B*256)+C.
-  /// Returns null on NO DATA or a PID-echo mismatch. (#719)
-  static double? parseMfgOdometer3Byte(
-    String raw, {
-    required int expectedPidHi,
-    required int expectedPidLo,
-  }) {
-    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
-        minBytes: 6);
-    if (bytes == null) return null;
-    final km = ((bytes[3] << 16) | (bytes[4] << 8) | bytes[5]).toDouble();
-    return _plausibleOdometerKm(km) ? km : null; // #3275
-  }
-
-  /// Parse a 2-byte (big-endian, km) manufacturer odometer — used by
-  /// Mercedes (22 F1 5B), PSA (22 D1 01). Expected response:
-  /// `62 PH PL A B` → km = (A*256)+B. (#719)
-  static double? parseMfgOdometer2Byte(
-    String raw, {
-    required int expectedPidHi,
-    required int expectedPidLo,
-  }) {
-    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
-        minBytes: 5);
-    if (bytes == null) return null;
-    final km = ((bytes[3] << 8) | bytes[4]).toDouble();
-    return _plausibleOdometerKm(km) ? km : null; // #3275
-  }
-
-  /// Parse a Ford-style 2-byte miles-times-10 odometer (22 40 4D).
-  /// Response: `62 40 4D A B` → miles_x10 = (A*256)+B. The raw value
-  /// is miles × 10, so divide by 10 before converting to km. (#719)
-  static double? parseMfgOdometerMilesTimes10(
-    String raw, {
-    required int expectedPidHi,
-    required int expectedPidLo,
-  }) {
-    final bytes = _parseMode22Body(raw, expectedPidHi, expectedPidLo,
-        minBytes: 5);
-    if (bytes == null) return null;
-    final milesTimes10 = (bytes[3] << 8) | bytes[4];
-    final km = (milesTimes10 / 10.0) * 1.609344;
-    return _plausibleOdometerKm(km) ? km : null; // #3275
   }
 
   /// Parse fuel type from Mode 01 PID 51 response (#1399).
@@ -468,52 +416,4 @@ class Elm327Parsers {
   /// 17 chars" heuristic returned a wrong-but-plausible VIN on multiline
   /// replies). Returns null on NO DATA or fewer than 17 VIN characters.
   static String? parseVin(String raw) => Elm327VinParser.parse(raw);
-
-  static List<int>? _parseMode22Body(
-    String raw,
-    int expectedPidHi,
-    int expectedPidLo, {
-    required int minBytes,
-  }) {
-    final clean = cleanResponse22(raw);
-    if (clean == null) return null;
-    final bytes = _parseHexBytes(clean);
-    if (bytes.length < minBytes) return null;
-    if (bytes[0] != 0x62 ||
-        bytes[1] != expectedPidHi ||
-        bytes[2] != expectedPidLo) {
-      return null;
-    }
-    return bytes;
-  }
-
-  /// Mode 22 response cleaner. Same as [cleanResponse] but anchors on
-  /// the "62" Mode 22 echo instead of "41".
-  static String? cleanResponse22(String raw) {
-    final cleaned = raw
-        .replaceAll('>', '')
-        .replaceAll('\r', ' ')
-        .replaceAll('\n', ' ')
-        .trim();
-    if (cleaned.isEmpty ||
-        cleaned.contains('NO DATA') ||
-        cleaned.contains('UNABLE TO CONNECT') ||
-        cleaned.contains('ERROR') ||
-        cleaned.contains('?')) {
-      return null;
-    }
-    final idx = cleaned.indexOf('62');
-    if (idx >= 0) return cleaned.substring(idx).trim();
-    return cleaned;
-  }
-
-  /// Parse hex string "41 0D FF" into list of byte values [0x41, 0x0D, 0xFF].
-  static List<int> _parseHexBytes(String hex) {
-    return hex
-        .split(RegExp(r'\s+'))
-        .where((s) => s.isNotEmpty)
-        .map((s) => int.tryParse(s, radix: 16))
-        .whereType<int>()
-        .toList();
-  }
 }

--- a/lib/features/obd2/data/elm327_protocol.dart
+++ b/lib/features/obd2/data/elm327_protocol.dart
@@ -26,6 +26,7 @@ library;
 
 import 'elm327_commands.dart';
 import 'elm327_parsers.dart';
+import 'elm327_mode22_parsers.dart';
 import 'elm327_vin_parser.dart';
 
 export 'elm327_commands.dart';
@@ -186,7 +187,7 @@ class Elm327Protocol {
     required int expectedPidHi,
     required int expectedPidLo,
   }) =>
-      Elm327Parsers.parseMfgOdometer3Byte(
+      Elm327Mode22Parsers.parseMfgOdometer3Byte(
         raw,
         expectedPidHi: expectedPidHi,
         expectedPidLo: expectedPidLo,
@@ -197,7 +198,7 @@ class Elm327Protocol {
     required int expectedPidHi,
     required int expectedPidLo,
   }) =>
-      Elm327Parsers.parseMfgOdometer2Byte(
+      Elm327Mode22Parsers.parseMfgOdometer2Byte(
         raw,
         expectedPidHi: expectedPidHi,
         expectedPidLo: expectedPidLo,
@@ -208,7 +209,7 @@ class Elm327Protocol {
     required int expectedPidHi,
     required int expectedPidLo,
   }) =>
-      Elm327Parsers.parseMfgOdometerMilesTimes10(
+      Elm327Mode22Parsers.parseMfgOdometerMilesTimes10(
         raw,
         expectedPidHi: expectedPidHi,
         expectedPidLo: expectedPidLo,
@@ -223,5 +224,5 @@ class Elm327Protocol {
       Elm327Parsers.parseFuelType(raw);
 
   static String? cleanResponse22(String raw) =>
-      Elm327Parsers.cleanResponse22(raw);
+      Elm327Mode22Parsers.cleanResponse22(raw);
 }

--- a/lib/features/obd2/data/obd2_connect_trace_handle.dart
+++ b/lib/features/obd2/data/obd2_connect_trace_handle.dart
@@ -178,10 +178,16 @@ class Obd2ConnectTraceHandle {
     final root = _root;
     final prior = root._outcome;
     if (prior != null) {
-      final upgrades = prior != Obd2ConnectOutcome.success &&
+      // A later success / pairingRequired upgrades a prior outcome ONLY when
+      // that prior is a RETRIED channel-open transient (#3243). It must NOT
+      // override a considered terminal — notably `ignitionOff`, which a
+      // SUCCESSFUL init stamps after finding a silent bus (#3009): a later
+      // generic `success` stamp on the same connect would otherwise mask the
+      // engine-off diagnosis. `scanEmpty`, `permissionDenied`, `bluetoothOff`
+      // etc. are likewise preserved.
+      final upgrades = _retriedTransients.contains(prior) &&
           (outcome == Obd2ConnectOutcome.success ||
-              (outcome == Obd2ConnectOutcome.pairingRequired &&
-                  _retriedTransients.contains(prior)));
+              outcome == Obd2ConnectOutcome.pairingRequired);
       if (!upgrades) return;
     }
     root._outcome = outcome;

--- a/test/features/obd2/data/elm327_parsers_test.dart
+++ b/test/features/obd2/data/elm327_parsers_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/elm327_mode22_parsers.dart';
 import 'package:tankstellen/features/obd2/data/elm327_parsers.dart';
 
 /// Pure-logic coverage for [Elm327Parsers] — every public static parser
@@ -63,42 +64,42 @@ void main() {
 
   group('cleanResponse22', () {
     test('empty string returns null', () {
-      expect(Elm327Parsers.cleanResponse22(''), isNull);
+      expect(Elm327Mode22Parsers.cleanResponse22(''), isNull);
     });
 
     test('NO DATA returns null', () {
-      expect(Elm327Parsers.cleanResponse22('NO DATA'), isNull);
+      expect(Elm327Mode22Parsers.cleanResponse22('NO DATA'), isNull);
     });
 
     test('UNABLE TO CONNECT returns null', () {
-      expect(Elm327Parsers.cleanResponse22('UNABLE TO CONNECT'), isNull);
+      expect(Elm327Mode22Parsers.cleanResponse22('UNABLE TO CONNECT'), isNull);
     });
 
     test('ERROR returns null', () {
-      expect(Elm327Parsers.cleanResponse22('ERROR'), isNull);
+      expect(Elm327Mode22Parsers.cleanResponse22('ERROR'), isNull);
     });
 
     test('? returns null', () {
-      expect(Elm327Parsers.cleanResponse22('?'), isNull);
+      expect(Elm327Mode22Parsers.cleanResponse22('?'), isNull);
     });
 
     test('anchors to 62 (drops Mode 22 command echo)', () {
       expect(
-        Elm327Parsers.cleanResponse22('22 22 03 62 22 03 00 27 10'),
+        Elm327Mode22Parsers.cleanResponse22('22 22 03 62 22 03 00 27 10'),
         '62 22 03 00 27 10',
       );
     });
 
     test('returns cleaned string when no 62 echo present', () {
       expect(
-        Elm327Parsers.cleanResponse22('00 0B FF'),
+        Elm327Mode22Parsers.cleanResponse22('00 0B FF'),
         '00 0B FF',
       );
     });
 
     test('strips > prompt', () {
       expect(
-        Elm327Parsers.cleanResponse22('62 F1 5B 00 64\r\n>'),
+        Elm327Mode22Parsers.cleanResponse22('62 F1 5B 00 64\r\n>'),
         '62 F1 5B 00 64',
       );
     });
@@ -726,7 +727,7 @@ void main() {
     test('62 22 03 00 27 10 -> 10000.0 km (VW group)', () {
       // 0x002710 = 10000.
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           '62 22 03 00 27 10',
           expectedPidHi: 0x22,
           expectedPidLo: 0x03,
@@ -739,7 +740,7 @@ void main() {
       // 0xFFFFFF = 16,777,215 km — well past any real car (cap 2,000,000 km),
       // so a saturated clone frame is rejected rather than surfaced.
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           '62 22 03 FF FF FF',
           expectedPidHi: 0x22,
           expectedPidLo: 0x03,
@@ -750,7 +751,7 @@ void main() {
 
     test('wrong PID-Hi returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           '62 22 03 00 27 10',
           expectedPidHi: 0x30,
           expectedPidLo: 0x03,
@@ -761,7 +762,7 @@ void main() {
 
     test('wrong PID-Lo returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           '62 22 03 00 27 10',
           expectedPidHi: 0x22,
           expectedPidLo: 0x99,
@@ -772,7 +773,7 @@ void main() {
 
     test('short response returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           '62 22 03 00 27',
           expectedPidHi: 0x22,
           expectedPidLo: 0x03,
@@ -783,7 +784,7 @@ void main() {
 
     test('NO DATA returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer3Byte(
+        Elm327Mode22Parsers.parseMfgOdometer3Byte(
           'NO DATA',
           expectedPidHi: 0x22,
           expectedPidLo: 0x03,
@@ -796,7 +797,7 @@ void main() {
   group('parseMfgOdometer2Byte', () {
     test('62 F1 5B 00 64 -> 100.0 km (Mercedes)', () {
       expect(
-        Elm327Parsers.parseMfgOdometer2Byte(
+        Elm327Mode22Parsers.parseMfgOdometer2Byte(
           '62 F1 5B 00 64',
           expectedPidHi: 0xF1,
           expectedPidLo: 0x5B,
@@ -807,7 +808,7 @@ void main() {
 
     test('62 D1 01 FF FF -> 65535.0 km (PSA)', () {
       expect(
-        Elm327Parsers.parseMfgOdometer2Byte(
+        Elm327Mode22Parsers.parseMfgOdometer2Byte(
           '62 D1 01 FF FF',
           expectedPidHi: 0xD1,
           expectedPidLo: 0x01,
@@ -818,7 +819,7 @@ void main() {
 
     test('wrong PID returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer2Byte(
+        Elm327Mode22Parsers.parseMfgOdometer2Byte(
           '62 F1 5B 00 64',
           expectedPidHi: 0xF1,
           expectedPidLo: 0x99,
@@ -829,7 +830,7 @@ void main() {
 
     test('short response returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometer2Byte(
+        Elm327Mode22Parsers.parseMfgOdometer2Byte(
           '62 F1 5B 00',
           expectedPidHi: 0xF1,
           expectedPidLo: 0x5B,
@@ -842,7 +843,7 @@ void main() {
   group('parseMfgOdometerMilesTimes10', () {
     test('62 40 4D 00 64 -> ~16.09344 km (Ford-style miles*10)', () {
       // (0x0064 = 100) / 10 * 1.609344 = 10 mi * 1.609344 = 16.09344 km
-      final result = Elm327Parsers.parseMfgOdometerMilesTimes10(
+      final result = Elm327Mode22Parsers.parseMfgOdometerMilesTimes10(
         '62 40 4D 00 64',
         expectedPidHi: 0x40,
         expectedPidLo: 0x4D,
@@ -855,7 +856,7 @@ void main() {
       // #3275 — a 0 km/mi odometer is rejected as a no-data sentinel rather
       // than surfaced as a real reading.
       expect(
-        Elm327Parsers.parseMfgOdometerMilesTimes10(
+        Elm327Mode22Parsers.parseMfgOdometerMilesTimes10(
           '62 40 4D 00 00',
           expectedPidHi: 0x40,
           expectedPidLo: 0x4D,
@@ -866,7 +867,7 @@ void main() {
 
     test('wrong PID returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometerMilesTimes10(
+        Elm327Mode22Parsers.parseMfgOdometerMilesTimes10(
           '62 40 4D 00 64',
           expectedPidHi: 0xAA,
           expectedPidLo: 0x4D,
@@ -877,7 +878,7 @@ void main() {
 
     test('short response returns null', () {
       expect(
-        Elm327Parsers.parseMfgOdometerMilesTimes10(
+        Elm327Mode22Parsers.parseMfgOdometerMilesTimes10(
           '62 40 4D 00',
           expectedPidHi: 0x40,
           expectedPidLo: 0x4D,

--- a/test/features/obd2/data/obd2_connect_trace_log_test.dart
+++ b/test/features/obd2/data/obd2_connect_trace_log_test.dart
@@ -120,6 +120,21 @@ void main() {
           Obd2ConnectOutcome.scanEmpty);
     });
 
+    test('#3243 a later success does NOT override ignitionOff '
+        '(engine-off diagnosis preserved, #3009)', () {
+      // The #3009 engine-off path: a SUCCESSFUL init finds a silent bus and
+      // stamps ignitionOff; a later generic success stamp on the same connect
+      // must NOT mask it. (ignitionOff is not a retried channel-open transient.)
+      final h = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      h.setOutcome(Obd2ConnectOutcome.ignitionOff);
+      h.setOutcome(Obd2ConnectOutcome.success);
+      Obd2ConnectTraceLog.endTrace(h);
+
+      expect(Obd2ConnectTraceLog.snapshot().single.outcome,
+          Obd2ConnectOutcome.ignitionOff);
+    });
+
     test('#3243 a real success is never overwritten by a later failure', () {
       final h = Obd2ConnectTraceLog.beginTrace(
           origin: Obd2ConnectOrigin.firstConnect);

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -418,12 +418,14 @@ void main() {
     // `_parseFuelTrim` / `_parse1BytePercent` / `_parseModeOneBody`
     // plumbing. Decomposition tracked separately by #2187/#2188.
     // #3275 — bumped 538 → 551 for the `_plausibleOdometerKm` odometer gate.
-    // #3278/#3279 — ratcheted DOWN 551 → 519: the Mode 09 VIN decoder was
-    // extracted to `elm327_vin_parser.dart` (a framing-aware parse that fixes
-    // the multiline wrong-VIN bug). First slice of the #3279 decomposition;
-    // the Mode 22 manufacturer slice is still pending there.
+    // #3278/#3279 — ratcheted DOWN 551 → 519 (VIN decoder →
+    // `elm327_vin_parser.dart`) → 419 (Mode 22 manufacturer odometer parsers →
+    // `elm327_mode22_parsers.dart`, + shared `parseElmHexBytes` /
+    // `isPlausibleOdometerKm` → `elm327_decode_util.dart`). Two #3279 slices
+    // done; the remaining Mode 01 bulk keeps it just over the 400 norm, so the
+    // decomposition issue stays referenced for the final slice.
     'lib/features/obd2/data/elm327_parsers.dart': (
-      lines: 519,
+      lines: 419,
       bumps: 3,
       decompositionIssue: 3279,
     ),


### PR DESCRIPTION
## What & why

Second decomposition slice of the grandfathered `elm327_parsers.dart` (after the #3278 VIN extraction). Behavior-preserving, fully test-pinned.

- **`elm327_mode22_parsers.dart`** — the Mode 22 manufacturer-odometer parsers (`parseMfgOdometer{3Byte,2Byte,MilesTimes10}`, `_parseMode22Body`, `cleanResponse22`).
- **`elm327_decode_util.dart`** — the shared low-level helpers, now single-definition: `_parseHexBytes` → `parseElmHexBytes`, the odometer plausibility gate → `isPlausibleOdometerKm`.
- `Elm327Protocol`'s facade delegates repoint to the new class, so **production callers (which use the facade) are untouched**; only the direct `Elm327Parsers.parseMfgOdometer*` / `cleanResponse22` test references move.

`elm327_parsers.dart` ratchets **down 519 → 419** (file-length snapshot updated). The remaining Mode 01 bulk keeps it just over the 400 norm, so #3279 stays referenced for the final slice.

## Tests
Parser + manufacturer-odometer + file-length suites green (195 in the parser file alone). No behavior change.

Advances #3279.