### PR TITLE
fix(radar): route radar distance captions through the SSoT unit formatter — no mixed km/mi (#3258)

### DIFF
--- a/lib/features/consumption/domain/live_activity_content.dart
+++ b/lib/features/consumption/domain/live_activity_content.dart
@@ -198,17 +198,14 @@ LiveActivityContent? buildLiveActivityContent({
 
   LiveActivityContent approachContent(
     Station station,
-    double? distMeters, {
-    required bool kmCaption,
-  }) {
+    double? distMeters,
+  ) {
     final price = station.priceFor(fuel);
+    // #3258 — SSoT unit-aware distance (GB → miles, sub-km → metres/yards),
+    // consistent with the search cards instead of hardcoding km.
     final String? stationDistanceText = distMeters == null
         ? null
-        : kmCaption
-        ? (l.fuelStationRadarDistanceKm(
-            (distMeters / 1000.0).toStringAsFixed(1),
-          ))
-        : (l.approachStationDistance(distMeters.toStringAsFixed(0)));
+        : PriceFormatter.formatDistance(distMeters / 1000.0);
     return LiveActivityContent(
       mode: LiveActivityMode.approach,
       paused: paused,
@@ -228,24 +225,19 @@ LiveActivityContent? buildLiveActivityContent({
     );
   }
 
-  // 1 — in-radius / leaving wins (locked target, metres caption).
+  // 1 — in-radius / leaving wins (locked target).
   if (approach is ApproachInRadius) {
-    return approachContent(
-      approach.station,
-      approach.distanceMeters,
-      kmCaption: false,
-    );
+    return approachContent(approach.station, approach.distanceMeters);
   }
   if (approach is ApproachLeaving) {
-    return approachContent(approach.lastStation, null, kmCaption: false);
+    return approachContent(approach.lastStation, null);
   }
 
-  // 2 — polling radar hit (km caption — surfaces earlier than the fence).
+  // 2 — polling radar hit (surfaces earlier than the fence).
   if (radarStation != null) {
     return approachContent(
       radarStation,
       radarStation.dist > 0 ? radarStation.dist * 1000.0 : null,
-      kmCaption: true,
     );
   }
 

--- a/lib/features/consumption/presentation/widgets/trip_radar_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_radar_card.dart
@@ -203,16 +203,14 @@ class RadarCard extends StatelessWidget {
     final priceText = price != null ? PriceFormatter.formatPrice(price) : '--';
     final name = station.name.isNotEmpty ? station.name : station.brand;
 
-    // In-radius shows sub-km precision (metres); the fallback radar page-set
-    // shows km — the great-circle distance the driver still has to cover
-    // (#2661).
+    // #3258 — route through the SSoT distance formatter so the radar surface
+    // matches the search/favorites cards: GB renders miles (and sub-km shows
+    // metres/yards), instead of hardcoding km. formatDistance already shows
+    // metres under 1 km and km above, so the in-radius vs fallback precision
+    // split collapses into one unit-aware call.
     final String? distanceLabel = distanceMeters == null
         ? null
-        : live
-        ? (l.approachStationDistance(distanceMeters!.toStringAsFixed(0)))
-        : (l.fuelStationRadarDistanceKm(
-            (distanceMeters! / 1000.0).toStringAsFixed(1),
-          ));
+        : PriceFormatter.formatDistance(distanceMeters! / 1000.0);
     final subtitleParts = <String>[fuel.displayName, ?distanceLabel];
 
     // Tap → hand the station's coords to the SSoT navigation util, which

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -266,7 +266,6 @@ class TripRecordingBanner extends ConsumerWidget {
           distanceMeters: radarStation.dist > 0
               ? radarStation.dist * 1000.0
               : null,
-          kmCaption: true,
           radiusMeters: radiusMeters,
           onBodyTap: onBodyTap,
         );

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
@@ -38,10 +38,6 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
   /// Null hides the caption (the fill bar collapses too).
   final double? distanceMeters;
 
-  /// When true the caption reads in kilometres (the radar/polling variant,
-  /// #2661); when false it reads in metres (the in-radius variant, #2084).
-  final bool kmCaption;
-
   /// Radar radius in metres (`profile.approachRadiusKm * 1000`) — the
   /// proximity fill bar's "indicated radius". Null collapses the bar.
   final double? radiusMeters;
@@ -59,7 +55,6 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
     required this.backgroundColor,
     required this.foregroundColor,
     required this.distanceMeters,
-    required this.kmCaption,
     required this.radiusMeters,
     this.onBodyTap,
   });
@@ -72,11 +67,10 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
     final fuelLabel = fuel.displayName;
     final distance = distanceMeters;
 
-    final String? distanceText = distance == null
-        ? null
-        : kmCaption
-        ? (l.fuelStationRadarDistanceKm((distance / 1000.0).toStringAsFixed(1)))
-        : (l.approachStationDistance(distance.toStringAsFixed(0)));
+    // #3258 — SSoT unit-aware distance (GB → miles, sub-km → metres/yards),
+    // matching the search cards instead of hardcoding km.
+    final String? distanceText =
+        distance == null ? null : PriceFormatter.formatDistance(distance / 1000.0);
 
     final content = Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -103,7 +103,6 @@ class TripRecordingPipView extends StatelessWidget {
         backgroundColor: backgroundColor,
         foregroundColor: foregroundColor,
         distanceMeters: dist,
-        kmCaption: false,
         radiusMeters: radiusMeters,
         onBodyTap: onBodyTap,
       );
@@ -119,7 +118,6 @@ class TripRecordingPipView extends StatelessWidget {
         backgroundColor: backgroundColor,
         foregroundColor: foregroundColor,
         distanceMeters: radarDistanceMeters,
-        kmCaption: true,
         radiusMeters: radiusMeters,
         onBodyTap: onBodyTap,
       );

--- a/test/features/consumption/domain/live_activity_content_test.dart
+++ b/test/features/consumption/domain/live_activity_content_test.dart
@@ -199,7 +199,9 @@ void main() {
       expect(content.stationName, 'ARAL Hauptstr.');
       expect(content.priceText, PriceFormatter.formatPrice(1.789));
       expect(content.fuelLabel, FuelType.e10.displayName);
-      expect(content.stationDistanceText, l10nEn.approachStationDistance('450'));
+      // #3258 — radar distance now routes through the SSoT unit-aware
+      // formatter (GB→mi, sub-km→m/yd), matching the search cards.
+      expect(content.stationDistanceText, PriceFormatter.formatDistance(0.45));
       expect(content.progress, RadarCloseness.fillFor(450, 3000));
     });
 
@@ -237,7 +239,7 @@ void main() {
       final content = build(radarStation: station(dist: 1.2))!;
 
       expect(content.mode, LiveActivityMode.approach);
-      expect(content.stationDistanceText, l10nEn.fuelStationRadarDistanceKm('1.2'));
+      expect(content.stationDistanceText, PriceFormatter.formatDistance(1.2)); // #3258
       expect(content.progress, RadarCloseness.fillFor(1200, 3000));
       // The consumption hero stays populated for the expanded island.
       expect(content.bigFigure, isNotEmpty);
@@ -254,7 +256,7 @@ void main() {
         radarStation: station(dist: 1.2),
         radiusMeters: null,
       )!;
-      expect(content.stationDistanceText, l10nEn.fuelStationRadarDistanceKm('1.2'));
+      expect(content.stationDistanceText, PriceFormatter.formatDistance(1.2)); // #3258
       expect(content.progress, isNull);
     });
   });

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/obd2/data/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
@@ -215,8 +216,11 @@ void main() {
       // Leads with the station price + name (not L/100 km consumption).
       expect(find.text('Carrefour Pézenas'), findsOneWidget);
       expect(find.text('L/100 km'), findsNothing);
-      // Distance reads in KM (not metres).
-      expect(find.textContaining('2.4 km'), findsOneWidget);
+      // #3258 — distance reads in km via the SSoT unit-aware formatter (the
+      // locale decimal separator, GB→mi, are handled there) — not metres, and
+      // no hardcoded "km away".
+      expect(find.textContaining(PriceFormatter.formatDistance(2.4)),
+          findsOneWidget);
       expect(find.textContaining(' m away'), findsNothing);
     });
 


### PR DESCRIPTION
## What & why
The trip radar card, PiP price layout and Live Activity formatted distance as hardcoded **"X.X km"** (via the `fuelStationRadarDistanceKm`/`approachStationDistance` ARB keys), while search/favorites route through `PriceFormatter.formatDistance` → **miles for GB**. Once UK goes live (it's dark behind #3190 today, hence latent) the radar surfaces would show km while search showed mi — mixed units on one screen.

## Change
Route all three radar surfaces through `PriceFormatter.formatDistance` — unit-aware (GB→mi, sub-km→m/yd) and locale-correct, identical to the search cards. It already shows metres <1 km and km above, so the in-radius-vs-fallback precision split collapses into one call; the now-vestigial `kmCaption` param is removed from the PiP layout + Live Activity builder (and their 5 callers).

## Tests
Assert against `PriceFormatter.formatDistance` (locale-independent) rather than the old `"X.X km away"` literal. The two distance ARB keys are now unused (harmless — no unused-key gate); a future l10n-cleanup can prune them. Analyze + the affected consumption suites green.

Closes #3258.