### PR TITLE
fix(radar): show init progress on the search radar pill + overlap GPS with first paint (#3290)

### DIFF
--- a/lib/features/search/presentation/widgets/radar_search_fab.dart
+++ b/lib/features/search/presentation/widgets/radar_search_fab.dart
@@ -30,9 +30,33 @@ class RadarSearchFab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final active = ref.watch(radarSearchProvider).active;
+    final radar = ref.watch(radarSearchProvider);
+    final active = radar.active;
 
-    final label = active ? (l10n.stopRadar) : (l10n.fuelStationRadarStart);
+    // #3290 — while a run is initialising (acquiring the first GPS fix, or the
+    // first station list is still loading) the pill shows a spinner + a
+    // "Searching…" label so the user sees the radar is WORKING. Previously the
+    // pill flipped straight from "Start" to "Stop radar" with no progress sign,
+    // so a scan that takes a few seconds (cold GPS lock + first fetch) read as a
+    // button that did nothing. The pill stays tappable throughout so the user
+    // can still cancel mid-scan.
+    final initializing = active && (radar.locating || radar.stations.isLoading);
+
+    final String label;
+    final Widget icon;
+    if (!active) {
+      label = l10n.fuelStationRadarStart;
+      icon = const Icon(Icons.radar);
+    } else if (initializing) {
+      label = l10n.radarSearching;
+      icon = const SizedBox.square(
+        dimension: 18,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    } else {
+      label = l10n.stopRadar;
+      icon = const Icon(Icons.stop_circle);
+    }
 
     return FloatingActionButton.extended(
       key: const Key('radarSearchButton'),
@@ -46,7 +70,7 @@ class RadarSearchFab extends ConsumerWidget {
           unawaited(notifier.runRadar());
         }
       },
-      icon: Icon(active ? Icons.stop_circle : Icons.radar),
+      icon: icon,
       label: Text(label),
     );
   }

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -135,10 +135,19 @@ class RadarSearch extends _$RadarSearch {
     // is swallowed, keeping the radar usable off the persisted/refreshed fix).
     _subscribeGps();
 
+    // #3290 — kick the fresh GPS fix CONCURRENTLY with the provisional corridor
+    // paint instead of strictly after it. The cold one-shot lock and the first
+    // corridor fetch then overlap, so the authoritative (in-radius) scan lands
+    // ~one network round-trip sooner. `persisted` is read BEFORE the refresh so
+    // the provisional paint still uses the last-known point even if the fresh
+    // fix resolves first. Best-effort: a denied / timed-out fix keeps the
+    // persisted point (offline runs still scan the last spot).
+    final persisted = ref.read(userPositionProvider);
+    final gpsRefresh = _refreshGps();
+
     // #3267 — instant first paint from the last-known position (corridor-only,
     // no in-radius merge yet) so the user sees something immediately while the
     // fresh fix resolves, rather than a blank, blocked screen.
-    final persisted = ref.read(userPositionProvider);
     if (persisted != null) {
       state = state.copyWith(active: true, locating: true);
       await _scan(
@@ -155,18 +164,10 @@ class RadarSearch extends _$RadarSearch {
       );
     }
 
-    // #2806 — refresh the live GPS fix, exactly as the regular search does, so
-    // the authoritative scan is around the user's CURRENT spot, not a position
-    // minutes behind them. Best-effort: keep the persisted point if the fix is
-    // denied / times out, so an offline run still scans the last spot.
-    Object? gpsError;
-    StackTrace? gpsStack;
-    try {
-      await ref.read(userPositionProvider.notifier).updateFromGps();
-    } catch (e, st) {
-      gpsError = e;
-      gpsStack = st;
-    }
+    // #2806 — the authoritative scan must be around the user's CURRENT spot,
+    // not a position minutes behind them, so wait for the (already in-flight)
+    // fresh fix before the in-radius merge.
+    final (:gpsError, :gpsStack) = await gpsRefresh;
 
     final pos = ref.read(userPositionProvider);
     if (pos == null) {
@@ -195,6 +196,20 @@ class RadarSearch extends _$RadarSearch {
       heading: geo.sanitizedHeading(_lastFix?.heading),
       silent: false,
     );
+  }
+
+  /// Refresh the persisted position from a fresh one-shot GPS fix, capturing
+  /// any failure instead of throwing so it can run concurrently with the
+  /// provisional paint (#3290). A denied / timed-out fix is non-fatal — the
+  /// caller falls back to the persisted point, or surfaces the error (#3042)
+  /// only when there is no position to scan around at all.
+  Future<({Object? gpsError, StackTrace? gpsStack})> _refreshGps() async {
+    try {
+      await ref.read(userPositionProvider.notifier).updateFromGps();
+      return (gpsError: null, gpsStack: null);
+    } catch (e, st) {
+      return (gpsError: e, gpsStack: st);
+    }
   }
 
   /// Open the live GPS subscription if it isn't already. Never throws — a

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'55f444f30916d2a36f7c4691ec522b8b568a7f59';
+String _$radarSearchHash() => r'6915d5a189620edc8479072f08a23d7eecddd521';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -38,5 +38,9 @@
   "radarUpdatingLocation": "Standort wird aktualisiert…",
   "@radarUpdatingLocation": {
     "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
+  },
+  "radarSearching": "Suche läuft…",
+  "@radarSearching": {
+    "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
   }
 }

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -38,5 +38,9 @@
   "radarUpdatingLocation": "Updating your location…",
   "@radarUpdatingLocation": {
     "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3448,6 +3448,10 @@
   "@radarUpdatingLocation": {
     "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
   },
+  "radarSearching": "Suche läuft…",
+  "@radarSearching": {
+    "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
+  },
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7049,6 +7049,10 @@
   "@radarUpdatingLocation": {
     "description": "Status banner shown above the on-search Fuel Station Radar results while a fresh GPS fix is still resolving — the list is painted from the last-known position and refreshes once the live fix lands (#3267)."
   },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -2133,6 +2133,7 @@
   "fuelStationRadarResultBadge": "⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧",
   "radarAcquiringLocation": "⟦Ƒîñđîñǧ ýóúř łóçáŧîóñ… ·········⟧",
   "radarUpdatingLocation": "⟦Úƥđáŧîñǧ ýóúř łóçáŧîóñ… ·········⟧",
+  "radarSearching": "⟦Šéářçĥîñǧ… ····⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",
   "tripRecordingPinSemanticOff": "⟦Ƥîñ řéçóřđîñǧ ƒóřɱ ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4895,5 +4895,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13024,6 +13024,12 @@ abstract class AppLocalizations {
   /// **'Updating your location…'**
   String get radarUpdatingLocation;
 
+  /// Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290).
+  ///
+  /// In en, this message translates to:
+  /// **'Searching…'**
+  String get radarSearching;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7539,6 +7539,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Закачането задържа екрана включен — изразходва повече батерия';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7488,6 +7488,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Připnutí udržuje obrazovku zapnutou — spotřebuje více baterie';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7476,6 +7476,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fastgørelse holder skærmen tændt — bruger mere batteri';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7522,6 +7522,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get radarUpdatingLocation => 'Standort wird aktualisiert…';
 
   @override
+  String get radarSearching => 'Suche läuft…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7541,6 +7541,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Η καρφίτσωση κρατά την οθόνη αναμμένη — χρησιμοποιεί περισσότερη μπαταρία';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7440,6 +7440,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 
@@ -15433,6 +15436,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get radarUpdatingLocation => '⟦Úƥđáŧîñǧ ýóúř łóçáŧîóñ… ·········⟧';
+
+  @override
+  String get radarSearching => '⟦Šéářçĥîñǧ… ····⟧';
 
   @override
   String get tripRecordingPinTooltip =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7529,6 +7529,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fijar mantiene la pantalla encendida: consume más batería';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7470,6 +7470,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kinnitamine hoiab ekraani peal — kasutab rohkem akut';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7477,6 +7477,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kiinnittäminen pitää näytön päällä — kuluttaa enemmän akkua';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7555,6 +7555,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'L\'épinglage garde l\'écran allumé — consomme plus de batterie';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7502,6 +7502,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prikačivanje drži ekran uključenim — troši više baterije';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7522,6 +7522,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'A rögzítés bekapcsolva tartja a képernyőt — több akkumulátort használ';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7518,6 +7518,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fissare mantiene lo schermo acceso — consuma più batteria';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7515,6 +7515,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prisegimas palaiko ekraną įjungtą — naudoja daugiau baterijos';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7521,6 +7521,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Piespraušana patur ekrānu ieslēgtu — patērē vairāk akumulatora';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7472,6 +7472,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Festing holder skjermen på – bruker mer batteri';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7501,6 +7501,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Vastpinnen houdt het scherm aan — verbruikt meer batterij';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7507,6 +7507,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Przypięcie utrzymuje ekran włączony — zużywa więcej baterii';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7533,6 +7533,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixar mantém o ecrã ligado — usa mais bateria';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7529,6 +7529,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixarea menține ecranul aprins — consumă mai multă baterie';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7505,6 +7505,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pripnutie udržuje obrazovku zapnutú — vyčerpáva viac batérie';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7484,6 +7484,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Priklepanje ohranja zaslon vklopljen — porablja več baterije';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7472,6 +7472,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get radarUpdatingLocation => 'Updating your location…';
 
   @override
+  String get radarSearching => 'Searching…';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Nålning håller skärmen på – förbrukar mer batteri';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4792,5 +4792,10 @@
   "@radarUpdatingLocation": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "radarSearching": "Searching…",
+  "@radarSearching": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/features/search/presentation/widgets/radar_search_button_test.dart
+++ b/test/features/search/presentation/widgets/radar_search_button_test.dart
@@ -171,6 +171,45 @@ void main() {
     });
 
     testWidgets(
+        'while a run is initialising the pill shows a spinner + "Searching…" '
+        'so the user sees the radar is working (#3290)', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      // `settle: false` — the spinner animates forever, so pumpAndSettle would
+      // hang; a single frame is enough to assert the first paint.
+      await pumpApp(
+        tester,
+        const RadarSearchFab(),
+        overrides: [
+          ...test.overrides,
+          radarSearchProvider.overrideWith(_InitialisingRadar.new),
+        ].cast(),
+        settle: false,
+      );
+
+      // A working spinner + "Searching…" — NOT the silent flip to "Stop radar"
+      // or "Start" that gave no sign the scan was running.
+      expect(find.text('Searching…'), findsOneWidget);
+      expect(
+          find.descendant(
+            of: find.byType(FloatingActionButton),
+            matching: find.byType(CircularProgressIndicator),
+          ),
+          findsOneWidget);
+      expect(find.text('Stop radar'), findsNothing);
+      expect(find.text('Start fuel station radar'), findsNothing);
+      expect(find.widgetWithIcon(FloatingActionButton, Icons.stop_circle),
+          findsNothing);
+
+      // It stays tappable so the user can cancel mid-scan — dismiss flips it
+      // back to the idle start treatment (no spinner left to animate).
+      await tester.tap(find.byKey(const Key('radarSearchButton')));
+      await tester.pump();
+      expect(find.text('Start fuel station radar'), findsOneWidget);
+    });
+
+    testWidgets(
         'when the radar is active the pill flips to a stop treatment that '
         'dismisses it', (tester) async {
       final test = standardTestOverrides();
@@ -274,5 +313,17 @@ class _ActiveRadar extends RadarSearch {
   RadarSearchState build() => RadarSearchState(
         active: true,
         stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+/// #3290 — an active radar still acquiring its first fix: `locating` true with
+/// the list still loading. The pill must render the spinner + "Searching…"
+/// rather than the bare "Stop radar" treatment.
+class _InitialisingRadar extends RadarSearch {
+  @override
+  RadarSearchState build() => const RadarSearchState(
+        active: true,
+        locating: true,
+        stations: AsyncLoading<List<Station>>(),
       );
 }


### PR DESCRIPTION
Closes #3290. Follow-up to #3267.

## Problem

On-device report: the **search-form** Fuel Station Radar "still takes a very long time and the user is not aware of the initialization and search."

Two gaps:
1. **No awareness on the launch pill.** `RadarSearchFab` flipped straight from *Start fuel station radar* → *Stop radar* the instant it was tapped — no spinner, no progress label. A scan that takes a few seconds (cold GPS lock + first corridor/in-radius fetch) read as a button that did nothing. The results area already shows `_RadarLocatingState` / `_RadarUpdatingBanner` (#3267), but a user watching the button saw nothing.
2. **Serial init.** `runRadar()` ran provisional paint → fresh one-shot GPS fix → authoritative in-radius scan strictly in sequence, so the cold lock and first network fetch didn't overlap.

## Fix

- **Pill progress state (awareness):** while `active && (locating || stations.isLoading)` the pill shows a `CircularProgressIndicator` + a new `radarSearching` ("Searching…") label, staying tappable so the user can cancel mid-scan; reverts to *Stop radar* once results land.
- **Overlap GPS with the provisional paint (speed):** `runRadar()` kicks `updateFromGps()` concurrently with the corridor-only first paint via a new `_refreshGps()` helper, so the cold lock and the first round-trip overlap and the authoritative scan lands sooner. The last-known position is captured *before* the refresh, so the provisional paint is unchanged.

## Tests

- New `RadarSearchFab` widget test: a run that is initialising renders the spinner + "Searching…", hides *Stop radar* / *Start*, and stays tappable (dismiss flips it back to idle).
- Existing radar provider + FAB tests unchanged and green (the `locating:false` + `AsyncData` active state still shows *Stop radar*).
- `flutter analyze` clean; no-hardcoded-strings + l10n coverage gates green; `radarSearching` fanned out to all 23 locales + pseudo-locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)