### PR TITLE
fix(ev): EvPrice.parse anchors the per-kWh amount on the /kWh unit (#3340)

### DIFF
--- a/lib/core/domain/ev/ev_price.dart
+++ b/lib/core/domain/ev/ev_price.dart
@@ -85,6 +85,15 @@ class EvPrice {
   }
 
   static final _amount = RegExp(r'(\d+(?:[.,]\d+)?)');
+
+  /// #3340 — the amount ATTACHED to a per-kWh unit (`0,40 €/kWh`,
+  /// `0.49 EUR/kWh`, `€0,50/kWh`, `0.40 kw/h`). Anchoring on the unit means a
+  /// multi-component tariff like `"0,1008 €/min …, 0,4008 €/kWh"` yields the
+  /// €/kWh figure (0.4008), not the first (per-minute) number in the string.
+  /// Matches against the already-lowercased text.
+  static final _perKwhAmount = RegExp(
+    r'(\d+(?:[.,]\d+)?)\s*(?:€|eur|£|gbp|\$|usd|chf|kr|zł|pln)?\s*(?:/|per)?\s*kw\s*/?\s*h',
+  );
   static const _freeWords = <String>[
     'free', 'gratis', 'gratuit', 'kostenlos', 'gratuito', 'gratuita',
     'bezpłatn', 'ingyenes', 'nemokama', 'zdarma', 'besplatno',
@@ -108,26 +117,34 @@ class EvPrice {
 
     final low = raw.toLowerCase();
     final currency = _detectCurrency(low);
+
+    // #3340 — per-kWh first, using the amount ATTACHED to the kWh unit so a
+    // multi-component string ("0,1008 €/min …, 0,4008 €/kWh") reports the
+    // €/kWh figure, not the first (per-minute) number.
+    final perKwhMatch = _perKwhAmount.firstMatch(low);
+    if (perKwhMatch != null) {
+      final perKwhAmount =
+          double.tryParse(perKwhMatch.group(1)!.replaceAll(',', '.'));
+      if (perKwhAmount != null && perKwhAmount > 0) {
+        return EvPrice(
+          kind: EvPriceKind.perKwh,
+          amount: perKwhAmount,
+          currency: currency,
+          raw: raw,
+        );
+      }
+    }
+
     final amountMatch = _amount.firstMatch(raw);
     final amount = amountMatch == null
         ? null
         : double.tryParse(amountMatch.group(1)!.replaceAll(',', '.'));
 
-    final perKwh = low.contains('kwh') || low.contains('kw/h') ||
-        low.contains('/kw');
     final perSession = low.contains('session') ||
         low.contains('charge') ||
         low.contains('flat') ||
         low.contains('par recharge');
 
-    if (amount != null && amount > 0 && perKwh) {
-      return EvPrice(
-        kind: EvPriceKind.perKwh,
-        amount: amount,
-        currency: currency,
-        raw: raw,
-      );
-    }
     if (amount != null && amount > 0 && perSession) {
       return EvPrice(
         kind: EvPriceKind.perSession,
@@ -138,7 +155,7 @@ class EvPrice {
     }
     // No structured price — a "free" wording (or a bare 0) means free.
     final saysFree = _freeWords.any(low.contains);
-    if (saysFree || (amount == 0 && !perKwh && !perSession)) {
+    if (saysFree || (amount == 0 && !perSession)) {
       return EvPrice(kind: EvPriceKind.free, raw: raw);
     }
     return EvPrice(kind: EvPriceKind.unknown, raw: raw);

--- a/test/features/ev/domain/entities/ev_price_test.dart
+++ b/test/features/ev/domain/entities/ev_price_test.dart
@@ -29,6 +29,24 @@ void main() {
     test('a non-EUR currency is detected — "0.30 GBP/kWh"', () {
       expect(EvPrice.parse('0.30 GBP/kWh').currency, 'GBP');
     });
+
+    test('#3340 — a multi-component FR tariff reports the €/kWh figure, NOT '
+        'the leading €/min (parking) amount', () {
+      final p = EvPrice.parse(
+        '0,1008 €/min pour le stationnement (07-22, > 3 h), '
+        '0,1008 €/min pour la recharge (07-22, > 3 h), 0,4008 €/kWh',
+      );
+      expect(p.kind, EvPriceKind.perKwh);
+      expect(p.amount, 0.4008,
+          reason: 'must anchor on the /kWh unit, not the first number');
+      expect(p.currency, 'EUR');
+    });
+
+    test('#3340 — "0,40 €/kWh" (comma, attached unit) → perKwh 0.40', () {
+      final p = EvPrice.parse('0,40 €/kWh');
+      expect(p.kind, EvPriceKind.perKwh);
+      expect(p.amount, 0.40);
+    });
   });
 
   group('EvPrice.parse — per-session tariffs', () {


### PR DESCRIPTION
Closes #3340. First child of the EV-price-coverage Epic #3339.

## Why
`EvPrice.parse` grabbed the **first number anywhere** in the string and labelled it per-kWh whenever the text merely contained "kwh". A real French multi-component tariff (Révéo, from the user's screenshots):
```
0,1008 €/min pour le stationnement …, 0,1008 €/min pour la recharge …, 0,4008 €/kWh
```
parsed to **perKwh 0.1008** — the €/min *parking* rate — and that wrong price showed on the EV card + detail.

## Fix
Extract the amount **attached to the /kWh unit** (number immediately preceding `€/kWh` / `EUR/kWh` / `per kWh` / `kw/h`) instead of the first number. The existing parse→display pipeline (`EvPrice.parse` → `ev_station_card` / `ev_station_info_cards`) then shows the correct per-kWh. Single-number cases unchanged.

## Tests
`ev_price_test.dart` — the multi-component FR string → `perKwh 0.4008 EUR`; `"0,40 €/kWh"` → 0.40; all existing cases (incl. `"0.45 EUR per kWh"`, `"Free parking, 0.79 EUR/kWh"`) still green.

## Epic context (#3339)
The parse + display already work; this corrects what they show. The bigger wins — ingesting operator OCPI/Révéo per-kWh feeds (Child 2) and per-country enrichers (Child 3) — are tracked under the Epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
