### PR TITLE
fix(consumption): trip-path map crash on non-finite / zero-span GPS points (#3316)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_path_geometry.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_geometry.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'trip_detail_charts.dart';
+
+/// Pure geometry helpers for the trip-detail map (#3316), kept out of the
+/// widget so they're unit-testable without a live `FlutterMap` and so the
+/// near-cap card file stays small.
+///
+/// Both guard the two non-finite faults that crashed the map in the field:
+///   * a `NaN`/`Infinity` GPS coordinate reaching `MarkerLayer` →
+///     `Crs.checkLatLng` throws; and
+///   * a zero-span bounds (single point, or every fix at the SAME
+///     coordinate — a stationary / sub-100 m degenerate trip) making
+///     `CameraFit.bounds` compute an infinite fit-zoom that
+///     `_TileLayerState._clampToNativeZoom` turns into `Infinity.toInt()` →
+///     `UnsupportedError`.
+
+/// The map polyline points paired with the source samples they came from,
+/// index-aligned so the inner map can colour segments by telemetry.
+class TripPathPoints {
+  final List<LatLng> points;
+  final List<TripDetailSample> samples;
+
+  const TripPathPoints(this.points, this.samples);
+}
+
+/// Builds the index-aligned (point, sample) lists, dropping any fix whose
+/// latitude/longitude is null OR non-finite. The recorder writes the
+/// lat/lng pair atomically, but the type allows a half-set/NaN pair, so we
+/// filter defensively at the read site — a non-finite `LatLng` crashes
+/// flutter_map's `MarkerLayer` (`Crs.checkLatLng`).
+TripPathPoints buildTripPathPoints(List<TripDetailSample> samples) {
+  final points = <LatLng>[];
+  final kept = <TripDetailSample>[];
+  for (final s in samples) {
+    final lat = s.latitude;
+    final lng = s.longitude;
+    if (lat != null && lng != null && lat.isFinite && lng.isFinite) {
+      points.add(LatLng(lat, lng));
+      kept.add(s);
+    }
+  }
+  return TripPathPoints(points, kept);
+}
+
+/// The polyline bounds, with any near-zero span padded by [eps] so
+/// `CameraFit.bounds` always has a finite area to fit. Folds the
+/// single-point and all-identical-points cases into one path. [points]
+/// must be non-empty and all-finite (see [buildTripPathPoints]).
+LatLngBounds tripPathBounds(List<LatLng> points, {double eps = 0.0005}) {
+  // eps ≈ 50 m at the equator — a sane minimum frame for a stationary trip.
+  var minLat = points.first.latitude;
+  var maxLat = minLat;
+  var minLng = points.first.longitude;
+  var maxLng = minLng;
+  for (final p in points) {
+    if (p.latitude < minLat) minLat = p.latitude;
+    if (p.latitude > maxLat) maxLat = p.latitude;
+    if (p.longitude < minLng) minLng = p.longitude;
+    if (p.longitude > maxLng) maxLng = p.longitude;
+  }
+  if (maxLat - minLat < eps) {
+    minLat -= eps;
+    maxLat += eps;
+  }
+  if (maxLng - minLng < eps) {
+    minLng -= eps;
+    maxLng += eps;
+  }
+  return LatLngBounds(LatLng(minLat, minLng), LatLng(maxLat, maxLng));
+}

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -11,6 +11,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/driving_insights_hard_accel_indices.dart';
 import 'trip_detail_charts.dart';
+import 'trip_path_geometry.dart';
 
 // ---------------------------------------------------------------------------
 // Phase 3 thresholds (#1374) — fixed defaults.
@@ -69,20 +70,12 @@ class TripPathMapCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Build the parallel lists of (LatLng, source-sample) so the inner
-    // map can colour segments by the source sample's telemetry. Half-
-    // set fixes are dropped — the recorder writes the lat/lng pair
-    // atomically (see `TripSample` doc) but the type still allows it,
-    // so be defensive at the read site.
-    final points = <LatLng>[];
-    final pointSamples = <TripDetailSample>[];
-    for (final s in samples) {
-      final lat = s.latitude;
-      final lng = s.longitude;
-      if (lat != null && lng != null) {
-        points.add(LatLng(lat, lng));
-        pointSamples.add(s);
-      }
-    }
+    // map can colour segments by the source sample's telemetry. Null AND
+    // non-finite fixes are dropped (#3316) — a NaN/Infinity coordinate
+    // crashes flutter_map's MarkerLayer via Crs.checkLatLng.
+    final built = buildTripPathPoints(samples);
+    final points = built.points;
+    final pointSamples = built.samples;
     if (points.isEmpty) {
       // No GPS coords at all — skip the card entirely per the issue's
       // Phase 2 spec ("legacy trips, opted-out trips"). Rendering an
@@ -149,30 +142,16 @@ class _TripPathMapState extends State<_TripPathMap> {
   late final MapController _mapController = MapController();
 
   /// Pre-computed bounds for the polyline, fed to
-  /// [MapOptions.initialCameraFit]. Single-point polylines fall back to a
-  /// degenerate bounds box centered on the point (see [_computeBounds]) so
-  /// `CameraFit.bounds` centres on the point at a sane zoom rather than
-  /// dividing by zero.
-  late final LatLngBounds _bounds = _computeBounds(widget.points);
+  /// [MapOptions.initialCameraFit]. Any near-zero span (single point, or
+  /// every fix at the same coordinate — a stationary / sub-100 m trip) is
+  /// padded by [tripPathBounds] so `CameraFit.bounds` never computes an
+  /// infinite fit-zoom (#3316).
+  late final LatLngBounds _bounds = tripPathBounds(widget.points);
 
   /// Pre-fit fallback centre used by [MapOptions.initialCenter] for the
   /// degenerate case where layout hasn't run yet; `initialCameraFit`
   /// frames the real viewport on the first layout pass.
   late final LatLng _initialCenter = _bounds.center;
-
-  static LatLngBounds _computeBounds(List<LatLng> points) {
-    if (points.length == 1) {
-      // Single-point polyline — synthesize a tiny bounds box around
-      // the point so flutter_map's CameraFit doesn't divide-by-zero.
-      final p = points.first;
-      const eps = 0.0005; // ~50 m at the equator; fine for any latitude
-      return LatLngBounds(
-        LatLng(p.latitude - eps, p.longitude - eps),
-        LatLng(p.latitude + eps, p.longitude + eps),
-      );
-    }
-    return LatLngBounds.fromPoints(points);
-  }
 
   @override
   void dispose() {

--- a/test/features/consumption/presentation/widgets/trip_path_geometry_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_geometry_test.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_path_geometry.dart';
+
+/// #3316 — the trip-detail map threw two faces of one bug in the field:
+///   * `UnsupportedError` from `_TileLayerState._clampToNativeZoom`
+///     (`Infinity.toInt()`) when a degenerate trip yields a zero-span
+///     bounds → infinite CameraFit zoom; and
+///   * `Crs.checkLatLng` rejecting a non-finite `LatLng` in `MarkerLayer`.
+/// These pure helpers sanitise the points and pad the bounds so neither
+/// can reach flutter_map.
+TripDetailSample _s(double? lat, double? lng) =>
+    TripDetailSample(timestamp: DateTime(2026), speedKmh: 10, latitude: lat, longitude: lng);
+
+void main() {
+  group('buildTripPathPoints (#3316)', () {
+    test('drops null coordinates', () {
+      final r = buildTripPathPoints([_s(48.1, 11.5), _s(null, 11.6), _s(48.2, null)]);
+      expect(r.points, [const LatLng(48.1, 11.5)]);
+      expect(r.samples.length, 1);
+    });
+
+    test('drops NaN / Infinity coordinates (the MarkerLayer crash)', () {
+      final r = buildTripPathPoints([
+        _s(48.1, 11.5),
+        _s(double.nan, 11.6),
+        _s(48.2, double.infinity),
+        _s(double.negativeInfinity, double.nan),
+      ]);
+      expect(r.points, [const LatLng(48.1, 11.5)]);
+      expect(r.samples.length, 1);
+      for (final p in r.points) {
+        expect(p.latitude.isFinite && p.longitude.isFinite, isTrue);
+      }
+    });
+
+    test('keeps points and samples index-aligned', () {
+      final r = buildTripPathPoints([_s(1, 1), _s(double.nan, 2), _s(3, 3)]);
+      expect(r.points, [const LatLng(1, 1), const LatLng(3, 3)]);
+      expect(r.samples.length, 2);
+    });
+
+    test('empty / all-invalid input → empty', () {
+      expect(buildTripPathPoints(const []).points, isEmpty);
+      expect(buildTripPathPoints([_s(double.nan, double.nan)]).points, isEmpty);
+    });
+  });
+
+  group('tripPathBounds (#3316)', () {
+    test('a real multi-point span keeps its real corners', () {
+      final b = tripPathBounds(const [LatLng(48.0, 11.0), LatLng(48.5, 11.5)]);
+      expect(b.south, 48.0);
+      expect(b.north, 48.5);
+      expect(b.west, 11.0);
+      expect(b.east, 11.5);
+    });
+
+    test('a single point is padded to a finite non-zero-span box', () {
+      final b = tripPathBounds(const [LatLng(48.0, 11.0)]);
+      expect(b.north - b.south, greaterThan(0));
+      expect(b.east - b.west, greaterThan(0));
+      expect(b.center.latitude, closeTo(48.0, 1e-6));
+      expect(b.center.longitude, closeTo(11.0, 1e-6));
+    });
+
+    test('≥2 IDENTICAL points are padded too (the zero-span CameraFit crash)', () {
+      final b = tripPathBounds(const [
+        LatLng(48.0, 11.0),
+        LatLng(48.0, 11.0),
+        LatLng(48.0, 11.0),
+      ]);
+      expect(b.north - b.south, greaterThan(0),
+          reason: 'zero latitude span would make CameraFit zoom infinite');
+      expect(b.east - b.west, greaterThan(0));
+    });
+
+    test('a span that is zero on only ONE axis is padded on that axis', () {
+      // Same longitude, different latitude → only the lng axis is degenerate.
+      final b = tripPathBounds(const [LatLng(48.0, 11.0), LatLng(48.4, 11.0)]);
+      expect(b.north - b.south, closeTo(0.4, 1e-9), reason: 'real lat span preserved');
+      expect(b.east - b.west, greaterThan(0), reason: 'degenerate lng axis padded');
+    });
+
+    test('all corners stay finite', () {
+      final b = tripPathBounds(const [LatLng(48.0, 11.0), LatLng(48.0, 11.0)]);
+      expect(b.north.isFinite && b.south.isFinite, isTrue);
+      expect(b.east.isFinite && b.west.isFinite, isTrue);
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -385,4 +385,41 @@ void main() {
       expect(flutterMap.options.initialCameraFit, isNotNull);
     });
   });
+
+  group('TripPathMapCard — non-finite / degenerate guard (#3316)', () {
+    testWidgets('NaN / Infinity coords are dropped, the map still builds',
+        (tester) async {
+      // A field export crashed MarkerLayer (Crs.checkLatLng) on a NaN
+      // LatLng. The finite subset must still render, no exception thrown.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: double.nan, lng: 3.44),
+        _sample(sec: 2, lat: 43.48, lng: double.infinity),
+        _sample(sec: 3, lat: 43.49, lng: 3.46),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(FlutterMap), findsOneWidget);
+    });
+
+    testWidgets(
+        'all-identical points (a stationary trip) build without an infinite '
+        'CameraFit zoom', (tester) async {
+      // Every fix at the same coordinate → zero-span bounds → the old
+      // CameraFit computed an infinite fit-zoom that _clampToNativeZoom
+      // turned into Infinity.toInt() → UnsupportedError.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: 43.46, lng: 3.43),
+        _sample(sec: 2, lat: 43.46, lng: 3.43),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(FlutterMap), findsOneWidget);
+    });
+  });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -751,8 +751,10 @@ void main() {
     // #2624 — shrank 463 → 450: dropped the post-frame `fitCamera` block
     // (+ its dart:async / error_logger imports) in favour of
     // `MapOptions.initialCameraFit`, fixing the grey-tile cold-start race.
+    // #3316 — shrank 450 → 412: the finite-point filter + zero-span bounds
+    // padding moved to the pure trip_path_geometry.dart helper.
     'lib/features/consumption/presentation/widgets/trip_path_map_card.dart': (
-      lines: 450,
+      lines: 412,
       bumps: 0,
       decompositionIssue: null,
     ),


### PR DESCRIPTION
Closes #3316.

## Why
A field error-log export (the same session as #3311) showed the trip-detail map (`navigate:/trip/:id`) throwing two faces of one root cause:
- **4× `UnsupportedError`** — `_TileLayerState._clampToNativeZoom` ← a tile-prune `Timer`. A degenerate trip whose fixes are all at the **same coordinate** yields a zero-span `LatLngBounds`, so `CameraFit.bounds` computes an infinite fit-zoom that reaches `Infinity.toInt()`.
- **1× `_Exception`** — `Crs.checkLatLng` ← `MarkerLayer.build`. A `NaN`/`Infinity` GPS coordinate passed the null-only guard and became `LatLng(NaN, NaN)`.

(The observed 0.072 km gpsOnly trip is exactly the stationary/degenerate case that triggers the zero-span path.)

## What
- Filter points to **finite** coordinates (`lat.isFinite && lng.isFinite`), not just non-null.
- **Pad any near-zero bounds span** (either axis) to a small finite box — folds the old single-point eps-box case and covers all-identical points.
- Extract the finite-filter + bounds math into a pure `trip_path_geometry.dart` helper (unit-testable without a live `FlutterMap`); the near-cap card shrinks **450 → 412**.

## Tests
- `trip_path_geometry_test.dart` — NaN/Infinity drop, index-alignment, zero-span pad per axis, single-point, empty.
- `trip_path_map_card_test.dart` — two end-to-end regressions pumping the real card with NaN and all-identical samples, asserting `takeException() == null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
