### PR TITLE
refactor(vehicle): extract enums + converters out of vehicle_profile (entity half of #3234)

### DIFF
--- a/lib/core/domain/vehicle_enums.dart
+++ b/lib/core/domain/vehicle_enums.dart
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// #3234 — the standalone enums + their enum-only JSON converters extracted
+/// out of `vehicle_profile.dart` so the freezed entity file holds only the
+/// model. Re-exported by `vehicle_profile.dart`, so the ~200 sites that import
+/// these types via the model keep resolving them unchanged.
+
+/// Powertrain type for a stored vehicle.
+enum VehicleType {
+  combustion('combustion'),
+  hybrid('hybrid'),
+  ev('ev');
+
+  final String key;
+  const VehicleType(this.key);
+
+  static VehicleType fromKey(String? value) {
+    if (value == null) return VehicleType.combustion;
+    for (final v in VehicleType.values) {
+      if (v.key == value) return v;
+    }
+    return VehicleType.combustion;
+  }
+}
+
+/// How the per-vehicle baseline calibration (#779) should classify
+/// driving samples (#894).
+///
+/// * [rule] — the original winner-take-all classifier from #768:
+///   every sample is assigned to exactly one [DrivingSituation] and
+///   the Welford accumulator for that situation is bumped by one.
+/// * [fuzzy] — phase 2 from the #773 investigation: every sample
+///   contributes to ALL accumulators proportional to its membership
+///   in each situation. Smoother at borderline speeds (around
+///   60 km/h urban/highway) and at mode transitions, at the cost of
+///   a slightly longer cold-start (each bucket grows more slowly).
+///
+/// Default is [rule] so existing profiles keep their behaviour
+/// without migration.
+enum VehicleCalibrationMode {
+  rule('rule'),
+  fuzzy('fuzzy');
+
+  final String key;
+  const VehicleCalibrationMode(this.key);
+
+  static VehicleCalibrationMode fromKey(String? value) {
+    if (value == null) return VehicleCalibrationMode.rule;
+    for (final m in VehicleCalibrationMode.values) {
+      if (m.key == value) return m;
+    }
+    return VehicleCalibrationMode.rule;
+  }
+}
+
+/// Common EV connector standards used in Europe.
+///
+/// Stored as part of `VehicleProfile.supportedConnectors` so the app can
+/// filter charging stations by compatibility with the user's vehicle.
+enum ConnectorType {
+  type2('type2', 'Type 2'),
+  ccs('ccs', 'CCS'),
+  chademo('chademo', 'CHAdeMO'),
+  tesla('tesla', 'Tesla'),
+  schuko('schuko', 'Schuko'),
+  type1('type1', 'Type 1'),
+  threePin('three_pin', '3-pin');
+
+  final String key;
+  final String label;
+  const ConnectorType(this.key, this.label);
+
+  static ConnectorType? fromKey(String? value) {
+    if (value == null) return null;
+    for (final c in ConnectorType.values) {
+      if (c.key == value) return c;
+    }
+    return null;
+  }
+}
+
+/// Serializes [VehicleType] as its string key.
+class VehicleTypeJsonConverter
+    implements JsonConverter<VehicleType, String> {
+  const VehicleTypeJsonConverter();
+
+  @override
+  VehicleType fromJson(String json) => VehicleType.fromKey(json);
+
+  @override
+  String toJson(VehicleType object) => object.key;
+}
+
+/// Serializes [VehicleCalibrationMode] as its string key. Accepts
+/// `null` / unknown values as [VehicleCalibrationMode.rule] so
+/// pre-#894 profiles (which simply omit the field) deserialize with
+/// the existing rule-based behaviour.
+class VehicleCalibrationModeJsonConverter
+    implements JsonConverter<VehicleCalibrationMode, String?> {
+  const VehicleCalibrationModeJsonConverter();
+
+  @override
+  VehicleCalibrationMode fromJson(String? json) =>
+      VehicleCalibrationMode.fromKey(json);
+
+  @override
+  String toJson(VehicleCalibrationMode object) => object.key;
+}
+
+/// Serializes a `Set<ConnectorType>` as a list of string keys so it
+/// survives Hive's `Map<String, dynamic>` storage.
+class ConnectorTypeSetConverter
+    implements JsonConverter<Set<ConnectorType>, List<dynamic>> {
+  const ConnectorTypeSetConverter();
+
+  @override
+  Set<ConnectorType> fromJson(List<dynamic> json) {
+    final result = <ConnectorType>{};
+    for (final value in json) {
+      final c = ConnectorType.fromKey(value?.toString());
+      if (c != null) result.add(c);
+    }
+    return result;
+  }
+
+  @override
+  List<String> toJson(Set<ConnectorType> object) =>
+      object.map((c) => c.key).toList();
+}

--- a/lib/core/domain/vehicle_profile.dart
+++ b/lib/core/domain/vehicle_profile.dart
@@ -6,83 +6,15 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'gps_calibration_matrix.dart';
 import 'speed_consumption_histogram.dart';
 import 'trip_length_breakdown.dart';
+import 'vehicle_enums.dart';
+
+// #3234 — the powertrain / calibration-mode / connector enums and their
+// enum-only JSON converters moved into vehicle_enums.dart; re-export them so
+// the ~200 sites importing them via this model keep resolving unchanged.
+export 'vehicle_enums.dart';
 
 part 'vehicle_profile.freezed.dart';
 part 'vehicle_profile.g.dart';
-
-/// Powertrain type for a stored vehicle.
-enum VehicleType {
-  combustion('combustion'),
-  hybrid('hybrid'),
-  ev('ev');
-
-  final String key;
-  const VehicleType(this.key);
-
-  static VehicleType fromKey(String? value) {
-    if (value == null) return VehicleType.combustion;
-    for (final v in VehicleType.values) {
-      if (v.key == value) return v;
-    }
-    return VehicleType.combustion;
-  }
-}
-
-/// How the per-vehicle baseline calibration (#779) should classify
-/// driving samples (#894).
-///
-/// * [rule] — the original winner-take-all classifier from #768:
-///   every sample is assigned to exactly one [DrivingSituation] and
-///   the Welford accumulator for that situation is bumped by one.
-/// * [fuzzy] — phase 2 from the #773 investigation: every sample
-///   contributes to ALL accumulators proportional to its membership
-///   in each situation. Smoother at borderline speeds (around
-///   60 km/h urban/highway) and at mode transitions, at the cost of
-///   a slightly longer cold-start (each bucket grows more slowly).
-///
-/// Default is [rule] so existing profiles keep their behaviour
-/// without migration.
-enum VehicleCalibrationMode {
-  rule('rule'),
-  fuzzy('fuzzy');
-
-  final String key;
-  const VehicleCalibrationMode(this.key);
-
-  static VehicleCalibrationMode fromKey(String? value) {
-    if (value == null) return VehicleCalibrationMode.rule;
-    for (final m in VehicleCalibrationMode.values) {
-      if (m.key == value) return m;
-    }
-    return VehicleCalibrationMode.rule;
-  }
-}
-
-/// Common EV connector standards used in Europe.
-///
-/// Stored as part of [VehicleProfile.supportedConnectors] so the app can
-/// filter charging stations by compatibility with the user's vehicle.
-enum ConnectorType {
-  type2('type2', 'Type 2'),
-  ccs('ccs', 'CCS'),
-  chademo('chademo', 'CHAdeMO'),
-  tesla('tesla', 'Tesla'),
-  schuko('schuko', 'Schuko'),
-  type1('type1', 'Type 1'),
-  threePin('three_pin', '3-pin');
-
-  final String key;
-  final String label;
-  const ConnectorType(this.key, this.label);
-
-  static ConnectorType? fromKey(String? value) {
-    if (value == null) return null;
-    for (final c in ConnectorType.values) {
-      if (c.key == value) return c;
-    }
-    return null;
-  }
-}
 
 /// User preferences for how a vehicle should be charged.
 ///
@@ -404,34 +336,6 @@ abstract class VehicleProfile with _$VehicleProfile {
       type == VehicleType.combustion || type == VehicleType.hybrid;
 }
 
-/// Serializes [VehicleType] as its string key.
-class VehicleTypeJsonConverter
-    implements JsonConverter<VehicleType, String> {
-  const VehicleTypeJsonConverter();
-
-  @override
-  VehicleType fromJson(String json) => VehicleType.fromKey(json);
-
-  @override
-  String toJson(VehicleType object) => object.key;
-}
-
-/// Serializes [VehicleCalibrationMode] as its string key. Accepts
-/// `null` / unknown values as [VehicleCalibrationMode.rule] so
-/// pre-#894 profiles (which simply omit the field) deserialize with
-/// the existing rule-based behaviour.
-class VehicleCalibrationModeJsonConverter
-    implements JsonConverter<VehicleCalibrationMode, String?> {
-  const VehicleCalibrationModeJsonConverter();
-
-  @override
-  VehicleCalibrationMode fromJson(String? json) =>
-      VehicleCalibrationMode.fromKey(json);
-
-  @override
-  String toJson(VehicleCalibrationMode object) => object.key;
-}
-
 /// Serializes [ChargingPreferences] as a plain map so json_serializable
 /// does not store the nested object instance directly in the parent's
 /// `toJson` output (which would break round-trips through Hive).
@@ -445,27 +349,6 @@ class ChargingPreferencesJsonConverter
 
   @override
   Map<String, dynamic> toJson(ChargingPreferences object) => object.toJson();
-}
-
-/// Serializes a `Set<ConnectorType>` as a list of string keys so it
-/// survives Hive's `Map<String, dynamic>` storage.
-class ConnectorTypeSetConverter
-    implements JsonConverter<Set<ConnectorType>, List<dynamic>> {
-  const ConnectorTypeSetConverter();
-
-  @override
-  Set<ConnectorType> fromJson(List<dynamic> json) {
-    final result = <ConnectorType>{};
-    for (final value in json) {
-      final c = ConnectorType.fromKey(value?.toString());
-      if (c != null) result.add(c);
-    }
-    return result;
-  }
-
-  @override
-  List<String> toJson(Set<ConnectorType> object) =>
-      object.map((c) => c.key).toList();
 }
 
 /// Adapter-MAC resolution for the hands-free auto-record flow (#1949).

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -929,20 +929,13 @@ void main() {
     // dropped to ~168 content lines (below the cap). Removed from the
     // snapshot per the shrink ratchet; every extracted file is new and
     // under 400.
-    // #2885 — +17: the multiFuelCapable combustion field + its
-    // documentation block (the per-fuel comparison flag, Epic #2881).
-    // #3015 — re-grandfathered 470 → 480: the enginePowerKw field + its
-    // documentation block (catalog-pre-filled rated power, Epic #3015).
-    // #3122 — re-grandfathered 480 → 491: the LWW `updatedAt` stamp field
-    // + its documentation block (last-write-wins edit propagation).
-    // 3 bumps — decomposition forced (#3141), tracked by the OPEN #3234
-    // (vehicle god-files). #3130 — path-only update: moved to the shared
-    // domain kernel (lib/core/domain/), same grandfathered length.
-    'lib/core/domain/vehicle_profile.dart': (
-      lines: 491,
-      bumps: 3,
-      decompositionIssue: 3234,
-    ),
+    // #3234 — vehicle_profile.dart decomposed (491 → 377): the powertrain /
+    // calibration-mode / connector enums and their enum-only JSON converters
+    // moved into vehicle_enums.dart (132, re-exported for backward compat), so
+    // the freezed entity file holds only the model + ChargingPreferences and
+    // drops below the cap. Removed from the snapshot per the shrink ratchet;
+    // vehicle_enums.dart is new and under 400. The sibling edit_vehicle_screen
+    // decomposition stays tracked by the (still-open) #3234.
     // #2837 — re-grandfathered 806 → 817: the η_v calibration card now
     // receives a directFuelRateSupported flag computed from the vehicle's
     // recorded trips (vehicleReportsDirectFuelRate), so the irrelevant VE


### PR DESCRIPTION
Part of #3234 (the **entity** half). Leaves #3234 open for the sibling `edit_vehicle_screen` decomposition.

`vehicle_profile.dart` was a 491-line freezed entity (3 grandfathered `file_length` bumps, decomposition forced by #3141) that also carried the standalone enums + their JSON converters.

## Split

| File | Lines | Holds |
|------|-------|-------|
| `vehicle_enums.dart` | 132 | `VehicleType` / `VehicleCalibrationMode` / `ConnectorType` + their enum-only converters |
| `vehicle_profile.dart` | **491 → 377** | the freezed `VehicleProfile` + `ChargingPreferences` (+ its converter) + auto-record extension + legacy migration |

`vehicle_profile.dart` re-`export`s `vehicle_enums.dart`, so the ~200 sites importing the enums via the model resolve them unchanged — **zero call-site edits**.

## Safety

- Pure relocation: clean `build_runner` produced **no `.g.dart` / `.freezed.dart` drift**.
- JSON round-trip tests (`vehicle_profile_test`, repository, migrator) stay green — the re-exported converters resolve.
- `flutter analyze` clean across all 213 importers.
- Removed `vehicle_profile`'s grandfather entry from the `file_length` snapshot (both files < 400).

## Why not the screen too

`edit_vehicle_screen.dart` (879) is the other #3234 target, but its bulk is ~250 lines of intertwined `ConsumerState` logic (VIN decode, adapter pair/persist, auto-population, calibration overrides) that share ~10 mutable form fields. Getting it under the cap needs *both* a view-widget extraction *and* a logic mixin with a delicate field-ownership split — really a form-state-model redesign, not a mechanical move. That's left for a focused follow-up (tracked on #3234) rather than forced into this PR alongside the clean entity split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)