### PR TITLE
fix(consumption): GPS-only trip-path heatmap coloured by fuel estimate, not all-green (#3329)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -17,8 +17,9 @@ import 'trip_path_geometry.dart';
 // Phase 3 thresholds (#1374) — fixed defaults.
 //
 // The GPS-path heatmap colours each segment by its instantaneous
-// L/100 km, computed from the OBD-II `fuelRateLPerHour` and `speedKmh`
-// at the segment's start sample. Three buckets:
+// L/100 km, computed from `fuelRateLPerHour` — or, when absent (GPS-only /
+// OBD2-no-PID), the GPS estimate `estimatedFuelRateLPerHour` (#3329) — and
+// `speedKmh` at the segment's start sample. Three buckets:
 //
 //   * efficient   < 6.0 L/100 km  → DarkModeColors.success (green)
 //   * borderline  6.0 ≤ x < 10.0  → DarkModeColors.warning (orange)
@@ -27,11 +28,9 @@ import 'trip_path_geometry.dart';
 // Two safety gates classify a segment as efficient regardless of
 // computed L/100 km:
 //
-//   * `fuelRateLPerHour == null` — legacy / partial samples (no
-//     PID 5E and no MAF fallback) shouldn't paint red just because
-//     fuel rate wasn't measured.
-//   * `speedKmh < 5.0` — too-slow segments produce divide-by-near-
-//     zero L/100 km that's meaningless for coaching (creep, idle).
+//   * neither a measured rate nor an estimate — shouldn't paint red just
+//     because consumption wasn't known.
+//   * `speedKmh < 5.0` — too-slow segments give meaningless L/100 km.
 //
 // These thresholds are intentionally fixed; a future PR could derive
 // them per-vehicle from the consumption profile (tracked separately).
@@ -165,7 +164,9 @@ class _TripPathMapState extends State<_TripPathMap> {
   /// [_SegmentBucket.efficient] so legacy / idle samples don't paint
   /// red.
   static _SegmentBucket _classify(TripDetailSample start) {
-    final fuelRate = start.fuelRateLPerHour;
+    // #3329 — fall back to the GPS fuel ESTIMATE (GPS-only / OBD2-no-PID) so
+    // the route is coloured by estimated consumption, not painted all green.
+    final fuelRate = start.fuelRateLPerHour ?? start.estimatedFuelRateLPerHour;
     final speed = start.speedKmh;
     if (fuelRate == null || speed < _kMinClassifiableSpeedKmh) {
       return _SegmentBucket.efficient;

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -227,6 +227,14 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // live reading should carry then; the #2391 Avg + Fuel-used cards read
     // the smoother running figures it carries.
     final estimate = _estimateFolder?.fold(sample) ?? GpsLiveEstimate.none;
+    // #3329 — stamp the per-fix GPS fuel estimate (as L/h, the form
+    // Obd2GpsEstimateFallback uses) onto the persisted sample so the trip-path
+    // heatmap colours a GPS-only route by consumption instead of all-green.
+    final instant = estimate.instantLPer100Km;
+    if (instant != null && sample.speedKmh > 0 && _samples.isNotEmpty) {
+      _samples[_samples.length - 1] =
+          _samples.last.copyWithEstimatedFuelRate(instant / 100.0 * sample.speedKmh);
+    }
     final coaching = estimate.coachingHint;
     _host.state = _host.state.copyWith(
       phase: TripRecordingPhase.recording,

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -34,11 +34,13 @@ TripDetailSample _sample({
   double? lat,
   double? lng,
   double? fuelRate,
+  double? estFuelRate,
 }) {
   return TripDetailSample(
     timestamp: DateTime.utc(2026, 5, 3, 10, 0, sec),
     speedKmh: speed,
     fuelRateLPerHour: fuelRate,
+    estimatedFuelRateLPerHour: estFuelRate,
     latitude: lat,
     longitude: lng,
   );
@@ -168,6 +170,52 @@ void main() {
       expect(find.byType(FlutterMap), findsOneWidget);
       final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
       expect(layer.polylines, isEmpty);
+    });
+  });
+
+  group('TripPathMapCard — GPS-only estimate heatmap (#3329)', () {
+    testWidgets(
+        'a GPS-only trip (no OBD2 rate) is coloured by the GPS fuel ESTIMATE '
+        '— not painted all green', (tester) async {
+      // GPS-only samples carry NO measured fuelRateLPerHour, but DO carry the
+      // per-fix GPS estimate (estimatedFuelRateLPerHour). L/100 km =
+      // estFuelRate / speed * 100, same buckets:
+      //   * efficient   speed=60, est=3.0 → 5.0  (< 6)
+      //   * wasteful    speed=60, est=7.2 → 12.0 (≥ 10)  ← the climb
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60, estFuelRate: 3.0),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60, estFuelRate: 3.0),
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60, estFuelRate: 7.2),
+        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 60, estFuelRate: 7.2),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      final ctx = tester.element(find.byType(FlutterMap));
+      final colors = layer.polylines.map((p) => p.color).toSet();
+
+      expect(colors.length, greaterThan(1),
+          reason: 'must NOT be uniformly green — the estimate varies');
+      expect(colors, contains(DarkModeColors.error(ctx)),
+          reason: 'the high-consumption (climb) stretch is wasteful/red');
+      expect(colors, contains(DarkModeColors.success(ctx)));
+    });
+
+    testWidgets('a real OBD2 rate still wins over the estimate', (tester) async {
+      // fuelRate present (efficient) but estFuelRate would be wasteful — the
+      // measured rate must take precedence.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60, fuelRate: 3.0, estFuelRate: 7.2),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60, fuelRate: 3.0, estFuelRate: 7.2),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+      final ctx = tester.element(find.byType(FlutterMap));
+      expect(layer.polylines.single.color, DarkModeColors.success(ctx),
+          reason: 'measured fuelRateLPerHour wins; 3.0/60*100 = 5.0 → efficient');
     });
   });
 


### PR DESCRIPTION
Closes #3329.

## Why
On a GPS-only trip the trip-detail "Trace du trajet" heatmap painted the **entire** route green even at a 6.6 L/100km average with a documented 4% climb + stop-and-go restarts — the colour didn't fit the data (per the user's screenshots).

## Root cause
`TripPathMapCard._classify` bucketed by `fuelRateLPerHour` — the **OBD2** rate, which is **null for every GPS-only sample** — with a `null → efficient` gate, so GPS-only routes were always green. The per-fix GPS estimate that *does* vary with grade/accel was computed for the live reading but **never stamped onto the persisted samples** (`stop()` only imputed a summary-level avg).

## Fix
- `GpsOnlyRecordingPipeline` stamps the per-fix GPS estimate (`estimatedFuelRateLPerHour`, as L/h — the form `Obd2GpsEstimateFallback` already uses) onto each persisted sample.
- `_classify` falls back to `estimatedFuelRateLPerHour` when the measured rate is absent → GPS-only (and OBD2-no-PID) routes colour by estimated consumption; climb / stop-and-go stretches render borderline/wasteful. A real OBD2 rate still wins.

Applies to trips recorded **after** this change (existing history has no per-sample estimate).

## Tests
`trip_path_map_card_test.dart` — a GPS-only trip with a varying estimate renders >1 colour incl. the wasteful/red stretch (was uniformly green); a real OBD2 rate still wins over the estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
