### PR TITLE
refactor(maps): extract FlutterMap layer tree into StationMapBody — closes #3233

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_body.dart
+++ b/lib/features/map/presentation/widgets/station_map_body.dart
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../data/sparkilo_tile_layer.dart';
+import '../../../../core/widgets/osm_attribution.dart';
+import 'station_cluster_layers.dart';
+import 'station_map_geometry.dart';
+
+/// #3233 — the [FlutterMap] layer tree extracted out of [StationMapLayers]'s
+/// build as a pure presentational widget. It owns NO state: the parent
+/// computes the memoised marker model ([markers] / [markerMeta] /
+/// [priceRange]) and the camera [fitBounds], and threads its `_mapReady`
+/// latch through [onMapReady]. This leaves [StationMapLayers] holding only the
+/// memoisation + the camera-fit lifecycle, below the file-length cap.
+///
+/// The hardened single tile path ([SparkiloTileLayer]), the route polyline,
+/// the search-radius circle, the centre marker, the four marker-clustering
+/// modes and the OSM attribution all live here, byte-identical to the inline
+/// tree they replaced.
+class StationMapBody extends StatelessWidget {
+  const StationMapBody({
+    super.key,
+    required this.mapController,
+    required this.center,
+    required this.zoom,
+    required this.fitBounds,
+    required this.onMapReady,
+    required this.interactionOptions,
+    required this.onMapTap,
+    required this.routePolyline,
+    required this.showSearchRadius,
+    required this.searchRadiusKm,
+    required this.markers,
+    required this.markerMeta,
+    required this.priceRange,
+    required this.clusterAlways,
+    required this.excludeSelectedFromClustering,
+    required this.selectedStationIds,
+    required this.stationCount,
+    required this.extraLayers,
+  });
+
+  final MapController mapController;
+  final LatLng center;
+  final double zoom;
+  final LatLngBounds fitBounds;
+  final VoidCallback onMapReady;
+  final InteractionOptions? interactionOptions;
+  final void Function()? onMapTap;
+  final List<LatLng>? routePolyline;
+  final bool showSearchRadius;
+  final double searchRadiusKm;
+  final List<Marker> markers;
+  final Map<Marker, MarkerMeta> markerMeta;
+  final (double, double) priceRange;
+  final bool clusterAlways;
+  final bool excludeSelectedFromClustering;
+  final Set<String>? selectedStationIds;
+
+  /// The raw station count, used only to pick the legacy count-cluster mode
+  /// at [StationMapGeometry.clusterThreshold].
+  final int stationCount;
+  final List<Widget> extraLayers;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return FlutterMap(
+      mapController: mapController,
+      options: MapOptions(
+        initialCenter: center,
+        initialZoom: zoom,
+        // #2399 — frame the camera target during the FIRST layout pass, not
+        // via a post-frame `fitCamera`. The old post-frame fit raced the
+        // (now-deleted) cold-start reset window and could land on a degenerate
+        // viewport. Positioning the camera as part of layout means the very
+        // first tile fetch already targets the right viewport — no reset
+        // needed. #2755 — [fitBounds] is the explicit cameraFitBounds (route
+        // mode: the full itinerary) when supplied by the parent, else the
+        // search circle (nearby mode, unchanged).
+        initialCameraFit: CameraFit.bounds(
+          bounds: fitBounds,
+          padding: const EdgeInsets.all(32),
+        ),
+        // #2399 — keep the FlutterMap (and its loaded tiles) alive when
+        // offstage in an IndexedStack so a tab flip back to the map doesn't
+        // tear down + cold-rebuild the tile pipeline.
+        keepAlive: true,
+        onMapReady: onMapReady,
+        // #1457 — clamp the camera to the tile-layer's max zoom (19) so a
+        // programmatic `move(camera.zoom + 1)` past 19 doesn't leave the user
+        // staring at a grey viewport (tiles only render up to maxNativeZoom).
+        minZoom: StationMapGeometry.minZoom,
+        maxZoom: StationMapGeometry.maxZoom,
+        // #3002 — the DRIVING map passes its restricted gesture set (no pinch);
+        // every other map keeps the default all-gestures option.
+        interactionOptions: interactionOptions ??
+            const InteractionOptions(flags: InteractiveFlag.all),
+        // #3002 — driving wires a background-tap to its auto-lock reset.
+        onTap: onMapTap == null ? null : (_, _) => onMapTap!(),
+      ),
+      children: [
+        // #2398 — the SINGLE hardened tile path. No inline TileLayer, no reset
+        // stream: the cold-start reset storm that evicted tiles before they
+        // painted is gone. `SparkiloTileLayer` owns its retry provider
+        // lifecycle and uses the upstream default `abortObsoleteRequests: true`,
+        // unified with every other map surface.
+        const SparkiloTileLayer(key: ValueKey('main-tiles')),
+        // Route polyline (if in route search mode)
+        if (routePolyline != null && routePolyline!.isNotEmpty)
+          PolylineLayer(
+            polylines: [
+              Polyline(
+                points: routePolyline!,
+                color: theme.colorScheme.primary,
+                strokeWidth: 4.0,
+              ),
+            ],
+          ),
+        // Search radius circle
+        if (showSearchRadius)
+          CircleLayer(
+            circles: [
+              CircleMarker(
+                point: center,
+                radius: searchRadiusKm * 1000,
+                useRadiusInMeter: true,
+                color: theme.colorScheme.primary.withValues(alpha: 0.08),
+                borderColor: theme.colorScheme.primary.withValues(alpha: 0.3),
+                borderStrokeWidth: 2,
+              ),
+            ],
+          ),
+        // Center marker
+        MarkerLayer(
+          markers: [
+            Marker(
+              point: center,
+              width: 20,
+              height: 20,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 3),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.3),
+                      blurRadius: 4,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+        // Station markers (#1774 — `markers` is memoised by the parent). Modes:
+        //  - #3000 `clusterAlways` + `excludeSelectedFromClustering` (route
+        //    map): SELECTED stations stay un-clustered as full pills on top,
+        //    the rest fold into the cheapest cluster — so the Best/All
+        //    multi-select + list↔map 1:1 survive;
+        //  - #2939 `clusterAlways` (radar / Nearby): proximity-cluster EVERY
+        //    set with the cheapest-labelled badge;
+        //  - legacy huge set (≥ clusterThreshold): bare count cluster;
+        //  - legacy bounded set (#2510): plain [MarkerLayer], emphasis.
+        if (markers.isNotEmpty)
+          if (clusterAlways && excludeSelectedFromClustering)
+            ...selectionPartitionedClusterLayers(
+              markers: markers,
+              metaOf: (m) => markerMeta[m],
+              priceRange: priceRange,
+              selectedIds: selectedStationIds ?? const <String>{},
+            )
+          else if (clusterAlways)
+            cheapestLabelledClusterLayer(
+              markers: markers,
+              metaOf: (m) => markerMeta[m],
+              priceRange: priceRange,
+              selectedIds: selectedStationIds ?? const <String>{},
+            )
+          else if (stationCount >= StationMapGeometry.clusterThreshold)
+            countClusterLayer(markers: markers, theme: theme)
+          else
+            MarkerLayer(markers: markers),
+        // Extra layers (e.g. EV overlay)
+        ...extraLayers,
+        // Attribution — localized OSM credit (#2402).
+        const OsmAttribution(),
+      ],
+    );
+  }
+}

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -5,15 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../data/sparkilo_tile_layer.dart';
 import 'station_map_geometry.dart';
-import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
 import '../../../search/presentation/widgets/sort_selector.dart';
 import 'map_zoom_controls.dart';
 import 'price_legend.dart';
 import 'station_cluster_layers.dart';
+import 'station_map_body.dart';
 import 'station_marker.dart';
 import 'station_marker_model_builder.dart';
 
@@ -304,149 +303,32 @@ class _StationMapLayersState extends State<StationMapLayers> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Stack(
       children: [
-        FlutterMap(
+        // #3233 — the FlutterMap layer tree is the presentational
+        // [StationMapBody]; this widget keeps only the memoised marker model
+        // + the camera-fit lifecycle and feeds them down.
+        StationMapBody(
           mapController: widget.mapController,
-          options: MapOptions(
-            initialCenter: widget.center,
-            initialZoom: widget.zoom,
-            // #2399 — frame the camera target during the FIRST layout
-            // pass, not via a post-frame `fitCamera`. The old post-frame
-            // fit raced the (now-deleted) cold-start reset window and
-            // could land on a degenerate viewport. Positioning the
-            // camera as part of layout means the very first tile fetch
-            // already targets the right viewport — no reset needed.
-            // #2755 — `_fitBounds` is the explicit [cameraFitBounds] (route
-            // mode: the full itinerary) when supplied, else the search
-            // circle (nearby mode, unchanged).
-            initialCameraFit: CameraFit.bounds(
-              bounds: _fitBounds,
-              padding: const EdgeInsets.all(32),
-            ),
-            // #2399 — keep the FlutterMap (and its loaded tiles) alive
-            // when offstage in an IndexedStack so a tab flip back to the
-            // map doesn't tear down + cold-rebuild the tile pipeline.
-            keepAlive: true,
-            onMapReady: () {
-              if (mounted) _mapReady = true;
-            },
-            // #1457 — clamp the camera to the tile-layer's max zoom (19)
-            // so a programmatic `move(camera.zoom + 1)` past 19 doesn't
-            // leave the user staring at a grey viewport (tiles only
-            // render up to maxNativeZoom). The default flutter_map
-            // MapOptions.maxZoom is 25 — that lets the camera stride
-            // past where there are tiles to draw, which looks broken to
-            // the user. Min clamp guards against accidental zoom-out
-            // beyond the world wrap.
-            minZoom: StationMapGeometry.minZoom,
-            maxZoom: StationMapGeometry.maxZoom,
-            // #3002 — the DRIVING map passes its restricted gesture set (no
-            // pinch); every other map keeps the default all-gestures option.
-            interactionOptions: widget.interactionOptions ??
-                const InteractionOptions(flags: InteractiveFlag.all),
-            // #3002 — driving wires a background-tap to its auto-lock reset.
-            onTap: widget.onMapTap == null
-                ? null
-                : (_, _) => widget.onMapTap!(),
-          ),
-          children: [
-            // #2398 — the SINGLE hardened tile path. No inline TileLayer,
-            // no reset stream: the cold-start reset storm that evicted
-            // tiles before they painted is gone. `SparkiloTileLayer`
-            // owns its retry provider lifecycle and uses the upstream
-            // default `abortObsoleteRequests: true`, unified with every
-            // other map surface.
-            const SparkiloTileLayer(key: ValueKey('main-tiles')),
-            // Route polyline (if in route search mode)
-            if (widget.routePolyline != null &&
-                widget.routePolyline!.isNotEmpty)
-              PolylineLayer(
-                polylines: [
-                  Polyline(
-                    points: widget.routePolyline!,
-                    color: theme.colorScheme.primary,
-                    strokeWidth: 4.0,
-                  ),
-                ],
-              ),
-            // Search radius circle
-            if (widget.showSearchRadius)
-              CircleLayer(
-                circles: [
-                  CircleMarker(
-                    point: widget.center,
-                    radius: widget.searchRadiusKm * 1000,
-                    useRadiusInMeter: true,
-                    color: theme.colorScheme.primary.withValues(alpha: 0.08),
-                    borderColor:
-                        theme.colorScheme.primary.withValues(alpha: 0.3),
-                    borderStrokeWidth: 2,
-                  ),
-                ],
-              ),
-            // Center marker
-            MarkerLayer(
-              markers: [
-                Marker(
-                  point: widget.center,
-                  width: 20,
-                  height: 20,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primary,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.white, width: 3),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.3),
-                          blurRadius: 4,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            // Station markers (#1774 — `_markers` is memoised). Modes:
-            //  - #3000 `clusterAlways` + `excludeSelectedFromClustering`
-            //    (route map): SELECTED stations stay un-clustered as full
-            //    pills on top, the rest fold into the cheapest cluster — so
-            //    the Best/All multi-select + list↔map 1:1 survive;
-            //  - #2939 `clusterAlways` (radar / Nearby): proximity-cluster
-            //    EVERY set with the cheapest-labelled badge;
-            //  - legacy huge set (≥ clusterThreshold): bare count cluster;
-            //  - legacy bounded set (#2510): plain [MarkerLayer], emphasis.
-            if (_markers.isNotEmpty)
-              if (widget.clusterAlways &&
-                  widget.excludeSelectedFromClustering)
-                ...selectionPartitionedClusterLayers(
-                  markers: _markers,
-                  metaOf: (m) => _markerMeta[m],
-                  priceRange: _priceRange,
-                  selectedIds:
-                      widget.selectedStationIds ?? const <String>{},
-                )
-              else if (widget.clusterAlways)
-                cheapestLabelledClusterLayer(
-                  markers: _markers,
-                  metaOf: (m) => _markerMeta[m],
-                  priceRange: _priceRange,
-                  selectedIds:
-                      widget.selectedStationIds ?? const <String>{},
-                )
-              else if (widget.stations.length >=
-                  StationMapGeometry.clusterThreshold)
-                countClusterLayer(markers: _markers, theme: theme)
-              else
-                MarkerLayer(markers: _markers),
-            // Extra layers (e.g. EV overlay)
-            ...widget.extraLayers,
-            // Attribution — localized OSM credit (#2402).
-            const OsmAttribution(),
-          ],
+          center: widget.center,
+          zoom: widget.zoom,
+          fitBounds: _fitBounds,
+          onMapReady: () {
+            if (mounted) _mapReady = true;
+          },
+          interactionOptions: widget.interactionOptions,
+          onMapTap: widget.onMapTap,
+          routePolyline: widget.routePolyline,
+          showSearchRadius: widget.showSearchRadius,
+          searchRadiusKm: widget.searchRadiusKm,
+          markers: _markers,
+          markerMeta: _markerMeta,
+          priceRange: _priceRange,
+          clusterAlways: widget.clusterAlways,
+          excludeSelectedFromClustering: widget.excludeSelectedFromClustering,
+          selectedStationIds: widget.selectedStationIds,
+          stationCount: widget.stations.length,
+          extraLayers: widget.extraLayers,
         ),
         // Zoom controls — #3002: hidden on the driving map, which has its own
         // oversized bottom bar.

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -838,78 +838,15 @@ void main() {
       bumps: 0,
       decompositionIssue: null,
     ),
+    // #3233 — station_map_layers.dart graduated (700 → 354, below the cap):
+    // the pure geometry/marker-ranking statics → station_map_geometry.dart
+    // (#3289), the marker-model pipeline → station_marker_model_builder.dart +
+    // the zoom controls → map_zoom_controls.dart (#3295), and the FlutterMap
+    // layer tree → station_map_body.dart (the presentational StationMapBody,
+    // this PR). The widget now holds only the memoised marker model + the
+    // camera-fit lifecycle. Removed from the snapshot per the shrink ratchet;
+    // every extracted file is new and under 400.
     // #2510 — re-grandfathered 544 → 562: the nearby-search map no longer
-    // hides results behind count-clusters. Adds the `rankForEmphasis`
-    // helper + two `@visibleForTesting` constants (emphasisCount,
-    // clusterThreshold) and the de-clustering branch (a bounded set renders
-    // a plain MarkerLayer with the top-ranked stations emphasized; only a
-    // huge/zoomed-far set falls back to clustering). Net +18 is the helper,
-    // the constants and their dartdoc. Decomposition tracked by #2187/#2188.
-    // #2532 — re-grandfathered 562 → 574: the optional `onStationTap` field
-    // (so a wide-screen marker tap selects into the side panel instead of
-    // pushing the route) + its dartdoc, its constructor param, its pass-down
-    // in `_recomputeMarkers`, and the `didUpdateWidget` identity guard that
-    // rebuilds markers on a changed callback. Decomposition tracked by
-    // #2187/#2188.
-    // #2547 — tightened 574 → 562: the #2547 revert removed that
-    // `onStationTap` field (the map now takes the full horizontal width on
-    // wide/landscape — no side panel), so the marker tap is back to its
-    // pre-#2532 `/station/:id` push and the field + its plumbing are gone.
-    // #2631 — re-grandfathered 562 → 604: the optional cross-border
-    // `fuelResolver` field + its dartdoc, its constructor param + the
-    // `didUpdateWidget` identity guard, the resolver thread-through in
-    // `orderedByPriceForPainting` + `_recomputeMarkers`, and the small
-    // `_resolvedRange` helper that colours cross-border markers by each
-    // station's own country fuel. Lets a Spanish station show its E10 price
-    // instead of '--' on an E85 route. Decomposition tracked by #2187/#2188.
-    // #2755 — re-grandfathered 604 → 622: the optional `cameraFitBounds`
-    // field + its dartdoc and constructor param, plus the `_fitBounds`
-    // getter / `initialCameraFit` substitution that frames the explicit
-    // bounds (route mode: the full itinerary) instead of the search circle.
-    // Null path unchanged (nearby mode). Decomposition tracked by #2187/#2188.
-    // #2974 — re-grandfathered 622 → 625: the marker-selection haptic wraps
-    // the onStationTap callback once (3 lines: the selectionClick + the
-    // delegate + its dartdoc) so a marker tap that selects a list row buzzes
-    // like the other everyday tap surfaces. Decomposition still #2187/#2188.
-    // #3000 — re-grandfathered 625 → 654 (Epic #2997): selection-aware
-    // clustering for the route map. The partition LOGIC was extracted to
-    // `selectionPartitionedClusterLayers` in station_cluster_layers.dart (per
-    // the file-length rule, a helper over grandfathering); the residual growth
-    // here is the widget's own irreducible API — the `excludeSelectedFromClustering`
-    // flag + its dartdoc, its constructor param, the build-tree branch that
-    // spreads the partitioned layers, and the `markerMetaForTesting` seam that
-    // lets a test assert a clustered cross-border station carries its resolved
-    // price. None of these can move off the widget. Decomposition of this
-    // god-class is still tracked by #2187/#2188.
-    // #3002 — re-grandfathered 654 → 699 (Epic #2997, final child): the DRIVING
-    // map adopts the shared stack. The growth is the widget's own irreducible
-    // additive API — five new props + their dartdocs (`markerVariant`,
-    // `interactionOptions`, `onMapTap`, `showZoomControls`, `showLegend`), their
-    // constructor params, the variant threaded into the `StationMarkerBuilder`
-    // call, and the two `if (...)` guards that gate the zoom controls + legend
-    // off for driving. The big driver-legible marker BODY lives in
-    // `station_marker.dart` (the `_drivingMarker` content variant), not here, so
-    // nothing further can move off this widget. Decomposition of this god-class
-    // is still tracked by #2187/#2188.
-    // +1 (#3161): the `discarded_futures` burn-down added the lint-mandated
-    // `import 'dart:async';` line for the `unawaited(...)` wrap of the
-    // marker-tap HapticFeedback call. No new logic.
-    // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3233.
-    // #3233 — ratcheted DOWN 700 → 565: the pure geometry + marker-ranking
-    // statics (zoom/bounds/centroid + orderedByPriceForPainting/rankForEmphasis
-    // + their consts) were extracted to `station_map_geometry.dart`.
-    // #3233 — ratcheted DOWN 565 → 472: the marker-model builder
-    // (`_recomputeMarkers`'s price/emphasis/order/build pipeline →
-    // `station_marker_model_builder.dart`, the pure `StationMarkerModelBuilder`)
-    // and the top-right zoom/recenter control column (→ `map_zoom_controls.dart`,
-    // `MapZoomControls`). The remaining FlutterMap children tree is coupled to
-    // the memoised `_markers`/`_markerMeta`/`_priceRange` state, so the final
-    // slice is a stateful sub-view extraction; #3233 stays referenced for it.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': (
-      lines: 472,
-      bumps: 8,
-      decompositionIssue: 3233,
-    ),
     // #2681 — feature_management_section.dart graduated: the #2681 ordered-
     // category reorg decomposed the 718-line god-class into the
     // widgets/feature_management/ folder (conso_feature_card.dart,


### PR DESCRIPTION
Closes #3233 (final slice; after #3289 geometry + #3295 marker-builder/zoom-controls).

The FlutterMap layer tree — hardened tile path, route polyline, search circle, centre marker, the four marker-clustering modes, OSM attribution — moves into the pure presentational `StationMapBody` (`station_map_body.dart`). The parent computes the memoised marker model (`_markers` / `_markerMeta` / `_priceRange`) + the camera `fitBounds` and threads its `_mapReady` latch through an `onMapReady` callback; the body owns no state.

`station_map_layers.dart` **472 → 354** — below the 400 cap, so it **graduates off the `file_length` snapshot entirely** (8 grandfathered bumps cleared).

## Safety
- Pure relocation — the layer tree is byte-identical to the inline version.
- `flutter analyze` clean; the full map suite (210 tests incl. clustering modes, `markerMetaForTesting`, cross-border price) + all 57 lint tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)