### PR TITLE
fix(uk): OAuth2 client-credentials support for the statutory Fuel Finder API (#3190)

### DIFF
--- a/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
+++ b/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
@@ -15,6 +15,7 @@ import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
+import 'uk_fuel_finder_auth.dart';
 import 'uk_station_service.dart';
 
 /// UK CMA / Fuel Finder **bulk-file** fuel-price service (#2277).
@@ -47,30 +48,43 @@ class UkCmaBulkStationService
   final Dio _dio;
   final String _consolidatedUrl;
 
+  /// #3190 — OAuth 2.0 client-credentials token source for the statutory Fuel
+  /// Finder API. Null on the pre-credentials path (no GOV.UK One Login client
+  /// configured yet) → the consolidated request goes out unauthenticated, as
+  /// before. When set, each download carries a `Bearer` token (fetched +
+  /// cached by [UkFuelFinderAuth]); a 401 invalidates the token and retries
+  /// once.
+  final UkFuelFinderAuth? _auth;
+
   /// Disk persistence (read-through). When a [CacheStrategy] is supplied (the
   /// registry factory passes the shared CacheManager) the parsed consolidated
   /// record list is persisted to Hive so it survives a cold start and works
   /// offline. Null in the pure-in-memory parser tests.
   final PersistentDataset<List<Map<String, dynamic>>>? _persistent;
 
-  /// Default consolidated CMA / Fuel Finder download. Published twice daily
-  /// under the gov.uk Fuel Finder scheme; one file covers every forecourt.
-  /// Overridable so the subscription-issued URL (or an OAuth2-fronted variant)
-  /// drops in without touching the parse/persist/filter logic.
+  /// Default consolidated Fuel Finder download (#3190). The statutory Fuel
+  /// Finder Scheme (Motor Fuel Price (Open Data) Regulations 2025) replaced the
+  /// withdrawn voluntary CMA scheme on 2026-05-01; its public API lives on the
+  /// gov.uk developer portal. One consolidated file covers every forecourt.
+  /// Overridable so the exact `/public-api` price-list path — which must be
+  /// confirmed against the registered API docs — drops in without touching the
+  /// parse/persist/filter logic.
   // i18n-ignore: gov.uk data endpoint URL, not user-facing text
   static const String defaultConsolidatedUrl =
-      'https://www.fuel-finder.service.gov.uk/api/v1/prices/latest';
+      'https://developer.fuel-finder.service.gov.uk/public-api/v1/prices/latest';
 
   UkCmaBulkStationService({
     Dio? dio,
     String? consolidatedUrl,
     CacheStrategy? cache,
+    UkFuelFinderAuth? auth,
   })  : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 15),
               receiveTimeout: const Duration(seconds: 30),
               responseType: ResponseType.json,
             ),
+        _auth = auth,
         _consolidatedUrl = consolidatedUrl ?? defaultConsolidatedUrl,
         _persistent = cache == null
             ? null
@@ -150,13 +164,47 @@ class UkCmaBulkStationService
   /// Download + extract the consolidated record list. Tolerates the two
   /// standardized envelope shapes (`{stations:[...]}` / `{data:[...]}`) and a
   /// bare top-level list.
+  ///
+  /// #3190 — when an [UkFuelFinderAuth] is configured the request carries a
+  /// `Bearer` token; a 401 (token rotated / revoked server-side) invalidates
+  /// the cached token and retries ONCE with a fresh one before giving up.
   Future<List<Map<String, dynamic>>> _downloadConsolidated({
     CancelToken? cancelToken,
   }) async {
+    final auth = _auth;
+    if (auth == null) {
+      final response = await _dio.get<dynamic>(
+        _consolidatedUrl,
+        cancelToken: cancelToken,
+        options: Options(responseType: ResponseType.json),
+      );
+      return extractConsolidatedRecords(response.data);
+    }
+
+    try {
+      return await _authedDownload(auth, cancelToken: cancelToken);
+    } on DioException catch (e) { // ignore: catch_no_st — rethrow preserves the stack; the 401 branch retries
+      if (e.response?.statusCode == 401) {
+        // Stale/rotated token — drop it and retry once with a fresh one.
+        auth.invalidate();
+        return _authedDownload(auth, cancelToken: cancelToken);
+      }
+      rethrow;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _authedDownload(
+    UkFuelFinderAuth auth, {
+    CancelToken? cancelToken,
+  }) async {
+    final token = await auth.accessToken(cancelToken: cancelToken);
     final response = await _dio.get<dynamic>(
       _consolidatedUrl,
       cancelToken: cancelToken,
-      options: Options(responseType: ResponseType.json),
+      options: Options(
+        responseType: ResponseType.json,
+        headers: {'Authorization': 'Bearer $token'},
+      ),
     );
     return extractConsolidatedRecords(response.data);
   }

--- a/lib/features/station_services/uk/uk_fuel_finder_auth.dart
+++ b/lib/features/station_services/uk/uk_fuel_finder_auth.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+
+/// OAuth 2.0 **client-credentials** token source for the UK statutory Fuel
+/// Finder API (#3190).
+///
+/// The voluntary CMA scheme was withdrawn 2026-05-01 and replaced by the
+/// statutory Fuel Finder Scheme (*Motor Fuel Price (Open Data) Regulations
+/// 2025*), whose public API (developer.fuel-finder.service.gov.uk) is fronted
+/// by OAuth 2.0 client credentials — a `client_id` / `client_secret` pair
+/// generated via a GOV.UK One Login. This holds those credentials and the
+/// token endpoint, fetches a bearer token on demand (RFC 6749 §4.4), caches it
+/// until shortly before it expires, and re-fetches after [invalidate] (called
+/// on a 401).
+///
+/// It is deliberately a small, injectable collaborator — the bulk station
+/// service takes one (or null, the unauthenticated pre-credentials path) so the
+/// token flow is unit-testable against a mock [Dio] without a live endpoint.
+class UkFuelFinderAuth {
+  UkFuelFinderAuth({
+    required Dio dio,
+    required this.tokenUrl,
+    required this.clientId,
+    required this.clientSecret,
+    this.scope,
+    DateTime Function() now = DateTime.now,
+  })  : _dio = dio,
+        _now = now;
+
+  final Dio _dio;
+  final DateTime Function() _now;
+
+  /// The OAuth2 token endpoint (the `/token` URL from the Fuel Finder
+  /// developer portal). Injected — never guessed in code.
+  final String tokenUrl;
+  final String clientId;
+  final String clientSecret;
+
+  /// Optional space-delimited scope string, when the API requires one.
+  final String? scope;
+
+  String? _cachedToken;
+  DateTime? _expiresAt;
+
+  /// A refresh margin so a token that is *about* to expire is treated as
+  /// already stale — avoids racing the server clock on a borderline request.
+  static const Duration _refreshMargin = Duration(seconds: 30);
+
+  /// Returns a valid bearer token, fetching a fresh one when none is cached or
+  /// the cached one is within [_refreshMargin] of expiry. Throws the
+  /// underlying [DioException] when the token request itself fails.
+  Future<String> accessToken({CancelToken? cancelToken}) async {
+    final cached = _cachedToken;
+    final expiresAt = _expiresAt;
+    if (cached != null &&
+        expiresAt != null &&
+        _now().isBefore(expiresAt.subtract(_refreshMargin))) {
+      return cached;
+    }
+    return _fetch(cancelToken: cancelToken);
+  }
+
+  /// Drop the cached token so the next [accessToken] re-fetches. Called by the
+  /// caller on a 401 (the token was revoked / rotated server-side).
+  void invalidate() {
+    _cachedToken = null;
+    _expiresAt = null;
+  }
+
+  Future<String> _fetch({CancelToken? cancelToken}) async {
+    final response = await _dio.post<dynamic>(
+      tokenUrl,
+      data: {
+        'grant_type': 'client_credentials',
+        'client_id': clientId,
+        'client_secret': clientSecret,
+        if (scope != null) 'scope': scope,
+      },
+      options: Options(
+        contentType: Headers.formUrlEncodedContentType,
+        responseType: ResponseType.json,
+      ),
+      cancelToken: cancelToken,
+    );
+
+    final body = response.data;
+    if (body is! Map) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        error: 'Malformed OAuth2 token response (not a JSON object)',
+      );
+    }
+    final token = body['access_token'];
+    if (token is! String || token.isEmpty) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        error: 'OAuth2 token response missing access_token',
+      );
+    }
+    // `expires_in` is seconds (RFC 6749 §5.1). Default to a conservative
+    // 5 min when the server omits it so a missing field can't pin a stale
+    // token forever.
+    final expiresIn = body['expires_in'];
+    final seconds = expiresIn is num ? expiresIn.toInt() : 300;
+    _cachedToken = token;
+    _expiresAt = _now().add(Duration(seconds: seconds));
+    return token;
+  }
+}

--- a/test/features/station_services/uk/uk_cma_bulk_station_service_test.dart
+++ b/test/features/station_services/uk/uk_cma_bulk_station_service_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/core/domain/search_params.dart';
 import 'package:tankstellen/features/station_services/uk/uk_cma_bulk_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_fuel_finder_auth.dart';
 import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
 
 /// #2277 — the UK consolidated CMA bulk-file path: ONE download, persisted,
@@ -206,4 +207,109 @@ void main() {
       expect(bulkResult.data.first.e5, legacy.first.e5);
     });
   });
+
+  group('OAuth2 client-credentials auth (#3190)', () {
+    test('fetches a token then sends the consolidated GET with a Bearer header',
+        () async {
+      final adapter = _OAuthRoutingAdapter(
+        consolidatedBody: _consolidated([
+          _record(siteId: 'gb-1', brand: 'BP', lat: 51.5, lng: -0.12),
+        ]),
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final auth = UkFuelFinderAuth(
+        dio: dio,
+        tokenUrl: 'https://developer.fuel-finder.service.gov.uk/oauth/token',
+        clientId: 'client-abc',
+        clientSecret: 'secret-xyz',
+      );
+      final bulk = UkCmaBulkStationService(dio: dio, auth: auth);
+
+      final result = await bulk.searchStations(_london);
+
+      expect(result.data, isNotEmpty);
+      // Token POST happened, then the data GET carried the Bearer token.
+      expect(adapter.tokenRequests, 1);
+      expect(adapter.dataAuthHeaders, ['Bearer tok-1']);
+    });
+
+    test('on a 401 it invalidates the token and retries the download once',
+        () async {
+      final adapter = _OAuthRoutingAdapter(
+        consolidatedBody: _consolidated([
+          _record(siteId: 'gb-1', brand: 'BP', lat: 51.5, lng: -0.12),
+        ]),
+        failDataOnceWith401: true,
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final auth = UkFuelFinderAuth(
+        dio: dio,
+        tokenUrl: 'https://developer.fuel-finder.service.gov.uk/oauth/token',
+        clientId: 'c',
+        clientSecret: 's',
+      );
+      final bulk = UkCmaBulkStationService(dio: dio, auth: auth);
+
+      final result = await bulk.searchStations(_london);
+
+      // The 401 forced a fresh token (2 token fetches) and the retry succeeded.
+      expect(result.data, isNotEmpty);
+      expect(adapter.tokenRequests, 2);
+      expect(adapter.dataAuthHeaders, ['Bearer tok-1', 'Bearer tok-2']);
+    });
+  });
+}
+
+/// Routes the OAuth2 token POST vs the consolidated data GET by path, captures
+/// the data request's Authorization header, and can fail the first data GET
+/// with a 401 to exercise the invalidate-and-retry path.
+class _OAuthRoutingAdapter implements HttpClientAdapter {
+  _OAuthRoutingAdapter({
+    required this.consolidatedBody,
+    this.failDataOnceWith401 = false,
+  });
+
+  final String consolidatedBody;
+  final bool failDataOnceWith401;
+
+  int tokenRequests = 0;
+  final List<String> dataAuthHeaders = [];
+  bool _dataFailed = false;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final isToken = options.path.contains('/oauth/token');
+    if (isToken) {
+      tokenRequests++;
+      return ResponseBody.fromString(
+        jsonEncode({'access_token': 'tok-$tokenRequests', 'expires_in': 3600}),
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    }
+    // Data GET — record the bearer the service attached.
+    dataAuthHeaders.add(options.headers['Authorization']?.toString() ?? '');
+    if (failDataOnceWith401 && !_dataFailed) {
+      _dataFailed = true;
+      return ResponseBody.fromString('{}', 401, headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      });
+    }
+    return ResponseBody.fromString(
+      consolidatedBody,
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/test/features/station_services/uk/uk_fuel_finder_auth_test.dart
+++ b/test/features/station_services/uk/uk_fuel_finder_auth_test.dart
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_services/uk/uk_fuel_finder_auth.dart';
+
+/// #3190 — the statutory Fuel Finder API is fronted by OAuth 2.0 client
+/// credentials. These pin the token flow against a mock transport (no live
+/// endpoint): the POST shape (RFC 6749 §4.4), caching until expiry, expiry
+/// re-fetch, [UkFuelFinderAuth.invalidate] re-fetch, and the malformed-response
+/// guards.
+
+/// Captures every request and serves a programmable queue of JSON bodies.
+class _CapturingAdapter implements HttpClientAdapter {
+  _CapturingAdapter(this.bodies);
+
+  /// One canned (statusCode, jsonBody) per request, consumed in order; the
+  /// last entry repeats once the queue is drained.
+  final List<(int, Map<String, dynamic>)> bodies;
+
+  final List<RequestOptions> requests = [];
+  final List<String> requestBodies = [];
+  int _i = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (requestStream != null) {
+      final chunks = await requestStream.toList();
+      requestBodies.add(utf8.decode(chunks.expand((c) => c).toList()));
+    } else {
+      requestBodies.add('');
+    }
+    final entry = bodies[_i < bodies.length ? _i : bodies.length - 1];
+    _i++;
+    return ResponseBody.fromString(
+      jsonEncode(entry.$2),
+      entry.$1,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _dio(_CapturingAdapter adapter) {
+  final dio = Dio();
+  dio.httpClientAdapter = adapter;
+  return dio;
+}
+
+void main() {
+  const tokenUrl = 'https://developer.fuel-finder.service.gov.uk/oauth/token';
+
+  group('UkFuelFinderAuth — client-credentials token flow (#3190)', () {
+    test('POSTs grant_type=client_credentials with the client id + secret', () async {
+      final adapter = _CapturingAdapter([
+        (200, {'access_token': 'tok-1', 'token_type': 'Bearer', 'expires_in': 3600}),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'client-abc',
+        clientSecret: 'secret-xyz',
+        scope: 'fuel-prices:read',
+      );
+
+      final token = await auth.accessToken();
+
+      expect(token, 'tok-1');
+      expect(adapter.requests.single.path, tokenUrl);
+      expect(adapter.requests.single.method, 'POST');
+      final body = adapter.requestBodies.single;
+      expect(body, contains('grant_type=client_credentials'));
+      expect(body, contains('client_id=client-abc'));
+      expect(body, contains('client_secret=secret-xyz'));
+      expect(body, contains('scope=fuel-prices'));
+    });
+
+    test('caches the token — a second call within expiry does NOT re-POST',
+        () async {
+      var clock = DateTime(2026, 6, 13, 12);
+      final adapter = _CapturingAdapter([
+        (200, {'access_token': 'tok-1', 'expires_in': 3600}),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'c',
+        clientSecret: 's',
+        now: () => clock,
+      );
+
+      expect(await auth.accessToken(), 'tok-1');
+      clock = clock.add(const Duration(minutes: 10)); // still well within 1h
+      expect(await auth.accessToken(), 'tok-1');
+      expect(adapter.requests.length, 1, reason: 'second call served from cache');
+    });
+
+    test('re-fetches once the cached token is within the refresh margin of '
+        'expiry', () async {
+      var clock = DateTime(2026, 6, 13, 12);
+      final adapter = _CapturingAdapter([
+        (200, {'access_token': 'tok-1', 'expires_in': 60}),
+        (200, {'access_token': 'tok-2', 'expires_in': 60}),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'c',
+        clientSecret: 's',
+        now: () => clock,
+      );
+
+      expect(await auth.accessToken(), 'tok-1');
+      // 40s in: 60s token, 30s margin → effective expiry at 30s, so this is stale.
+      clock = clock.add(const Duration(seconds: 40));
+      expect(await auth.accessToken(), 'tok-2');
+      expect(adapter.requests.length, 2);
+    });
+
+    test('invalidate() forces a re-fetch on the next call', () async {
+      final adapter = _CapturingAdapter([
+        (200, {'access_token': 'tok-1', 'expires_in': 3600}),
+        (200, {'access_token': 'tok-2', 'expires_in': 3600}),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'c',
+        clientSecret: 's',
+      );
+
+      expect(await auth.accessToken(), 'tok-1');
+      auth.invalidate();
+      expect(await auth.accessToken(), 'tok-2');
+      expect(adapter.requests.length, 2);
+    });
+
+    test('throws when the response carries no access_token', () async {
+      final adapter = _CapturingAdapter([
+        (200, {'token_type': 'Bearer', 'expires_in': 3600}),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'c',
+        clientSecret: 's',
+      );
+
+      expect(() => auth.accessToken(), throwsA(isA<DioException>()));
+    });
+  });
+}


### PR DESCRIPTION
Advances #3190 (the migration's auth plumbing). Keeps GB `verified:false` — the live-verification + `verified` flip needs a registered GOV.UK One Login client, which a person must create.

## Context
The voluntary CMA scheme was **withdrawn 2026-05-01**, replaced by the statutory **Fuel Finder Scheme** (Motor Fuel Price (Open Data) Regulations 2025). Its public API (`developer.fuel-finder.service.gov.uk`) is fronted by **OAuth 2.0 client credentials**. The bulk service already existed (gated behind `BulkMigrationFlags.ukCmaBulk`) with an injectable URL anticipating OAuth2; this adds the auth.

## Change
- **`uk_fuel_finder_auth.dart`** (`UkFuelFinderAuth`) — injectable client-credentials token source: POSTs `grant_type=client_credentials` with `client_id`/`client_secret` (RFC 6749 §4.4), caches the bearer until shortly before `expires_in`, re-fetches after `invalidate()`. Token endpoint + creds are **injected, never guessed**.
- **`UkCmaBulkStationService`** takes an optional `UkFuelFinderAuth`: when set, each consolidated download carries a `Bearer` token; a **401 invalidates the cached token and retries once**. Null (default) keeps the unauthenticated path → the registry builder is unchanged.
- `defaultConsolidatedUrl` → the `developer.fuel-finder.service.gov.uk/public-api` host (exact price path kept overridable, flagged to confirm against the registered API docs).

## Tests (mock transport, no live endpoint)
- Auth helper: token POST shape, caching within expiry, refresh-margin expiry re-fetch, `invalidate()` re-fetch, missing-`access_token` guard.
- Bulk service: token-then-`Bearer` on the data GET; 401 → invalidate + retry once.
- `flutter analyze` clean; all 46 UK service tests green.

## Still needs you
The exact `/public-api` price-list path, the OAuth2 token endpoint URL, and real `client_id`/`secret` (GOV.UK One Login requires a person). The flow + host ship and are mock-verified now; live verification flips `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)