### PR TITLE
feat(obd2): Cancel button on the trip-start OBD2 connecting card (#3335)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -829,6 +829,13 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         child: TripStartProgress(
           key: const Key('tripRecordingConnectingProgress'),
           stage: state.connectStage ?? TripStartStage.connectingAdapter,
+          // #3335 — let the user bail out of a stuck/slow init: reset to idle
+          // (the coordinator's pre-start guard tears down any link that lands
+          // after this) and leave the recording screen so they can retry.
+          onCancel: () {
+            ref.read(tripRecordingProvider.notifier).cancelConnecting();
+            if (Navigator.canPop(context)) Navigator.of(context).pop();
+          },
         ),
       );
     }

--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -170,6 +170,14 @@ class RecordingStartCoordinator {
         unawaited(service.disconnect());
         return;
       }
+      // #3335 — the user may have hit Cancel on the connecting card while
+      // the BLE connect was in flight. If the session is no longer
+      // connecting, tear the freshly-linked service down and do NOT start a
+      // trip they backed out of.
+      if (!ref.read(tripRecordingProvider).isConnecting) {
+        unawaited(service.disconnect());
+        return;
+      }
       notifier.setConnectStage(TripStartStage.readingVehicleData);
       await notifier.start(service);
       notifier.setConnectStage(TripStartStage.startingRecording);

--- a/lib/features/consumption/presentation/widgets/trip_start_progress.dart
+++ b/lib/features/consumption/presentation/widgets/trip_start_progress.dart
@@ -20,7 +20,12 @@ export '../../domain/entities/trip_start_stage.dart' show TripStartStage;
 class TripStartProgress extends StatefulWidget {
   final TripStartStage stage;
 
-  const TripStartProgress({super.key, required this.stage});
+  /// #3335 — when non-null, a "Cancel" affordance is shown so the user can
+  /// interrupt a stuck/slow OBD2 initialization and retry later without
+  /// restarting the app. Null hides the button (e.g. legacy inline use).
+  final VoidCallback? onCancel;
+
+  const TripStartProgress({super.key, required this.stage, this.onCancel});
 
   @override
   State<TripStartProgress> createState() => _TripStartProgressState();
@@ -120,6 +125,22 @@ class _TripStartProgressState extends State<TripStartProgress>
                 color: theme.colorScheme.onPrimaryContainer,
               ),
             ),
+            // #3335 — escape hatch for a stuck / slow init. Interrupts the
+            // connect and returns to idle so the user can retry.
+            if (widget.onCancel != null) ...[
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  key: const Key('trip_start_progress_cancel'),
+                  onPressed: widget.onCancel,
+                  style: TextButton.styleFrom(
+                    foregroundColor: theme.colorScheme.onPrimaryContainer,
+                  ),
+                  child: Text(l.cancel),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
@@ -197,6 +197,44 @@ void main() {
     expect(errors, isEmpty);
     expect(recording.startCallCount, 1);
   });
+
+  testWidgets(
+      '#3335 — Cancel during connect: a link that lands after the user backed '
+      'out is torn down and NO trip is started', (tester) async {
+    // Healthy bus, but the user hits Cancel (cancelConnecting → idle) while
+    // the BLE connect is in flight. The connect then completes; the
+    // coordinator must NOT start a trip and must disconnect the orphan link.
+    final service = _FakeObd2Service(
+      busAnswered: true,
+      busProbe: Obd2BusProbeResult.answered,
+    );
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        // Simulate the user tapping Cancel mid-connect: the session leaves the
+        // connecting phase just before the link comes up.
+        openPicker: () async {
+          notifier.cancelConnecting();
+          return service;
+        },
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    expect(errors, isEmpty, reason: 'a cancel is not a connection error');
+    expect(recording.startCallCount, 0,
+        reason: 'no trip may start once the user has cancelled');
+    expect(service.disconnectCallCount, 1,
+        reason: 'the orphaned link must be torn down');
+  });
 }
 
 /// Spy [TripRecording] that records the calls the coordinator makes. The

--- a/test/features/consumption/presentation/widgets/trip_start_progress_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_start_progress_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_start_progress.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #3335 — the connecting card must offer a Cancel affordance so the user can
+/// interrupt a stuck/slow OBD2 init and retry without restarting.
+void main() {
+  testWidgets('shows a Cancel button that invokes onCancel when provided',
+      (tester) async {
+    var cancelled = 0;
+    // settle:false — the card has indefinite spin/pulse animations that
+    // pumpAndSettle would wait on forever.
+    await pumpApp(
+      tester,
+      TripStartProgress(
+        stage: TripStartStage.connectingAdapter,
+        onCancel: () => cancelled++,
+      ),
+      settle: false,
+    );
+
+    final cancel = find.byKey(const Key('trip_start_progress_cancel'));
+    expect(cancel, findsOneWidget);
+
+    await tester.tap(cancel);
+    await tester.pump();
+    expect(cancelled, 1);
+  });
+
+  testWidgets('hides the Cancel button when onCancel is null', (tester) async {
+    await pumpApp(
+      tester,
+      const TripStartProgress(stage: TripStartStage.connectingAdapter),
+      settle: false,
+    );
+    expect(find.byKey(const Key('trip_start_progress_cancel')), findsNothing);
+  });
+}


### PR DESCRIPTION
Closes #3335.

## Why
The green "Connexion à l'adaptateur OBD2…" progress card (recording screen, start-now-connect-later, #2274) had **no way out** — a slow/unreachable adapter left the user stuck on the spinner with only force-quit as an option. They asked for a Cancel that interrupts the init so they can retry without restarting.

## What
- **`TripStartProgress`** — optional `onCancel` renders a **Cancel** (`l10n.cancel`) button under the progress bar; hidden when null.
- **Recording screen** (connecting phase) — `onCancel` calls `cancelConnecting()` (reset to idle; CTA reverts to "Start recording") and pops back to the Trajets tab.
- **`RecordingStartCoordinator`** — before `notifier.start(service)`, if the session is no longer connecting (cancelled), it **disconnects the freshly-linked service and returns** — so a connect that lands *after* Cancel never starts an unwanted trip.

## Tests
- `trip_start_progress_test.dart` — Cancel shows + invokes `onCancel`; hidden when null.
- `recording_start_coordinator_bus_silent_test.dart` — a connect that completes after cancel tears down the link and starts no trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
