### PR TITLE
perf(search): radar responds before brand enrichment + negative-cache OSM misses (#3326, #3327)

### DIFF
--- a/lib/core/services/brand_enrich_budget.dart
+++ b/lib/core/services/brand_enrich_budget.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import '../domain/station.dart';
+import 'impl/osm_brand_enricher.dart';
+
+/// #3326 — enrich [stations] with OSM brand names, but never block the caller
+/// (e.g. the radar's first paint) longer than [budget].
+///
+/// On a cold brand cache `enrich` calls Nominatim (slow + rate-limited); the
+/// stations already carry coordinates + prices, so a search shouldn't wait on
+/// the optional brand label. If enrichment resolves within [budget] the
+/// enriched list is returned; otherwise [stations] is returned immediately and
+/// enrichment keeps running in the background (its token is NOT cancelled) to
+/// warm the persistent brand cache for the next search. Never throws — a
+/// failed enrichment just yields the un-enriched stations.
+Future<List<Station>> enrichWithinBudget(
+  OsmBrandEnricher? enricher,
+  List<Station> stations, {
+  required Duration budget,
+  CancelToken? cancelToken,
+}) {
+  if (enricher == null) return Future.value(stations);
+  // Best-effort: an enrichment error (fast or slow) must never break the
+  // search — fall back to the un-enriched stations.
+  final pending = enricher
+      .enrich(stations, cancelToken: cancelToken)
+      .catchError((_) => stations);
+  return pending.timeout(
+    budget,
+    onTimeout: () {
+      unawaited(pending.then((_) {}, onError: (_) {}));
+      return stations;
+    },
+  );
+}

--- a/lib/core/services/impl/osm_brand_enricher.dart
+++ b/lib/core/services/impl/osm_brand_enricher.dart
@@ -27,13 +27,17 @@ class OsmBrandEnricher {
   final SettingsStorage _storage;
   final Map<String, String> _sessionCache = {};
 
-  OsmBrandEnricher(this._storage);
+  /// Rate-limiting is handled by DioFactory's RateLimitInterceptor (#2315).
+  /// Injectable (#3327) so the enrichment/negative-cache path is testable
+  /// without hitting the live Nominatim endpoint.
+  final Dio _dio;
 
-  // Rate-limiting is handled by DioFactory's RateLimitInterceptor (#2315).
-  static final _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 8),
-    receiveTimeout: const Duration(seconds: 10),
-  );
+  OsmBrandEnricher(this._storage, {Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 8),
+              receiveTimeout: const Duration(seconds: 10),
+            );
 
   Future<List<Station>> enrich(
     List<Station> stations, {
@@ -43,7 +47,10 @@ class OsmBrandEnricher {
 
     var result = _applyCachedBrands(stations);
 
-    final uncached = result.where(_needsBrand).toList();
+    // #3327 — exclude stations we've already resolved to "no OSM brand" (the
+    // negative cache) so we don't re-hit Nominatim for them on every search.
+    final uncached =
+        result.where((s) => _needsBrand(s) && !_isNegativelyCached(s)).toList();
     if (uncached.isEmpty) return result;
 
     await _fetchBrandsFromNominatim(stations, cancelToken: cancelToken);
@@ -52,11 +59,24 @@ class OsmBrandEnricher {
     return result;
   }
 
+  /// #3327 — sentinel stored in the brand cache for a station that OSM has no
+  /// usable brand for. A real brand can never be this (it carries a control
+  /// char), and it's handled explicitly before sanitisation on read, so it
+  /// only ever means "resolved: no brand — don't re-query".
+  @visibleForTesting
+  static const String noBrandMarker = ' __no_osm_brand__';
+
   bool _needsBrand(Station s) =>
       s.brand.isEmpty ||
       s.brand == 'Station' || // legacy value from before #482
       s.brand == BrandRegistry.independentLabel ||
       s.brand == 'Autoroute';
+
+  /// Whether [s] has been negatively cached (#3327) — enrichment previously
+  /// found no OSM brand, so it must not be re-queried.
+  bool _isNegativelyCached(Station s) =>
+      _sessionCache[s.id] == noBrandMarker ||
+      _storage.getSetting('brand_${s.id}') == noBrandMarker;
 
   Future<void> _fetchBrandsFromNominatim(
     List<Station> stations, {
@@ -108,13 +128,21 @@ class OsmBrandEnricher {
         // gated by _needsBrand, but a future caller must not be able to
         // overwrite a real brand from a neighbouring POI).
         if (!_needsBrand(s)) continue;
+        // #3327 — already resolved as no-brand; don't re-write the marker.
+        if (_isNegativelyCached(s)) continue;
         final nearest = attributeBrandPoi(s.lat, s.lng, pois);
-        if (nearest != null) {
-          final sanitized = sanitizeOsmBrand(nearest.name);
-          if (sanitized != null) {
-            _sessionCache[s.id] = sanitized;
-            writes.add(_storage.putSetting('brand_${s.id}', sanitized));
-          }
+        final sanitized =
+            nearest != null ? sanitizeOsmBrand(nearest.name) : null;
+        if (sanitized != null) {
+          _sessionCache[s.id] = sanitized;
+          writes.add(_storage.putSetting('brand_${s.id}', sanitized));
+        } else {
+          // #3327 — negative cache: no usable OSM brand for this station.
+          // Record the miss so it isn't re-queried on every search (same
+          // forever-cache semantics as a positive hit; the displayed brand
+          // stays the independent/sentinel label).
+          _sessionCache[s.id] = noBrandMarker;
+          writes.add(_storage.putSetting('brand_${s.id}', noBrandMarker));
         }
       }
       if (writes.isNotEmpty) await Future.wait(writes);
@@ -125,8 +153,15 @@ class OsmBrandEnricher {
     return stations.map((s) {
       if (!_needsBrand(s)) return s;
       final cached = _sessionCache[s.id];
+      // #3327 — resolved as "no OSM brand": keep the station as-is (don't
+      // stamp the marker as a brand) and don't re-query.
+      if (cached == noBrandMarker) return s;
       if (cached != null) return s.copyWith(brand: cached);
       final persisted = _storage.getSetting('brand_${s.id}');
+      if (persisted == noBrandMarker) {
+        _sessionCache[s.id] = noBrandMarker; // promote to session cache
+        return s;
+      }
       if (persisted is String) {
         // Validate on read — anything that fails sanitisation (empty,
         // too short, "ff", phone-number-looking, etc.) is treated as

--- a/lib/features/station_services/france/prix_carburants_queries.dart
+++ b/lib/features/station_services/france/prix_carburants_queries.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../../../core/network/dio_offline.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import 'prix_carburants_parsers.dart' as parser;
+
+/// The two ODSQL `records` queries against the data.economie.gouv.fr
+/// flux-instantane endpoint, split out of `PrixCarburantsStationService` (#3326)
+/// so that orchestrator stays under the file-length cap. Pure transport: each
+/// takes the caller's [dio] + [baseUrl], returns raw result maps, and swallows
+/// an OFFLINE failure to `[]` (only a real API error gets an ERROR trace).
+
+Future<List<Map<String, dynamic>>> queryPrixCarburantsByPostalCode(
+  Dio dio,
+  String baseUrl,
+  String cp, {
+  CancelToken? cancelToken,
+}) async {
+  try {
+    final response = await dio.get<dynamic>(baseUrl, queryParameters: {
+      'where': "cp='$cp'",
+      'limit': 50,
+    }, cancelToken: cancelToken);
+    return parser.extractPrixCarburantsResults(response.data);
+  } on DioException catch (e, st) {
+    // #2524 — an OFFLINE failure (no network) is expected and already handled
+    // (returns []), so it must NOT pollute the user error spool. Drop it to a
+    // debugPrint; only a real API error (4xx/5xx, malformed) gets an ERROR.
+    if (_isOffline(e)) {
+      debugPrint('Prix-Carburants ZIP fetch skipped — offline ($e)');
+      return [];
+    }
+    unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        context: const {'where': 'Prix-Carburants ZIP fetch failed'}));
+    return [];
+  }
+}
+
+Future<List<Map<String, dynamic>>> queryPrixCarburantsByGeo(
+  Dio dio,
+  String baseUrl,
+  double lat,
+  double lng,
+  double radiusKm, {
+  CancelToken? cancelToken,
+}) async {
+  // Use within_distance with km unit — the distance() function with meters
+  // is unreliable on this API and often returns 0 results. Preserve one
+  // decimal of precision so sub-km radius selections aren't silently
+  // rounded to the nearest integer.
+  final radiusStr = radiusKm.toStringAsFixed(1);
+  // #2966 — order the corridor server-side by distance so the `limit: 50`
+  // slice keeps the NEAREST 50, not an arbitrary 50. Without it a dense
+  // corridor (e.g. 140 stations within 10 km of central Paris) returns an
+  // un-distance-ordered subset and the genuinely-nearest forecourt can be
+  // truncated out entirely — the server-side root cause behind the radar /
+  // closeness / in-trip "missing nearest station" symptoms (deferred #2813
+  // dense case; #2806 / #2965 in-radius merges become belt-and-braces). The
+  // old `distance()` "0 results" note was the metres form; the validated v2.1
+  // ODSQL `order_by=distance(geom,geom'POINT(lon lat)')` form (lon-lat order)
+  // is accepted live and returns rows nearest-first — it changes only the
+  // ordering / cap survival, never which stations are in-radius (still gated
+  // by the unchanged `within_distance` filter).
+  final point = "geom'POINT($lng $lat)'";
+  try {
+    final response = await dio.get<dynamic>(baseUrl, queryParameters: {
+      'where': 'within_distance(geom,$point,${radiusStr}km)',
+      'order_by': 'distance(geom,$point)',
+      'limit': 50,
+    }, cancelToken: cancelToken);
+    return parser.extractPrixCarburantsResults(response.data);
+  } on DioException catch (e, st) {
+    // #2524 — an offline failure is expected and swallowed; only a real API
+    // error gets an ERROR trace.
+    if (_isOffline(e)) {
+      // #2745 — the field trace #1 was a `DioException[unknown]` wrapping an
+      // `HttpException('Software caused connection abort')` while offline. Drop
+      // it to a diagnostic breadcrumb instead of an ERROR.
+      BreadcrumbCollector.add(
+        'Prix-Carburants geo fetch skipped — offline',
+        detail: 'lat=$lat lng=$lng type=${e.type}',
+      );
+      debugPrint('Prix-Carburants geo fetch skipped — offline ($e)');
+      return [];
+    }
+    unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        context: const {'where': 'Prix-Carburants geo fetch failed'}));
+    return [];
+  }
+}
+
+/// Whether [e] is an offline / no-network failure rather than a real API
+/// error (#2524). Delegates to the shared [isOfflineError] classifier so this
+/// and the trace-recorder de-noise gate classify offline transients
+/// identically and can't drift (#2703/#2745).
+bool _isOffline(DioException e) => isOfflineError(e);

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -4,19 +4,18 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import '../../../core/domain/search_params.dart';
 import '../../../core/domain/station.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/services/impl/osm_brand_enricher.dart';
 import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_parsers.dart' as parser;
-import '../../../core/network/dio_offline.dart';
-import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
+import '../../../core/services/brand_enrich_budget.dart';
+import 'prix_carburants_queries.dart';
 import '../../../core/logging/error_logger.dart';
 
 /// Real French fuel price data from Prix-Carburants (gouv.fr).
@@ -37,16 +36,24 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
   final Dio _dio;
   final String _baseUrl;
 
+  /// #3326 — how long the search path will wait for OSM brand enrichment
+  /// before returning the (already-fetched) stations and letting enrichment
+  /// finish in the background. Keeps a cold-cache Nominatim lookup from
+  /// gating the radar's first paint. Injectable for tests.
+  final Duration _enrichBudget;
+
   PrixCarburantsStationService({
     OsmBrandEnricher? enricher,
     Dio? dio,
     String? baseUrl,
+    Duration enrichBudget = const Duration(seconds: 2),
   })  : _enricher = enricher,
         _dio = dio ?? DioFactory.create(
           connectTimeout: const Duration(seconds: 15),
           receiveTimeout: const Duration(seconds: 15),
         ),
-        _baseUrl = baseUrl ?? defaultBaseUrl;
+        _baseUrl = baseUrl ?? defaultBaseUrl,
+        _enrichBudget = enrichBudget;
 
   static const String defaultBaseUrl =
       'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets'
@@ -74,10 +81,10 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       //    cap results at the village's own ~5 stations regardless of
       //    radius — bug #315.
       // 3. Merge and dedupe by station id.
-      final cpResults = await _queryByPostalCode(params.postalCode!, cancelToken: cancelToken);
+      final cpResults = await queryPrixCarburantsByPostalCode(_dio, _baseUrl, params.postalCode!, cancelToken: cancelToken);
 
       if (hasValidCoords) {
-        final geoResults = await _queryByGeo(params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
+        final geoResults = await queryPrixCarburantsByGeo(_dio, _baseUrl, params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
         allResults = _mergeById(cpResults, geoResults);
       } else {
         allResults = cpResults;
@@ -90,7 +97,7 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       }
     } else {
       // GPS / coordinate search: geo query is the only option
-      allResults = await _queryByGeo(params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
+      allResults = await queryPrixCarburantsByGeo(_dio, _baseUrl, params.lat, params.lng, params.radiusKm, cancelToken: cancelToken);
     }
 
     // Parse all results into Station objects
@@ -120,10 +127,15 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       );
     }
 
-    // Enrich with brand names from OpenStreetMap (best-effort)
-    final enriched = _enricher != null
-        ? await _enricher.enrich(stations, cancelToken: cancelToken)
-        : stations;
+    // #3326 — enrich brands without gating the radar's first paint: return
+    // the (already-fetched) stations once the budget elapses and let
+    // enrichment finish in the background. See [enrichWithinBudget].
+    final enriched = await enrichWithinBudget(
+      _enricher,
+      stations,
+      budget: _enrichBudget,
+      cancelToken: cancelToken,
+    );
 
     return ServiceResult(
       data: enriched,
@@ -132,85 +144,6 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     );
   }
 
-  Future<List<Map<String, dynamic>>> _queryByPostalCode(String cp, {CancelToken? cancelToken}) async {
-    try {
-      final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
-        'where': "cp='$cp'",
-        'limit': 50,
-      }, cancelToken: cancelToken);
-      return parser.extractPrixCarburantsResults(response.data);
-    } on DioException catch (e, st) {
-      // #2524 — an OFFLINE failure (no network) is expected and already
-      // handled (returns []), so it must NOT pollute the user error spool.
-      // Drop it to a debugPrint; only a real API error (4xx/5xx, malformed
-      // response) is worth an ERROR trace.
-      if (_isOffline(e)) {
-        debugPrint('Prix-Carburants ZIP fetch skipped — offline ($e)');
-        return [];
-      }
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Prix-Carburants ZIP fetch failed'}));
-      return [];
-    }
-  }
-
-
-  Future<List<Map<String, dynamic>>> _queryByGeo(
-    double lat, double lng, double radiusKm, {CancelToken? cancelToken}
-  ) async {
-    // Use within_distance with km unit — the distance() function with meters
-    // is unreliable on this API and often returns 0 results. Preserve one
-    // decimal of precision so sub-km radius selections aren't silently
-    // rounded to the nearest integer.
-    final radiusStr = radiusKm.toStringAsFixed(1);
-    // #2966 — order the corridor server-side by distance so the `limit: 50`
-    // slice keeps the NEAREST 50, not an arbitrary 50. Without it a dense
-    // corridor (e.g. 140 stations within 10 km of central Paris) returns an
-    // un-distance-ordered subset and the genuinely-nearest forecourt can be
-    // truncated out entirely — the server-side root cause behind the radar /
-    // closeness / in-trip "missing nearest station" symptoms (deferred #2813
-    // dense case; #2806 / #2965 in-radius merges become belt-and-braces). The
-    // old `distance()` "0 results" note was the metres form; the validated v2.1
-    // ODSQL `order_by=distance(geom,geom'POINT(lon lat)')` form (lon-lat order)
-    // is accepted live and returns rows nearest-first — it changes only the
-    // ordering / cap survival, never which stations are in-radius (still gated
-    // by the unchanged `within_distance` filter).
-    final point = "geom'POINT($lng $lat)'";
-    try {
-      final response = await _dio.get<dynamic>(_baseUrl, queryParameters: {
-        'where': 'within_distance(geom,$point,${radiusStr}km)',
-        'order_by': 'distance(geom,$point)',
-        'limit': 50,
-      }, cancelToken: cancelToken);
-      return parser.extractPrixCarburantsResults(response.data);
-    } on DioException catch (e, st) {
-      // #2524 — see [_queryByPostalCode]: an offline failure is expected and
-      // swallowed (returns []); only a real API error gets an ERROR trace.
-      if (_isOffline(e)) {
-        // #2745 — the field trace #1 was a `DioException[unknown]` wrapping
-        // an `HttpException('Software caused connection abort')` from
-        // data.economie.gouv.fr while the device was offline. Drop it to a
-        // diagnostic breadcrumb (still triageable from any surviving trace)
-        // instead of an ERROR — it is an expected no-network condition.
-        BreadcrumbCollector.add(
-          'Prix-Carburants geo fetch skipped — offline',
-          detail: 'lat=$lat lng=$lng type=${e.type}',
-        );
-        debugPrint('Prix-Carburants geo fetch skipped — offline ($e)');
-        return [];
-      }
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Prix-Carburants geo fetch failed'}));
-      return [];
-    }
-  }
-
-  /// Whether [e] is an offline / no-network failure rather than a real
-  /// API error (#2524). Delegates to the shared [isOfflineError] classifier
-  /// (#2703/#2745) so this and the trace-recorder de-noise gate classify
-  /// offline transients identically and can't drift. #2745 broadened from
-  /// [isOfflineDioException] to [isOfflineError] so a `DioException[unknown]`
-  /// wrapping an `HttpException` connection-abort (the field trace #1) is
-  /// recognised as offline at the call site too.
-  static bool _isOffline(DioException e) => isOfflineError(e);
 
   /// Merge two raw API result lists, deduplicating by station id.
   /// Stations from [primary] win when an id collides.

--- a/test/core/services/brand_enrich_budget_test.dart
+++ b/test/core/services/brand_enrich_budget_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/brand_enrich_budget.dart';
+import 'package:tankstellen/core/services/impl/osm_brand_enricher.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+
+/// #3326 — `enrichWithinBudget` must never gate the caller longer than the
+/// budget, and must never throw (a brand-enrichment failure can't break search).
+Station _station(String id, {String brand = ''}) => Station(
+      id: id,
+      name: 'S$id',
+      brand: brand,
+      street: 'x',
+      postCode: '00000',
+      place: 'p',
+      lat: 48.0,
+      lng: 2.0,
+      isOpen: true,
+    );
+
+class _SlowEnricher extends OsmBrandEnricher {
+  _SlowEnricher() : super(FakeHiveStorage());
+  @override
+  Future<List<Station>> enrich(List<Station> s, {CancelToken? cancelToken}) async {
+    await Future<void>.delayed(const Duration(seconds: 5));
+    return s.map((e) => e.copyWith(brand: 'LATE')).toList();
+  }
+}
+
+class _ThrowingEnricher extends OsmBrandEnricher {
+  _ThrowingEnricher() : super(FakeHiveStorage());
+  @override
+  Future<List<Station>> enrich(List<Station> s, {CancelToken? cancelToken}) async {
+    throw Exception('enrichment blew up');
+  }
+}
+
+class _FastEnricher extends OsmBrandEnricher {
+  _FastEnricher() : super(FakeHiveStorage());
+  @override
+  Future<List<Station>> enrich(List<Station> s, {CancelToken? cancelToken}) async {
+    return s.map((e) => e.copyWith(brand: 'Esso')).toList();
+  }
+}
+
+void main() {
+  test('null enricher → returns the stations unchanged', () async {
+    final stations = [_station('1')];
+    expect(await enrichWithinBudget(null, stations, budget: const Duration(seconds: 1)),
+        same(stations));
+  });
+
+  test('slow enrichment → returns un-enriched within the budget', () async {
+    final stations = [_station('1')];
+    final sw = Stopwatch()..start();
+    final result = await enrichWithinBudget(_SlowEnricher(), stations,
+        budget: const Duration(milliseconds: 10));
+    sw.stop();
+    expect(result.single.brand, '', reason: 'budget elapsed before enrichment');
+    expect(sw.elapsed, lessThan(const Duration(milliseconds: 250)));
+  });
+
+  test('fast enrichment within budget → returns enriched', () async {
+    final result = await enrichWithinBudget(_FastEnricher(), [_station('1')],
+        budget: const Duration(seconds: 2));
+    expect(result.single.brand, 'Esso');
+  });
+
+  test('a throwing enricher is swallowed — completes with the un-enriched '
+      'stations, never throws (#2349)', () async {
+    final stations = [_station('1')];
+    final call = enrichWithinBudget(_ThrowingEnricher(), stations,
+        budget: const Duration(seconds: 1));
+    await expectLater(call, completes);
+    expect((await call).single.brand, '');
+  });
+}

--- a/test/core/services/impl/osm_brand_enricher_test.dart
+++ b/test/core/services/impl/osm_brand_enricher_test.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/impl/osm_brand_enricher.dart';
 import 'package:tankstellen/core/domain/station.dart';
@@ -138,4 +141,102 @@ void main() {
       expect(fakeStorage.getSetting('brand_s2'), 'Shell');
     });
   });
+
+  group('negative cache (#3327)', () {
+    test('a station with no OSM match is negatively cached, not re-queried',
+        () async {
+      // Nominatim responds with an empty list → no POI matches any station.
+      final adapter = _NominatimAdapter(body: <dynamic>[]);
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = OsmBrandEnricher(fakeStorage, dio: dio);
+
+      final result = await svc.enrich([makeStation(id: '1')]);
+
+      // No brand found → station unchanged, AND the miss is cached.
+      expect(result.single.brand, '');
+      expect(fakeStorage.getSetting('brand_1'), OsmBrandEnricher.noBrandMarker);
+      expect(adapter.calls, 1);
+
+      // Second enrich: the station is negatively cached → NO Nominatim call.
+      final result2 = await svc.enrich([makeStation(id: '1')]);
+      expect(result2.single.brand, '');
+      expect(adapter.calls, 1,
+          reason: 'must not re-query a negatively cached station');
+    });
+
+    test('a station negatively cached on DISK (fresh session) is not '
+        're-queried', () async {
+      await fakeStorage.putSetting('brand_1', OsmBrandEnricher.noBrandMarker);
+      // Adapter throws if hit — proving no network call is made.
+      final adapter = _NominatimAdapter(throwIfCalled: true);
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = OsmBrandEnricher(fakeStorage, dio: dio);
+
+      final result = await svc.enrich([makeStation(id: '1')]);
+
+      expect(result.single.brand, '', reason: 'still shows no brand');
+      expect(adapter.calls, 0,
+          reason: 'disk negative cache short-circuits the fetch');
+    });
+
+    test('the negative marker is never shown as a brand', () async {
+      await fakeStorage.putSetting('brand_1', OsmBrandEnricher.noBrandMarker);
+      final svc = OsmBrandEnricher(fakeStorage);
+      final result = await svc.enrich([makeStation(id: '1')]);
+      expect(result.single.brand, isNot(OsmBrandEnricher.noBrandMarker));
+      expect(result.single.brand, '');
+    });
+
+    test('a real OSM match still wins (negative cache only applies to misses)',
+        () async {
+      final adapter = _NominatimAdapter(body: <dynamic>[
+        {'name': 'Total', 'lat': '48.8', 'lon': '2.3'},
+      ]);
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = OsmBrandEnricher(fakeStorage, dio: dio);
+
+      final result =
+          await svc.enrich([makeStation(id: '1', lat: 48.8, lng: 2.3)]);
+      expect(result.single.brand, isNot(OsmBrandEnricher.noBrandMarker));
+      expect(fakeStorage.getSetting('brand_1'),
+          isNot(OsmBrandEnricher.noBrandMarker));
+    });
+  });
+}
+
+/// Minimal Nominatim `HttpClientAdapter` stub (#3327): returns a fixed JSON
+/// list and counts calls, so the enrichment / negative-cache path is testable
+/// without the live endpoint.
+class _NominatimAdapter implements HttpClientAdapter {
+  _NominatimAdapter({this.body = const <dynamic>[], this.throwIfCalled = false});
+
+  final List<dynamic> body;
+  final bool throwIfCalled;
+  int calls = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    calls++;
+    if (throwIfCalled) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.unknown,
+        error: 'Nominatim must not be called',
+      );
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -1443,6 +1443,63 @@ void main() {
       expect(adapter.lastRequestUri, startsWith('https://data.economie.gouv.fr'));
     });
   });
+
+  group('searchStations brand-enrichment budget (#3326)', () {
+    Map<String, dynamic> geoResponse() => {
+          'results': [
+            {
+              'id': '1',
+              'adresse': 'RUE DU PORT',
+              'ville': 'SETE',
+              'cp': '34200',
+              'geom': {'lat': 43.3, 'lon': 3.5},
+              'e85_prix': 0.899,
+            },
+          ],
+        };
+
+    test('returns the (un-enriched) geo stations without waiting for a slow '
+        'brand lookup — the radar paints immediately', () async {
+      final adapter = _TrackingMockAdapter()..addResponse(geoResponse());
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final slow = _SlowEnricher(delay: const Duration(milliseconds: 400));
+      final svc = PrixCarburantsStationService(
+        dio: dio,
+        enricher: slow,
+        enrichBudget: const Duration(milliseconds: 10),
+      );
+
+      final sw = Stopwatch()..start();
+      final result =
+          await svc.searchStations(const SearchParams(lat: 43.3, lng: 3.5, radiusKm: 10.0));
+      sw.stop();
+
+      expect(result.data, isNotEmpty, reason: 'geo stations available at once');
+      expect(result.data.first.brand, isNot('SLOW-BRAND'),
+          reason: 'budget elapsed before the slow enricher resolved');
+      expect(slow.enrichCalls, 1,
+          reason: 'enrichment still fires (warms the cache in the background)');
+      expect(sw.elapsed, lessThan(const Duration(milliseconds: 250)),
+          reason: 'must NOT block on the 400ms enrichment');
+    });
+
+    test('a fast enricher still enriches within the budget', () async {
+      final adapter = _TrackingMockAdapter()..addResponse(geoResponse());
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(
+        dio: dio,
+        enricher: _FakeBrandEnricher(brand: 'Total Access'),
+        enrichBudget: const Duration(seconds: 2),
+      );
+
+      final result =
+          await svc.searchStations(const SearchParams(lat: 43.3, lng: 3.5, radiusKm: 10.0));
+
+      expect(result.data, isNotEmpty);
+      expect(result.data.first.brand, 'Total Access',
+          reason: 'fast enrichment resolves within budget → brand shown');
+    });
+  });
 }
 
 /// Test [OsmBrandEnricher] that resolves a fixed [brand] for every station
@@ -1466,6 +1523,26 @@ class _FakeBrandEnricher extends OsmBrandEnricher {
     final resolved = brand;
     if (resolved == null) return stations;
     return stations.map((s) => s.copyWith(brand: resolved)).toList();
+  }
+}
+
+/// #3326 — an enricher that stamps 'SLOW-BRAND' but only after [delay], so the
+/// search path's enrich-budget race can be exercised: the result must come
+/// back BEFORE this resolves.
+class _SlowEnricher extends OsmBrandEnricher {
+  _SlowEnricher({required this.delay}) : super(FakeStorageRepository());
+
+  final Duration delay;
+  int enrichCalls = 0;
+
+  @override
+  Future<List<Station>> enrich(
+    List<Station> stations, {
+    CancelToken? cancelToken,
+  }) async {
+    enrichCalls++;
+    await Future<void>.delayed(delay);
+    return stations.map((s) => s.copyWith(brand: 'SLOW-BRAND')).toList();
   }
 }
 


### PR DESCRIPTION
Closes #3326. Closes #3327.

## Why
The fuel-station radar's "Searching…" lingered ~10–18 s after the GPS fix even though the station data was already fetched — it blocked on inline OSM brand enrichment (Nominatim, slow + rate-limited on a cold cache). And stations with no OSM brand were never cached, so they were re-queried on every search.

## What
- **#3326** — `enrichWithinBudget()` races brand enrichment against a short budget (default 2 s). The geo results (coordinates + prices — everything the radar needs to render + rank) are returned immediately when the budget elapses; enrichment finishes in the **background** to warm the persistent cache for the next search. Never throws. Wired into `PrixCarburantsStationService.searchStations`; `getStationDetail` stays blocking.
- **#3327** — negative-cache stations with no OSM brand (`noBrandMarker`) so they're excluded from future Nominatim fetches. Never shown as a brand (station keeps its independent label); a real match still wins.
- Extracted the two ODSQL queries → `prix_carburants_queries.dart` and the budget helper → `brand_enrich_budget.dart` to keep the service under the 400-line cap (both reusable by other country services). Enricher `Dio` made injectable for tests.

## Tests
- `brand_enrich_budget_test.dart` — null/slow/fast/throwing (never-throws #2349 fault path).
- `osm_brand_enricher_test.dart` — negative-cache write, no re-query (session + disk), marker never shown, real-match-wins.
- `prix_carburants_station_service_test.dart` — search returns within budget on a slow enricher; fast enricher still enriches.

Follow-up (separate): two-phase emit so brands patch onto radar cards in place when background enrichment completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
