### PR TITLE
refactor(maps): extract pure geometry + marker-ranking statics into StationMapGeometry (#3233)

### DIFF
--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -20,6 +20,7 @@ import '../../../search/providers/search_mode_provider.dart';
 import '../../../search/providers/search_provider.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
 import '../../../search/providers/selected_station_provider.dart';
+import 'station_map_geometry.dart';
 import 'station_map_layers.dart';
 
 /// A reusable map widget that displays station markers in the split-screen
@@ -150,7 +151,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
     // radius (and a sparse one larger), so the radius zoom framed the wrong
     // viewport in the narrow split pane.
     final bounds = _boundsOf(stations);
-    final center = StationMapLayers.centerOf(stations);
+    final center = StationMapGeometry.centerOf(stations);
 
     // #2939 — two-way sync: emphasise the selected row's marker, and a marker
     // tap selects its row (keeping the map visible) instead of navigating.
@@ -160,7 +161,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
       mapController: _mapController,
       stations: stations,
       center: center,
-      zoom: StationMapLayers.zoomForRadius(searchRadius),
+      zoom: StationMapGeometry.zoomForRadius(searchRadius),
       searchRadiusKm: searchRadius,
       selectedFuel: selectedFuel,
       sortMode: sortMode,

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -17,6 +17,7 @@ import '../../../ev/providers/ev_providers.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/search_result_item.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
+import 'station_map_geometry.dart';
 import 'station_map_layers.dart';
 
 /// Displays a map of nearby stations from the current search results.
@@ -100,11 +101,11 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         // the screen empty (#692). Fall back to userPos only when the
         // result set is empty (no station centroid to compute).
         final center = stations.isNotEmpty
-            ? StationMapLayers.centerOf(stations)
+            ? StationMapGeometry.centerOf(stations)
             : (userPos != null
                   ? LatLng(userPos.lat, userPos.lng)
                   : const LatLng(0, 0));
-        final zoom = StationMapLayers.zoomForRadius(searchRadiusKm);
+        final zoom = StationMapGeometry.zoomForRadius(searchRadiusKm);
 
         final evLat = center.latitude;
         final evLng = center.longitude;
@@ -127,7 +128,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         // changed search centre. The old per-build post-frame `fitCamera`
         // here raced the (now-deleted) cold-start reset window and is
         // gone. `bounds` is still computed for the recenter button.
-        final bounds = StationMapLayers.boundsForRadius(center, searchRadiusKm);
+        final bounds = StationMapGeometry.boundsForRadius(center, searchRadiusKm);
 
         return Stack(
           children: [

--- a/lib/features/map/presentation/widgets/station_map_geometry.dart
+++ b/lib/features/map/presentation/widgets/station_map_geometry.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../../core/domain/fuel_type.dart';
+import '../../../../core/domain/station.dart';
+import '../../../../core/utils/price_utils.dart';
+
+/// Pure geometry + marker-ranking helpers for the station map (#3233).
+///
+/// Extracted from `StationMapLayers` so this map math (camera zoom/bounds,
+/// centroid, the price-paint ordering + emphasis ranking) lives next to its
+/// own unit tests without dragging in the widget, and the widget file stays
+/// closer to the line cap. All members are pure (no widget state).
+class StationMapGeometry {
+  const StationMapGeometry._();
+
+  /// Camera zoom bounds for the +/− button handlers + the [MapOptions]
+  /// camera constraints. Aligned with the OSM tile cap (`maxNativeZoom: 19`)
+  /// so a programmatic zoom-in past the cap doesn't park the camera at
+  /// a level with no tiles to render. The min is conservative — flutter_map
+  /// itself wraps the world at zoom 0, but anything below ~3 puts every
+  /// pin in a single pixel, which is unhelpful UX. Per #1457.
+  static const double minZoom = 3.0;
+  static const double maxZoom = 19.0;
+
+  /// Calculate zoom level from search radius.
+  static double zoomForRadius(double radiusKm) {
+    if (radiusKm <= 5) return 13;
+    if (radiusKm <= 10) return 12;
+    if (radiusKm <= 15) return 11;
+    if (radiusKm <= 25) return 10;
+    return 9;
+  }
+
+  /// Compute the [LatLngBounds] of a circle of [radiusKm] around [center].
+  ///
+  /// Uses a flat-earth approximation that is accurate enough for the
+  /// search radii we deal with (< 100 km). 1 degree latitude is ~111 km;
+  /// the longitude degree shrinks with the cosine of the latitude.
+  static LatLngBounds boundsForRadius(LatLng center, double radiusKm) {
+    const double kmPerLatDegree = 111.0;
+    final double latDelta = radiusKm / kmPerLatDegree;
+    final double cosLat = math.cos(center.latitude * math.pi / 180.0).abs();
+    // Guard against the poles where cos(lat) approaches zero.
+    final double safeCos = cosLat < 0.01 ? 0.01 : cosLat;
+    final double lngDelta = radiusKm / (kmPerLatDegree * safeCos);
+    final double south = (center.latitude - latDelta).clamp(-90.0, 90.0);
+    final double north = (center.latitude + latDelta).clamp(-90.0, 90.0);
+    final double west = (center.longitude - lngDelta).clamp(-180.0, 180.0);
+    final double east = (center.longitude + lngDelta).clamp(-180.0, 180.0);
+    return LatLngBounds(
+      LatLng(south, west),
+      LatLng(north, east),
+    );
+  }
+
+  /// Calculate center point from a list of stations.
+  static LatLng centerOf(List<Station> stations) {
+    double sumLat = 0, sumLng = 0;
+    for (final s in stations) {
+      sumLat += s.lat;
+      sumLng += s.lng;
+    }
+    return LatLng(sumLat / stations.length, sumLng / stations.length);
+  }
+
+  /// How many top-ranked stations keep their full price label; the rest
+  /// render as compact price-band dots (#2510). Small enough that the
+  /// emphasized bubbles stay legible at the search zoom, large enough to
+  /// surface the handful of stations a driver actually compares.
+  static const int emphasisCount = 4;
+
+  /// At or above this many stations a NON-`clusterAlways` map falls back to
+  /// count-clustering (#2510): a bounded nearby search stays well under this,
+  /// only a genuinely huge / zoomed-far set collapses into tappable clusters.
+  static const int clusterThreshold = 80;
+
+  /// Order [stations] so that, when their markers are handed to the
+  /// marker layer, the CHEAPEST (green/günstig) marker is painted ON
+  /// TOP of any more-expensive (orange/red) markers it overlaps (#2434).
+  ///
+  /// flutter_map paints markers in the order of the source list — a marker
+  /// LATER in the list is painted on top of earlier ones. So the rule is:
+  ///   - sort by the SELECTED-fuel price (`station.priceFor(selectedFuel)`)
+  ///     — the SAME price the marker is COLOURED by and the SAME strict
+  ///     resolution the search list uses (#2510, reverting the #2400
+  ///     fallback chain) — DESCENDING: most expensive first (painted at
+  ///     the bottom), cheapest last (painted on top), so colour and
+  ///     stacking always agree;
+  ///   - markers with NO selected-fuel price (the grey "--" bubble) sort
+  ///     to the very FRONT (the bottom of the stack) so a price-less
+  ///     marker can never cover a real green one.
+  ///
+  /// Returns a NEW list; the input is not mutated. A stable sort keeps the
+  /// relative order of equal-priced stations.
+  static List<Station> orderedByPriceForPainting(
+    List<Station> stations,
+    FuelType selectedFuel, {
+    FuelType Function(Station)? fuelResolver,
+  }) {
+    // A null selected-fuel price is treated as the most-expensive bucket
+    // (+infinity) so, under a descending sort, it lands first → painted
+    // at the very bottom, beneath every priced marker. #2631 — when a
+    // cross-border resolver is set, the key is each station's OWN country
+    // fuel price so the cheapest ES (E10) marker still paints on top.
+    double sortKey(Station s) =>
+        priceForFuelType(s, fuelResolver != null ? fuelResolver(s) : selectedFuel) ??
+        double.infinity;
+    final ordered = List<Station>.of(stations);
+    // Descending: highest price first (bottom), lowest last (top).
+    mergeSort<Station>(ordered,
+        compare: (a, b) => sortKey(b).compareTo(sortKey(a)));
+    return ordered;
+  }
+
+  /// Rank [stations] for marker EMPHASIS (#2510): the cheapest stations first
+  /// when [byPrice] (a price-oriented sort), the closest first otherwise. The
+  /// first [emphasisCount] entries get the full price bubble; the rest become
+  /// compact dots. Stations without a comparable value sort last so they never
+  /// steal emphasis from a station that has a real price/distance.
+  ///
+  /// [byPrice] is passed in (not the SortMode enum) so this map-geometry helper
+  /// stays free of a search-feature import (#3233 keeps the feature boundary).
+  ///
+  /// Returns a NEW list; the input is not mutated. Stable for ties.
+  static List<Station> rankForEmphasis(
+    List<Station> stations,
+    FuelType selectedFuel, {
+    required bool byPrice,
+  }) {
+    final ranked = List<Station>.of(stations);
+    int compare(Station a, Station b) {
+      if (byPrice) {
+        // Cheapest first; price-less stations sort last (sentinel handled
+        // inside compareByPrice).
+        return compareByPrice(a, b, selectedFuel);
+      }
+      // Closest first for distance / 24h / rating / name sorts — distance
+      // is the universally available, savings-relevant tie-breaker.
+      return a.dist.compareTo(b.dist);
+    }
+
+    mergeSort<Station>(ranked, compare: compare);
+    return ranked;
+  }
+}

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
-import 'dart:math' as math;
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -12,6 +10,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../../data/sparkilo_tile_layer.dart';
 import '../../../../core/utils/price_utils.dart';
+import 'station_map_geometry.dart';
 import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
@@ -23,10 +22,6 @@ import 'station_marker.dart';
 /// Camera zoom bounds (#1457). Top end matches the OSM tile cap so a
 /// `move(camera.zoom + 1)` past the cap doesn't park the user on a
 /// grey viewport with no tiles to draw. Bottom end is conservative —
-/// flutter_map wraps the world at zoom 0, but anything below ~3 puts
-/// every pin in a single pixel which is unhelpful UX.
-const double _kMinZoom = 3.0;
-const double _kMaxZoom = 19.0;
 
 /// Shared map widget containing all layers: tiles, search radius circle,
 /// center marker, station markers with clustering, attribution, zoom
@@ -183,139 +178,6 @@ class StationMapLayers extends StatefulWidget {
   @override
   State<StationMapLayers> createState() => _StationMapLayersState();
 
-  /// Camera zoom bounds for the +/− button handlers + the [MapOptions]
-  /// camera constraints. Aligned with the OSM tile cap (`maxNativeZoom: 19`)
-  /// so a programmatic zoom-in past the cap doesn't park the camera at
-  /// a level with no tiles to render. The min is conservative — flutter_map
-  /// itself wraps the world at zoom 0, but anything below ~3 puts every
-  /// pin in a single pixel, which is unhelpful UX. Per #1457.
-  @visibleForTesting
-  static const double minZoom = _kMinZoom;
-  @visibleForTesting
-  static const double maxZoom = _kMaxZoom;
-
-  /// Calculate zoom level from search radius.
-  static double zoomForRadius(double radiusKm) {
-    if (radiusKm <= 5) return 13;
-    if (radiusKm <= 10) return 12;
-    if (radiusKm <= 15) return 11;
-    if (radiusKm <= 25) return 10;
-    return 9;
-  }
-
-  /// Compute the [LatLngBounds] of a circle of [radiusKm] around [center].
-  ///
-  /// Uses a flat-earth approximation that is accurate enough for the
-  /// search radii we deal with (< 100 km). 1 degree latitude is ~111 km;
-  /// the longitude degree shrinks with the cosine of the latitude.
-  static LatLngBounds boundsForRadius(LatLng center, double radiusKm) {
-    const double kmPerLatDegree = 111.0;
-    final double latDelta = radiusKm / kmPerLatDegree;
-    final double cosLat = math.cos(center.latitude * math.pi / 180.0).abs();
-    // Guard against the poles where cos(lat) approaches zero.
-    final double safeCos = cosLat < 0.01 ? 0.01 : cosLat;
-    final double lngDelta = radiusKm / (kmPerLatDegree * safeCos);
-    final double south = (center.latitude - latDelta).clamp(-90.0, 90.0);
-    final double north = (center.latitude + latDelta).clamp(-90.0, 90.0);
-    final double west = (center.longitude - lngDelta).clamp(-180.0, 180.0);
-    final double east = (center.longitude + lngDelta).clamp(-180.0, 180.0);
-    return LatLngBounds(
-      LatLng(south, west),
-      LatLng(north, east),
-    );
-  }
-
-  /// Calculate center point from a list of stations.
-  static LatLng centerOf(List<Station> stations) {
-    double sumLat = 0, sumLng = 0;
-    for (final s in stations) {
-      sumLat += s.lat;
-      sumLng += s.lng;
-    }
-    return LatLng(sumLat / stations.length, sumLng / stations.length);
-  }
-
-  /// Order [stations] so that, when their markers are handed to the
-  /// marker layer, the CHEAPEST (green/günstig) marker is painted ON
-  /// TOP of any more-expensive (orange/red) markers it overlaps (#2434).
-  ///
-  /// flutter_map paints markers in the order of the source list — a marker
-  /// LATER in the list is painted on top of earlier ones. So the rule is:
-  ///   - sort by the SELECTED-fuel price (`station.priceFor(selectedFuel)`)
-  ///     — the SAME price the marker is COLOURED by and the SAME strict
-  ///     resolution the search list uses (#2510, reverting the #2400
-  ///     fallback chain) — DESCENDING: most expensive first (painted at
-  ///     the bottom), cheapest last (painted on top), so colour and
-  ///     stacking always agree;
-  ///   - markers with NO selected-fuel price (the grey "--" bubble) sort
-  ///     to the very FRONT (the bottom of the stack) so a price-less
-  ///     marker can never cover a real green one.
-  ///
-  /// Returns a NEW list; the input is not mutated. A stable sort keeps the
-  /// relative order of equal-priced stations.
-  static List<Station> orderedByPriceForPainting(
-    List<Station> stations,
-    FuelType selectedFuel, {
-    FuelType Function(Station)? fuelResolver,
-  }) {
-    // A null selected-fuel price is treated as the most-expensive bucket
-    // (+infinity) so, under a descending sort, it lands first → painted
-    // at the very bottom, beneath every priced marker. #2631 — when a
-    // cross-border resolver is set, the key is each station's OWN country
-    // fuel price so the cheapest ES (E10) marker still paints on top.
-    double sortKey(Station s) =>
-        priceForFuelType(s, fuelResolver != null ? fuelResolver(s) : selectedFuel) ??
-        double.infinity;
-    final ordered = List<Station>.of(stations);
-    // Descending: highest price first (bottom), lowest last (top).
-    mergeSort<Station>(ordered,
-        compare: (a, b) => sortKey(b).compareTo(sortKey(a)));
-    return ordered;
-  }
-
-  /// How many top-ranked stations keep their full price label; the rest
-  /// render as compact price-band dots (#2510). Small enough that the
-  /// emphasized bubbles stay legible at the search zoom, large enough to
-  /// surface the handful of stations a driver actually compares.
-  @visibleForTesting
-  static const int emphasisCount = 4;
-
-  /// At or above this many stations a NON-[clusterAlways] map falls back to
-  /// count-clustering (#2510): a bounded nearby search stays well under this,
-  /// only a genuinely huge / zoomed-far set collapses into tappable clusters.
-  @visibleForTesting
-  static const int clusterThreshold = 80;
-
-  /// Rank [stations] for marker EMPHASIS per the active [sortMode] (#2510):
-  /// the cheapest stations first for a price-oriented sort, the closest
-  /// first otherwise. The first [StationMapLayers.emphasisCount] entries
-  /// get the full price bubble; the rest become compact dots. Stations
-  /// without a comparable value sort last so they never steal emphasis
-  /// from a station that has a real price/distance.
-  ///
-  /// Returns a NEW list; the input is not mutated. Stable for ties.
-  static List<Station> rankForEmphasis(
-    List<Station> stations,
-    FuelType selectedFuel,
-    SortMode sortMode,
-  ) {
-    final ranked = List<Station>.of(stations);
-    final byPrice =
-        sortMode == SortMode.price || sortMode == SortMode.priceDistance;
-    int compare(Station a, Station b) {
-      if (byPrice) {
-        // Cheapest first; price-less stations sort last (sentinel handled
-        // inside compareByPrice).
-        return compareByPrice(a, b, selectedFuel);
-      }
-      // Closest first for distance / 24h / rating / name sorts — distance
-      // is the universally available, savings-relevant tie-breaker.
-      return a.dist.compareTo(b.dist);
-    }
-
-    mergeSort<Station>(ranked, compare: compare);
-    return ranked;
-  }
 }
 
 class _StationMapLayersState extends State<StationMapLayers> {
@@ -360,7 +222,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// pre-#2755 behaviour.
   LatLngBounds get _fitBounds =>
       widget.cameraFitBounds ??
-      StationMapLayers.boundsForRadius(widget.center, widget.searchRadiusKm);
+      StationMapGeometry.boundsForRadius(widget.center, widget.searchRadiusKm);
 
   /// Recompute the memoised price range + marker list from the current
   /// widget inputs.
@@ -383,18 +245,19 @@ class _StationMapLayersState extends State<StationMapLayers> {
     // bubble; the rest render as compact price-band dots so a bounded
     // result set stays fully visible without the bubbles overlapping into
     // an illegible pile. The set is small, so a Set lookup is cheap.
-    final emphasized = StationMapLayers.rankForEmphasis(
+    final emphasized = StationMapGeometry.rankForEmphasis(
       widget.stations,
       widget.selectedFuel,
-      widget.sortMode,
-    ).take(StationMapLayers.emphasisCount).map((s) => s.id).toSet();
+      byPrice: widget.sortMode == SortMode.price ||
+          widget.sortMode == SortMode.priceDistance,
+    ).take(StationMapGeometry.emphasisCount).map((s) => s.id).toSet();
 
     // #2434 — order so the cheapest (green) marker paints ON TOP of the
     // more-expensive ones it overlaps. The marker layer paints in
     // source-list order (later = on top), so we sort price-descending:
     // expensive at the bottom, cheapest last/on top, price-less markers
     // beneath everything. Same price the marker is coloured by.
-    final ordered = StationMapLayers.orderedByPriceForPainting(
+    final ordered = StationMapGeometry.orderedByPriceForPainting(
       widget.stations,
       widget.selectedFuel,
       fuelResolver: resolver,
@@ -535,8 +398,8 @@ class _StationMapLayersState extends State<StationMapLayers> {
             // past where there are tiles to draw, which looks broken to
             // the user. Min clamp guards against accidental zoom-out
             // beyond the world wrap.
-            minZoom: _kMinZoom,
-            maxZoom: _kMaxZoom,
+            minZoom: StationMapGeometry.minZoom,
+            maxZoom: StationMapGeometry.maxZoom,
             // #3002 — the DRIVING map passes its restricted gesture set (no
             // pinch); every other map keeps the default all-gestures option.
             interactionOptions: widget.interactionOptions ??
@@ -632,7 +495,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
                       widget.selectedStationIds ?? const <String>{},
                 )
               else if (widget.stations.length >=
-                  StationMapLayers.clusterThreshold)
+                  StationMapGeometry.clusterThreshold)
                 countClusterLayer(markers: _markers, theme: theme)
               else
                 MarkerLayer(markers: _markers),
@@ -653,7 +516,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
                 ZoomButton(
                   icon: Icons.add,
                   onPressed: () {
-                    // #1457 — clamp to [_kMinZoom, _kMaxZoom]. Without
+                    // #1457 — clamp to [StationMapGeometry.minZoom, StationMapGeometry.maxZoom]. Without
                     // the clamp, a + tap at the cap silently no-ops AND
                     // pushes the camera to a zoom level with no tiles
                     // (the user sees a grey screen and assumes the button
@@ -662,7 +525,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
                     // already at max zoom" instead of "the button is
                     // dead".
                     final z = (widget.mapController.camera.zoom + 1)
-                        .clamp(_kMinZoom, _kMaxZoom);
+                        .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
                     widget.mapController
                         .move(widget.mapController.camera.center, z);
                   },
@@ -672,7 +535,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
                   icon: Icons.remove,
                   onPressed: () {
                     final z = (widget.mapController.camera.zoom - 1)
-                        .clamp(_kMinZoom, _kMaxZoom);
+                        .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
                     widget.mapController
                         .move(widget.mapController.camera.center, z);
                   },

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -12,6 +12,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/map/presentation/widgets/nearby_map_view.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_geometry.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/search_result_item.dart';
@@ -195,8 +196,8 @@ void main() {
 
         // And the first-paint fit target IS the search circle around the
         // station centroid at the 19 km radius — not a route bound.
-        final expected = StationMapLayers.boundsForRadius(
-          StationMapLayers.centerOf(parisStations),
+        final expected = StationMapGeometry.boundsForRadius(
+          StationMapGeometry.centerOf(parisStations),
           19,
         );
         final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/map/data/sparkilo_tile_layer.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_cluster_layers.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_geometry.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
 import 'package:tankstellen/core/domain/fuel_type.dart';
@@ -16,21 +17,21 @@ import 'package:tankstellen/features/search/presentation/widgets/sort_selector.d
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
-  group('StationMapLayers.zoomForRadius', () {
+  group('StationMapGeometry.zoomForRadius', () {
     test('returns appropriate zoom levels for radius buckets', () {
-      expect(StationMapLayers.zoomForRadius(2), 13);
-      expect(StationMapLayers.zoomForRadius(5), 13);
-      expect(StationMapLayers.zoomForRadius(10), 12);
-      expect(StationMapLayers.zoomForRadius(15), 11);
-      expect(StationMapLayers.zoomForRadius(25), 10);
-      expect(StationMapLayers.zoomForRadius(50), 9);
+      expect(StationMapGeometry.zoomForRadius(2), 13);
+      expect(StationMapGeometry.zoomForRadius(5), 13);
+      expect(StationMapGeometry.zoomForRadius(10), 12);
+      expect(StationMapGeometry.zoomForRadius(15), 11);
+      expect(StationMapGeometry.zoomForRadius(25), 10);
+      expect(StationMapGeometry.zoomForRadius(50), 9);
     });
   });
 
-  group('StationMapLayers.boundsForRadius', () {
+  group('StationMapGeometry.boundsForRadius', () {
     test('returns bounds that contain the input point', () {
       const center = LatLng(48.8566, 2.3522); // Paris
-      final bounds = StationMapLayers.boundsForRadius(center, 10);
+      final bounds = StationMapGeometry.boundsForRadius(center, 10);
 
       // The input point lies inside the bounds and is close to the midpoint.
       expect(bounds.contains(center), isTrue);
@@ -40,7 +41,7 @@ void main() {
 
     test('latitude delta matches ~1 degree per 111 km', () {
       const center = LatLng(0, 0); // equator
-      final bounds = StationMapLayers.boundsForRadius(center, 111);
+      final bounds = StationMapGeometry.boundsForRadius(center, 111);
       // 111 km north of equator => roughly +1 degree latitude.
       expect(bounds.north, closeTo(1.0, 0.05));
       expect(bounds.south, closeTo(-1.0, 0.05));
@@ -53,8 +54,8 @@ void main() {
       // underlying flat-earth approximation.
       const equator = LatLng(0, 0);
       const north = LatLng(60, 0);
-      final eqBounds = StationMapLayers.boundsForRadius(equator, 50);
-      final nBounds = StationMapLayers.boundsForRadius(north, 50);
+      final eqBounds = StationMapGeometry.boundsForRadius(equator, 50);
+      final nBounds = StationMapGeometry.boundsForRadius(north, 50);
       // Raw east/west around longitude 0 => half-width equals east.
       final eqLngHalfWidth = eqBounds.east;
       final nLngHalfWidth = nBounds.east;
@@ -64,8 +65,8 @@ void main() {
 
     test('bounds expand monotonically with radius', () {
       const center = LatLng(48.8566, 2.3522);
-      final small = StationMapLayers.boundsForRadius(center, 5);
-      final big = StationMapLayers.boundsForRadius(center, 25);
+      final small = StationMapGeometry.boundsForRadius(center, 5);
+      final big = StationMapGeometry.boundsForRadius(center, 25);
 
       expect(big.north, greaterThan(small.north));
       expect(big.south, lessThan(small.south));
@@ -75,7 +76,7 @@ void main() {
 
     test('handles near-pole positions without dividing by zero', () {
       const center = LatLng(89.99, 0);
-      final bounds = StationMapLayers.boundsForRadius(center, 10);
+      final bounds = StationMapGeometry.boundsForRadius(center, 10);
       // Just assert we get a sensible (non-NaN, non-infinite) result.
       expect(bounds.east.isFinite, isTrue);
       expect(bounds.west.isFinite, isTrue);
@@ -93,14 +94,14 @@ void main() {
       // with no tiles to draw, producing the "+ button does nothing"
       // symptom that triggered #1457. Tile cap and camera cap MUST be
       // updated together if either ever changes.
-      expect(StationMapLayers.maxZoom, 19.0);
+      expect(StationMapGeometry.maxZoom, 19.0);
     });
 
     test('minZoom keeps every pin from collapsing into a single pixel', () {
       // Zoom 3 shows a continent-scale viewport; below that, station
       // markers cluster into a single illegible blob and the search
       // affordances stop being meaningful.
-      expect(StationMapLayers.minZoom, 3.0);
+      expect(StationMapGeometry.minZoom, 3.0);
     });
 
     test('the clamp expression in the +/− handlers is well-formed', () {
@@ -110,26 +111,26 @@ void main() {
       // tap-at-the-cap into a graceful no-op (camera stays at the
       // bound) instead of pushing past where there are tiles.
       double inc(double current) => (current + 1).clamp(
-        StationMapLayers.minZoom,
-        StationMapLayers.maxZoom,
+        StationMapGeometry.minZoom,
+        StationMapGeometry.maxZoom,
       );
       double dec(double current) => (current - 1).clamp(
-        StationMapLayers.minZoom,
-        StationMapLayers.maxZoom,
+        StationMapGeometry.minZoom,
+        StationMapGeometry.maxZoom,
       );
       // Below the cap → increment normally.
       expect(inc(13.0), 14.0);
       expect(dec(13.0), 12.0);
       // At the upper cap → + becomes a no-op, − still moves.
-      expect(inc(StationMapLayers.maxZoom), StationMapLayers.maxZoom);
-      expect(dec(StationMapLayers.maxZoom), StationMapLayers.maxZoom - 1.0);
+      expect(inc(StationMapGeometry.maxZoom), StationMapGeometry.maxZoom);
+      expect(dec(StationMapGeometry.maxZoom), StationMapGeometry.maxZoom - 1.0);
       // At the lower cap → − becomes a no-op, + still moves.
-      expect(dec(StationMapLayers.minZoom), StationMapLayers.minZoom);
-      expect(inc(StationMapLayers.minZoom), StationMapLayers.minZoom + 1.0);
+      expect(dec(StationMapGeometry.minZoom), StationMapGeometry.minZoom);
+      expect(inc(StationMapGeometry.minZoom), StationMapGeometry.minZoom + 1.0);
       // Past the upper cap (e.g. via prior pinch-zoom that escaped
       // the camera before #1457 set MapOptions.maxZoom) → the next
       // tap snaps back to the cap rather than pushing further.
-      expect(inc(25.0), StationMapLayers.maxZoom);
+      expect(inc(25.0), StationMapGeometry.maxZoom);
     });
   });
 
@@ -234,7 +235,7 @@ void main() {
     });
   });
 
-  group('StationMapLayers.orderedByPriceForPainting (#2434)', () {
+  group('StationMapGeometry.orderedByPriceForPainting (#2434)', () {
     // The (cluster) layer paints in source-list order — a marker LATER
     // in the list paints ON TOP of earlier ones. The helper must order
     // stations so the cheapest (green) marker ends up LAST (top) and a
@@ -261,7 +262,7 @@ void main() {
       final expensive = station('expensive', diesel: 1.90);
 
       // Feed them in an arbitrary order.
-      final ordered = StationMapLayers.orderedByPriceForPainting([
+      final ordered = StationMapGeometry.orderedByPriceForPainting([
         mid,
         expensive,
         cheap,
@@ -280,7 +281,7 @@ void main() {
       final expensive = station('expensive', diesel: 1.90);
       final noPrice = station('noprice'); // no diesel, no fallback fuel
 
-      final ordered = StationMapLayers.orderedByPriceForPainting([
+      final ordered = StationMapGeometry.orderedByPriceForPainting([
         cheap,
         noPrice,
         expensive,
@@ -309,7 +310,7 @@ void main() {
       final dieselPriced = station('diesel-priced', diesel: 1.95);
       final e10Only = station('e10-only', e10: 1.40);
 
-      final ordered = StationMapLayers.orderedByPriceForPainting([
+      final ordered = StationMapGeometry.orderedByPriceForPainting([
         dieselPriced,
         e10Only,
       ], FuelType.diesel);
@@ -323,7 +324,7 @@ void main() {
     test('is a pure function — does not mutate the input list', () {
       final input = [station('a', diesel: 1.90), station('b', diesel: 1.50)];
       final before = input.map((s) => s.id).toList();
-      StationMapLayers.orderedByPriceForPainting(input, FuelType.diesel);
+      StationMapGeometry.orderedByPriceForPainting(input, FuelType.diesel);
       expect(
         input.map((s) => s.id).toList(),
         before,
@@ -334,7 +335,7 @@ void main() {
     test('is stable for equal prices (preserves relative order)', () {
       final first = station('first', diesel: 1.70);
       final second = station('second', diesel: 1.70);
-      final ordered = StationMapLayers.orderedByPriceForPainting([
+      final ordered = StationMapGeometry.orderedByPriceForPainting([
         first,
         second,
       ], FuelType.diesel);
@@ -347,7 +348,7 @@ void main() {
   // "4"/"2"/"3" count bubbles + one stray marker, HIDING the results. The
   // bounded set must now render every station as its OWN marker (a plain
   // [MarkerLayer]); clustering is kept only as a fallback for a genuinely
-  // huge / zoomed-far set (>= [StationMapLayers.clusterThreshold]).
+  // huge / zoomed-far set (>= [StationMapGeometry.clusterThreshold]).
   group('StationMapLayers de-clustering (#2510)', () {
     List<Station> nStations(int n) => List.generate(
       n,
@@ -446,8 +447,8 @@ void main() {
         final dots = stationMarkers
             .where((m) => m.width == kStationDotSize)
             .length;
-        expect(fullBubbles, StationMapLayers.emphasisCount);
-        expect(dots, 10 - StationMapLayers.emphasisCount);
+        expect(fullBubbles, StationMapGeometry.emphasisCount);
+        expect(dots, 10 - StationMapGeometry.emphasisCount);
       },
     );
 
@@ -462,7 +463,7 @@ void main() {
       'a genuinely huge set (>= clusterThreshold) still falls back to '
       'clustering',
       (tester) async {
-        await pumpWith(tester, nStations(StationMapLayers.clusterThreshold));
+        await pumpWith(tester, nStations(StationMapGeometry.clusterThreshold));
         expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
       },
     );

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -945,10 +945,13 @@ void main() {
     // +1 (#3161): the `discarded_futures` burn-down added the lint-mandated
     // `import 'dart:async';` line for the `unawaited(...)` wrap of the
     // marker-tap HapticFeedback call. No new logic.
-    // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3233
-    // (marker-model builder out of the widget).
+    // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3233.
+    // #3233 — ratcheted DOWN 700 → 565: the pure geometry + marker-ranking
+    // statics (zoom/bounds/centroid + orderedByPriceForPainting/rankForEmphasis
+    // + their consts) were extracted to `station_map_geometry.dart`. First
+    // slice; the in-widget marker BUILDER (`_recomputeMarkers`) is the next.
     'lib/features/map/presentation/widgets/station_map_layers.dart': (
-      lines: 700,
+      lines: 565,
       bumps: 8,
       decompositionIssue: 3233,
     ),


### PR DESCRIPTION
First decomposition slice of the 8-bump god-class `station_map_layers.dart`. Moves the **pure, widget-state-free** statics (zoom/bounds/centroid + price-paint ordering + emphasis ranking + their consts) into `station_map_geometry.dart`. Behaviour-preserving; callers (widget, inline_map, nearby_map_view, 2 tests) repointed to `StationMapGeometry.*`; `rankForEmphasis` now takes a plain `bool byPrice` (not the SortMode enum) so the helper keeps the map→search feature boundary. File ratchets 700 → 565 (snapshot updated); the in-widget marker builder is the next slice, so #3233 stays referenced. analyze + map suites green.

Advances #3233.