### PR TITLE
fix(trips): route OBD2-trip GPS through the shared recording settings — fix 5s Android cadence + iOS background GPS (#3249)

### DIFF
--- a/lib/core/location/geolocator_wrapper.dart
+++ b/lib/core/location/geolocator_wrapper.dart
@@ -289,6 +289,17 @@ class _SharedPositionSource {
     _openUpstream(settings);
     // Cancel the superseded coarse subscription after the fine one is live so
     // there is no gap in fixes; the broadcast bus + `_last` replay bridge it.
+    //
+    // #3249 — KNOWN LIMITATION (verified against geolocator 14.0.2): opening
+    // the new stream BEFORE cancelling the old means geolocator_android can
+    // hand back its CACHED first-caller stream (the coarse one), so the
+    // "recorder cadence wins on a late join" guarantee above is not reliable
+    // when a coarse consumer opened the channel first. The correct fix is
+    // cancel-THEN-reopen (accepting a brief fix gap that `_last` replay
+    // bridges), but it changes the live GPS continuity of every trip and so
+    // needs on-device validation before shipping — deliberately deferred (the
+    // #3249 primary fix routes the recorder to `recording: true`, which wins
+    // when it opens the channel first, the common case).
     unawaited(old?.safeCancel());
   }
 

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -9,6 +9,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/location/recording_location_settings.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../glide_coach/domain/entities/glide_coach_advice.dart';
@@ -50,9 +51,11 @@ class TripGpsStreamController {
   ///
   /// No-op when [Feature.gpsTripPath] is disabled — the user can still
   /// turn it off from Feature management, and the flag-off path never
-  /// touches the Geolocator plugin (zero battery cost). When the flag
-  /// is on we open the stream at [LocationAccuracy.high] because the
-  /// eventual heatmap (Phase 3) wants ~10 m precision.
+  /// touches the Geolocator plugin (zero battery cost). When the flag is on we
+  /// open the SHARED, recording-promoted source (#3249) — the same fine-cadence
+  /// foreground-service stream the GPS-only recorder uses — so OBD2 trips get
+  /// the 1 s Android cadence + iOS background updates, not the bare-settings
+  /// 5 s / background-off defaults.
   ///
   /// #1981 — before opening the stream we ensure foreground location
   /// permission: `getPositionStream` does not prompt, so without a
@@ -78,11 +81,23 @@ class TripGpsStreamController {
           permission != LocationPermission.always) {
         return;
       }
+      // #3249 — route the OBD2-trip GPS through the SHARED, recording-promoted
+      // source, exactly like the GPS-only recorder
+      // (gps_only_recording_pipeline.dart). The previous bare
+      // `getPositionStream(LocationSettings(high))` (a) let geolocator_android
+      // default the interval to 5 s — so OBD2 trips got 5 s GPS even
+      // foregrounded and the #3173 foreground-service un-throttle never
+      // reached them — and (b) mapped to `allowsBackgroundLocationUpdates=NO`
+      // on iOS, so a backgrounded OBD2 trip lost GPS (null lat/lng → polyline
+      // holes). recordingLocationSettingsForRef carries the 1 s Android
+      // cadence + iOS background updates, and `recording: true` makes this
+      // consumer's fine cadence win the shared upstream (the same #2646/#2766
+      // path), so it no longer races the ApproachDetector for the platform
+      // stream.
       _gpsSub = geolocator
-          .getPositionStream(
-        locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.high,
-        ),
+          .sharedPositionStream(
+        recording: true,
+        locationSettings: recordingLocationSettingsForRef(_ref),
       )
           .listen(
         (pos) {

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -151,6 +151,44 @@ void main() {
     });
 
     test(
+        '#3249 — the OBD2-trip GPS opens with the un-throttled RECORDING '
+        'settings (shared source), not the bare 5 s defaults', () async {
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      await Future<void>.delayed(Duration.zero);
+
+      // The stream was opened (via the shared source) with the recorder's
+      // fine cadence — on the (Android) test platform that's an AndroidSettings
+      // with a 1 s interval + high accuracy, NOT a bare LocationSettings whose
+      // geolocator_android default is 5 s. (recordingLocationSettingsForRef.)
+      final settings = fakeGeo.lastSettings;
+      expect(settings, isA<AndroidSettings>(),
+          reason: 'OBD2 GPS must use the platform recording settings (#3249)');
+      expect((settings! as AndroidSettings).intervalDuration,
+          const Duration(seconds: 1));
+      expect(settings.accuracy, LocationAccuracy.high);
+
+      await notifier.stop();
+    });
+
+    test(
         'flag ON but Geolocator stream errors mid-trip — error is '
         'logged + swallowed; the trip recording continues; subsequent '
         'samples carry whatever was in the latch (or null)', () async {
@@ -373,6 +411,10 @@ Position _pos(
 class _RecordingGeolocator extends GeolocatorWrapper {
   int positionStreamCallCount = 0;
   LocationAccuracy? lastAccuracy;
+  // #3249 — the full settings the OBD2-trip GPS path opened with (through the
+  // shared source), so a test can assert it uses the un-throttled recording
+  // settings, not the bare 5 s defaults.
+  LocationSettings? lastSettings;
   // Re-created on each getPositionStream call so onListen / onCancel
   // hooks accurately reflect whether the production code is currently
   // subscribed (a single shared controller would conflate the two).
@@ -394,6 +436,7 @@ class _RecordingGeolocator extends GeolocatorWrapper {
   Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
     positionStreamCallCount++;
     lastAccuracy = locationSettings?.accuracy;
+    lastSettings = locationSettings;
     // Close any prior controller so the analyzer's `close_sinks`
     // lint stays quiet across re-subscribes.
     final prev = _controller;


### PR DESCRIPTION
## What & why
`trip_gps_stream_controller` opened a **bare** `LocationSettings(high)` via raw `getPositionStream`, so OBD2 trips got geolocator_android's **5000 ms** default interval even foregrounded (the #3173 FGS un-throttle never reached them), and geolocator_apple mapped the bare settings to `allowsBackgroundLocationUpdates=NO` — a backgrounded iOS OBD2 trip **lost GPS** (null lat/lng → polyline holes) unless it happened to win the cached-stream race with the ApproachDetector (the #2646 dual-consumer pattern).

## Change
Route it through `sharedPositionStream(recording: true, recordingLocationSettingsForRef(ref))` — **exactly the GPS-only recorder's path** (an already-shipped, tested pattern): 1 s Android cadence + iOS background updates, and `recording: true` makes its fine cadence win the shared upstream instead of racing the detector.

## Tests
A settings-equality test pins the OBD2 path to the recording settings (AndroidSettings, 1 s interval, high accuracy — not the bare 5 s default). The existing GPS-trip suite stays green (the shared source routes through the same `getPositionStream` seam).

## Scope / what remains (not auto-closing)
- The **#3249 bundle** flags `_SharedPositionSource._reopenUpstream` (open-before-cancel can return geolocator's cached coarse stream): the cancel-then-reopen fix changes every trip's GPS continuity, so it's **documented** in-code and deferred for on-device validation rather than blind-changed.
- The AC's **iOS on-device check** (backgrounded OBD2 trip keeps stamping lat/lng) is an inherent bench step — please verify on a device to fully close #3249.

Addresses #3249.