### PR TITLE
feat(android): battery-optimization exemption prompt on manual recording start (#3313)

### DIFF
--- a/android/app/src/fdroid/AndroidManifestFgsApproved.xml
+++ b/android/app/src/fdroid/AndroidManifestFgsApproved.xml
@@ -24,10 +24,17 @@
      geolocator's foregroundServiceType="location" service). No Android
      Auto components (the Auto host is GMS, absent from the GMS-free fdroid
      build) and no AutoRecordForegroundService / CONNECTED_DEVICE here —
-     extending hands-free auto-record to fdroid is a separate decision. -->
+     extending hands-free auto-record to fdroid is a separate decision.
+
+     #3313 — REQUEST_IGNORE_BATTERY_OPTIMIZATIONS lets the recording FGS
+     prompt the user to be whitelisted from battery optimization, so a long
+     drive survives Doze / aggressive OEM task-killers (a foreground service
+     alone does not stop Doze CPU-sleep). Normal install-time permission,
+     shipped only in this FGS-approved overlay so default builds stay clean. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 </manifest>

--- a/android/app/src/play/AndroidManifestFgsApproved.xml
+++ b/android/app/src/play/AndroidManifestFgsApproved.xml
@@ -48,6 +48,14 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+    <!-- #3313 — lets the recording FGS prompt for a battery-optimization
+         exemption so a long drive survives Doze / aggressive OEM
+         task-killers (a foreground service alone does not stop Doze
+         CPU-sleep). Normal install-time permission; Play accepts the
+         "persistent peripheral-device connection" (OBD2) justification.
+         Shipped only in this FGS-approved overlay so default builds stay
+         clean. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <application>
         <!-- Android Auto v1 (#2951) bound POI service: no android:permission

--- a/lib/core/permissions/battery_optimization_permissions.dart
+++ b/lib/core/permissions/battery_optimization_permissions.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:permission_handler/permission_handler.dart';
+
+/// Facade over the Android battery-optimization-exemption permission
+/// (`REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`), kept behind an interface so the
+/// recording layer can be unit-tested without the real `permission_handler`
+/// binding (#3313).
+///
+/// Whitelisting the app from battery optimization keeps a recording
+/// foreground service alive through Doze and aggressive OEM task-killers
+/// (Xiaomi/MIUI, Huawei, Samsung) on long drives — a foreground service is
+/// the lifecycle signal, but Doze still ignores wake locks unless the app is
+/// on the exemption list.
+///
+/// Android-only: it is only ever invoked behind the
+/// `kGpsRecordingForegroundServiceEnabled` build gate (an Android
+/// FGS-approved-flavour flag), so this never runs on iOS. The plugin impl is
+/// defensive anyway — an unsupported platform reports "exempt" so the caller
+/// no-ops rather than throwing.
+abstract class BatteryOptimizationPermissions {
+  /// Whether the app is already exempt from battery optimization. `true`
+  /// short-circuits the prompt. Treats an unsupported platform / probe
+  /// error as exempt (nothing to do).
+  Future<bool> isExempt();
+
+  /// Trigger the system `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+  /// dialog. Android shows it at most once per app; a later call is a no-op
+  /// unless the user cleared the decision in system settings.
+  Future<void> requestExemption();
+}
+
+class PluginBatteryOptimizationPermissions
+    implements BatteryOptimizationPermissions {
+  const PluginBatteryOptimizationPermissions();
+
+  @override
+  Future<bool> isExempt() async {
+    try {
+      return (await Permission.ignoreBatteryOptimizations.status).isGranted;
+    } catch (_) {
+      // Unsupported platform (iOS) / missing plugin — nothing to exempt.
+      return true;
+    }
+  }
+
+  @override
+  Future<void> requestExemption() async {
+    await Permission.ignoreBatteryOptimizations.request();
+  }
+}

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -37,6 +37,15 @@ class StorageKeys {
   static const String consentSyncTrips = 'consent_sync_trips';
 
   static const String swipeTutorialShown = 'swipe_tutorial_shown';
+
+  /// #3313 — set once we've prompted the user to exempt the app from
+  /// battery optimization (so a recording foreground service survives
+  /// Doze / aggressive OEM task-killers on long drives). One-time: set
+  /// the first time a recording FGS starts, never re-prompted, so a
+  /// declined dialog doesn't nag. Only ever consulted in FGS-approved
+  /// builds (`kGpsRecordingForegroundServiceEnabled`).
+  static const String batteryOptExemptionAsked = 'battery_opt_exemption_asked';
+
   static const String consumptionLog = 'consumption_log';
   static const String vehicleProfiles = 'vehicle_profiles';
   static const String activeVehicleProfileId = 'active_vehicle_profile_id';

--- a/lib/features/consumption/providers/recording_battery_exemption.dart
+++ b/lib/features/consumption/providers/recording_battery_exemption.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/location/recording_location_settings.dart';
+import '../../../core/logging/error_logger.dart';
+import '../../../core/permissions/battery_optimization_permissions.dart';
+import '../../../core/storage/storage_keys.dart';
+import '../../../core/storage/storage_providers.dart';
+
+/// Prompts the user — once — to exempt the app from battery optimization
+/// when a recording foreground service is about to run, so a long drive
+/// survives Doze and aggressive OEM task-killers (#3313).
+///
+/// Deliberately conservative:
+///   * gated on [kGpsRecordingForegroundServiceEnabled] — default builds
+///     have no recording FGS, so there is nothing to keep alive and the
+///     `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission isn't even shipped;
+///   * one-time — the asked flag is persisted BEFORE the prompt, so a
+///     declined (or crashed) dialog never re-nags;
+///   * skipped when already exempt;
+///   * fired only from MANUAL recording starts (the app is foreground, so
+///     the system Activity dialog can actually show);
+///   * never throws — it is a best-effort side effect of starting a trip.
+class RecordingBatteryExemption {
+  final BatteryOptimizationPermissions _permissions;
+  final bool Function() _alreadyAsked;
+  final Future<void> Function() _markAsked;
+
+  /// Build gate, injectable for tests. Defaults to the production flag.
+  final bool fgsEnabled;
+
+  RecordingBatteryExemption({
+    required BatteryOptimizationPermissions permissions,
+    required bool Function() alreadyAsked,
+    required Future<void> Function() markAsked,
+    this.fgsEnabled = kGpsRecordingForegroundServiceEnabled,
+  })  : _permissions = permissions,
+        _alreadyAsked = alreadyAsked,
+        _markAsked = markAsked;
+
+  /// Best-effort one-time prompt. Safe to fire-and-forget from a manual
+  /// recording start; never throws into the recording path.
+  Future<void> maybePrompt() async {
+    if (!fgsEnabled) return; // no recording FGS in this build → nothing to do
+    if (_alreadyAsked()) return;
+    try {
+      // Mark first: a declined dialog or a crash mid-prompt must not re-nag.
+      await _markAsked();
+      if (await _permissions.isExempt()) return; // already whitelisted
+      await _permissions.requestExemption();
+    } catch (e, st) {
+      // A failed prompt must never break recording — log and move on.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'RecordingBatteryExemption.maybePrompt'}));
+    }
+  }
+}
+
+/// Production wiring: the real plugin permission + the persisted one-time
+/// flag in the settings box.
+final recordingBatteryExemptionProvider =
+    Provider<RecordingBatteryExemption>((ref) {
+  // The settings read is LAZY (inside the closures, not the factory) so the
+  // gated path — `fgsEnabled == false`, the default/every-test build — never
+  // touches the Hive settings box. Only a real FGS-approved manual start
+  // (which has passed the gate) ever reads/writes the asked flag.
+  return RecordingBatteryExemption(
+    permissions: const PluginBatteryOptimizationPermissions(),
+    alreadyAsked: () =>
+        ref.read(settingsStorageProvider).getSetting(
+              StorageKeys.batteryOptExemptionAsked,
+            ) ==
+        true,
+    markAsked: () => ref.read(settingsStorageProvider).putSetting(
+          StorageKeys.batteryOptExemptionAsked,
+          true,
+        ),
+  );
+});

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -24,6 +24,7 @@ import '../domain/entities/trip_start_stage.dart';
 import '../domain/services/physics_scale_calibrator.dart';
 import '../domain/trip_recorder.dart';
 import 'gps_only_recording_pipeline.dart';
+import 'recording_battery_exemption.dart';
 import 'recording_pipeline.dart';
 import 'trip_discard_guard.dart';
 import 'trip_baseline_recorder.dart';
@@ -369,6 +370,11 @@ class TripRecording extends _$TripRecording {
     // never locks recording out permanently.
     if (state.isActive || _startInProgress) return;
     _startInProgress = true;
+    if (!automatic) {
+      // #3313 — manual (foreground) start: prompt once, FGS-gated. Auto
+      // starts skip it (may be backgrounded; the dialog can't show).
+      unawaited(ref.read(recordingBatteryExemptionProvider).maybePrompt());
+    }
     try {
       await _startInternal(service, automatic: automatic);
     } finally {
@@ -1125,6 +1131,7 @@ class TripRecording extends _$TripRecording {
       return StartTripOutcome.alreadyActive;
     }
     _startInProgress = true;
+    unawaited(ref.read(recordingBatteryExemptionProvider).maybePrompt()); // #3313
     try {
       final pipeline = GpsOnlyRecordingPipeline(
         ref: ref,

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'dcd0df09390968dd09bd92c50687cbeeb9f922a9';
+String _$tripRecordingHash() => r'59a3c0bbc2ff91e919f92d369e9e1bb367db4d27';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/providers/recording_battery_exemption_test.dart
+++ b/test/features/consumption/providers/recording_battery_exemption_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/permissions/battery_optimization_permissions.dart';
+import 'package:tankstellen/features/consumption/providers/recording_battery_exemption.dart';
+
+/// #3313 — the one-time, FGS-gated battery-optimization-exemption prompt
+/// fired from a manual recording start.
+class _FakePermissions implements BatteryOptimizationPermissions {
+  bool exempt = false;
+  int isExemptCalls = 0;
+  int requestCalls = 0;
+
+  @override
+  Future<bool> isExempt() async {
+    isExemptCalls++;
+    return exempt;
+  }
+
+  @override
+  Future<void> requestExemption() async {
+    requestCalls++;
+  }
+}
+
+void main() {
+  late _FakePermissions perms;
+  late bool asked;
+
+  RecordingBatteryExemption build({required bool fgsEnabled}) {
+    return RecordingBatteryExemption(
+      permissions: perms,
+      alreadyAsked: () => asked,
+      markAsked: () async => asked = true,
+      fgsEnabled: fgsEnabled,
+    );
+  }
+
+  setUp(() {
+    perms = _FakePermissions();
+    asked = false;
+  });
+
+  test('FGS disabled (default build) → never prompts, never marks', () async {
+    await build(fgsEnabled: false).maybePrompt();
+    expect(perms.isExemptCalls, 0);
+    expect(perms.requestCalls, 0);
+    expect(asked, isFalse);
+  });
+
+  test('first manual start (FGS on, not exempt) → marks then requests', () async {
+    await build(fgsEnabled: true).maybePrompt();
+    expect(asked, isTrue, reason: 'asked flag persisted');
+    expect(perms.requestCalls, 1, reason: 'system dialog requested once');
+  });
+
+  test('already asked → never re-prompts (no nag)', () async {
+    asked = true;
+    await build(fgsEnabled: true).maybePrompt();
+    expect(perms.isExemptCalls, 0);
+    expect(perms.requestCalls, 0);
+  });
+
+  test('already exempt → marks asked but does NOT show the dialog', () async {
+    perms.exempt = true;
+    await build(fgsEnabled: true).maybePrompt();
+    expect(asked, isTrue);
+    expect(perms.isExemptCalls, 1);
+    expect(perms.requestCalls, 0, reason: 'no point prompting when whitelisted');
+  });
+
+  test('a throwing dialog is swallowed (best-effort, never throws into the '
+      'recording path) and the asked flag still sticks (#2349)', () async {
+    final c = RecordingBatteryExemption(
+      permissions: _ThrowingOnRequest(),
+      alreadyAsked: () => asked,
+      markAsked: () async => asked = true,
+      fgsEnabled: true,
+    );
+    // Fault injected (the request dialog throws): the call must still
+    // complete normally — never rethrow into the start path.
+    await expectLater(c.maybePrompt(), completes);
+    // And the asked flag was set BEFORE the throwing request, so a second
+    // start is a no-op (no nag).
+    expect(asked, isTrue);
+  });
+}
+
+class _ThrowingOnRequest implements BatteryOptimizationPermissions {
+  @override
+  Future<bool> isExempt() async => false;
+
+  @override
+  Future<void> requestExemption() async => throw Exception('dialog blew up');
+}


### PR DESCRIPTION
Closes #3313.

## Why
The background-recording audit found the architecture already correct (gated behind `FGS_FORM_APPROVED`, #3173). The one practical "works in the background" gap: the app never asks to be exempt from **battery optimization**, so on Doze / aggressive OEM task-killers (Xiaomi/MIUI, Huawei, Samsung) a recording foreground service is killed mid-drive. A foreground service is the lifecycle signal, but Doze still ignores wake locks unless the app is whitelisted.

## What
- **`BatteryOptimizationPermissions`** facade (mirrors `CameraPermissions`) over `permission_handler`'s `Permission.ignoreBatteryOptimizations`; an unsupported platform (iOS) reports "exempt" so the caller no-ops.
- **`RecordingBatteryExemption`** coordinator — prompts **once** (asked flag persisted *before* the dialog, so a decline never re-nags), skips when already exempt, **gated on `kGpsRecordingForegroundServiceEnabled`** (default builds have no recording FGS → nothing to do, and the permission isn't even shipped), and **never throws** into the recording path.
- Wired into the **manual** start paths only — `TripRecording.start` when `!automatic`, and `startGpsOnly` — where the app is foreground so the system dialog can actually show. The hands-free auto path (`automatic: true`) is skipped (it may be backgrounded).
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` declared **only in the FGS-approved overlays** (play + fdroid), so default builds stay Play-clean. Play accepts the "persistent peripheral-device connection" (OBD2) justification.

No new ARB strings (the system dialog needs none). A **Settings re-trigger** for users who declined is a noted follow-up.

## Tests
`recording_battery_exemption_test.dart` — gate off → no prompt/no mark; first manual start → marks then requests; already-asked → no re-prompt; already-exempt → marks but no dialog; a throwing dialog completes normally (#2349 fault path) with the flag stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
