### PR TITLE
refactor(maps): extract marker-model builder + zoom controls from station_map_layers (#3233)

### DIFF
--- a/lib/features/map/presentation/widgets/map_zoom_controls.dart
+++ b/lib/features/map/presentation/widgets/map_zoom_controls.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'price_legend.dart' show ZoomButton;
+import 'station_map_geometry.dart';
+
+/// #3233 — the top-right zoom / recenter control column extracted out of
+/// [StationMapLayers.build]. A [Positioned] so it drops straight into the map
+/// [Stack]; rendered only when the host enables zoom controls (the driving map
+/// hides it behind its own oversized bottom bar, #3002).
+class MapZoomControls extends StatelessWidget {
+  const MapZoomControls({
+    super.key,
+    required this.mapController,
+    required this.center,
+    required this.zoom,
+    this.showRecenterButton = false,
+    this.onRecenter,
+  });
+
+  final MapController mapController;
+  final LatLng center;
+  final double zoom;
+  final bool showRecenterButton;
+  final VoidCallback? onRecenter;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 16,
+      top: 16,
+      child: Column(
+        children: [
+          ZoomButton(
+            icon: Icons.add,
+            onPressed: () {
+              // #1457 — clamp to [StationMapGeometry.minZoom,
+              // StationMapGeometry.maxZoom]. Without the clamp, a + tap at the
+              // cap silently no-ops AND pushes the camera to a zoom level with
+              // no tiles (the user sees a grey screen and assumes the button is
+              // broken). The clamp turns it into a graceful no-op AT the cap —
+              // the visible feedback is "I'm already at max zoom" instead of
+              // "the button is dead".
+              final z = (mapController.camera.zoom + 1)
+                  .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
+              mapController.move(mapController.camera.center, z);
+            },
+          ),
+          const SizedBox(height: 8),
+          ZoomButton(
+            icon: Icons.remove,
+            onPressed: () {
+              final z = (mapController.camera.zoom - 1)
+                  .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
+              mapController.move(mapController.camera.center, z);
+            },
+          ),
+          if (showRecenterButton) ...[
+            const SizedBox(height: 8),
+            ZoomButton(
+              icon: Icons.my_location,
+              onPressed: onRecenter ?? () => mapController.move(center, zoom),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -1,23 +1,21 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../data/sparkilo_tile_layer.dart';
-import '../../../../core/utils/price_utils.dart';
 import 'station_map_geometry.dart';
 import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
 import '../../../search/presentation/widgets/sort_selector.dart';
+import 'map_zoom_controls.dart';
 import 'price_legend.dart';
 import 'station_cluster_layers.dart';
 import 'station_marker.dart';
+import 'station_marker_model_builder.dart';
 
 /// Camera zoom bounds (#1457). Top end matches the OSM tile cap so a
 /// `move(camera.zoom + 1)` past the cap doesn't park the user on a
@@ -225,81 +223,26 @@ class _StationMapLayersState extends State<StationMapLayers> {
       StationMapGeometry.boundsForRadius(widget.center, widget.searchRadiusKm);
 
   /// Recompute the memoised price range + marker list from the current
-  /// widget inputs.
+  /// widget inputs. #3233 — the pricing / emphasis / ordering / build pipeline
+  /// is the pure [StationMarkerModelBuilder]; this only latches its result.
   void _recomputeMarkers() {
-    // #2510 — colour by the SELECTED-fuel price (the same strict
-    // resolution the list uses), not a fallback chain. A station without
-    // the selected fuel paints grey ("--") instead of being re-coloured
-    // by E10's price. #2631 — when a cross-border resolver is set, each
-    // station's price is taken for ITS country fuel, so the colour range
-    // is computed over those resolved prices to keep colour ↔ price aligned.
-    final resolver = widget.fuelResolver;
-    _priceRange = resolver == null
-        ? priceRange(widget.stations, widget.selectedFuel)
-        : resolvedPriceRangeWith(widget.stations, resolver);
-    final ids = widget.selectedStationIds;
-    final hasSelection = ids != null && ids.isNotEmpty;
-
-    // #2510 — emphasis: the top-ranked stations per the active sort
-    // (cheapest for a price sort, closest otherwise) keep the full price
-    // bubble; the rest render as compact price-band dots so a bounded
-    // result set stays fully visible without the bubbles overlapping into
-    // an illegible pile. The set is small, so a Set lookup is cheap.
-    final emphasized = StationMapGeometry.rankForEmphasis(
-      widget.stations,
-      widget.selectedFuel,
+    final model = StationMarkerModelBuilder.build(
+      context: context,
+      stations: widget.stations,
+      selectedFuel: widget.selectedFuel,
+      selectedStationIds: widget.selectedStationIds,
       byPrice: widget.sortMode == SortMode.price ||
           widget.sortMode == SortMode.priceDistance,
-    ).take(StationMapGeometry.emphasisCount).map((s) => s.id).toSet();
-
-    // #2434 — order so the cheapest (green) marker paints ON TOP of the
-    // more-expensive ones it overlaps. The marker layer paints in
-    // source-list order (later = on top), so we sort price-descending:
-    // expensive at the bottom, cheapest last/on top, price-less markers
-    // beneath everything. Same price the marker is coloured by.
-    final ordered = StationMapGeometry.orderedByPriceForPainting(
-      widget.stations,
-      widget.selectedFuel,
-      fuelResolver: resolver,
+      clusterAlways: widget.clusterAlways,
+      fuelResolver: widget.fuelResolver,
+      onStationTap: widget.onStationTap,
+      markerVariant: widget.markerVariant,
     );
-
-    // #2939 — in clusterAlways mode the clustering de-overlaps the pane, so a
-    // SINGLETON keeps its full price pill (never a dot); only clustered members
-    // roll up into the cheapest-price badge. The emphasis-dot scheme stays for
-    // the legacy non-clustered surfaces.
-    // #2974 — a marker tap that selects its list row also fires a selection
-    // tick (selectionClick only). Null on the default push-to-detail map → no
-    // haptic; the route push owns its own feedback.
-    final onTap = widget.onStationTap == null
-        ? null
-        : (String id) {
-            unawaited(HapticFeedback.selectionClick());
-            widget.onStationTap!(id);
-          };
-    _markerMeta.clear();
-    _markers = ordered.map((station) {
-      final isPastel = hasSelection && !ids.contains(station.id);
-      final isSelected = hasSelection && ids.contains(station.id);
-      final marker = StationMarkerBuilder.build(
-        context,
-        station,
-        widget.selectedFuel,
-        _priceRange.$1,
-        _priceRange.$2,
-        pastel: isPastel,
-        compact: !widget.clusterAlways && !emphasized.contains(station.id),
-        selected: isSelected,
-        onTap: onTap == null ? null : () => onTap(station.id),
-        fuelResolver: resolver,
-        variant: widget.markerVariant,
-      );
-      _markerMeta[marker] = (
-        id: station.id,
-        price: priceForFuelType(
-            station, resolver != null ? resolver(station) : widget.selectedFuel),
-      );
-      return marker;
-    }).toList();
+    _markers = model.markers;
+    _priceRange = model.priceRange;
+    _markerMeta
+      ..clear()
+      ..addAll(model.meta);
   }
 
   @override
@@ -508,49 +451,12 @@ class _StationMapLayersState extends State<StationMapLayers> {
         // Zoom controls — #3002: hidden on the driving map, which has its own
         // oversized bottom bar.
         if (widget.showZoomControls)
-          Positioned(
-            right: 16,
-            top: 16,
-            child: Column(
-              children: [
-                ZoomButton(
-                  icon: Icons.add,
-                  onPressed: () {
-                    // #1457 — clamp to [StationMapGeometry.minZoom, StationMapGeometry.maxZoom]. Without
-                    // the clamp, a + tap at the cap silently no-ops AND
-                    // pushes the camera to a zoom level with no tiles
-                    // (the user sees a grey screen and assumes the button
-                    // is broken). The clamp turns it into a graceful
-                    // no-op AT the cap — the visible feedback is "I'm
-                    // already at max zoom" instead of "the button is
-                    // dead".
-                    final z = (widget.mapController.camera.zoom + 1)
-                        .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
-                    widget.mapController
-                        .move(widget.mapController.camera.center, z);
-                  },
-                ),
-                const SizedBox(height: 8),
-                ZoomButton(
-                  icon: Icons.remove,
-                  onPressed: () {
-                    final z = (widget.mapController.camera.zoom - 1)
-                        .clamp(StationMapGeometry.minZoom, StationMapGeometry.maxZoom);
-                    widget.mapController
-                        .move(widget.mapController.camera.center, z);
-                  },
-                ),
-                if (widget.showRecenterButton) ...[
-                  const SizedBox(height: 8),
-                  ZoomButton(
-                    icon: Icons.my_location,
-                    onPressed: widget.onRecenter ??
-                        () => widget.mapController
-                            .move(widget.center, widget.zoom),
-                  ),
-                ],
-              ],
-            ),
+          MapZoomControls(
+            mapController: widget.mapController,
+            center: widget.center,
+            zoom: widget.zoom,
+            showRecenterButton: widget.showRecenterButton,
+            onRecenter: widget.onRecenter,
           ),
         // Price legend — #3002: hidden on the driving map so it never sits
         // under the oversized driving bottom bar.

--- a/lib/features/map/presentation/widgets/station_marker_model_builder.dart
+++ b/lib/features/map/presentation/widgets/station_marker_model_builder.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import '../../../../core/domain/fuel_type.dart';
+import '../../../../core/domain/station.dart';
+import '../../../../core/utils/price_utils.dart';
+import 'station_cluster_layers.dart';
+import 'station_map_geometry.dart';
+import 'station_marker.dart';
+
+/// The memoised marker model [StationMapLayers] paints: the ordered [Marker]
+/// list, the per-marker [MarkerMeta] (price + station id, keyed by marker
+/// identity so the cluster badge can roll up to the cheapest member), and the
+/// selected-fuel price range the colour scale uses.
+typedef StationMarkerModel = ({
+  List<Marker> markers,
+  Map<Marker, MarkerMeta> meta,
+  (double, double) priceRange,
+});
+
+/// #3233 — the pure marker-model builder extracted out of
+/// `_StationMapLayersState._recomputeMarkers`, so the widget memoises by
+/// calling this instead of carrying the ~70-line price/emphasis/order/build
+/// pipeline inline. No widget state, no side effects: same inputs → same model.
+class StationMarkerModelBuilder {
+  const StationMarkerModelBuilder._();
+
+  /// Compute the [StationMarkerModel] from the current map inputs.
+  ///
+  /// Mirrors the list's strict per-fuel pricing: a station without the
+  /// selected fuel paints grey ("--") rather than being re-coloured by a
+  /// fallback fuel (#2510); when a cross-border [fuelResolver] is set each
+  /// station is priced for ITS country fuel and the colour range is computed
+  /// over those resolved prices (#2631).
+  static StationMarkerModel build({
+    required BuildContext context,
+    required List<Station> stations,
+    required FuelType selectedFuel,
+    required Set<String>? selectedStationIds,
+    required bool byPrice,
+    required bool clusterAlways,
+    required FuelType Function(Station)? fuelResolver,
+    required void Function(String stationId)? onStationTap,
+    required StationMarkerVariant markerVariant,
+  }) {
+    final resolver = fuelResolver;
+    final priceRangeValue = resolver == null
+        ? priceRange(stations, selectedFuel)
+        : resolvedPriceRangeWith(stations, resolver);
+    final ids = selectedStationIds;
+    final hasSelection = ids != null && ids.isNotEmpty;
+
+    // #2510 — emphasis: the top-ranked stations per the active sort (cheapest
+    // for a price sort, closest otherwise) keep the full price bubble; the rest
+    // render as compact price-band dots so a bounded result set stays fully
+    // visible without the bubbles overlapping into an illegible pile. The set
+    // is small, so a Set lookup is cheap.
+    final emphasized = StationMapGeometry.rankForEmphasis(
+      stations,
+      selectedFuel,
+      byPrice: byPrice,
+    ).take(StationMapGeometry.emphasisCount).map((s) => s.id).toSet();
+
+    // #2434 — order so the cheapest (green) marker paints ON TOP of the
+    // more-expensive ones it overlaps. The marker layer paints in source-list
+    // order (later = on top), so we sort price-descending: expensive at the
+    // bottom, cheapest last/on top, price-less markers beneath everything.
+    final ordered = StationMapGeometry.orderedByPriceForPainting(
+      stations,
+      selectedFuel,
+      fuelResolver: resolver,
+    );
+
+    // #2974 — a marker tap that selects its list row also fires a selection
+    // tick (selectionClick only). Null on the default push-to-detail map → no
+    // haptic; the route push owns its own feedback.
+    final onTap = onStationTap == null
+        ? null
+        : (String id) {
+            unawaited(HapticFeedback.selectionClick());
+            onStationTap(id);
+          };
+
+    final meta = <Marker, MarkerMeta>{};
+    final markers = ordered.map((station) {
+      final isPastel = hasSelection && !ids.contains(station.id);
+      final isSelected = hasSelection && ids.contains(station.id);
+      final marker = StationMarkerBuilder.build(
+        context,
+        station,
+        selectedFuel,
+        priceRangeValue.$1,
+        priceRangeValue.$2,
+        pastel: isPastel,
+        // #2939 — in clusterAlways mode the clustering de-overlaps the pane, so
+        // a SINGLETON keeps its full price pill (never a dot); only clustered
+        // members roll up. The emphasis-dot scheme stays for non-clustered
+        // surfaces.
+        compact: !clusterAlways && !emphasized.contains(station.id),
+        selected: isSelected,
+        onTap: onTap == null ? null : () => onTap(station.id),
+        fuelResolver: resolver,
+        variant: markerVariant,
+      );
+      meta[marker] = (
+        id: station.id,
+        price: priceForFuelType(
+            station, resolver != null ? resolver(station) : selectedFuel),
+      );
+      return marker;
+    }).toList();
+
+    return (markers: markers, meta: meta, priceRange: priceRangeValue);
+  }
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -900,10 +900,16 @@ void main() {
     // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3233.
     // #3233 — ratcheted DOWN 700 → 565: the pure geometry + marker-ranking
     // statics (zoom/bounds/centroid + orderedByPriceForPainting/rankForEmphasis
-    // + their consts) were extracted to `station_map_geometry.dart`. First
-    // slice; the in-widget marker BUILDER (`_recomputeMarkers`) is the next.
+    // + their consts) were extracted to `station_map_geometry.dart`.
+    // #3233 — ratcheted DOWN 565 → 472: the marker-model builder
+    // (`_recomputeMarkers`'s price/emphasis/order/build pipeline →
+    // `station_marker_model_builder.dart`, the pure `StationMarkerModelBuilder`)
+    // and the top-right zoom/recenter control column (→ `map_zoom_controls.dart`,
+    // `MapZoomControls`). The remaining FlutterMap children tree is coupled to
+    // the memoised `_markers`/`_markerMeta`/`_priceRange` state, so the final
+    // slice is a stateful sub-view extraction; #3233 stays referenced for it.
     'lib/features/map/presentation/widgets/station_map_layers.dart': (
-      lines: 565,
+      lines: 472,
       bumps: 8,
       decompositionIssue: 3233,
     ),


### PR DESCRIPTION
Second decomposition slice for #3233 (after #3289's geometry extraction took it 700 → 565). Ratchets `station_map_layers.dart` further down; the issue stays open for the final stateful sub-view slice.

## Extracted

| File | Holds |
|------|-------|
| `station_marker_model_builder.dart` (`StationMarkerModelBuilder`) | the pure price/emphasis/order/build pipeline that was `_recomputeMarkers`'s ~70-line body — same inputs → same `(markers, meta, priceRange)` record; the State just latches the result |
| `map_zoom_controls.dart` (`MapZoomControls`) | the top-right zoom/recenter control column, a `Positioned` that drops into the map `Stack` |

`station_map_layers.dart` **565 → 472**.

## Notes

- The builder takes a plain `bool byPrice` (not `SortMode`) so it doesn't reach into the `search` feature — keeps the `map → search` import count at its baseline (the `feature_boundary` gate enforces this; same pattern as `StationMapGeometry.rankForEmphasis`).
- The remaining `FlutterMap` children tree is coupled to the memoised `_markers` / `_markerMeta` / `_priceRange` state, so the final slice is a stateful sub-view extraction — left for a focused follow-up on #3233.
- Pure relocation: `flutter analyze` clean; the full map test suite (208 tests, incl. the `markerMetaForTesting` cluster + cross-border price assertions) and all 57 lint tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)