### PR TITLE
fix(sync): de-noise PGRST205 'deletions table absent' on an outdated self-host schema (#3331)

### DIFF
--- a/lib/core/sync/deletions_sync.dart
+++ b/lib/core/sync/deletions_sync.dart
@@ -10,6 +10,7 @@ import 'pending_deletions_journal.dart';
 import 'sync_device_identity.dart';
 import 'sync_transport.dart';
 import '../../core/logging/error_logger.dart';
+import '../telemetry/collectors/breadcrumb_collector.dart';
 
 /// Deletion tombstones (#3078, Epic #3075).
 ///
@@ -95,10 +96,24 @@ class DeletionsSync {
           'for "$tableName"');
       return true;
     } catch (e, st) {
+      if (isDeletionsTableAbsent(e)) {
+        _breadcrumbDeletionsAbsent();
+        return false;
+      }
       unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'DeletionsSync.record FAILED'}));
       return false;
     }
+  }
+
+  /// #3331 — one actionable breadcrumb (NOT an ERROR trace) for the
+  /// outdated-self-host-schema case, so it doesn't flood the error log.
+  static void _breadcrumbDeletionsAbsent() {
+    BreadcrumbCollector.add(
+      'sync: deletions table absent',
+      detail: 'self-host TankSync schema predates the deletion-tombstones '
+          'migration — re-run the wizard SQL to enable cross-device deletes',
+    );
   }
 
   /// Upsert [rows] with the #3125 forensic columns; a self-host schema
@@ -144,6 +159,21 @@ class DeletionsSync {
         message.toLowerCase().contains('column');
   }
 
+  /// #3331 — whether [error] is a PGRST205 "the `deletions` table doesn't
+  /// exist" failure: a self-host TankSync schema that predates the
+  /// deletion-tombstones migration. `deletions` is OPTIONAL, so the verifier
+  /// doesn't flag its absence, yet every entity sync calls
+  /// [fetchTombstonedIds] — so an outdated self-host would flood the error
+  /// log. Classify it to breadcrumb (actionable) instead of ERROR-logging.
+  @visibleForTesting
+  static bool isDeletionsTableAbsent(Object error) {
+    final message = error.toString().toLowerCase();
+    final missingTable = message.contains('pgrst205') ||
+        (message.contains('could not find the table') &&
+            message.contains('schema cache'));
+    return missingTable && message.contains('deletions');
+  }
+
   /// Replay every journaled-but-unconfirmed tombstone (#3123). Called at
   /// the start of [fetchTombstonedIds] so pending tombstones land
   /// server-side *before* the caller's union merge runs. Never throws —
@@ -184,6 +214,10 @@ class DeletionsSync {
         ...PendingDeletionsJournal.pendingIds(tableName),
       };
     } catch (e, st) {
+      if (isDeletionsTableAbsent(e)) {
+        _breadcrumbDeletionsAbsent();
+        return PendingDeletionsJournal.pendingIds(tableName);
+      }
       unawaited(errorLogger.log(ErrorLayer.sync, e, st,
           context: const {'where': 'DeletionsSync.fetchTombstonedIds FAILED'}));
       return PendingDeletionsJournal.pendingIds(tableName);

--- a/test/core/sync/deletions_sync_test.dart
+++ b/test/core/sync/deletions_sync_test.dart
@@ -37,4 +37,42 @@ void main() {
       expect(await DeletionsSync.fetchTombstonedIds('itineraries'), isEmpty);
     });
   });
+
+  group('isDeletionsTableAbsent (#3331)', () {
+    test('the field PGRST205 message is classified as table-absent', () {
+      final err = Exception(
+        'PostgrestException(message: Could not find the table '
+        "'public.deletions' in the schema cache, code: PGRST205, "
+        "details: Not Found, hint: Perhaps you meant 'public.ignored_stations')",
+      );
+      expect(DeletionsSync.isDeletionsTableAbsent(err), isTrue);
+    });
+
+    test('the find-table/schema-cache phrasing (no code) still matches', () {
+      final err = Exception(
+        "Could not find the table 'public.deletions' in the schema cache",
+      );
+      expect(DeletionsSync.isDeletionsTableAbsent(err), isTrue);
+    });
+
+    test('a PGRST205 for a DIFFERENT table is not classified', () {
+      final err = Exception(
+        "Could not find the table 'public.widgets' in the schema cache PGRST205",
+      );
+      expect(DeletionsSync.isDeletionsTableAbsent(err), isFalse);
+    });
+
+    test('the PGRST204 missing-column case is NOT table-absent', () {
+      final err = Exception(
+        "PostgrestException(message: Could not find the 'device_id' column "
+        "of 'deletions', code: PGRST204)",
+      );
+      expect(DeletionsSync.isDeletionsTableAbsent(err), isFalse);
+    });
+
+    test('a generic sync error is not classified as table-absent', () {
+      expect(DeletionsSync.isDeletionsTableAbsent(Exception('network down')),
+          isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Closes #3331.

## Why
A field error-log export was **9× `PostgrestException ... Could not find the table 'public.deletions' in the schema cache (PGRST205)`** — flooding the log on every sync run. The self-hosted TankSync schema predates the `deletion-tombstones` migration; `deletions` is an **optional** table so `SchemaVerifier` never flags its absence, yet every entity sync calls `DeletionsSync.fetchTombstonedIds`.

## What
Mirror the existing `_isMissingForensicColumn` (PGRST204) de-noise: `isDeletionsTableAbsent` classifies the PGRST205 deletions-table-absent error, and the `record` + `fetchTombstonedIds` catch sites emit one **actionable breadcrumb** ("re-run the wizard SQL") instead of an ERROR trace. The existing fail-open fallback (journaled ids) already degrades correctly; a genuine sync error — and the PGRST204 column case — still ERROR-log.

## Tests
`deletions_sync_test.dart` — the field PGRST205 message → table-absent; the find-table/schema-cache phrasing → table-absent; a PGRST205 for a *different* table → not; the PGRST204 column case → not; a generic error → not.

## Resolution for the user
The real fix is on the self-host: re-run the updated TankSync wizard SQL to add the `deletions` table (cross-device delete propagation is silently off until then). Follow-up (#3331 notes): have `SchemaVerifier` surface a missing **optional** table so the user gets one "schema outdated" notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
