### PR TITLE
fix(ios): match the TankstellenWidget App ID for App Store archive signing

### DIFF
--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -9,7 +9,18 @@ git_url("git@github.com:fdittgen-png/tankstellen-ios-certs.git")
 storage_mode("git")
 
 type("appstore")
-app_identifier(["de.tankstellen.tankstellen"])
+# Both signed targets must be covered, or the App Store archive fails with
+# "No profile for ... matching 'match AppStore <id>'". The WidgetKit
+# extension (TankstellenWidget) is a separate code-signed target with its own
+# App ID, so it needs its own match profile alongside the host app. Both App
+# IDs must have the App Groups capability enabled in the Apple Developer
+# Portal (they share `group.de.tankstellen.tankstellen` for the host↔widget
+# UserDefaults bridge) so the regenerated profiles carry the
+# `com.apple.security.application-groups` entitlement.
+app_identifier([
+  "de.tankstellen.tankstellen",
+  "de.tankstellen.tankstellen.TankstellenWidget",
+])
 team_id("C4Y5RDF8P9")
 
 # CI must always run match in readonly mode — only humans on a trusted


### PR DESCRIPTION
## Why
The manual **iOS TestFlight Build** went red — archive failed on signing:
```
error: No profile for team 'C4Y5RDF8P9' matching 'match AppStore de.tankstellen.tankstellen.TankstellenWidget' found
error: Provisioning profile "match AppStore de.tankstellen.tankstellen" doesn't include the App Groups capability
       (com.apple.security.application-groups / group.de.tankstellen.tankstellen)
```
Pre-existing iOS signing/provisioning debt — **not** a regression from any recent merge (the App Groups entitlements have been in the repo since #2915/#1555; no recent PR touched iOS entitlements).

## What this PR fixes (repo-side)
The `Matchfile` listed only the host app ID, so `match appstore` never fetched — and `match_bootstrap` never minted — a profile for the separately-signed **WidgetKit extension** (`de.tankstellen.tankstellen.TankstellenWidget`). Added it to `app_identifier`.

## ⚠️ Still needs a credentialed step to fully green (CI is readonly by design)
A maintainer must, **once, on a trusted machine** (Apple creds + 2FA, not CI):
1. In the Apple Developer Portal, ensure the **App Groups** capability is enabled on **both** App IDs (`de.tankstellen.tankstellen` and `…​.TankstellenWidget`) with group `group.de.tankstellen.tankstellen`.
2. Regenerate the App Store profiles (now covering both IDs, with the App Groups entitlement) and push them to the certs repo:
   ```
   cd ios && bundle exec fastlane match appstore --force --readonly false
   # (or the existing `match_bootstrap` lane)
   ```
3. Re-run the **iOS TestFlight Build** workflow → CI consumes the regenerated profiles → green.

This PR is the prerequisite config (the widget App ID coverage); step 2 mints the actual profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
