### PR TITLE
fix(alerts): zone-alert fuel dropdown follows the active country, not hardcoded Germany (#3333)

### DIFF
--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -8,6 +8,7 @@ import 'package:uuid/uuid.dart';
 
 import '../../background/fuel_price_fields.dart';
 import '../../../../core/country/country_config.dart';
+import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/services/country_service_registry.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -149,15 +150,17 @@ class _RadiusAlertCreateSheetState
   /// The country the alert's centre falls in (#2865) — resolved from the
   /// picked coordinates via the registry's bounding boxes, exactly like
   /// the background radius runner. Before a centre is set the form has no
-  /// location yet, so it falls back to the default country (preserving the
-  /// historical euro labels). Updates live as the user picks GPS / a map
-  /// point; the parent re-`build`s on every centre change.
+  /// location yet, so it falls back to the user's ACTIVE country (#3333) —
+  /// not a hardcoded Germany, which limited a French user's fuel dropdown to
+  /// the German e5/e10/diesel trio (E85 / SP98 / GPLc were missing). Updates
+  /// live as the user picks GPS / a map point; the parent re-`build`s on
+  /// every centre change.
   String get _centerCountry {
     final lat = _centerLat;
     final lng = _centerLng;
-    if (lat == null || lng == null) return Countries.germany.code;
-    return CountryServiceRegistry.countryForLatLng(lat, lng) ??
-        Countries.germany.code;
+    final fallback = ref.read(activeCountryProvider).code;
+    if (lat == null || lng == null) return fallback;
+    return CountryServiceRegistry.countryForLatLng(lat, lng) ?? fallback;
   }
 
   /// Currency symbol for the centre's country (#2865) — used on the

--- a/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
+++ b/test/features/alerts/presentation/widgets/radius_alert_create_sheet_test.dart
@@ -6,8 +6,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
 import 'package:tankstellen/features/alerts/presentation/widgets/radius_alert_create_sheet.dart';
+import 'package:tankstellen/features/alerts/presentation/widgets/radius_alert_form_fields.dart';
 import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -37,6 +40,34 @@ void main() {
         find.byKey(const Key('radius_alert_germany_only_note')),
         findsNothing,
       );
+    });
+
+    testWidgets('fuel dropdown follows the ACTIVE country before a centre is '
+        'picked, not hardcoded Germany (#3333)', (tester) async {
+      // Active country = France. Before any centre is bound the sheet must
+      // offer FRANCE's evaluable fuels (E85 / GPLc included), not the German
+      // e5/e10/diesel trio that the old `Countries.germany` default forced.
+      final test = standardTestOverrides(country: Countries.france);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const RadiusAlertCreateSheet(),
+        overrides: [
+          ...test.overrides,
+          radiusAlertsProvider.overrideWith(_CapturingRadiusAlerts.new),
+        ],
+      );
+
+      final field = tester.widget<RadiusAlertFuelTypeField>(
+        find.byType(RadiusAlertFuelTypeField),
+      );
+      expect(field.evaluableFuels, contains(FuelType.e85),
+          reason: 'France sells E85 — it must be offerable without first '
+              'picking a French centre');
+      expect(field.evaluableFuels, contains(FuelType.lpg));
+      expect(field.evaluableFuels.length, greaterThan(3),
+          reason: 'more than the German e5/e10/diesel trio');
     });
 
     testWidgets('threshold label uses the centre country currency (#2865)', (


### PR DESCRIPTION
Closes #3333.

## Why
"Créer une alerte de zone" offered only the German **Super E5 / Super E10 / Diesel** trio even for a French user — France also sells **E85, SP98 (E98), GPLc**.

## Root cause
`RadiusAlertCreateSheet._centerCountry` resolves the country from the picked centre, but **before a location is set it fell back to `Countries.germany.code`**, so `alertEvaluableFuelsFor(_centerCountry)` (which is correctly country-aware) returned Germany's 3 fuels. The station-based `CreateAlertDialog` was fine (it uses the station's real country).

## Fix
Default the fallback to the user's **active country** (`activeCountryProvider`). A French user immediately sees France's full evaluable set (e5/e10/e98/diesel/**e85/lpg**); picking a GPS/map centre still updates it live to that location's country. The currency symbol (derived from `_centerCountry`) follows for free.

## Tests
`radius_alert_create_sheet_test.dart` — with active country = France and no centre picked, the fuel field's `evaluableFuels` contains E85 + GPLc and has >3 entries (was the German trio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
