### PR TITLE
feat(android): Companion Device Manager auto-start for the OBD2 connectedDevice FGS (#3320)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
@@ -9,6 +9,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.util.Rational
 import de.tankstellen.tankstellen.autorecord.BackgroundAdapterChannel
+import de.tankstellen.tankstellen.autorecord.CompanionDeviceAssociator
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -49,6 +50,13 @@ class MainActivity : FlutterActivity() {
         // foreground service that the channel starts on demand owns
         // its own GATT client.
         BackgroundAdapterChannel.registerWith(flutterEngine, applicationContext)
+
+        // #3320 (Epic #3314) — Companion-Device-Manager association bridge.
+        // Activity-coupled (the association dialog launches via an
+        // IntentSender), so it lives on the Activity unlike the context-only
+        // BackgroundAdapterChannel. Inert below API 34 / without the CDM
+        // feature, and only ever driven behind the Dart FGS gate.
+        CompanionDeviceAssociator(this).registerWith(flutterEngine)
 
         // Public file-export bridge (#2014). Routes exports to the
         // device's MediaStore.Downloads collection so the user can

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/CompanionDeviceAssociator.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/CompanionDeviceAssociator.kt
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.autorecord
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.companion.AssociationInfo
+import android.companion.AssociationRequest
+import android.companion.BluetoothDeviceFilter
+import android.companion.CompanionDeviceManager
+import android.content.Context
+import android.content.IntentSender
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * #3320 (Epic #3314) — Companion-Device-Manager association with the OBD2
+ * dongle, bridged to the Dart `CompanionDeviceAssociation` facade over the
+ * `tankstellen/auto_record/cdm` MethodChannel.
+ *
+ * The CDM association is the documented way to start the connectedDevice
+ * [AutoRecordForegroundService] from the background (via
+ * [CompanionPresenceService]) when the paired dongle appears, WITHOUT
+ * `ACCESS_BACKGROUND_LOCATION`.
+ *
+ * Activity-coupled: [associate] launches the system association dialog via an
+ * [IntentSender], which needs an [Activity]; the channel is therefore
+ * registered from `MainActivity` (not a context-only object like
+ * [BackgroundAdapterChannel]). Methods:
+ *   - `isSupported()`  -> Bool   API 34+ AND the CDM system feature present
+ *   - `isAssociated()` -> Bool   we already hold an association
+ *   - `associate(mac)` -> Bool   true once the system dialog is confirmed
+ *   - `disassociate()` -> Bool   drop all of our associations
+ *
+ * Gated on API 34+ (the stable `myAssociations` + associate-callback +
+ * [AssociationInfo] APIs; the version churn below 34 isn't worth carrying for
+ * a dark feature). Each CDM-touching method opens with an `SDK_INT` guard so
+ * the Android `NewApi` lint is satisfied without scattering `@RequiresApi`.
+ *
+ * UNVALIDATED ON-DEVICE: ships behind the dark FGS gate, not yet exercised
+ * against a real dongle (needs the #3173 form + hardware). CI's Android build
+ * verifies it compiles.
+ */
+class CompanionDeviceAssociator(private val activity: Activity) {
+
+    fun registerWith(flutterEngine: FlutterEngine) {
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+            .setMethodCallHandler { call, result -> handle(call, result) }
+    }
+
+    private fun handle(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "isSupported" -> result.success(isSupported())
+            "isAssociated" -> result.success(isAssociated())
+            "disassociate" -> result.success(disassociate())
+            "associate" -> {
+                val mac = call.argument<String>("mac")
+                if (mac.isNullOrBlank()) {
+                    result.error("arg", "mac missing", null)
+                } else {
+                    associate(mac, result)
+                }
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun isSupported(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        return activity.packageManager
+            .hasSystemFeature(PackageManager.FEATURE_COMPANION_DEVICE_SETUP)
+    }
+
+    private fun cdm(): CompanionDeviceManager? {
+        if (!isSupported()) return null
+        return activity.getSystemService(Context.COMPANION_DEVICE_SERVICE)
+            as? CompanionDeviceManager
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun isAssociated(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        val manager = cdm() ?: return false
+        return try {
+            manager.myAssociations.isNotEmpty()
+        } catch (e: Exception) {
+            Log.w(TAG, "isAssociated: query failed", e)
+            false
+        }
+    }
+
+    private fun disassociate(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        val manager = cdm() ?: return false
+        return try {
+            for (info in manager.myAssociations) {
+                manager.disassociate(info.id)
+            }
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "disassociate failed", e)
+            false
+        }
+    }
+
+    private fun associate(mac: String, result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            result.success(false)
+            return
+        }
+        val manager = cdm()
+        if (manager == null) {
+            result.success(false)
+            return
+        }
+        val request = AssociationRequest.Builder()
+            .addDeviceFilter(
+                BluetoothDeviceFilter.Builder().setAddress(mac.uppercase()).build(),
+            )
+            // The exact dongle MAC is known, so auto-associate the single
+            // match rather than showing a chooser list.
+            .setSingleDevice(true)
+            .build()
+
+        var settled = false
+        fun settle(value: Boolean) {
+            if (!settled) {
+                settled = true
+                result.success(value)
+            }
+        }
+
+        manager.associate(
+            request,
+            ContextCompat.getMainExecutor(activity),
+            object : CompanionDeviceManager.Callback() {
+                override fun onAssociationPending(intentSender: IntentSender) {
+                    try {
+                        activity.startIntentSender(intentSender, null, 0, 0, 0)
+                    } catch (e: IntentSender.SendIntentException) {
+                        Log.w(TAG, "associate: startIntentSender failed", e)
+                        settle(false)
+                    }
+                }
+
+                override fun onAssociationCreated(associationInfo: AssociationInfo) {
+                    startObserving(manager, associationInfo)
+                    settle(true)
+                }
+
+                override fun onFailure(error: CharSequence?) {
+                    Log.w(TAG, "associate failed: $error")
+                    settle(false)
+                }
+            },
+        )
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startObserving(
+        manager: CompanionDeviceManager,
+        info: AssociationInfo,
+    ) {
+        val mac = info.deviceMacAddress?.toString() ?: return
+        try {
+            // The String overload is deprecated in API 35 but is the broadest
+            // compatible call; the request-object overload is 35+.
+            @Suppress("DEPRECATION")
+            manager.startObservingDevicePresence(mac)
+        } catch (e: Exception) {
+            Log.w(TAG, "startObservingDevicePresence failed", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "CompanionAssociator"
+        private const val METHOD_CHANNEL = "tankstellen/auto_record/cdm"
+    }
+}

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/CompanionPresenceService.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/CompanionPresenceService.kt
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.autorecord
+
+import android.companion.AssociationInfo
+import android.companion.CompanionDeviceService
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+
+/**
+ * #3320 (Epic #3314) — the system binds this [CompanionDeviceService] on
+ * Companion-Device-Manager presence transitions for an associated OBD2
+ * dongle.
+ *
+ * [onDeviceAppeared] starts the `connectedDevice`
+ * [AutoRecordForegroundService] from the background — the CDM exemption to
+ * the Android 12+ background-foreground-service-start restriction — so a
+ * hands-free trip can begin the moment the car's dongle powers up, WITHOUT
+ * `ACCESS_BACKGROUND_LOCATION` (that gate, #1498, only blocks the GPS half).
+ *
+ * Inert in default builds: the service is declared only in the FGS-approved
+ * play overlay, and association is only ever requested behind the Dart
+ * `kGpsRecordingForegroundServiceEnabled` gate. Requires API 33+ (the
+ * [AssociationInfo] presence callbacks); the manifest declaration is gated by
+ * the merge, and the class is annotated accordingly.
+ *
+ * UNVALIDATED ON-DEVICE: this ships behind the dark FGS gate and has not been
+ * exercised against a real dongle yet (needs the #3173 form + hardware). CI's
+ * Android build verifies it compiles.
+ */
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+class CompanionPresenceService : CompanionDeviceService() {
+    override fun onDeviceAppeared(associationInfo: AssociationInfo) {
+        val mac = associationInfo.deviceMacAddress?.toString()
+        if (mac.isNullOrBlank()) {
+            Log.w(TAG, "onDeviceAppeared: association has no MAC; cannot arm")
+            return
+        }
+        try {
+            val intent = Intent(this, AutoRecordForegroundService::class.java)
+                .apply {
+                    putExtra(AutoRecordForegroundService.EXTRA_MAC, mac.uppercase())
+                }
+            startForegroundService(intent)
+        } catch (e: Exception) {
+            // Best-effort: a failed background start (OEM policy, race) must
+            // never crash the bound service. The next presence event retries.
+            Log.w(TAG, "onDeviceAppeared: could not start auto-record FGS", e)
+        }
+    }
+
+    override fun onDeviceDisappeared(associationInfo: AssociationInfo) {
+        // No-op: the trip-recording teardown is already driven by the BLE GATT
+        // disconnect that AutoRecordForegroundService observes. We don't stop
+        // the FGS here — a brief out-of-range blip shouldn't kill a live trip.
+    }
+
+    companion object {
+        private const val TAG = "CompanionPresence"
+    }
+}

--- a/android/app/src/play/AndroidManifestFgsApproved.xml
+++ b/android/app/src/play/AndroidManifestFgsApproved.xml
@@ -56,6 +56,22 @@
          Shipped only in this FGS-approved overlay so default builds stay
          clean. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <!-- #3320 (Epic #3314) — Companion Device Manager association with the
+         OBD2 dongle. The association grants
+         REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM_BACKGROUND, the
+         documented exemption that lets CompanionPresenceService start the
+         connectedDevice AutoRecordForegroundService from the background when
+         the paired dongle comes into range — WITHOUT ACCESS_BACKGROUND_LOCATION
+         (that gate, #1498, only blocks the GPS half). REQUEST_COMPANION_RUN_IN
+         _BACKGROUND keeps the association observable in the background. Both are
+         normal install-time permissions, shipped only in this FGS-approved
+         overlay. companion_device_setup is not required (graceful no-op on a
+         device/ROM without CDM). -->
+    <uses-feature
+        android:name="android.software.companion_device_setup"
+        android:required="false"/>
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_RUN_IN_BACKGROUND"/>
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM_BACKGROUND"/>
 
     <application>
         <!-- Android Auto v1 (#2951) bound POI service: no android:permission
@@ -82,5 +98,21 @@
             android:name=".autorecord.AutoRecordForegroundService"
             android:exported="false"
             android:foregroundServiceType="connectedDevice"/>
+
+        <!-- #3320 — the system binds this CompanionDeviceService when an
+             associated dongle appears/disappears (CDM presence observation).
+             onDeviceAppeared starts the connectedDevice AutoRecordForegroundService
+             from the background under the CDM FGS-start exemption. The
+             BIND_COMPANION_DEVICE_SERVICE permission + the
+             android.companion.CompanionDeviceService intent-filter are the
+             system-required wiring. -->
+        <service
+            android:name=".autorecord.CompanionPresenceService"
+            android:exported="true"
+            android:permission="android.permission.BIND_COMPANION_DEVICE_SERVICE">
+            <intent-filter>
+                <action android:name="android.companion.CompanionDeviceService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/lib/features/obd2/data/companion_auto_record_coordinator.dart
+++ b/lib/features/obd2/data/companion_auto_record_coordinator.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/location/recording_location_settings.dart';
+import '../../../core/logging/error_logger.dart';
+import 'companion_device_association.dart';
+
+/// #3320 (Epic #3314) — decides whether to establish a Companion-Device-Manager
+/// association for the OBD2 dongle so hands-free auto-record can start the
+/// connectedDevice FGS from the background.
+///
+/// Called from a FOREGROUND, user-initiated moment (the system association
+/// dialog needs an Activity) — e.g. the first manual OBD2 trip start with a
+/// pinned dongle, which both proves the dongle works and is a natural consent
+/// point. One-time in effect: once associated, [ensureAssociated] short-circuits.
+///
+/// Conservative gating (mirrors the #3313 battery-exemption coordinator):
+///   * no-op unless [kGpsRecordingForegroundServiceEnabled] (the recording FGS
+///     only runs in FGS-approved builds; the CDM permissions aren't even
+///     shipped otherwise);
+///   * no-op when CDM isn't supported (iOS / pre-34 / no CDM feature);
+///   * skips the dialog when already associated;
+///   * never throws into the caller's path.
+class CompanionAutoRecordCoordinator {
+  CompanionAutoRecordCoordinator({
+    required CompanionDeviceAssociation association,
+    bool fgsEnabled = kGpsRecordingForegroundServiceEnabled,
+  })  : _association = association,
+        _fgsEnabled = fgsEnabled;
+
+  final CompanionDeviceAssociation _association;
+  final bool _fgsEnabled;
+
+  /// Ensure a CDM association exists for [mac]. Returns true if associated
+  /// (already or newly). Best-effort; never throws.
+  Future<bool> ensureAssociated(String mac) async {
+    if (!_fgsEnabled) return false;
+    try {
+      if (!await _association.isSupported()) return false;
+      if (await _association.isAssociated()) return true;
+      return await _association.associate(mac);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'CompanionAutoRecordCoordinator.ensureAssociated'
+      }));
+      return false;
+    }
+  }
+}
+
+/// Production wiring: the method-channel-backed association.
+final companionAutoRecordCoordinatorProvider =
+    Provider<CompanionAutoRecordCoordinator>((ref) {
+  return CompanionAutoRecordCoordinator(
+    association: const MethodChannelCompanionDeviceAssociation(),
+  );
+});

--- a/lib/features/obd2/data/companion_device_association.dart
+++ b/lib/features/obd2/data/companion_device_association.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+
+/// #3320 (Epic #3314) — facade over the Android Companion-Device-Manager
+/// association with the OBD2 dongle.
+///
+/// A CDM association grants `REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM
+/// _BACKGROUND` — the documented exemption that lets the native
+/// `CompanionPresenceService` start the `connectedDevice`
+/// `AutoRecordForegroundService` from the background when the paired dongle
+/// appears, WITHOUT `ACCESS_BACKGROUND_LOCATION`. So a hands-free trip can
+/// begin the moment the car's dongle powers up.
+///
+/// Behind an interface so the [CompanionAutoRecordCoordinator] is unit-testable
+/// without the platform channel. Android-only + API 34+; every method degrades
+/// to a safe `false` on an unsupported platform (the channel throws
+/// `MissingPluginException` on iOS / pre-34, caught here).
+abstract class CompanionDeviceAssociation {
+  /// Whether CDM association is available (Android 34+ with the CDM feature).
+  Future<bool> isSupported();
+
+  /// Whether we already hold an association for the dongle.
+  Future<bool> isAssociated();
+
+  /// Launch the system association dialog for the dongle at [mac]. Must be
+  /// called from the foreground (it shows an Activity dialog). Returns true
+  /// once the user confirms.
+  Future<bool> associate(String mac);
+
+  /// Drop all of our associations.
+  Future<bool> disassociate();
+}
+
+class MethodChannelCompanionDeviceAssociation
+    implements CompanionDeviceAssociation {
+  const MethodChannelCompanionDeviceAssociation();
+
+  static const MethodChannel _channel =
+      MethodChannel('tankstellen/auto_record/cdm');
+
+  @override
+  Future<bool> isSupported() => _callBool('isSupported');
+
+  @override
+  Future<bool> isAssociated() => _callBool('isAssociated');
+
+  @override
+  Future<bool> associate(String mac) =>
+      _callBool('associate', <String, Object?>{'mac': mac});
+
+  @override
+  Future<bool> disassociate() => _callBool('disassociate');
+
+  Future<bool> _callBool(String method, [Map<String, Object?>? args]) async {
+    try {
+      return (await _channel.invokeMethod<bool>(method, args)) ?? false;
+    } on MissingPluginException {
+      // iOS / pre-34 / default builds without the channel registered.
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/test/features/obd2/data/companion_auto_record_coordinator_test.dart
+++ b/test/features/obd2/data/companion_auto_record_coordinator_test.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/companion_auto_record_coordinator.dart';
+import 'package:tankstellen/features/obd2/data/companion_device_association.dart';
+
+/// #3320 — the FGS-gated, one-time Companion-Device-Manager association
+/// decision for hands-free auto-record.
+class _FakeAssociation implements CompanionDeviceAssociation {
+  bool supported = true;
+  bool associated = false;
+  int associateCalls = 0;
+  String? associatedMac;
+
+  @override
+  Future<bool> isSupported() async => supported;
+
+  @override
+  Future<bool> isAssociated() async => associated;
+
+  @override
+  Future<bool> associate(String mac) async {
+    associateCalls++;
+    associatedMac = mac;
+    associated = true;
+    return true;
+  }
+
+  @override
+  Future<bool> disassociate() async {
+    associated = false;
+    return true;
+  }
+}
+
+void main() {
+  late _FakeAssociation fake;
+
+  CompanionAutoRecordCoordinator build({required bool fgsEnabled}) =>
+      CompanionAutoRecordCoordinator(association: fake, fgsEnabled: fgsEnabled);
+
+  setUp(() => fake = _FakeAssociation());
+
+  test('FGS disabled (default build) → never touches the platform', () async {
+    final ok = await build(fgsEnabled: false).ensureAssociated('AA:BB:CC:DD:EE:FF');
+    expect(ok, isFalse);
+    expect(fake.associateCalls, 0);
+  });
+
+  test('unsupported (iOS / pre-34) → false, no associate', () async {
+    fake.supported = false;
+    final ok = await build(fgsEnabled: true).ensureAssociated('AA:BB:CC:DD:EE:FF');
+    expect(ok, isFalse);
+    expect(fake.associateCalls, 0);
+  });
+
+  test('already associated → true without re-prompting', () async {
+    fake.associated = true;
+    final ok = await build(fgsEnabled: true).ensureAssociated('AA:BB:CC:DD:EE:FF');
+    expect(ok, isTrue);
+    expect(fake.associateCalls, 0);
+  });
+
+  test('supported + not associated → associates the given MAC', () async {
+    final ok = await build(fgsEnabled: true).ensureAssociated('AA:BB:CC:DD:EE:FF');
+    expect(ok, isTrue);
+    expect(fake.associateCalls, 1);
+    expect(fake.associatedMac, 'AA:BB:CC:DD:EE:FF');
+  });
+
+  test('a throwing platform call is swallowed — never throws into the start '
+      'path, resolves false (#2349)', () async {
+    final coordinator = CompanionAutoRecordCoordinator(
+      association: _ThrowingAssociation(),
+      fgsEnabled: true,
+    );
+    // Fault injected (isSupported throws): the call must complete normally...
+    await expectLater(
+        coordinator.ensureAssociated('AA:BB:CC:DD:EE:FF'), completes);
+    // ...and resolve false rather than propagating.
+    expect(await coordinator.ensureAssociated('AA:BB:CC:DD:EE:FF'), isFalse);
+  });
+}
+
+class _ThrowingAssociation implements CompanionDeviceAssociation {
+  @override
+  Future<bool> isSupported() async => throw Exception('channel blew up');
+  @override
+  Future<bool> isAssociated() async => false;
+  @override
+  Future<bool> associate(String mac) async => false;
+  @override
+  Future<bool> disassociate() async => false;
+}


### PR DESCRIPTION
Child of Epic #3314.

## Why
Android 12+ blocks starting a foreground service from the background. A **Companion-Device-Manager** association with the OBD2 dongle grants `REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM_BACKGROUND` — the documented exemption that lets the system start the `connectedDevice` `AutoRecordForegroundService` when the paired dongle appears, **without `ACCESS_BACKGROUND_LOCATION`** (that gate, #1498, only blocks the GPS half). This advances hands-free auto-record for the OBD2 half.

## What
- **`CompanionPresenceService`** (`CompanionDeviceService`) — `onDeviceAppeared` starts `AutoRecordForegroundService` from the background.
- **`CompanionDeviceAssociator`** — `associate` / `isAssociated` / `disassociate` bridged to Dart over `tankstellen/auto_record/cdm`; Activity-coupled (the system dialog launches via an `IntentSender`), registered from `MainActivity`. Gated to **API 34+** with `SDK_INT` guards the `NewApi` lint recognises.
- **`CompanionDeviceAssociation`** Dart facade + **`CompanionAutoRecordCoordinator`** (FGS-gated, one-time, best-effort, never-throws) + provider + tests.
- CDM permissions + the `CompanionPresenceService` + the `companion_device_setup` feature declared **only in the FGS-approved play overlay**, so default builds stay clean.

Everything is gated on `kGpsRecordingForegroundServiceEnabled`, so it is **inert in current (dark) builds**.

## ⚠️ Validation status
**Unvalidated on-device** (per the maintainer's explicit decision to implement now): the native CDM flow needs a real OBD2 dongle **and** the #3173 FGS form to exercise end-to-end. CI's `build-android` job verifies it **compiles**; the `CompanionAutoRecordCoordinator` decision logic is unit-tested. The remaining integration is one foreground call — `ensureAssociated(pinnedMac)` from the auto-record enable action — deferred to the FGS-form rollout where it can be validated (wiring it now would add a cross-feature import that raises the `feature_boundary` baseline / touch a file-length-capped god-class).

## Tests
`companion_auto_record_coordinator_test.dart` — FGS-off no-op, unsupported, already-associated short-circuit, associate-on-first, throwing-platform-call swallowed (#2349 fault path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
