### PR TITLE
refactor(consumption): extract the pure FillUpTripLinker from the FillUpList notifier (#3138)

### DIFF
--- a/lib/features/consumption/domain/services/fill_up_trip_linker.dart
+++ b/lib/features/consumption/domain/services/fill_up_trip_linker.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../data/trip_history_repository.dart';
+import '../entities/fill_up.dart';
+
+/// The plein-to-plein window a fill-up's linked trips fall in (#1361).
+///
+/// * [upper] — `fillUp.date` (inclusive).
+/// * [start] — the lower bound; `null` means "no lower bound" (everything
+///   before [upper] qualifies, the legacy #888 semantics for a first fill).
+/// * [inclusiveLower] — whether [start] itself is in the window: exclusive
+///   after a prior plein, inclusive at the earliest same-vehicle fill.
+class FillUpLinkWindow {
+  const FillUpLinkWindow({
+    required this.start,
+    required this.inclusiveLower,
+    required this.upper,
+  });
+
+  final DateTime? start;
+  final bool inclusiveLower;
+  final DateTime upper;
+
+  /// Whether [when] falls inside the window.
+  bool contains(DateTime when) {
+    final lower = start;
+    if (lower != null) {
+      final afterStart =
+          inclusiveLower ? !when.isBefore(lower) : when.isAfter(lower);
+      if (!afterStart) return false;
+    }
+    return !when.isAfter(upper);
+  }
+}
+
+/// #3138 — the pure fill-up ↔ OBD2-trip linking logic, extracted out of the
+/// `FillUpList` notifier where the same window math (find the previous plein →
+/// derive the lower bound → test membership) was duplicated across the
+/// "compute this fill's links" and "re-link the open window" paths.
+///
+/// It is a pure function over the data the caller has already loaded — no
+/// Riverpod, no repository I/O, no side effects — so the plein-to-plein window
+/// semantics (#1361 / #888) are unit-testable in isolation. The notifier keeps
+/// the I/O (load the trip history + sibling fills, save the merged links).
+class FillUpTripLinker {
+  const FillUpTripLinker();
+
+  /// The trip-history ids recorded for [fillUp]'s vehicle inside the open
+  /// plein-to-plein window that ends at [fillUp]. [history] is the full
+  /// trip-history list; [allFills] is every persisted fill-up (the linker
+  /// filters to the same vehicle itself). Empty when [fillUp] has no vehicle
+  /// bound or no trips fall in the window.
+  List<String> linkedTripIdsInWindow({
+    required FillUp fillUp,
+    required List<TripHistoryEntry> history,
+    required List<FillUp> allFills,
+  }) {
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null) return const <String>[];
+    final window = windowFor(fillUp, allFills);
+    final ids = <String>[];
+    for (final entry in history) {
+      if (entry.vehicleId != vehicleId) continue;
+      final when = entry.summary.startedAt;
+      if (when == null) continue;
+      if (!window.contains(when)) continue;
+      ids.add(entry.id);
+    }
+    return List.unmodifiable(ids);
+  }
+
+  /// The OTHER same-vehicle fills inside [fillUp]'s window — the partials the
+  /// closing plein's link set propagates onto (#1361 whole-window semantics).
+  List<FillUp> siblingsInWindow({
+    required FillUp fillUp,
+    required List<FillUp> allFills,
+  }) {
+    final window = windowFor(fillUp, allFills);
+    return _siblings(fillUp, allFills)
+        .where((f) => window.contains(f.date))
+        .toList(growable: false);
+  }
+
+  /// The plein-to-plein window that ends at [fillUp].
+  ///
+  /// Lower bound: the most-recent prior **plein** (exclusive); failing that the
+  /// earliest same-vehicle fill (inclusive); failing that no lower bound.
+  FillUpLinkWindow windowFor(FillUp fillUp, List<FillUp> allFills) {
+    final siblings = _siblings(fillUp, allFills);
+    FillUp? previousPlein;
+    for (final f in siblings) {
+      if (!f.date.isBefore(fillUp.date)) continue;
+      if (!f.isFullTank) continue;
+      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
+        previousPlein = f;
+      }
+    }
+    if (previousPlein != null) {
+      return FillUpLinkWindow(
+        start: previousPlein.date,
+        inclusiveLower: false,
+        upper: fillUp.date,
+      );
+    }
+    if (siblings.isNotEmpty) {
+      return FillUpLinkWindow(
+        start: siblings.first.date,
+        inclusiveLower: true,
+        upper: fillUp.date,
+      );
+    }
+    return FillUpLinkWindow(
+      start: null,
+      inclusiveLower: true,
+      upper: fillUp.date,
+    );
+  }
+
+  /// Same-vehicle fills other than [fillUp], excluding corrections, oldest
+  /// first. Empty when [fillUp] has no vehicle bound.
+  List<FillUp> _siblings(FillUp fillUp, List<FillUp> allFills) {
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null) return const <FillUp>[];
+    return allFills
+        .where((f) =>
+            f.vehicleId == vehicleId && f.id != fillUp.id && !f.isCorrection)
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+  }
+}

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -28,6 +28,7 @@ import '../domain/entities/fill_up.dart';
 import '../domain/entities/pending_reconciliation.dart';
 import '../domain/gps_driving_features.dart';
 import '../domain/services/eco_score_calculator.dart';
+import '../domain/services/fill_up_trip_linker.dart';
 import '../domain/services/gps_matrix_reconciler.dart';
 import '../domain/services/reconciler.dart';
 import '../domain/trip_recorder.dart';
@@ -286,64 +287,15 @@ class FillUpList extends _$FillUpList {
   /// the trip-history repository isn't available, or no trips fall
   /// in the window.
   List<String> _linkedTripIdsForWholeWindow(FillUp fillUp) {
-    final vehicleId = fillUp.vehicleId;
-    if (vehicleId == null) return const <String>[];
+    // #3138 — the plein-to-plein window math is the pure [FillUpTripLinker];
+    // the notifier only supplies the loaded trip history + sibling fills.
     final repo = ref.read(tripHistoryRepositoryProvider);
     if (repo == null) return const <String>[];
-    final history = repo.loadAll();
-    final fillRepo = ref.read(fillUpRepositoryProvider);
-    final allFills = fillRepo
-        .getAll()
-        .where(
-          (f) =>
-              f.vehicleId == vehicleId &&
-              f.id != fillUp.id &&
-              !f.isCorrection,
-        )
-        .toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
-
-    FillUp? previousPlein;
-    for (final f in allFills) {
-      if (!f.date.isBefore(fillUp.date)) continue;
-      if (!f.isFullTank) continue;
-      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
-        previousPlein = f;
-      }
-    }
-
-    // Window lower bound:
-    //   - prior plein → strictly after that plein's date
-    //   - no prior plein but earlier same-vehicle fills exist → at-or-
-    //     after the earliest such fill (inclusive)
-    //   - no prior fills at all → no lower bound (everything before
-    //     this fill qualifies, matching the legacy #888 semantics)
-    DateTime? windowStart;
-    bool inclusiveLower = true;
-    if (previousPlein != null) {
-      windowStart = previousPlein.date;
-      inclusiveLower = false;
-    } else if (allFills.isNotEmpty) {
-      windowStart = allFills.first.date;
-      inclusiveLower = true;
-    }
-    final upperBound = fillUp.date;
-
-    final matches = <TripHistoryEntry>[];
-    for (final entry in history) {
-      if (entry.vehicleId != vehicleId) continue;
-      final when = entry.summary.startedAt;
-      if (when == null) continue;
-      if (windowStart != null) {
-        final afterStart = inclusiveLower
-            ? !when.isBefore(windowStart)
-            : when.isAfter(windowStart);
-        if (!afterStart) continue;
-      }
-      if (when.isAfter(upperBound)) continue;
-      matches.add(entry);
-    }
-    return matches.map((e) => e.id).toList(growable: false);
+    return const FillUpTripLinker().linkedTripIdsInWindow(
+      fillUp: fillUp,
+      history: repo.loadAll(),
+      allFills: ref.read(fillUpRepositoryProvider).getAll(),
+    );
   }
 
   /// After saving [closing], propagate its `linkedTripIds` to every
@@ -359,53 +311,13 @@ class FillUpList extends _$FillUpList {
   /// cover the open window so the prior partial picks up the new
   /// trips.
   Future<void> _relinkOpenWindow(FillUp closing) async {
-    final vehicleId = closing.vehicleId;
-    if (vehicleId == null) return;
     final repo = ref.read(fillUpRepositoryProvider);
-    final allFills = repo
-        .getAll()
-        .where(
-          (f) =>
-              f.vehicleId == vehicleId &&
-              f.id != closing.id &&
-              !f.isCorrection,
-        )
-        .toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
-
-    FillUp? previousPlein;
-    for (final f in allFills) {
-      if (!f.date.isBefore(closing.date)) continue;
-      if (!f.isFullTank) continue;
-      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
-        previousPlein = f;
-      }
-    }
-
-    DateTime? windowStart;
-    bool inclusiveLower = true;
-    if (previousPlein != null) {
-      windowStart = previousPlein.date;
-      inclusiveLower = false;
-    } else if (allFills.isNotEmpty) {
-      windowStart = allFills.first.date;
-      inclusiveLower = true;
-    }
-    final upperBound = closing.date;
-
-    bool inWindow(DateTime when) {
-      if (windowStart != null) {
-        final afterStart = inclusiveLower
-            ? !when.isBefore(windowStart)
-            : when.isAfter(windowStart);
-        if (!afterStart) return false;
-      }
-      return !when.isAfter(upperBound);
-    }
-
+    // #3138 — same window math as [_linkedTripIdsForWholeWindow], via the
+    // shared [FillUpTripLinker]: the partials in [closing]'s open window.
+    final inWindow = const FillUpTripLinker()
+        .siblingsInWindow(fillUp: closing, allFills: repo.getAll());
     final newIds = closing.linkedTripIds;
-    for (final f in allFills) {
-      if (!inWindow(f.date)) continue;
+    for (final f in inWindow) {
       // Merge — preserve any pre-existing ids, add the new set.
       final merged = <String>{...f.linkedTripIds, ...newIds}.toList();
       if (merged.length == f.linkedTripIds.length &&

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -467,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'051edb6ed52f4288036b33f5211e87a56209dcd5';
+String _$fillUpListHash() => r'99a6abc6445acf15e09631e07a86981077b09df4';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/test/features/consumption/domain/services/fill_up_trip_linker_test.dart
+++ b/test/features/consumption/domain/services/fill_up_trip_linker_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/fill_up_trip_linker.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #3138 — pins the plein-to-plein window semantics (#1361 / #888) now that the
+/// linking math lives in the pure [FillUpTripLinker] (extracted out of the
+/// `FillUpList` notifier). All behaviour is a function of the inputs — no
+/// Riverpod, no Hive.
+
+DateTime _d(int day) => DateTime.utc(2026, 6, day);
+
+FillUp _fill({
+  required String id,
+  required int day,
+  String? vehicleId = 'veh-a',
+  bool isFullTank = true,
+  bool isCorrection = false,
+  List<String> linkedTripIds = const [],
+}) =>
+    FillUp(
+      id: id,
+      date: _d(day),
+      liters: 40,
+      totalCost: 60,
+      odometerKm: 10000,
+      fuelType: FuelType.e10,
+      vehicleId: vehicleId,
+      isFullTank: isFullTank,
+      isCorrection: isCorrection,
+      linkedTripIds: linkedTripIds,
+    );
+
+TripSummary _summary(DateTime start) => TripSummary(
+      distanceKm: 12,
+      maxRpm: 2800,
+      highRpmSeconds: 10,
+      idleSeconds: 30,
+      harshBrakes: 0,
+      harshAccelerations: 0,
+      startedAt: start,
+      endedAt: start.add(const Duration(minutes: 20)),
+    );
+
+TripHistoryEntry _trip(String id, int day, {String? vehicleId = 'veh-a'}) =>
+    TripHistoryEntry(
+      id: id,
+      vehicleId: vehicleId,
+      summary: _summary(_d(day)),
+    );
+
+void main() {
+  const linker = FillUpTripLinker();
+
+  group('windowFor', () {
+    test('prior plein → lower bound is that plein, EXCLUSIVE', () {
+      final closing = _fill(id: 'b', day: 20);
+      final priorPlein = _fill(id: 'a', day: 10);
+      final window = linker.windowFor(closing, [priorPlein, closing]);
+
+      expect(window.start, _d(10));
+      expect(window.inclusiveLower, isFalse);
+      expect(window.upper, _d(20));
+      // the prior plein's own date is excluded; the day after is in.
+      expect(window.contains(_d(10)), isFalse);
+      expect(window.contains(_d(11)), isTrue);
+      expect(window.contains(_d(20)), isTrue); // upper inclusive
+      expect(window.contains(_d(21)), isFalse);
+    });
+
+    test('no prior plein but earlier fills → earliest fill, INCLUSIVE', () {
+      final closing = _fill(id: 'c', day: 20);
+      final partialA = _fill(id: 'a', day: 8, isFullTank: false);
+      final partialB = _fill(id: 'b', day: 12, isFullTank: false);
+      final window = linker.windowFor(closing, [partialA, partialB, closing]);
+
+      expect(window.start, _d(8));
+      expect(window.inclusiveLower, isTrue);
+      expect(window.contains(_d(8)), isTrue); // earliest fill IS in window
+    });
+
+    test('no prior fills at all → no lower bound (legacy #888)', () {
+      final closing = _fill(id: 'a', day: 20);
+      final window = linker.windowFor(closing, [closing]);
+
+      expect(window.start, isNull);
+      expect(window.contains(_d(1)), isTrue); // everything before upper qualifies
+      expect(window.contains(_d(21)), isFalse);
+    });
+  });
+
+  group('linkedTripIdsInWindow', () {
+    test('returns only the in-window, same-vehicle trips', () {
+      final closing = _fill(id: 'plein', day: 20);
+      final priorPlein = _fill(id: 'prev', day: 10);
+      final history = [
+        _trip('t-early', 9), // before the prior plein → out
+        _trip('t-in1', 12), // in window
+        _trip('t-in2', 18), // in window
+        _trip('t-other', 15, vehicleId: 'veh-b'), // other vehicle → out
+        _trip('t-late', 25), // after closing → out
+      ];
+
+      final ids = linker.linkedTripIdsInWindow(
+        fillUp: closing,
+        history: history,
+        allFills: [priorPlein, closing],
+      );
+
+      expect(ids, ['t-in1', 't-in2']);
+    });
+
+    test('empty when the fill-up has no vehicle bound', () {
+      final closing = _fill(id: 'x', day: 20, vehicleId: null);
+      expect(
+        linker.linkedTripIdsInWindow(
+          fillUp: closing,
+          history: [_trip('t', 12, vehicleId: null)],
+          allFills: [closing],
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('siblingsInWindow', () {
+    test('the partials in the open window, excluding corrections + the close',
+        () {
+      final closing = _fill(id: 'plein', day: 20);
+      final priorPlein = _fill(id: 'prev', day: 10);
+      final partial = _fill(id: 'partial', day: 14, isFullTank: false);
+      final correction = _fill(id: 'corr', day: 15, isCorrection: true);
+
+      final siblings = linker.siblingsInWindow(
+        fillUp: closing,
+        allFills: [priorPlein, partial, correction, closing],
+      );
+
+      // prior plein is the EXCLUSIVE lower bound (out); the partial is in;
+      // the correction is filtered; the closing fill itself is excluded.
+      expect(siblings.map((f) => f.id), ['partial']);
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -786,8 +786,13 @@ void main() {
     // tracked #2187/#2188.
     // 5 bumps — decomposition forced (#3141), tracked by the OPEN #3138
     // (this providers file / FillUpList is named in that issue).
+    // #3138 — ratcheted DOWN 1025 → 938: the duplicated plein-to-plein window
+    // math in the FillUpList notifier's `_linkedTripIdsForWholeWindow` +
+    // `_relinkOpenWindow` moved into the pure, unit-tested FillUpTripLinker
+    // (domain/services/fill_up_trip_linker.dart). First #3138 slice; the
+    // trips/fillups feature split is the remaining work.
     'lib/features/consumption/providers/consumption_providers.dart': (
-      lines: 1025,
+      lines: 938,
       bumps: 5,
       decompositionIssue: 3138,
     ),


### PR DESCRIPTION
First slice of #3138 (the trips/fillups feature split is the remaining work; the issue stays open).

The `FillUpList` notifier duplicated the plein-to-plein window math across `_linkedTripIdsForWholeWindow` and `_relinkOpenWindow`: find the previous plein → derive the lower bound (exclusive after a plein, inclusive at the earliest fill, none for a first fill) → test membership.

## Change

- **`fill_up_trip_linker.dart`** (`FillUpTripLinker` + `FillUpLinkWindow`, 131) — the pure window/linking logic: no Riverpod, no repo I/O, no side effects, so the #1361 / #888 semantics are **unit-testable in isolation**. The notifier keeps the I/O (load history + sibling fills, save merged links).
- **`consumption_providers.dart` 1025 → 938** — the two methods now load the data and delegate; the duplicated window math is gone (a real DRY win, not just relocation).

## Safety
- New `fill_up_trip_linker_test` pins the window semantics (prior-plein exclusive lower bound, earliest-fill inclusive, no-prior no-bound, vehicle/correction filtering).
- `flutter analyze` clean; the **full consumption provider suite (270 tests, incl. the #1361 whole-window `relinking` integration test)** stays green.
- Ratcheted the `file_length` snapshot DOWN per the shrink rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)