### PR TITLE
chore: remove stale dependency-pinning comments in pubspec.yaml (#3269)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,9 +67,6 @@ dependencies:
   # Utilities
   collection: ^1.19.0
   meta: ^1.17.0
-  # Pinned to 6.x — xml 7.x is a major bump; the 17 country
-  # station-service parsers depend on the 6.x API. Bump under its own
-  # pass (#1684).
   xml: ^7.0.1
   path_provider: ^2.1.5
   uuid: ^4.5.1
@@ -87,8 +84,6 @@ dependencies:
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.1
   http: ^1.3.0
-  # Pinned to 12.x — share_plus 13.x is a major bump; deferred to its
-  # own migration pass (#1684).
   share_plus: ^13.1.0
   # Inbound OS share-intent receiver (#2735 / Epic #2687) is now served by
   # the in-repo, GMS-free ShareIntentChannel (Android MethodChannel/
@@ -110,9 +105,6 @@ dependencies:
   async: ^2.11.0
   permission_handler: ^12.0.3
   flutter_secure_storage: ^10.3.1
-  # Pinned to 8.x — package_info_plus 9.x/10.x are major bumps; the app
-  # only reads the version string, so the upgrade is low-value and
-  # deferred to its own pass (#1684).
   package_info_plus: ^10.1.0
   sentry_flutter: ^9.21.0
   home_widget: ^0.9.3


### PR DESCRIPTION
Removes the stale "pinned to older major" comments on `xml`, `share_plus` and `package_info_plus` — all three are already bumped (xml ^7.0.1, share_plus ^13.1.0, package_info_plus ^10.1.0), so the comments contradicted the real constraints. The `latlong2` (0.x) and `flutter_blue_plus` (1.x, #2072) pins remain accurate and keep their comments. Comment-only; no version/lock change.

Closes #3269.