### PR TITLE
refactor(core): decompose country_config — country-definition rows out of the registry (#3296)

### DIFF
--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -3,6 +3,8 @@
 
 import '../domain/fuel_type.dart';
 import 'country_bounding_box.dart';
+import 'country_config_data_core.dart';
+import 'country_config_data_extended.dart';
 
 /// Configuration for each supported country.
 /// Determines which services, fuel types, postal code formats,
@@ -70,7 +72,7 @@ class CountryConfig {
     required this.name,
     required this.flag,
     this.currency = 'EUR',
-    this.currencySymbol = '\u20ac',
+    this.currencySymbol = '€',
     required this.locale,
     required this.postalCodeLength,
     required this.postalCodeRegex,
@@ -90,7 +92,7 @@ class CountryConfig {
     this.exampleCity = '',
     this.distanceUnit = 'km',
     this.volumeUnit = 'L',
-    this.pricePerUnitSuffix = '\u20ac/L',
+    this.pricePerUnitSuffix = '€/L',
     this.pricePerUnitSuffixByFuel = const {},
     this.verified = true,
   });
@@ -104,508 +106,36 @@ class CountryConfig {
       pricePerUnitSuffix;
 }
 
+/// Registry of all supported countries + the station-id / locale / bbox
+/// lookups over them.
+///
+/// #3296 — the per-country [CountryConfig] data rows were extracted into
+/// `country_config_data_core.dart` (the original pre-v4.1.0 set) and
+/// `country_config_data_extended.dart` (v4.1.0+). Each `Countries.<name>`
+/// below is a `static const` alias of the matching `k<Name>` data const, so
+/// every call site (`Countries.germany`, …) is unchanged; this class keeps the
+/// `all` / `verified` / `byCode` / `fromLocale` / station-id resolution.
 class Countries {
   Countries._();
 
-  static const germany = CountryConfig(
-    code: 'DE',
-    name: 'Deutschland',
-    flag: '\u{1F1E9}\u{1F1EA}',
-    locale: 'de_DE',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'PLZ',
-    requiresApiKey: true,
-    apiKeyRegistrationUrl: 'https://onboarding.tankerkoenig.de/',
-    apiProvider: 'Tankerkönig',
-    attribution: 'Daten von Tankerkoenig.de (CC BY 4.0)',
-    fuelTypes: ['Super E5', 'Super E10', 'Diesel'],
-    examplePostalCode: '10115',
-    exampleCity: 'Berlin',
-  );
-
-  static const france = CountryConfig(
-    code: 'FR',
-    name: 'France',
-    flag: '\u{1F1EB}\u{1F1F7}',
-    locale: 'fr_FR',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'Code postal',
-    requiresApiKey: false,
-    apiProvider: 'Prix-Carburants (gouv.fr)',
-    attribution: 'Données: prix-carburants.gouv.fr',
-    fuelTypes: ['SP95', 'SP98', 'E10', 'Gazole', 'E85', 'GPLc'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e10,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.e85,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '75001',
-    exampleCity: 'Lyon',
-  );
-
-  static const austria = CountryConfig(
-    code: 'AT',
-    name: 'Österreich',
-    flag: '\u{1F1E6}\u{1F1F9}',
-    locale: 'de_AT',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'PLZ',
-    requiresApiKey: false,
-    apiProvider: 'E-Control Spritpreisrechner',
-    attribution: 'Daten von E-Control (spritpreisrechner.at)',
-    fuelTypes: ['Super 95', 'Diesel'],
-    // #3198 — E-Control publishes exactly one petrol grade (SUP); the old
-    // default set advertised an E10 the feed never carries (the service
-    // mirrored e5 into e10 to fill it). Catalog now matches the source.
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.diesel,
-      FuelType.electric,
-    },
-    examplePostalCode: '1010',
-    exampleCity: 'Wien',
-  );
-
-  static const spain = CountryConfig(
-    code: 'ES',
-    name: 'España',
-    flag: '\u{1F1EA}\u{1F1F8}',
-    locale: 'es_ES',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'Código postal',
-    requiresApiKey: false,
-    apiProvider: 'Geoportal Gasolineras (MITECO)',
-    attribution: 'Datos: geoportalgasolineras.es',
-    fuelTypes: ['Gasolina 95', 'Gasolina 98', 'Gasóleo A', 'GLP'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e10,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.dieselPremium,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '28001',
-    exampleCity: 'Madrid',
-  );
-
-  static const italy = CountryConfig(
-    code: 'IT',
-    name: 'Italia',
-    flag: '\u{1F1EE}\u{1F1F9}',
-    locale: 'it_IT',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'CAP',
-    requiresApiKey: false,
-    apiProvider: 'Osservaprezzi (MISE)',
-    attribution: 'Dati: osservaprezzi.mise.gov.it',
-    fuelTypes: ['Benzina', 'Gasolio', 'GPL', 'Metano'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.cng,
-      FuelType.electric,
-    },
-    examplePostalCode: '00100',
-    exampleCity: 'Roma',
-  );
-
-  static const denmark = CountryConfig(
-    code: 'DK',
-    name: 'Danmark',
-    flag: '\u{1F1E9}\u{1F1F0}',
-    currency: 'DKK',
-    currencySymbol: 'kr',
-    locale: 'da_DK',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'Postnummer',
-    requiresApiKey: false,
-    apiProvider: 'OK / Shell / Q8',
-    attribution: 'Data: ok.dk, shell.dk, q8.dk',
-    fuelTypes: ['Blyfri 95', 'Oktan 100', 'Diesel', 'V-Power Diesel'],
-    // #3198 — the single Danish 95-octane grade is e5 only (the #2180
-    // e5→e10 mirror asserted an E10 price no DK feed publishes); the
-    // #3187 exact-grade mapping added the real premium grades instead:
-    // Oktan 100 / V-Power → e98, V-Power Diesel → dieselPremium.
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.dieselPremium,
-      FuelType.electric,
-    },
-    examplePostalCode: '1000',
-    exampleCity: 'København',
-    pricePerUnitSuffix: 'kr/L',
-  );
-
-  static const argentina = CountryConfig(
-    code: 'AR',
-    name: 'Argentina',
-    flag: '\u{1F1E6}\u{1F1F7}',
-    currency: 'ARS',
-    currencySymbol: '\$',
-    locale: 'es_AR',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'Código postal',
-    requiresApiKey: false,
-    apiProvider: 'Secretaría de Energía',
-    attribution: 'Datos: datos.energia.gob.ar',
-    fuelTypes: ['Nafta', 'Gas Oil', 'GNC'],
-    // #2180/#3198 — aligned to what ArgentinaStationService actually
-    // emits: Nafta súper → e5 (no e10 — the old mirror asserted an E10
-    // price the feed never publishes), Nafta premium → e98, Gas oil →
-    // diesel, Gas oil premium → dieselPremium, GNC → cng (see
-    // classifyArgentinaProduct and the service's Station mapping).
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.dieselPremium,
-      FuelType.cng,
-      FuelType.electric,
-    },
-    examplePostalCode: '1000',
-    exampleCity: 'Buenos Aires',
-    pricePerUnitSuffix: '\$/L',
-    // #3198 — GNC (CNG) is priced per cubic metre upstream, not per
-    // litre; the per-fuel override keeps every other fuel on \$/L.
-    pricePerUnitSuffixByFuel: {FuelType.cng: '\$/m\u00b3'},
-  );
-
-  // ── New countries (v4.1.0) ──
-
-  static const portugal = CountryConfig(
-    code: 'PT',
-    name: 'Portugal',
-    flag: '\u{1F1F5}\u{1F1F9}',
-    locale: 'pt_PT',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}(-\d{3})?$',
-    postalCodeLabel: 'Código postal',
-    apiProvider: 'DGEG',
-    attribution: 'Dados: DGEG (dgeg.gov.pt)',
-    fuelTypes: ['Gasolina 95', 'Gasolina 98', 'Gasóleo', 'GPL Auto'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '1000',
-    exampleCity: 'Lisboa',
-  );
-
-  static const unitedKingdom = CountryConfig(
-    code: 'GB',
-    name: 'United Kingdom',
-    flag: '\u{1F1EC}\u{1F1E7}',
-    currency: 'GBP',
-    currencySymbol: '\u00a3',
-    locale: 'en_GB',
-    postalCodeLength: 7,
-    postalCodeRegex: r'^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$',
-    postalCodeLabel: 'Postcode',
-    apiProvider: 'CMA Fuel Finder',
-    attribution: 'Data: Competition and Markets Authority',
-    fuelTypes: ['Unleaded', 'Super Unleaded', 'E10', 'Diesel'],
-    // #2180 — UkStationService parses the CMA feed into e5 (E5/unleaded),
-    // e10 (E10), e98 (super_unleaded), diesel (B7/diesel). It never emits
-    // dieselPremium, so drop it and add e10 to match the live selector.
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e10,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.electric,
-    },
-    examplePostalCode: 'SW1A 1AA',
-    exampleCity: 'London',
-    // UK road signs and speedometers use miles; fuel is still sold by
-    // the litre so volume stays 'L'. Price convention is pence-per-
-    // litre ("p/L") on forecourt signage.
-    distanceUnit: 'mi',
-    pricePerUnitSuffix: 'p/L',
-  );
-
-  static const australia = CountryConfig(
-    code: 'AU',
-    name: 'Australia',
-    flag: '\u{1F1E6}\u{1F1FA}',
-    currency: 'AUD',
-    currencySymbol: '\u0024',
-    locale: 'en_AU',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'Postcode',
-    apiProvider: 'FuelCheck NSW',
-    attribution: 'Data: NSW Government FuelCheck',
-    fuelTypes: ['Unleaded 91', 'Unleaded 95', 'Unleaded 98', 'Diesel', 'LPG'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e10,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '2000',
-    exampleCity: 'Sydney',
-    // AU forecourts quote cents-per-litre on signage.
-    pricePerUnitSuffix: 'c/L',
-    // #2264 — AustraliaStationService is a documented stub that throws on
-    // every search (the legacy FuelCheckApp/v2 endpoint is retired and the
-    // replacement needs OAuth2 we don't ship; tracked in #804). Advertising
-    // it as verified put a country in the picker that can only ever error,
-    // so gate it out until #804 lands a working endpoint. The entry stays
-    // *registered* — an `au-` station id still resolves — it is only hidden
-    // from the user-facing pickers via [Countries.verified].
-    verified: false,
-  );
-
-  static const slovenia = CountryConfig(
-    code: 'SI',
-    name: 'Slovenija',
-    flag: '\u{1F1F8}\u{1F1EE}',
-    locale: 'sl_SI',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'Poštna številka',
-    requiresApiKey: false,
-    apiProvider: 'goriva.si (gov.si)',
-    attribution: 'Podatki: goriva.si / Ministrstvo za gospodarstvo',
-    fuelTypes: ['NMB-95', 'NMB-100', 'Dizel', 'Dizel Premium', 'LPG'],
-    // #3198 — the single NMB-95 grade is e5 only (the old e5→e10 mirror
-    // asserted an E10 price goriva.si never publishes).
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.dieselPremium,
-      FuelType.lpg,
-      FuelType.cng,
-      FuelType.electric,
-    },
-    examplePostalCode: '1000',
-    exampleCity: 'Ljubljana',
-  );
-
-  static const mexico = CountryConfig(
-    code: 'MX',
-    name: 'México',
-    flag: '\u{1F1F2}\u{1F1FD}',
-    currency: 'MXN',
-    currencySymbol: '\u0024',
-    locale: 'es_MX',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'Código postal',
-    apiProvider: 'CRE / datos.gob.mx',
-    attribution: 'Datos: Comisión Reguladora de Energía',
-    fuelTypes: ['Regular', 'Premium', 'Diesel'],
-    // #2704 — MexicoStationService maps CRE regular→e5, premium→e98 (MX's
-    // high-octane 91–92 grade, NOT the European e10 ethanol blend, absent in
-    // MX), diesel→diesel. The picker must offer e98 (not e10) to match the
-    // data the search selector surfaces.
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.electric,
-    },
-    examplePostalCode: '06600',
-    exampleCity: 'Ciudad de México',
-    pricePerUnitSuffix: '\$/L',
-  );
-
-  /// Luxembourg has government-regulated fuel prices — uniform nationally
-  /// by ministerial arrêté, with no station-level variance. See
-  /// `LuxembourgStationService` for the uniform-price model.
-  static const luxembourg = CountryConfig(
-    code: 'LU',
-    name: 'Luxembourg',
-    flag: '\u{1F1F1}\u{1F1FA}',
-    locale: 'fr_LU',
-    postalCodeLength: 4,
-    postalCodeRegex: r'^\d{4}$',
-    postalCodeLabel: 'Code postal',
-    apiProvider: 'Ministère de l\'Économie (LU)',
-    attribution: 'Prix réglementés — gouvernement.lu',
-    fuelTypes: ['Sans Plomb 95', 'Sans Plomb 98', 'Diesel', 'LPG'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e10,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '1009',
-    exampleCity: 'Luxembourg',
-  );
-
-  /// South Korea — OPINET (Korea National Oil Corporation) REST API
-  /// (#597). ~14 000 stations nationwide; gasoline, premium gasoline,
-  /// diesel, LPG (kerosene published but unmapped until we add a
-  /// FuelType enum for it). Prices are in KRW per litre (integer).
-  static const southKorea = CountryConfig(
-    code: 'KR',
-    name: '대한민국',
-    flag: '\u{1F1F0}\u{1F1F7}',
-    currency: 'KRW',
-    currencySymbol: '₩',
-    locale: 'ko_KR',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: '우편번호',
-    requiresApiKey: true,
-    apiKeyRegistrationUrl: 'https://www.opinet.co.kr/',
-    apiProvider: 'OPINET (KNOC)',
-    attribution: 'Data: OPINET / Korea National Oil Corporation',
-    fuelTypes: ['휘발유', '고급휘발유', '경유', 'LPG'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '04524',
-    exampleCity: '서울',
-    pricePerUnitSuffix: '₩/L',
-    // #1828 — OPINET endpoint path is a best guess, unverified
-    // against the live portal (#1823). Hidden from the picker.
-    verified: false,
-  );
-
-  /// Chile — CNE "Bencina en Línea" REST API (#596). ~6 000 service
-  /// stations nationwide. Gasolina 93/95 (→ e5), Gasolina 97 (→ e98),
-  /// Diésel, Gas licuado/LPG. Kerosene is published but unmapped until
-  /// we add a FuelType enum for it. Prices are in CLP per litre.
-  static const chile = CountryConfig(
-    code: 'CL',
-    name: 'Chile',
-    flag: '\u{1F1E8}\u{1F1F1}',
-    currency: 'CLP',
-    currencySymbol: '\$',
-    locale: 'es_CL',
-    postalCodeLength: 7,
-    // Chilean postal codes are 7 digits (RUT-style "1234567"). The
-    // regex is lenient enough to accept the common "123-4567" form as
-    // well — both variants appear on government records.
-    postalCodeRegex: r'^\d{7}$',
-    postalCodeLabel: 'Código postal',
-    requiresApiKey: true,
-    apiKeyRegistrationUrl: 'https://apidocs.cne.cl/', // #3200 docs portal
-    apiProvider: 'CNE Bencina en Linea',
-    attribution: 'Datos: Comisión Nacional de Energía (cne.cl)',
-    fuelTypes: ['Gasolina 93', 'Gasolina 95', 'Gasolina 97', 'Diésel', 'GLP'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '8320000',
-    exampleCity: 'Santiago',
-    pricePerUnitSuffix: '\$/L',
-    // #3200 — path + Bearer auth match apidocs.cne.cl; hidden until a
-    // registered token confirms the payload shape end-to-end.
-    verified: false,
-  );
-
-  /// Greece — Paratiritirio Timon (Fuel Price Observatory) via the
-  /// community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
-  /// API (#576). The community feed is free and open — no key required.
-  /// Coverage is prefecture-level (not station-level): we synthesize one
-  /// virtual station per major prefecture, each showing that region's
-  /// daily mean price. Fuels: Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98),
-  /// Diesel (→ diesel), Υγραέριο / LPG (→ lpg). Diesel heating is
-  /// published but dropped — not a motoring fuel.
-  static const greece = CountryConfig(
-    code: 'GR',
-    name: 'Ελλάδα',
-    flag: '\u{1F1EC}\u{1F1F7}',
-    locale: 'el_GR',
-    postalCodeLength: 5,
-    postalCodeRegex: r'^\d{5}$',
-    postalCodeLabel: 'Ταχυδρομικός κώδικας',
-    requiresApiKey: false,
-    apiProvider: 'Paratiritirio Timon',
-    attribution:
-        'Data: fuelprices.gr (Paratiritirio Timon) via fuelpricesgr community API',
-    fuelTypes: ['Αμόλυβδη 95', 'Αμόλυβδη 100', 'Diesel', 'LPG'],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '10431',
-    exampleCity: 'Αθήνα',
-    // #3194 — default host is NXDOMAIN; the service short-circuits to
-    // "unavailable" unless self-hosted. Hidden until a real source exists.
-    verified: false,
-  );
-
-  /// Romania — *Monitorul Prețurilor*, the Competition Council's
-  /// official observatory at monitorulpreturilor.info (#577; #3193
-  /// rebased off the dead third-party pretcarburant.ro). ~1 500
-  /// stations, public feed, no key. Fuels (catalog ids): Benzină
-  /// standard 11 (→ e5), premium 12 (→ e98), Motorină standard 21
-  /// (→ diesel), premium 22 (→ diesel premium), GPL 31 (→ lpg).
-  static const romania = CountryConfig(
-    code: 'RO',
-    name: 'România',
-    flag: '\u{1F1F7}\u{1F1F4}',
-    currency: 'RON',
-    currencySymbol: 'lei',
-    locale: 'ro_RO',
-    postalCodeLength: 6,
-    postalCodeRegex: r'^\d{6}$',
-    postalCodeLabel: 'Cod poștal',
-    requiresApiKey: false,
-    apiProvider: 'Monitorul Prețurilor',
-    attribution:
-        'Date: Consiliul Concurenței — monitorulpreturilor.info',
-    fuelTypes: [
-      'Benzină Standard',
-      'Benzină Premium',
-      'Motorină Standard',
-      'Motorină Premium',
-      'GPL',
-    ],
-    supportedFuelTypes: {
-      FuelType.e5,
-      FuelType.e98,
-      FuelType.diesel,
-      FuelType.dieselPremium,
-      FuelType.lpg,
-      FuelType.electric,
-    },
-    examplePostalCode: '010101',
-    exampleCity: 'București',
-    pricePerUnitSuffix: 'lei/L',
-    // #3193 — rebased onto the real monitorulpreturilor.info backend;
-    // hidden until the maintainer field-verifies, then flip to true.
-    verified: false,
-  );
+  static const germany = kGermany;
+  static const france = kFrance;
+  static const austria = kAustria;
+  static const spain = kSpain;
+  static const italy = kItaly;
+  static const denmark = kDenmark;
+  static const argentina = kArgentina;
+  // New countries (v4.1.0+).
+  static const portugal = kPortugal;
+  static const unitedKingdom = kUnitedKingdom;
+  static const australia = kAustralia;
+  static const slovenia = kSlovenia;
+  static const mexico = kMexico;
+  static const luxembourg = kLuxembourg;
+  static const southKorea = kSouthKorea;
+  static const chile = kChile;
+  static const greece = kGreece;
+  static const romania = kRomania;
 
   /// All registered countries, ordered for display.
   ///

--- a/lib/core/country/country_config_data_core.dart
+++ b/lib/core/country/country_config_data_core.dart
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/fuel_type.dart';
+import 'country_config.dart';
+
+/// #3296 — the original (pre-v4.1.0) country-definition rows extracted out of
+/// `Countries`. `Countries.<name>` stays as a `static const` alias of the
+/// matching `k<Name>` here, so every call site is unchanged. The v4.1.0+
+/// additions live in `country_config_data_extended.dart`.
+
+const kGermany = CountryConfig(
+  code: 'DE',
+  name: 'Deutschland',
+  flag: '\u{1F1E9}\u{1F1EA}',
+  locale: 'de_DE',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: true,
+  apiKeyRegistrationUrl: 'https://onboarding.tankerkoenig.de/',
+  apiProvider: 'Tankerkönig',
+  attribution: 'Daten von Tankerkoenig.de (CC BY 4.0)',
+  fuelTypes: ['Super E5', 'Super E10', 'Diesel'],
+  examplePostalCode: '10115',
+  exampleCity: 'Berlin',
+);
+
+const kFrance = CountryConfig(
+  code: 'FR',
+  name: 'France',
+  flag: '\u{1F1EB}\u{1F1F7}',
+  locale: 'fr_FR',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Code postal',
+  requiresApiKey: false,
+  apiProvider: 'Prix-Carburants (gouv.fr)',
+  attribution: 'Données: prix-carburants.gouv.fr',
+  fuelTypes: ['SP95', 'SP98', 'E10', 'Gazole', 'E85', 'GPLc'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.e85,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '75001',
+  exampleCity: 'Lyon',
+);
+
+const kAustria = CountryConfig(
+  code: 'AT',
+  name: 'Österreich',
+  flag: '\u{1F1E6}\u{1F1F9}',
+  locale: 'de_AT',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'PLZ',
+  requiresApiKey: false,
+  apiProvider: 'E-Control Spritpreisrechner',
+  attribution: 'Daten von E-Control (spritpreisrechner.at)',
+  fuelTypes: ['Super 95', 'Diesel'],
+  // #3198 — E-Control publishes exactly one petrol grade (SUP); the old
+  // default set advertised an E10 the feed never carries (the service
+  // mirrored e5 into e10 to fill it). Catalog now matches the source.
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.diesel,
+    FuelType.electric,
+  },
+  examplePostalCode: '1010',
+  exampleCity: 'Wien',
+);
+
+const kSpain = CountryConfig(
+  code: 'ES',
+  name: 'España',
+  flag: '\u{1F1EA}\u{1F1F8}',
+  locale: 'es_ES',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Código postal',
+  requiresApiKey: false,
+  apiProvider: 'Geoportal Gasolineras (MITECO)',
+  attribution: 'Datos: geoportalgasolineras.es',
+  fuelTypes: ['Gasolina 95', 'Gasolina 98', 'Gasóleo A', 'GLP'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.dieselPremium,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '28001',
+  exampleCity: 'Madrid',
+);
+
+const kItaly = CountryConfig(
+  code: 'IT',
+  name: 'Italia',
+  flag: '\u{1F1EE}\u{1F1F9}',
+  locale: 'it_IT',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'CAP',
+  requiresApiKey: false,
+  apiProvider: 'Osservaprezzi (MISE)',
+  attribution: 'Dati: osservaprezzi.mise.gov.it',
+  fuelTypes: ['Benzina', 'Gasolio', 'GPL', 'Metano'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.cng,
+    FuelType.electric,
+  },
+  examplePostalCode: '00100',
+  exampleCity: 'Roma',
+);
+
+const kDenmark = CountryConfig(
+  code: 'DK',
+  name: 'Danmark',
+  flag: '\u{1F1E9}\u{1F1F0}',
+  currency: 'DKK',
+  currencySymbol: 'kr',
+  locale: 'da_DK',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'Postnummer',
+  requiresApiKey: false,
+  apiProvider: 'OK / Shell / Q8',
+  attribution: 'Data: ok.dk, shell.dk, q8.dk',
+  fuelTypes: ['Blyfri 95', 'Oktan 100', 'Diesel', 'V-Power Diesel'],
+  // #3198 — the single Danish 95-octane grade is e5 only (the #2180
+  // e5→e10 mirror asserted an E10 price no DK feed publishes); the
+  // #3187 exact-grade mapping added the real premium grades instead:
+  // Oktan 100 / V-Power → e98, V-Power Diesel → dieselPremium.
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.dieselPremium,
+    FuelType.electric,
+  },
+  examplePostalCode: '1000',
+  exampleCity: 'København',
+  pricePerUnitSuffix: 'kr/L',
+);
+
+const kArgentina = CountryConfig(
+  code: 'AR',
+  name: 'Argentina',
+  flag: '\u{1F1E6}\u{1F1F7}',
+  currency: 'ARS',
+  currencySymbol: '\$',
+  locale: 'es_AR',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'Código postal',
+  requiresApiKey: false,
+  apiProvider: 'Secretaría de Energía',
+  attribution: 'Datos: datos.energia.gob.ar',
+  fuelTypes: ['Nafta', 'Gas Oil', 'GNC'],
+  // #2180/#3198 — aligned to what ArgentinaStationService actually
+  // emits: Nafta súper → e5 (no e10 — the old mirror asserted an E10
+  // price the feed never publishes), Nafta premium → e98, Gas oil →
+  // diesel, Gas oil premium → dieselPremium, GNC → cng (see
+  // classifyArgentinaProduct and the service's Station mapping).
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.dieselPremium,
+    FuelType.cng,
+    FuelType.electric,
+  },
+  examplePostalCode: '1000',
+  exampleCity: 'Buenos Aires',
+  pricePerUnitSuffix: '\$/L',
+  // #3198 — GNC (CNG) is priced per cubic metre upstream, not per
+  // litre; the per-fuel override keeps every other fuel on \$/L.
+  pricePerUnitSuffixByFuel: {FuelType.cng: '\$/m³'},
+);

--- a/lib/core/country/country_config_data_extended.dart
+++ b/lib/core/country/country_config_data_extended.dart
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/fuel_type.dart';
+import 'country_config.dart';
+
+/// #3296 — the v4.1.0+ country-definition rows extracted out of `Countries`.
+/// `Countries.<name>` stays as a `static const` alias of the matching
+/// `k<Name>` here, so every call site is unchanged. The original pre-v4.1.0
+/// set lives in `country_config_data_core.dart`.
+
+const kPortugal = CountryConfig(
+  code: 'PT',
+  name: 'Portugal',
+  flag: '\u{1F1F5}\u{1F1F9}',
+  locale: 'pt_PT',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}(-\d{3})?$',
+  postalCodeLabel: 'Código postal',
+  apiProvider: 'DGEG',
+  attribution: 'Dados: DGEG (dgeg.gov.pt)',
+  fuelTypes: ['Gasolina 95', 'Gasolina 98', 'Gasóleo', 'GPL Auto'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '1000',
+  exampleCity: 'Lisboa',
+);
+
+const kUnitedKingdom = CountryConfig(
+  code: 'GB',
+  name: 'United Kingdom',
+  flag: '\u{1F1EC}\u{1F1E7}',
+  currency: 'GBP',
+  currencySymbol: '£',
+  locale: 'en_GB',
+  postalCodeLength: 7,
+  postalCodeRegex: r'^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$',
+  postalCodeLabel: 'Postcode',
+  apiProvider: 'CMA Fuel Finder',
+  attribution: 'Data: Competition and Markets Authority',
+  fuelTypes: ['Unleaded', 'Super Unleaded', 'E10', 'Diesel'],
+  // #2180 — UkStationService parses the CMA feed into e5 (E5/unleaded),
+  // e10 (E10), e98 (super_unleaded), diesel (B7/diesel). It never emits
+  // dieselPremium, so drop it and add e10 to match the live selector.
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.electric,
+  },
+  examplePostalCode: 'SW1A 1AA',
+  exampleCity: 'London',
+  // UK road signs and speedometers use miles; fuel is still sold by
+  // the litre so volume stays 'L'. Price convention is pence-per-
+  // litre ("p/L") on forecourt signage.
+  distanceUnit: 'mi',
+  pricePerUnitSuffix: 'p/L',
+);
+
+const kAustralia = CountryConfig(
+  code: 'AU',
+  name: 'Australia',
+  flag: '\u{1F1E6}\u{1F1FA}',
+  currency: 'AUD',
+  currencySymbol: '\$',
+  locale: 'en_AU',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'Postcode',
+  apiProvider: 'FuelCheck NSW',
+  attribution: 'Data: NSW Government FuelCheck',
+  fuelTypes: ['Unleaded 91', 'Unleaded 95', 'Unleaded 98', 'Diesel', 'LPG'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '2000',
+  exampleCity: 'Sydney',
+  // AU forecourts quote cents-per-litre on signage.
+  pricePerUnitSuffix: 'c/L',
+  // #2264 — AustraliaStationService is a documented stub that throws on
+  // every search (the legacy FuelCheckApp/v2 endpoint is retired and the
+  // replacement needs OAuth2 we don't ship; tracked in #804). Advertising
+  // it as verified put a country in the picker that can only ever error,
+  // so gate it out until #804 lands a working endpoint. The entry stays
+  // *registered* — an `au-` station id still resolves — it is only hidden
+  // from the user-facing pickers via [Countries.verified].
+  verified: false,
+);
+
+const kSlovenia = CountryConfig(
+  code: 'SI',
+  name: 'Slovenija',
+  flag: '\u{1F1F8}\u{1F1EE}',
+  locale: 'sl_SI',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'Poštna številka',
+  requiresApiKey: false,
+  apiProvider: 'goriva.si (gov.si)',
+  attribution: 'Podatki: goriva.si / Ministrstvo za gospodarstvo',
+  fuelTypes: ['NMB-95', 'NMB-100', 'Dizel', 'Dizel Premium', 'LPG'],
+  // #3198 — the single NMB-95 grade is e5 only (the old e5→e10 mirror
+  // asserted an E10 price goriva.si never publishes).
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.dieselPremium,
+    FuelType.lpg,
+    FuelType.cng,
+    FuelType.electric,
+  },
+  examplePostalCode: '1000',
+  exampleCity: 'Ljubljana',
+);
+
+const kMexico = CountryConfig(
+  code: 'MX',
+  name: 'México',
+  flag: '\u{1F1F2}\u{1F1FD}',
+  currency: 'MXN',
+  currencySymbol: '\$',
+  locale: 'es_MX',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Código postal',
+  apiProvider: 'CRE / datos.gob.mx',
+  attribution: 'Datos: Comisión Reguladora de Energía',
+  fuelTypes: ['Regular', 'Premium', 'Diesel'],
+  // #2704 — MexicoStationService maps CRE regular→e5, premium→e98 (MX's
+  // high-octane 91–92 grade, NOT the European e10 ethanol blend, absent in
+  // MX), diesel→diesel. The picker must offer e98 (not e10) to match the
+  // data the search selector surfaces.
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.electric,
+  },
+  examplePostalCode: '06600',
+  exampleCity: 'Ciudad de México',
+  pricePerUnitSuffix: '\$/L',
+);
+
+/// Luxembourg has government-regulated fuel prices — uniform nationally
+/// by ministerial arrêté, with no station-level variance. See
+/// `LuxembourgStationService` for the uniform-price model.
+const kLuxembourg = CountryConfig(
+  code: 'LU',
+  name: 'Luxembourg',
+  flag: '\u{1F1F1}\u{1F1FA}',
+  locale: 'fr_LU',
+  postalCodeLength: 4,
+  postalCodeRegex: r'^\d{4}$',
+  postalCodeLabel: 'Code postal',
+  apiProvider: 'Ministère de l\'Économie (LU)',
+  attribution: 'Prix réglementés — gouvernement.lu',
+  fuelTypes: ['Sans Plomb 95', 'Sans Plomb 98', 'Diesel', 'LPG'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '1009',
+  exampleCity: 'Luxembourg',
+);
+
+/// South Korea — OPINET (Korea National Oil Corporation) REST API
+/// (#597). ~14 000 stations nationwide; gasoline, premium gasoline,
+/// diesel, LPG (kerosene published but unmapped until we add a
+/// FuelType enum for it). Prices are in KRW per litre (integer).
+const kSouthKorea = CountryConfig(
+  code: 'KR',
+  name: '대한민국',
+  flag: '\u{1F1F0}\u{1F1F7}',
+  currency: 'KRW',
+  currencySymbol: '₩',
+  locale: 'ko_KR',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: '우편번호',
+  requiresApiKey: true,
+  apiKeyRegistrationUrl: 'https://www.opinet.co.kr/',
+  apiProvider: 'OPINET (KNOC)',
+  attribution: 'Data: OPINET / Korea National Oil Corporation',
+  fuelTypes: ['휘발유', '고급휘발유', '경유', 'LPG'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '04524',
+  exampleCity: '서울',
+  pricePerUnitSuffix: '₩/L',
+  // #1828 — OPINET endpoint path is a best guess, unverified
+  // against the live portal (#1823). Hidden from the picker.
+  verified: false,
+);
+
+/// Chile — CNE "Bencina en Línea" REST API (#596). ~6 000 service
+/// stations nationwide. Gasolina 93/95 (→ e5), Gasolina 97 (→ e98),
+/// Diésel, Gas licuado/LPG. Kerosene is published but unmapped until
+/// we add a FuelType enum for it. Prices are in CLP per litre.
+const kChile = CountryConfig(
+  code: 'CL',
+  name: 'Chile',
+  flag: '\u{1F1E8}\u{1F1F1}',
+  currency: 'CLP',
+  currencySymbol: '\$',
+  locale: 'es_CL',
+  postalCodeLength: 7,
+  // Chilean postal codes are 7 digits (RUT-style "1234567"). The
+  // regex is lenient enough to accept the common "123-4567" form as
+  // well — both variants appear on government records.
+  postalCodeRegex: r'^\d{7}$',
+  postalCodeLabel: 'Código postal',
+  requiresApiKey: true,
+  apiKeyRegistrationUrl: 'https://apidocs.cne.cl/', // #3200 docs portal
+  apiProvider: 'CNE Bencina en Linea',
+  attribution: 'Datos: Comisión Nacional de Energía (cne.cl)',
+  fuelTypes: ['Gasolina 93', 'Gasolina 95', 'Gasolina 97', 'Diésel', 'GLP'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '8320000',
+  exampleCity: 'Santiago',
+  pricePerUnitSuffix: '\$/L',
+  // #3200 — path + Bearer auth match apidocs.cne.cl; hidden until a
+  // registered token confirms the payload shape end-to-end.
+  verified: false,
+);
+
+/// Greece — Paratiritirio Timon (Fuel Price Observatory) via the
+/// community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
+/// API (#576). The community feed is free and open — no key required.
+/// Coverage is prefecture-level (not station-level): we synthesize one
+/// virtual station per major prefecture, each showing that region's
+/// daily mean price. Fuels: Αμόλυβδη 95 (→ e5), Αμόλυβδη 100 (→ e98),
+/// Diesel (→ diesel), Υγραέριο / LPG (→ lpg). Diesel heating is
+/// published but dropped — not a motoring fuel.
+const kGreece = CountryConfig(
+  code: 'GR',
+  name: 'Ελλάδα',
+  flag: '\u{1F1EC}\u{1F1F7}',
+  locale: 'el_GR',
+  postalCodeLength: 5,
+  postalCodeRegex: r'^\d{5}$',
+  postalCodeLabel: 'Ταχυδρομικός κώδικας',
+  requiresApiKey: false,
+  apiProvider: 'Paratiritirio Timon',
+  attribution:
+      'Data: fuelprices.gr (Paratiritirio Timon) via fuelpricesgr community API',
+  fuelTypes: ['Αμόλυβδη 95', 'Αμόλυβδη 100', 'Diesel', 'LPG'],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '10431',
+  exampleCity: 'Αθήνα',
+  // #3194 — default host is NXDOMAIN; the service short-circuits to
+  // "unavailable" unless self-hosted. Hidden until a real source exists.
+  verified: false,
+);
+
+/// Romania — *Monitorul Prețurilor*, the Competition Council's
+/// official observatory at monitorulpreturilor.info (#577; #3193
+/// rebased off the dead third-party pretcarburant.ro). ~1 500
+/// stations, public feed, no key. Fuels (catalog ids): Benzină
+/// standard 11 (→ e5), premium 12 (→ e98), Motorină standard 21
+/// (→ diesel), premium 22 (→ diesel premium), GPL 31 (→ lpg).
+const kRomania = CountryConfig(
+  code: 'RO',
+  name: 'România',
+  flag: '\u{1F1F7}\u{1F1F4}',
+  currency: 'RON',
+  currencySymbol: 'lei',
+  locale: 'ro_RO',
+  postalCodeLength: 6,
+  postalCodeRegex: r'^\d{6}$',
+  postalCodeLabel: 'Cod poștal',
+  requiresApiKey: false,
+  apiProvider: 'Monitorul Prețurilor',
+  attribution:
+      'Date: Consiliul Concurenței — monitorulpreturilor.info',
+  fuelTypes: [
+    'Benzină Standard',
+    'Benzină Premium',
+    'Motorină Standard',
+    'Motorină Premium',
+    'GPL',
+  ],
+  supportedFuelTypes: {
+    FuelType.e5,
+    FuelType.e98,
+    FuelType.diesel,
+    FuelType.dieselPremium,
+    FuelType.lpg,
+    FuelType.electric,
+  },
+  examplePostalCode: '010101',
+  exampleCity: 'București',
+  pricePerUnitSuffix: 'lei/L',
+  // #3193 — rebased onto the real monitorulpreturilor.info backend;
+  // hidden until the maintainer field-verifies, then flip to true.
+  verified: false,
+);

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -162,15 +162,12 @@ void main() {
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246
     // lines (below the cap). Removed from the snapshot per the shrink
     // ratchet; the extracted files are all new and under 400.
-    // #3198 — re-grandfathered 723 → 751: the per-fuel price-unit
-    // suffix facility (pricePerUnitSuffixByFuel + pricePerUnitSuffixFor)
-    // and the honest per-country fuel-catalog comments (AT/DK/SI/AR no
-    // longer advertise a phantom E10).
-    'lib/core/country/country_config.dart': (
-      lines: 751,
-      bumps: 1,
-      decompositionIssue: null,
-    ),
+    // #3296 — country_config.dart decomposed (751 → 284): the 17 per-country
+    // CountryConfig data rows moved to country_config_data_core.dart (pre-v4.1.0
+    // set, 189) + country_config_data_extended.dart (v4.1.0+, 329); each
+    // `Countries.<name>` is now a const alias of the matching `k<Name>`, so the
+    // ~86 importers + every `Countries.germany`-style call site are unchanged.
+    // Removed from the snapshot per the shrink ratchet; both data files < 400.
     // #3232 — country_service_registry.dart decomposed (864 → 241): the data
     // rows moved out into country_service_data.dart (entries + kDefaultFuelTypes,
     // 316) + country_service_policies.dart (the per-service FuelServicePolicy


### PR DESCRIPTION
Closes #3296.

`country_config.dart` was a 751-line god-file — structurally the twin of the already-split `country_service_registry` (#3232): a `CountryConfig` model + a `Countries` registry whose bulk was 17 `static const` country-definition rows.

## Split

| File | Lines | Holds |
|------|-------|-------|
| `country_config_data_core.dart` | 189 | pre-v4.1.0 rows as top-level `k<Country>` consts (kGermany … kArgentina) |
| `country_config_data_extended.dart` | 329 | v4.1.0+ rows (kPortugal … kRomania) |
| `country_config.dart` | **751 → 284** | the `CountryConfig` model + lookups (`all` / `verified` / `byCode` / `fromLocale` / station-id prefix resolution) |

Each `Countries.<name>` is now `static const <name> = k<Name>;`, so every call site (`Countries.germany`, …) and the ~86 importers are **unchanged**. (The data files import `country_config.dart` for the `CountryConfig` type — a benign Dart import cycle, the same const data is canonicalised at compile time.)

## Safety

- Pure relocation — identical data + behaviour, no codegen.
- `flutter analyze` clean; the full `core/country` suite (236 tests) + `file_length` stay green.
- Removed `country_config` from the `file_length` snapshot (all three files < 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)