### PR TITLE
feat(consumption): recording-isolate transport foundation (#3321)

### DIFF
--- a/lib/features/consumption/domain/services/recording_isolate_protocol.dart
+++ b/lib/features/consumption/domain/services/recording_isolate_protocol.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// #3321 (Epic #3314) — the typed messages that cross the recording-isolate
+/// `SendPort` boundary.
+///
+/// A `SendPort` only carries primitives / Maps / Lists, so every message
+/// serialises to a `Map<String, Object?>` tagged with `_t`. This pure codec is
+/// the testable heart of the isolate-hosted recording foundation: the UI
+/// isolate sends [RecordingIsolateCommand]s down, and the background isolate
+/// streams [RecordingFixMessage]s (GPS fixes) back. Keeping it primitive-only
+/// (no `TripSample` / Dart object across the port) is what makes it safe to
+/// send and trivial to unit-test without spawning an isolate.
+library;
+
+/// Control verbs sent UI-isolate → recording isolate.
+enum RecordingIsolateCommand { start, stop }
+
+/// A GPS fix streamed recording isolate → UI isolate, as the bare primitives
+/// the recorder needs to fold a sample. Mirrors the GPS-only fix shape the
+/// [GpsOnlyRecordingPipeline] already builds, but as a port-safe map.
+class RecordingFixMessage {
+  const RecordingFixMessage({
+    required this.epochMs,
+    required this.speedKmh,
+    this.latitude,
+    this.longitude,
+    this.altitudeM,
+    this.hAccuracyM,
+    this.bearingDeg,
+  });
+
+  final int epochMs;
+  final double speedKmh;
+  final double? latitude;
+  final double? longitude;
+  final double? altitudeM;
+  final double? hAccuracyM;
+  final double? bearingDeg;
+
+  static const String type = 'fix';
+
+  Map<String, Object?> toMap() => <String, Object?>{
+        '_t': type,
+        'ts': epochMs,
+        'spd': speedKmh,
+        if (latitude != null) 'lat': latitude,
+        if (longitude != null) 'lng': longitude,
+        if (altitudeM != null) 'alt': altitudeM,
+        if (hAccuracyM != null) 'hac': hAccuracyM,
+        if (bearingDeg != null) 'brg': bearingDeg,
+      };
+
+  static RecordingFixMessage fromMap(Map<String, Object?> m) =>
+      RecordingFixMessage(
+        epochMs: (m['ts'] as num).toInt(),
+        speedKmh: (m['spd'] as num).toDouble(),
+        latitude: (m['lat'] as num?)?.toDouble(),
+        longitude: (m['lng'] as num?)?.toDouble(),
+        altitudeM: (m['alt'] as num?)?.toDouble(),
+        hAccuracyM: (m['hac'] as num?)?.toDouble(),
+        bearingDeg: (m['brg'] as num?)?.toDouble(),
+      );
+}
+
+/// Encode a command as a port-safe map.
+Map<String, Object?> encodeRecordingCommand(RecordingIsolateCommand cmd) =>
+    <String, Object?>{'_t': 'cmd', 'cmd': cmd.name};
+
+/// Decode a command map, or null if [raw] is not a command.
+RecordingIsolateCommand? decodeRecordingCommand(Object? raw) {
+  if (raw is! Map) return null;
+  if (raw['_t'] != 'cmd') return null;
+  final name = raw['cmd'];
+  for (final c in RecordingIsolateCommand.values) {
+    if (c.name == name) return c;
+  }
+  return null;
+}
+
+/// Decode a fix map, or null if [raw] is not a fix.
+RecordingFixMessage? decodeRecordingFix(Object? raw) {
+  if (raw is! Map) return null;
+  if (raw['_t'] != RecordingFixMessage.type) return null;
+  return RecordingFixMessage.fromMap(raw.cast<String, Object?>());
+}

--- a/lib/features/consumption/providers/recording_isolate_host.dart
+++ b/lib/features/consumption/providers/recording_isolate_host.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:isolate';
+
+import '../domain/services/recording_isolate_protocol.dart';
+
+/// #3321 (Epic #3314) — hosts the recording loop in a dedicated background
+/// isolate so it survives independently of the UI isolate (which Flutter
+/// pauses when the app is backgrounded). The foreground service keeps the
+/// process alive; this host keeps the recording WORK off the UI isolate.
+///
+/// FOUNDATION ONLY (non-destructive). The live recording cutover — running
+/// the geolocator subscription + WAL writes inside the spawned isolate via
+/// `BackgroundIsolateBinaryMessenger` — is the on-device-validation step
+/// deferred until the #3173 FGS form clears (a geolocator-in-isolate path
+/// can only be verified on hardware). Today's UI-isolate
+/// [GpsOnlyRecordingPipeline] stays the untouched default; this host is gated
+/// behind `kGpsRecordingForegroundServiceEnabled` at its (future) call site.
+///
+/// What IS done + tested here: the isolate lifecycle + the port handshake +
+/// the typed [RecordingFixMessage] / [RecordingIsolateCommand] protocol, so
+/// the cutover is a wiring step on a proven transport rather than new plumbing.
+class RecordingIsolateHost {
+  Isolate? _isolate;
+  ReceivePort? _fromIsolate;
+  SendPort? _toIsolate;
+  final _fixes = StreamController<RecordingFixMessage>.broadcast();
+  final _ready = Completer<void>();
+
+  /// Decoded GPS fixes streamed back from the recording isolate.
+  Stream<RecordingFixMessage> get fixes => _fixes.stream;
+
+  /// Completes once the isolate has sent back its command [SendPort]
+  /// (the handshake), i.e. it is ready to receive commands.
+  Future<void> get ready => _ready.future;
+
+  /// Spawn [entryPoint] in a new isolate, handing it the host's [SendPort].
+  /// The entry point must send its own command [SendPort] back as the FIRST
+  /// message (the handshake); subsequent messages are fix maps.
+  Future<void> spawn(void Function(SendPort) entryPoint) async {
+    final from = ReceivePort();
+    _fromIsolate = from;
+    from.listen(_onMessage);
+    _isolate = await Isolate.spawn(entryPoint, from.sendPort);
+  }
+
+  void _onMessage(Object? message) {
+    // First message is the handshake: the isolate's command SendPort.
+    if (message is SendPort) {
+      _toIsolate = message;
+      if (!_ready.isCompleted) _ready.complete();
+      return;
+    }
+    final fix = decodeRecordingFix(message);
+    if (fix != null && !_fixes.isClosed) {
+      _fixes.add(fix);
+    }
+  }
+
+  /// Send a control command to the isolate. No-op until the handshake lands.
+  void send(RecordingIsolateCommand command) {
+    _toIsolate?.send(encodeRecordingCommand(command));
+  }
+
+  /// Tear down the isolate and the port (end of trip).
+  Future<void> dispose() async {
+    try {
+      _toIsolate?.send(encodeRecordingCommand(RecordingIsolateCommand.stop));
+    } catch (_) {
+      // ignore: silent_catch — best-effort stop on a port that may already be
+      // closed (the isolate could have exited); dispose must never throw
+      // during teardown, and there is no actionable cause to log here.
+    }
+    _fromIsolate?.close();
+    _fromIsolate = null;
+    _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+    _toIsolate = null;
+    if (!_fixes.isClosed) await _fixes.close();
+  }
+}

--- a/test/features/consumption/domain/services/recording_isolate_protocol_test.dart
+++ b/test/features/consumption/domain/services/recording_isolate_protocol_test.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/recording_isolate_protocol.dart';
+
+/// #3321 — the port-safe codec that crosses the recording-isolate boundary.
+void main() {
+  group('RecordingFixMessage codec', () {
+    test('round-trips a full GPS fix through the map form', () {
+      const fix = RecordingFixMessage(
+        epochMs: 1734000000000,
+        speedKmh: 53.4,
+        latitude: 48.137,
+        longitude: 11.575,
+        altitudeM: 519.0,
+        hAccuracyM: 4.5,
+        bearingDeg: 270.0,
+      );
+      final back = RecordingFixMessage.fromMap(fix.toMap());
+      expect(back.epochMs, fix.epochMs);
+      expect(back.speedKmh, fix.speedKmh);
+      expect(back.latitude, fix.latitude);
+      expect(back.longitude, fix.longitude);
+      expect(back.altitudeM, fix.altitudeM);
+      expect(back.hAccuracyM, fix.hAccuracyM);
+      expect(back.bearingDeg, fix.bearingDeg);
+    });
+
+    test('omits null optionals from the map but decodes them back as null', () {
+      const fix = RecordingFixMessage(epochMs: 1, speedKmh: 0);
+      final map = fix.toMap();
+      expect(map.containsKey('lat'), isFalse);
+      expect(map.containsKey('brg'), isFalse);
+      final back = RecordingFixMessage.fromMap(map);
+      expect(back.latitude, isNull);
+      expect(back.bearingDeg, isNull);
+      expect(back.speedKmh, 0);
+    });
+
+    test('the map carries only primitives (port-safe)', () {
+      const fix = RecordingFixMessage(
+          epochMs: 1, speedKmh: 2, latitude: 3, longitude: 4);
+      for (final v in fix.toMap().values) {
+        expect(v is num || v is String, isTrue,
+            reason: 'a SendPort only carries primitives — got ${v.runtimeType}');
+      }
+    });
+
+    test('decodeRecordingFix rejects a non-fix message', () {
+      expect(decodeRecordingFix(<String, Object?>{'_t': 'cmd'}), isNull);
+      expect(decodeRecordingFix('not a map'), isNull);
+    });
+  });
+
+  group('command codec', () {
+    test('round-trips every command', () {
+      for (final c in RecordingIsolateCommand.values) {
+        expect(decodeRecordingCommand(encodeRecordingCommand(c)), c);
+      }
+    });
+
+    test('decodeRecordingCommand rejects a fix / junk', () {
+      expect(decodeRecordingCommand(<String, Object?>{'_t': 'fix'}), isNull);
+      expect(decodeRecordingCommand(42), isNull);
+      expect(
+          decodeRecordingCommand(<String, Object?>{'_t': 'cmd', 'cmd': 'x'}),
+          isNull);
+    });
+  });
+}

--- a/test/features/consumption/providers/recording_isolate_host_test.dart
+++ b/test/features/consumption/providers/recording_isolate_host_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:isolate';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/recording_isolate_protocol.dart';
+import 'package:tankstellen/features/consumption/providers/recording_isolate_host.dart';
+
+/// #3321 — proves the [RecordingIsolateHost] transport works end-to-end with a
+/// REAL spawned isolate: handshake → command down → fixes streamed back. The
+/// echo entry point stands in for the (device-validated) geolocator-in-isolate
+/// production entry point; the machinery under test is identical.
+@pragma('vm:entry-point')
+void _echoEntryPoint(SendPort toMain) {
+  final fromMain = ReceivePort();
+  // Handshake: hand the host our command port first.
+  toMain.send(fromMain.sendPort);
+  fromMain.listen((Object? message) {
+    final cmd = decodeRecordingCommand(message);
+    if (cmd == RecordingIsolateCommand.start) {
+      // Emit two synthetic fixes, then idle.
+      toMain.send(const RecordingFixMessage(
+        epochMs: 1000,
+        speedKmh: 30,
+        latitude: 48.1,
+        longitude: 11.5,
+      ).toMap());
+      toMain.send(const RecordingFixMessage(epochMs: 2000, speedKmh: 45).toMap());
+    } else if (cmd == RecordingIsolateCommand.stop) {
+      fromMain.close();
+    }
+  });
+}
+
+void main() {
+  test('spawn → handshake → start streams decoded fixes back from the isolate',
+      () async {
+    final host = RecordingIsolateHost();
+    addTearDown(host.dispose);
+
+    final received = <RecordingFixMessage>[];
+    final twoFixes = host.fixes.take(2).forEach(received.add);
+
+    await host.spawn(_echoEntryPoint);
+    await host.ready; // handshake landed
+    host.send(RecordingIsolateCommand.start);
+
+    await twoFixes.timeout(const Duration(seconds: 10));
+
+    expect(received, hasLength(2));
+    expect(received[0].speedKmh, 30);
+    expect(received[0].latitude, 48.1);
+    expect(received[1].speedKmh, 45);
+    expect(received[1].latitude, isNull);
+  });
+
+  test('dispose before any command is safe (no hang, no throw)', () async {
+    final host = RecordingIsolateHost();
+    await host.spawn(_echoEntryPoint);
+    await host.ready;
+    await host.dispose(); // must complete
+    // A late send after dispose is a no-op, not a crash.
+    host.send(RecordingIsolateCommand.start);
+  });
+}


### PR DESCRIPTION
Child of Epic #3314 (final child).

## Why
The recording loop runs in the **UI isolate**, which Flutter pauses when the app is backgrounded; today it survives only because the foreground service keeps the process alive and WAL covers process death. The docs-recommended hardening is a dedicated background isolate.

## What — safe, tested foundation (non-destructive)
Today's UI-isolate `GpsOnlyRecordingPipeline` is **untouched and stays the default**. This lands the transport groundwork:
- **`recording_isolate_protocol.dart`** — the port-safe typed codec (`RecordingFixMessage` + `RecordingIsolateCommand`). A `SendPort` only carries primitives, so every message serialises to a tagged `Map` (no `TripSample`/Dart object crosses the boundary). Pure + fully unit-tested.
- **`RecordingIsolateHost`** — spawns the isolate, performs the `SendPort` handshake, sends commands down and streams decoded fixes back. **Verified end-to-end with a real spawned isolate** in the test (handshake → start → fixes streamed back → dispose).

## ⚠️ Deferred (the on-device-validation step)
The live cutover — running the geolocator subscription + WAL writes *inside* the isolate via `BackgroundIsolateBinaryMessenger` — is deferred to the #3173 FGS-form rollout, because a geolocator-in-isolate path **can only be verified on hardware**, and this is the one change that could regress *currently-working* recording. With this PR the cutover becomes a wiring step on a **proven transport** (gated behind `kGpsRecordingForegroundServiceEnabled`), not new plumbing. Per the maintainer's explicit decision to implement the epic now despite no on-device validation being possible.

## Tests
`recording_isolate_protocol_test.dart` (codec round-trip, null-omission, primitive-only, reject-junk) + `recording_isolate_host_test.dart` (real-isolate handshake→stream→dispose; dispose-before-command safety).

Closes the Epic #3314 child set (#3319 ✅ merged, #3320 ✅ merged, #3321 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
