### PR TITLE
feat(consumption): motion-gate the GPS-only recording receiver (battery) (#3319)

### DIFF
--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -170,6 +170,7 @@ LocationSettings recordingLocationSettings({
   required AppLocalizations l10n,
   TargetPlatform? platform,
   bool? foregroundServiceEnabled,
+  bool coarse = false,
 }) {
   final target = platform ?? defaultTargetPlatform;
   // #3173 — test seam: production always follows the build-time define
@@ -180,12 +181,19 @@ LocationSettings recordingLocationSettings({
   switch (target) {
     case TargetPlatform.android:
       return AndroidSettings(
-        accuracy: LocationAccuracy.high,
+        // #3319 — when the motion gate has detected a stationary stretch we
+        // back the receiver off (medium accuracy, 5 s interval, 25 m gate)
+        // to save battery. A coarse fix still arrives, so resumed motion
+        // re-fines the stream. The FGS config is kept either way so the
+        // service (and its wake lock) stays alive across the quiet period.
+        accuracy:
+            coarse ? LocationAccuracy.medium : LocationAccuracy.high,
         // Self-bounded fine cadence: ask for a fix every second and let
         // every one through (no distance gate) so the trace stays dense
         // even at a standstill / in stop-and-go traffic.
-        intervalDuration: const Duration(seconds: 1),
-        distanceFilter: 0,
+        intervalDuration:
+            coarse ? const Duration(seconds: 5) : const Duration(seconds: 1),
+        distanceFilter: coarse ? 25 : 0,
         // The un-throttle lever: promote geolocator to a foreground service so
         // the OS stops the ~5 s background batching for the trip. Gated by
         // [kGpsRecordingForegroundServiceEnabled] (#3173 trigger:
@@ -231,6 +239,7 @@ LocationSettings recordingLocationSettings({
 LocationSettings recordingLocationSettingsForRef(
   Ref ref, {
   TargetPlatform? platform,
+  bool coarse = false,
 }) {
   String code;
   try {
@@ -244,5 +253,5 @@ LocationSettings recordingLocationSettingsForRef(
   } catch (_) {
     l10n = lookupAppLocalizations(const ui.Locale('en'));
   }
-  return recordingLocationSettings(l10n: l10n, platform: platform);
+  return recordingLocationSettings(l10n: l10n, platform: platform, coarse: coarse);
 }

--- a/lib/features/consumption/domain/services/motion_gate.dart
+++ b/lib/features/consumption/domain/services/motion_gate.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// The GPS request profile the recorder should use right now (#3319).
+enum GpsProfile {
+  /// Full-rate fixes (1 s / no distance filter) — the device is moving.
+  fine,
+
+  /// Coarse fixes (longer interval + distance filter) — the device has been
+  /// stationary, so we back off the GPS receiver to save battery. A coarse
+  /// stream still delivers the occasional fix, so resumed motion is detected
+  /// and the profile snaps back to [fine] — no separate wake signal needed.
+  coarse,
+}
+
+/// Pure stop-detection state machine that decides whether the recording GPS
+/// stream should run [GpsProfile.fine] or [GpsProfile.coarse] (#3319).
+///
+/// Replicates the battery lesson of motion-gated trackers (full-rate GPS
+/// while moving, backed off while parked) using ONLY signals the recorder
+/// already has — per-fix GPS ground speed (both pipelines) and, when
+/// available, the IMU horizontal-acceleration magnitude (GPS-only trips). No
+/// activity-recognition dependency, no extra permission.
+///
+/// Deliberately time-injected (callers pass `elapsed`) and side-effect free
+/// so the transitions are deterministically unit-testable. It never calls
+/// `DateTime.now()` itself.
+///
+/// Transitions (hysteresis so a single stray fix never thrashes the GPS
+/// receiver):
+///   * a clearly-moving fix (speed >= [movingSpeedKmh], or an IMU magnitude
+///     >= [imuMovingThreshold]) → [GpsProfile.fine] immediately;
+///   * sustained slow-and-still — speed <= [stationarySpeedKmh] AND (no IMU,
+///     or IMU < [imuStillThreshold]) — for at least [stationaryAfter] →
+///     [GpsProfile.coarse];
+///   * anything in between holds the current profile.
+class MotionGate {
+  MotionGate({
+    this.stationarySpeedKmh = 3.0,
+    this.movingSpeedKmh = 8.0,
+    this.stationaryAfter = const Duration(seconds: 20),
+    this.imuStillThreshold = 0.4,
+    this.imuMovingThreshold = 1.5,
+  });
+
+  /// At or below this ground speed (km/h) a fix is a stationary candidate.
+  final double stationarySpeedKmh;
+
+  /// At or above this ground speed (km/h) the device is unambiguously moving.
+  final double movingSpeedKmh;
+
+  /// How long the device must stay slow-and-still before backing GPS off.
+  final Duration stationaryAfter;
+
+  /// Horizontal IMU acceleration magnitude (m/s²) below which the device is
+  /// considered still. Ignored when no IMU sample is supplied.
+  final double imuStillThreshold;
+
+  /// Horizontal IMU acceleration magnitude (m/s²) at/above which the device
+  /// is unambiguously moving (re-fines immediately, e.g. pulling away).
+  final double imuMovingThreshold;
+
+  GpsProfile _profile = GpsProfile.fine;
+  Duration? _slowSince;
+
+  /// The current GPS profile. Starts [GpsProfile.fine] so a trip records at
+  /// full rate the moment it begins.
+  GpsProfile get profile => _profile;
+
+  /// Feed a recording fix. [speedKmh] is the per-fix ground speed;
+  /// [imuMagnitude] is the optional horizontal IMU acceleration (m/s²),
+  /// null when the trip has no IMU (OBD2/hybrid). [elapsed] is a monotonic
+  /// time since recording start (any consistent clock). Returns the profile
+  /// in effect after this fix.
+  GpsProfile onFix({
+    required double speedKmh,
+    double? imuMagnitude,
+    required Duration elapsed,
+  }) {
+    final imuMoving =
+        imuMagnitude != null && imuMagnitude >= imuMovingThreshold;
+    final imuStill = imuMagnitude == null || imuMagnitude < imuStillThreshold;
+
+    if (speedKmh >= movingSpeedKmh || imuMoving) {
+      // Unambiguously moving — fine, and reset the stillness timer.
+      _slowSince = null;
+      _profile = GpsProfile.fine;
+      return _profile;
+    }
+
+    if (speedKmh <= stationarySpeedKmh && imuStill) {
+      // Slow and still: arm / hold the stillness timer.
+      _slowSince ??= elapsed;
+      if (elapsed - _slowSince! >= stationaryAfter) {
+        _profile = GpsProfile.coarse;
+      }
+      return _profile;
+    }
+
+    // Intermediate (rolling slowly, or IMU shows some motion): not a
+    // stationary candidate, but not clearly moving either — break the
+    // stillness timer and hold the current profile.
+    _slowSince = null;
+    return _profile;
+  }
+
+  /// Reset to the initial fine profile (e.g. on a new trip).
+  void reset() {
+    _profile = GpsProfile.fine;
+    _slowSince = null;
+  }
+}

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/location/geolocator_wrapper.dart';
-import '../../../core/location/recording_location_settings.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/sensors/imu_sample.dart';
 import '../../../core/sensors/imu_sensor_source.dart';
@@ -22,6 +20,7 @@ import '../domain/services/gps_fuel_estimator.dart';
 import '../domain/services/gps_live_estimate_folder.dart';
 import '../domain/services/imu_event_detector.dart';
 import '../domain/trip_recorder.dart';
+import 'motion_gated_gps_source.dart';
 import 'recording_pipeline.dart';
 import 'trip_recording_phase.dart';
 import 'trip_recording_state.dart';
@@ -79,7 +78,11 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
   /// Pure accumulator — same recorder the OBD2 path uses, so the
   /// distance / harsh-event / idle integration is byte-identical.
   TripRecorder? _recorder;
-  StreamSubscription<Position>? _sub;
+
+  /// #3319 — owns the recording GPS subscription and motion-gates its cadence
+  /// (fine while moving, coarse once stationary). Null between trips; opened
+  /// on [start], cancelled on [stop].
+  MotionGatedGpsSource? _gpsSource;
   final List<TripSample> _samples = [];
   DateTime? _startedAt;
 
@@ -149,21 +152,8 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // coarse settings. The notification copy comes from the already-merged
     // ARB keys, resolved for the active in-app language without a
     // BuildContext (this runs from the notifier, not a widget).
-    final geo = _ref.read(geolocatorWrapperProvider);
-    _sub = geo
-        .sharedPositionStream(
-          recording: true,
-          locationSettings: recordingLocationSettingsForRef(_ref),
-        )
-        .listen(
-          _onPosition,
-          onError: (Object e, StackTrace st) {
-            unawaited(errorLogger.log(ErrorLayer.providers, e, st,
-                context: const {
-                  'where': 'GpsOnlyRecordingPipeline.start: stream error'
-                }));
-          },
-        );
+    _gpsSource = MotionGatedGpsSource(ref: _ref, onPosition: _onPosition)
+      ..start();
     // #2760 — attach IMU sensor fusion (this dongle-less pipeline ONLY).
     // The detector feeds confirmed accel/brake episodes onto the SAME live
     // harsh-event bus the OBD2 / GPS-speed paths use (mirroring the recorder's
@@ -218,6 +208,9 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // min-speed gate and accel-vs-brake direction classification track the
     // real vehicle speed (the inertial stream alone has no speed).
     _imuDetector?.currentSpeedKmh = sample.speedKmh;
+    // #3319 — motion-gate the receiver (FGS-approved builds only).
+    _gpsSource?.onSpeed(
+        sample.speedKmh, DateTime.now().difference(startedAt));
     // #2653 — a GPS-only trip's speed is the device's Doppler ground
     // speed (genuine ~1 Hz, not 1 km/h-quantised dead reckoning), so it
     // is differentiable; the detector's accuracy + min-speed +
@@ -253,8 +246,8 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
   @override
   Future<StoppedTripResult> stop({bool automatic = false}) async {
     final recorder = _recorder;
-    await _sub?.cancel();
-    _sub = null;
+    await _gpsSource?.cancel();
+    _gpsSource = null;
     // #2760 — tear down the IMU stream alongside the GPS one so no inertial
     // subscription survives between trips (the battery / lifecycle bound).
     await _imuSub?.cancel();

--- a/lib/features/consumption/providers/motion_gated_gps_source.dart
+++ b/lib/features/consumption/providers/motion_gated_gps_source.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/location/recording_location_settings.dart';
+import '../../../core/logging/error_logger.dart';
+import '../domain/services/motion_gate.dart';
+
+/// #3319 — owns the recording GPS subscription and motion-gates its cadence:
+/// full-rate ([GpsProfile.fine]) while moving, backed off
+/// ([GpsProfile.coarse]) once the device has been stationary, re-fining on
+/// resumed motion. The cadence only changes in FGS-approved builds — where
+/// the recording stream actually runs in the background and the battery save
+/// is real; otherwise this just relays fixes at the fine cadence (backing a
+/// foreground-only stream off buys nothing and risks a trace gap).
+///
+/// Extracted from [GpsOnlyRecordingPipeline] so the gate + subscription
+/// lifecycle is self-contained and independently testable, and so the
+/// pipeline stays under the file-length cap.
+class MotionGatedGpsSource {
+  MotionGatedGpsSource({
+    required Ref ref,
+    required void Function(Position) onPosition,
+    MotionGate? gate,
+    bool? foregroundServiceEnabled,
+  })  : _ref = ref,
+        _onPosition = onPosition,
+        _gate = gate ?? MotionGate(),
+        _fgsEnabled =
+            foregroundServiceEnabled ?? kGpsRecordingForegroundServiceEnabled;
+
+  final Ref _ref;
+  final void Function(Position) _onPosition;
+  final MotionGate _gate;
+  final bool _fgsEnabled;
+
+  StreamSubscription<Position>? _sub;
+  GpsProfile _profile = GpsProfile.fine;
+
+  /// The cadence currently in effect (for diagnostics / tests).
+  GpsProfile get profile => _profile;
+
+  /// Open the fine-cadence recording stream.
+  void start() {
+    _sub = _open(coarse: false);
+  }
+
+  /// Feed the latest fix's ground speed (km/h) and the monotonic [elapsed]
+  /// since recording start. Swaps the subscription cadence when the motion
+  /// gate flips. No-op unless the recording FGS is enabled. Best-effort: a
+  /// failed swap leaves the existing subscription running (new-before-cancel,
+  /// so we never end up with no GPS).
+  void onSpeed(double speedKmh, Duration elapsed) {
+    if (!_fgsEnabled) return;
+    final next = _gate.onFix(speedKmh: speedKmh, elapsed: elapsed);
+    if (next == _profile) return;
+    _profile = next;
+    try {
+      final old = _sub;
+      _sub = _open(coarse: next == GpsProfile.coarse);
+      unawaited(old?.cancel());
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+          context: const {'where': 'MotionGatedGpsSource: profile swap'}));
+    }
+  }
+
+  /// Cancel the current subscription (end of trip).
+  Future<void> cancel() async {
+    await _sub?.cancel();
+    _sub = null;
+  }
+
+  StreamSubscription<Position> _open({required bool coarse}) {
+    return _ref
+        .read(geolocatorWrapperProvider)
+        .sharedPositionStream(
+          recording: true,
+          locationSettings:
+              recordingLocationSettingsForRef(_ref, coarse: coarse),
+        )
+        .listen(
+          _onPosition,
+          onError: (Object e, StackTrace st) {
+            unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+                context: const {'where': 'MotionGatedGpsSource: stream error'}));
+          },
+        );
+  }
+}

--- a/test/core/location/recording_location_settings_test.dart
+++ b/test/core/location/recording_location_settings_test.dart
@@ -114,6 +114,36 @@ void main() {
       });
     });
 
+    group('#3319 — coarse (stationary) profile', () {
+      test('Android coarse → backed-off cadence (5 s / 25 m / medium) but '
+          'the FGS config is kept alive', () {
+        final coarse = recordingLocationSettings(
+          l10n: l10n,
+          platform: TargetPlatform.android,
+          foregroundServiceEnabled: true,
+          coarse: true,
+        ) as AndroidSettings;
+
+        expect(coarse.intervalDuration, const Duration(seconds: 5),
+            reason: 'back the receiver off while parked');
+        expect(coarse.distanceFilter, 25);
+        expect(coarse.accuracy, LocationAccuracy.medium);
+        expect(coarse.foregroundNotificationConfig, isNotNull,
+            reason: 'the FGS (and its wake lock) must stay alive across the '
+                'stationary stretch so it can re-fine on resumed motion');
+      });
+
+      test('Android fine (coarse:false) keeps the 1 s / 0 / high cadence', () {
+        final fine = recordingLocationSettings(
+          l10n: l10n,
+          platform: TargetPlatform.android,
+        ) as AndroidSettings;
+        expect(fine.intervalDuration, const Duration(seconds: 1));
+        expect(fine.distanceFilter, 0);
+        expect(fine.accuracy, LocationAccuracy.high);
+      });
+    });
+
     test('iOS → AppleSettings: automotiveNavigation + background updates', () {
       final settings = recordingLocationSettings(
         l10n: l10n,

--- a/test/features/consumption/domain/services/motion_gate_test.dart
+++ b/test/features/consumption/domain/services/motion_gate_test.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/motion_gate.dart';
+
+/// #3319 — the pure stop-detection state machine that backs the recording
+/// GPS receiver off (fine → coarse) once the device has been stationary,
+/// using only the GPS speed (+ optional IMU) signals the recorder already has.
+void main() {
+  group('MotionGate', () {
+    test('starts fine so a trip records at full rate immediately', () {
+      expect(MotionGate().profile, GpsProfile.fine);
+    });
+
+    test('a clearly-moving fix keeps it fine', () {
+      final g = MotionGate();
+      expect(
+        g.onFix(speedKmh: 50, elapsed: const Duration(seconds: 1)),
+        GpsProfile.fine,
+      );
+    });
+
+    test('sustained slow+still for >= stationaryAfter → coarse', () {
+      final g = MotionGate(stationaryAfter: const Duration(seconds: 20));
+      // First slow fix arms the timer but does not yet flip.
+      expect(g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 1)),
+          GpsProfile.fine);
+      // Still slow at +10 s — not long enough.
+      expect(g.onFix(speedKmh: 0.5, elapsed: const Duration(seconds: 11)),
+          GpsProfile.fine);
+      // Slow through the full window → coarse.
+      expect(g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 22)),
+          GpsProfile.coarse);
+    });
+
+    test('a moving fix re-fines immediately from coarse and re-arms', () {
+      final g = MotionGate(stationaryAfter: const Duration(seconds: 20));
+      g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 0));
+      g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 25));
+      expect(g.profile, GpsProfile.coarse);
+      // Pulling away — back to fine at once.
+      expect(g.onFix(speedKmh: 30, elapsed: const Duration(seconds: 26)),
+          GpsProfile.fine);
+      // And the stillness timer was reset: one slow fix doesn't re-coarse.
+      expect(g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 27)),
+          GpsProfile.fine);
+    });
+
+    test('a single stray slow fix in motion does not flip to coarse', () {
+      final g = MotionGate(stationaryAfter: const Duration(seconds: 20));
+      g.onFix(speedKmh: 40, elapsed: const Duration(seconds: 0));
+      // One slow fix (traffic light tap) then moving again, well within window.
+      g.onFix(speedKmh: 1, elapsed: const Duration(seconds: 2));
+      expect(g.onFix(speedKmh: 45, elapsed: const Duration(seconds: 3)),
+          GpsProfile.fine);
+    });
+
+    test('intermediate (rolling) speed holds the current profile and breaks '
+        'the stillness timer', () {
+      final g = MotionGate(
+        stationarySpeedKmh: 3,
+        movingSpeedKmh: 8,
+        stationaryAfter: const Duration(seconds: 10),
+      );
+      g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 0)); // arm
+      // Rolling at 5 km/h (between thresholds) breaks the timer...
+      expect(g.onFix(speedKmh: 5, elapsed: const Duration(seconds: 5)),
+          GpsProfile.fine);
+      // ...so being slow again only now restarts the clock — not coarse yet.
+      expect(g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 12)),
+          GpsProfile.fine);
+    });
+
+    group('IMU fusion (GPS-only trips)', () {
+      test('IMU stillness is required to coarse — a still IMU + slow speed '
+          'coarsens', () {
+        final g = MotionGate(stationaryAfter: const Duration(seconds: 10));
+        g.onFix(
+            speedKmh: 0, imuMagnitude: 0.1, elapsed: const Duration(seconds: 0));
+        expect(
+          g.onFix(
+              speedKmh: 0,
+              imuMagnitude: 0.1,
+              elapsed: const Duration(seconds: 11)),
+          GpsProfile.coarse,
+        );
+      });
+
+      test('a busy IMU keeps it fine even when GPS speed reads ~0 '
+          '(GPS drift while the car shakes)', () {
+        final g = MotionGate(stationaryAfter: const Duration(seconds: 10));
+        g.onFix(
+            speedKmh: 0, imuMagnitude: 2.0, elapsed: const Duration(seconds: 0));
+        expect(
+          g.onFix(
+              speedKmh: 0,
+              imuMagnitude: 2.0,
+              elapsed: const Duration(seconds: 11)),
+          GpsProfile.fine,
+          reason: 'IMU above the moving threshold → never stationary',
+        );
+      });
+
+      test('an IMU spike re-fines from coarse immediately', () {
+        final g = MotionGate(stationaryAfter: const Duration(seconds: 10));
+        g.onFix(
+            speedKmh: 0, imuMagnitude: 0.1, elapsed: const Duration(seconds: 0));
+        g.onFix(
+            speedKmh: 0,
+            imuMagnitude: 0.1,
+            elapsed: const Duration(seconds: 11));
+        expect(g.profile, GpsProfile.coarse);
+        expect(
+          g.onFix(
+              speedKmh: 0, imuMagnitude: 3.0, elapsed: const Duration(seconds: 12)),
+          GpsProfile.fine,
+        );
+      });
+    });
+
+    test('reset returns to the initial fine profile', () {
+      final g = MotionGate(stationaryAfter: const Duration(seconds: 5));
+      g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 0));
+      g.onFix(speedKmh: 0, elapsed: const Duration(seconds: 6));
+      expect(g.profile, GpsProfile.coarse);
+      g.reset();
+      expect(g.profile, GpsProfile.fine);
+    });
+  });
+}


### PR DESCRIPTION
Child of Epic #3314.

## Why
The recording GPS stream ran at a fixed ~1 Hz for the whole trip. Motion-gated trackers (transistorsoft, our reference) get their battery win by running full-rate GPS only while *moving* and backing off while *parked*. Replicate that with **only signals the recorder already has** — per-fix GPS ground speed (+ optional IMU magnitude on GPS-only trips) — so **no activity-recognition dependency or extra permission** is needed (a nice simplification over the issue's original `ACTIVITY_RECOGNITION` sketch).

## What
- **`MotionGate`** — a pure, time-injected stop-detection state machine (`fine ⇄ coarse`) with hysteresis so a single stray fix never thrashes the receiver. Fully unit-tested.
- **`recordingLocationSettings(coarse: true)`** — Android backs off to medium accuracy / 5 s interval / 25 m filter while **keeping the FGS (and wake lock) alive**, so a coarse fix still arrives and re-fines on resumed motion (no separate wake signal needed).
- **`MotionGatedGpsSource`** — owns the recording GPS subscription and swaps its cadence when the gate flips (new-before-cancel, best-effort). Extracted from `GpsOnlyRecordingPipeline`, which drops ~50 lines back **under the 400-line cap**.
- **Gated on `kGpsRecordingForegroundServiceEnabled`** — only active where the recording FGS actually runs in the background; default builds and iOS are unchanged.

## Tests
- `motion_gate_test.dart` — fine→coarse after sustained stillness, immediate re-fine on motion, single-stray-fix rejection, intermediate-speed hold, IMU fusion (still/busy/spike), reset.
- `recording_location_settings_test.dart` — coarse cadence + FGS kept alive; fine unchanged.
- Existing pipeline tests still green (incl. "stop() cancels the subscription").

## Follow-ups (noted in #3319)
OBD2/hybrid motion-gating (no IMU → needs a different wake signal) and end-to-end on-device validation when the #3173 FGS form clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
