### PR TITLE
fix(fr): render open==close (01:00-01:00) opening hours as open24h, not 'non disponibles' (#3308)

### DIFF
--- a/lib/features/station_services/france/france_opening_hours_adapter.dart
+++ b/lib/features/station_services/france/france_opening_hours_adapter.dart
@@ -30,10 +30,15 @@ import '../opening_hours/opening_hours_adapter.dart';
 /// 3. **A day name with NO range** — a bare `Lundi` / a trailing `Dimanche`
 ///    means *closed that day* (Prix-Carburants `Fermé`). It resolves to
 ///    [DayState.closed], never dropped (#2742).
-/// 4. **The `01:00-01:00` degenerate sentinel** — the feed emits an
-///    open==close range to mean "no real interval". A day whose only token is
-///    such a range resolves to [DayState.unknown] (the literal range is
-///    dropped), never a real interval and never 24h ([TimeRange.isDegenerate]).
+/// 4. **The `01:00-01:00` round-the-clock convention** — the feed emits an
+///    open==close range (`ouverture == fermeture`, e.g. `01.00-01.00`) to mean
+///    the day is open continuously. The official prix-carburants site renders
+///    those days as their hours (it shows `01h-01h`), NOT as "closed", so a day
+///    whose only token is such a range resolves to [DayState.open24h] — not
+///    dropped to [DayState.unknown] (#3308: doing so hid hours the source
+///    publishes, rendering "Horaires d'ouverture non disponibles"). The literal
+///    interval is still not kept as a range ([TimeRange.isDegenerate]); the day
+///    is the 24h state instead.
 /// 5. **Split shifts / lunch breaks** — a day publishes two ranges joined by
 ///    ` et ` (`Lundi 08.00-12.00 et 14.00-18.00`) or, rarely, as two same-day
 ///    entries; both ranges coalesce into that day's [DayHours.ranges].
@@ -103,10 +108,11 @@ class FranceOpeningHoursAdapter extends OpeningHoursAdapter {
       // `Lundi 08.00-12.00 et 14.00-18.00` (split shift) uniformly.
       final matches = _dayWordRe.allMatches(trimmed).toList();
       // Per-day accumulators. `closed` = a bare day token with no clock at
-      // all; `unknown` = a day whose only clock was the degenerate sentinel.
+      // all; `roundTheClock` = a day whose only clock was an open==close range
+      // (#3308: the feed's 24h convention — open24h, not "no interval").
       final ranges = <OpeningDay, List<TimeRange>>{};
       final closed = <OpeningDay>{};
-      final degenerateOnly = <OpeningDay>{};
+      final roundTheClock = <OpeningDay>{};
 
       for (var i = 0; i < matches.length; i++) {
         final m = matches[i];
@@ -126,7 +132,10 @@ class FranceOpeningHoursAdapter extends OpeningHoursAdapter {
             endHour: int.parse(c.group(3)!),
             endMinute: int.parse(c.group(4)!),
           );
-          // Degenerate `01:00-01:00` carries no real interval — drop it.
+          // #3308 — an open==close range (`01:00-01:00`) is the feed's
+          // round-the-clock convention, not a real interval — don't keep it as
+          // a range, but DO mark the day open24h below (the official site shows
+          // these as hours, so we must too).
           if (range.isDegenerate) continue;
           sawUsable = true;
           (ranges[day] ??= <TimeRange>[]).add(range);
@@ -135,8 +144,8 @@ class FranceOpeningHoursAdapter extends OpeningHoursAdapter {
         if (sawUsable) {
           continue; // real ranges recorded above
         } else if (sawClock) {
-          // Only a degenerate sentinel → "no real interval" → unknown.
-          degenerateOnly.add(day);
+          // #3308 — only an open==close range → open the whole day (24h).
+          roundTheClock.add(day);
         } else {
           // Bare day name, no clock at all → closed (Fermé).
           closed.add(day);
@@ -152,15 +161,20 @@ class FranceOpeningHoursAdapter extends OpeningHoursAdapter {
           );
         } else if (closed.contains(day)) {
           days.add(DayHours(day: day, state: DayState.closed));
-        } else if (degenerateOnly.contains(day)) {
-          days.add(DayHours(day: day, state: DayState.unknown));
+        } else if (roundTheClock.contains(day)) {
+          // #3308 — open==close → the day is open 24h.
+          days.add(DayHours(day: day, state: DayState.open24h));
         }
         // else: omitted → implicitly unknown (left out of `days`).
       }
 
-      // Whether any staffed signal at all was resolved (open/closed/unknown).
+      // Whether any staffed signal at all was resolved (open/closed/24h).
       final hasSchedule = days.isNotEmpty;
-      final hasStaffedRanges = days.any((d) => d.state == DayState.openRanges);
+      // #3308 — an open24h day is a real "open" signal too, so an automate
+      // station that ALSO publishes open24h boutique days keeps that schedule
+      // rather than collapsing to the pump-only all-week 24h fallback below.
+      final hasStaffedRanges = days.any((d) =>
+          d.state == DayState.openRanges || d.state == DayState.open24h);
 
       // Automate-only: the flag is set but the feed gave no real staffed
       // ranges (every day is closed/unknown/omitted) → pump-only 24/7.

--- a/test/features/station_services/france/france_opening_hours_adapter_test.dart
+++ b/test/features/station_services/france/france_opening_hours_adapter_test.dart
@@ -183,7 +183,8 @@ void main() {
       expect(out.days, hasLength(2));
     });
 
-    test('01:00-01:00 degenerate sentinel → unknown, range dropped', () {
+    test('01:00-01:00 open==close → open24h (the round-the-clock convention '
+        'the official prix-carburants site renders), no kept range (#3308)', () {
       final out = adapter.parse({
         'horaires_jour': 'Lundi01.00-01.00, Mardi08.00-18.00',
         'horaires_automate_24_24': 'Non',
@@ -191,8 +192,11 @@ void main() {
 
       final monday = out.dayFor(OpeningDay.mon);
       expect(monday, isNotNull);
-      // Not a real interval, not 24h — explicitly unknown with no rendered range.
-      expect(monday!.state, DayState.unknown);
+      // #3308 — open==close is the feed's 24h convention; the official site
+      // shows it as the day's hours (`01h-01h`), so we render open24h instead
+      // of dropping it to unknown (which hid it as "non disponibles"). The
+      // literal interval is not kept as a range — the day IS the 24h state.
+      expect(monday!.state, DayState.open24h);
       expect(monday.ranges, isEmpty);
 
       final tuesday = out.dayFor(OpeningDay.tue);

--- a/test/features/station_services/france/prix_carburants_opening_hours_codec_test.dart
+++ b/test/features/station_services/france/prix_carburants_opening_hours_codec_test.dart
@@ -67,11 +67,15 @@ void main() {
     expect(roundTripped.is24h, isTrue);
   });
 
-  test('a genuinely hours-less FR record (all 01:00-01:00, automate off) '
-      'round-trips as not-available — honest, not a parse loss', () {
-    // The REAL 34120007 (18 AVENUE DE VERDUN, Pézenas) record: every day is
-    // the degenerate `01.00-01.00` sentinel and the automate flag is off, so
-    // the source genuinely carries NO usable hours.
+  test('an all-`01:00-01:00` FR record (open==close every day) round-trips as '
+      'open24h — the hours the official site shows, NOT "non disponibles" '
+      '(#3308 regression)', () {
+    // The REAL 34120007 (18 AVENUE DE VERDUN, Pézenas / STATION SERVICE PEZENAS
+    // | ENI) record: every day is `01.00-01.00` (open==close). The official
+    // prix-carburants site renders these as the day's hours ("Lundi : 01h-01h
+    // …"), so the app MUST show hours too. We previously dropped open==close as
+    // a "degenerate sentinel" → all days unknown → "Horaires d'ouverture non
+    // disponibles". Now it resolves to open24h (the round-the-clock convention).
     final record = <String, dynamic>{
       'id': '34120007',
       'geom': <String, dynamic>{'lat': 43.46, 'lon': 3.42},
@@ -87,11 +91,13 @@ void main() {
     };
     final parsed = parsePrixCarburantsStation(record, 43.46, 3.42);
     final oh = Station.fromJson(parsed!.toJson()).openingHours;
-    // No staffed ranges anywhere — every day is the degenerate sentinel.
-    final anyOpen = kRegularWeekdays
-        .any((d) => oh?.dayFor(d)?.state == DayState.openRanges);
-    expect(anyOpen, isFalse,
-        reason: 'the source data has no real intervals for this station — '
-            '"non disponibles" is the honest render, not a parse regression');
+    expect(oh, isNotNull);
+    // Every day open24h — survives the round-trip, renders as hours not
+    // "non disponibles".
+    for (final d in kRegularWeekdays) {
+      expect(oh!.dayFor(d)?.state, DayState.open24h,
+          reason: 'open==close is the 24h convention the official site shows');
+    }
+    expect(oh!.availability, isNot(OpeningHoursAvailability.notProvided));
   });
 }


### PR DESCRIPTION
Closes #3308.

A French station whose feed encodes a day as `ouverture == fermeture` (`01.00-01.00`) showed **"Horaires d'ouverture non disponibles"** in-app — even though the **official prix-carburants site renders those days as their hours**: STATION SERVICE PEZENAS | ENI (18 avenue de verdun, 34120) shows "Lundi : 01h-01h … Dimanche : 01h-01h".

**Verified against the live feed** (id 34120007): every day is `{"@ouverture":"01.00","@fermeture":"01.00"}`, `horaires_jour: "Lundi01.00-01.00, …"`.

## Root cause
`FranceOpeningHoursAdapter` treated `ouverture==fermeture` as a "degenerate, no-real-interval" sentinel and **dropped** it → the day → `DayState.unknown` → all-unknown → "non disponibles". That assumption was wrong: `ouverture==fermeture` is the feed's **round-the-clock (24h)** convention, which the authoritative source displays as hours.

## Fix
A day whose only clock token is an open==close range now resolves to **`DayState.open24h`** (the literal interval still isn't kept as a range — the day *is* the 24h state), and open24h counts as a real "open" signal in the automate-collapse logic.

## Tests
- Updated `france_opening_hours_adapter_test` (it was asserting the wrong `unknown` behaviour).
- Updated the search→codec round-trip test: the real all-`01:00-01:00` station now round-trips as `open24h` (RED on the old behaviour, GREEN now).
- `flutter analyze` clean; all FR station-service + opening-hours + station-detail suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)