### PR TITLE
feat(ui): station directions as a prominent FAB, not a tiny AppBar icon (#3337)

### DIFF
--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -11,6 +11,7 @@ import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/station.dart';
+import '../widgets/station_directions_fab.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_foldable.dart';
 import '../widgets/station_brand_header.dart';
@@ -125,6 +126,9 @@ class _StationDetailLoaded extends StatelessWidget {
     final bottomPadding = MediaQuery.of(context).viewPadding.bottom;
 
     return Scaffold(
+      // #3337 — surface "directions" as a prominent labelled FAB; it was a
+      // small AppBar icon users struggled to find.
+      floatingActionButton: StationDirectionsFab(station: station),
       body: CustomScrollView(
         slivers: [
           SliverAppBar(

--- a/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
@@ -9,6 +9,7 @@ import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/station.dart';
 import '../widgets/price_history_foldable.dart';
+import '../widgets/station_directions_fab.dart';
 import '../widgets/station_brand_header.dart';
 import '../widgets/station_detail_app_bar_actions.dart';
 import '../widgets/station_info_section.dart';
@@ -72,6 +73,9 @@ class StationDetailWideLayout extends StatelessWidget {
       actions: [
         StationDetailAppBarActions(stationId: stationId, station: station),
       ],
+      // #3337 — directions is now the prominent labelled FAB (was a small,
+      // hard-to-find AppBar icon).
+      floatingActionButton: StationDirectionsFab(station: station),
       bodyPadding: EdgeInsets.zero,
       body: Row(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
+++ b/lib/features/station_detail/presentation/widgets/station_detail_app_bar_actions.dart
@@ -8,7 +8,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/navigation/app_routes.dart';
-import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/animated_favorite_star.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -26,8 +25,9 @@ import '../../../sync/presentation/widgets/qr_scanner_screen.dart';
 import '../../providers/station_detail_provider.dart';
 import 'station_brand_helpers.dart';
 
-/// AppBar actions cluster for [StationDetailScreen]: directions, create
-/// price alert, scan payment QR, report price, favorite toggle.
+/// AppBar actions cluster for [StationDetailScreen]: create price alert,
+/// scan payment QR, report price, favorite toggle. (Directions moved to the
+/// prominent [StationDirectionsFab] in #3337.)
 ///
 /// Extracted so the screen stays under the 300-LOC cap (#563). Public
 /// behaviour is identical to the previous inline implementation —
@@ -51,22 +51,9 @@ class StationDetailAppBarActions extends ConsumerWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        IconButton(
-          icon: const Icon(Icons.directions),
-          onPressed: () {
-            final s = station;
-            if (s != null) {
-              unawaited(
-                NavigationUtils.openInMaps(
-                  s.lat,
-                  s.lng,
-                  label: hasRealBrand(s) ? s.brand : s.street,
-                ),
-              );
-            }
-          },
-          tooltip: l10n.navigate,
-        ),
+        // #3337 — directions moved out of this icon cluster to a prominent
+        // labelled FAB ([StationDirectionsFab]); users couldn't find the
+        // small icon here.
         IconButton(
           icon: const Icon(Icons.notifications_outlined),
           onPressed: () => _showCreateAlertDialog(context, ref),

--- a/lib/features/station_detail/presentation/widgets/station_directions_fab.dart
+++ b/lib/features/station_detail/presentation/widgets/station_directions_fab.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/domain/station.dart';
+import '../../../../core/utils/navigation_utils.dart';
+import '../../../../l10n/app_localizations.dart';
+import 'station_brand_helpers.dart';
+
+/// #3337 — prominent, labelled "directions" affordance for the station-detail
+/// screen.
+///
+/// Getting directions to a forecourt is the single most common action on this
+/// screen, but it used to be a small `Icons.directions` `IconButton` buried as
+/// one of five AppBar action icons — users struggled to find it ("très
+/// petit"). Surfacing it as an extended FAB (icon + `l10n.navigate` label)
+/// makes it immediately discoverable, mirroring the "Directions" affordance on
+/// a maps place card. Behaviour is identical to the old icon
+/// ([NavigationUtils.openInMaps]).
+class StationDirectionsFab extends StatelessWidget {
+  final Station station;
+
+  const StationDirectionsFab({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return FloatingActionButton.extended(
+      key: const Key('station_directions_fab'),
+      onPressed: () => unawaited(
+        NavigationUtils.openInMaps(
+          station.lat,
+          station.lng,
+          label: hasRealBrand(station) ? station.brand : station.street,
+        ),
+      ),
+      icon: const Icon(Icons.directions),
+      label: Text(l10n.navigate),
+    );
+  }
+}

--- a/test/features/station_detail/presentation/widgets/station_detail_app_bar_actions_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_detail_app_bar_actions_test.dart
@@ -26,7 +26,7 @@ class _FlagsWithout extends FeatureFlags {
 
 void main() {
   group('StationDetailAppBarActions', () {
-    testWidgets('renders the five action buttons with tooltips',
+    testWidgets('renders the four action buttons with tooltips (#3337)',
         (tester) async {
       await pumpApp(
         tester,
@@ -40,8 +40,9 @@ void main() {
         ],
       );
 
-      // Five icon buttons: directions, alert, scan QR, report, favorite.
-      expect(find.byIcon(Icons.directions), findsOneWidget);
+      // Four icon buttons: alert, scan QR, report, favorite. (#3337 moved
+      // directions out of this cluster to the prominent StationDirectionsFab.)
+      expect(find.byIcon(Icons.directions), findsNothing);
       expect(find.byIcon(Icons.notifications_outlined), findsOneWidget);
       expect(find.byIcon(Icons.qr_code_scanner), findsOneWidget);
       expect(find.byIcon(Icons.flag_outlined), findsOneWidget);
@@ -113,7 +114,8 @@ void main() {
       expect(find.byKey(const Key('report_price')), findsNothing);
       expect(find.byIcon(Icons.qr_code_scanner), findsNothing);
       expect(find.byIcon(Icons.flag_outlined), findsNothing);
-      expect(find.byIcon(Icons.directions), findsOneWidget);
+      expect(find.byIcon(Icons.directions), findsNothing,
+          reason: 'directions is the FAB now, not an app-bar icon (#3337)');
       expect(find.byIcon(Icons.notifications_outlined), findsOneWidget);
     });
   });

--- a/test/features/station_detail/presentation/widgets/station_directions_fab_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_directions_fab_test.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_directions_fab.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #3337 — directions must be a prominent, labelled affordance (it was a tiny
+/// AppBar icon users struggled to find).
+void main() {
+  Station station() => const Station(
+        id: 's1',
+        name: 'Test',
+        brand: 'Total',
+        street: '1 Rue Test',
+        postCode: '75001',
+        place: 'Paris',
+        lat: 48.86,
+        lng: 2.35,
+        isOpen: true,
+      );
+
+  testWidgets('renders an extended FAB with the directions icon + Navigate '
+      'label', (tester) async {
+    await pumpApp(tester, StationDirectionsFab(station: station()));
+
+    expect(find.byKey(const Key('station_directions_fab')), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+    expect(find.byIcon(Icons.directions), findsOneWidget);
+    // The label makes it discoverable (vs the old unlabelled icon).
+    expect(find.text('Navigate'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #3337.

## Why
Directions to a forecourt is the most common station-detail action, but it was a small `Icons.directions` `IconButton` buried as the first of five AppBar icons — the user "galéré… parce qu'il est très petit".

## What
- New **`StationDirectionsFab`** — a labelled extended FAB (`Icons.directions` + `l10n.navigate`) calling the same `NavigationUtils.openInMaps`.
- Added on **both** layouts (narrow `Scaffold`, wide `PageScaffold`).
- **Removed** the redundant directions `IconButton` from `StationDetailAppBarActions` (cluster 5 → 4 icons). Reuses the existing `navigate` ARB string — no new strings.

## Tests
- `station_directions_fab_test.dart` — renders an extended FAB with the directions icon + "Navigate" label.
- `station_detail_app_bar_actions_test.dart` — updated: directions is no longer in the icon cluster (it's the FAB now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
