### PR TITLE
feat(station): inline navigate button next to the station address (#3344)

### DIFF
--- a/lib/features/station_detail/presentation/widgets/station_brand_header.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_header.dart
@@ -1,8 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import '../../../../core/utils/geo_utils.dart';
+import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/brand_logo.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/station.dart';
@@ -92,6 +96,24 @@ class StationBrandHeader extends StatelessWidget {
               ],
             ),
           ),
+          // #3344 — a navigate button glued to the address: the spot the user
+          // is reading the location is the most natural place to reach for
+          // "take me there". Same behaviour as the directions FAB (#3337) —
+          // opens the device's default maps app at the station. Only shown when
+          // the coordinates are usable (an unusable pin can't be navigated to).
+          if (isUsableCoord(station.lat, station.lng))
+            IconButton.filledTonal(
+              key: const Key('station_address_navigate'),
+              tooltip: l10n.navigate,
+              icon: const Icon(Icons.directions),
+              onPressed: () => unawaited(
+                NavigationUtils.openInMaps(
+                  station.lat,
+                  station.lng,
+                  label: hasRealBrand(station) ? station.brand : station.street,
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
 import 'package:tankstellen/core/domain/station.dart';
@@ -103,6 +104,40 @@ void main() {
 
       expect(find.text('Only Street'), findsOneWidget,
           reason: 'street is the last-resort headline');
+    });
+
+    testWidgets(
+        '#3344 a navigate button sits next to the address for a usable station',
+        (tester) async {
+      await pumpApp(tester, const StationBrandHeader(station: testStation));
+
+      final button = find.byKey(const Key('station_address_navigate'));
+      expect(button, findsOneWidget);
+      expect(
+        find.descendant(of: button, matching: find.byIcon(Icons.directions)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        '#3344 the navigate button is hidden when coordinates are unusable',
+        (tester) async {
+      const noCoords = Station(
+        id: 'bare',
+        name: '',
+        brand: '',
+        street: 'Only Street',
+        postCode: '00000',
+        place: 'Nowhere',
+        lat: 0,
+        lng: 0,
+        isOpen: true,
+      );
+
+      await pumpApp(tester, const StationBrandHeader(station: noCoords));
+
+      expect(find.byKey(const Key('station_address_navigate')), findsNothing,
+          reason: 'an unusable (0,0) pin cannot be navigated to');
     });
   });
 }


### PR DESCRIPTION
Closes #3344.

The most natural place to reach for "take me there" is right at the address itself. This glues a compact directions `IconButton` to the station-detail header (`StationBrandHeader`), next to the name/address column.

- Tapping it opens the device's **default maps app** at the station — identical behaviour to the directions FAB (#3337), via `NavigationUtils.openInMaps` (`geo:` pin → default app, Google Maps web fallback).
- Hidden when the station's coordinates are unusable (`isUsableCoord`).
- No new ARB keys (reuses `navigate`).

### Tests
- button present + carries the directions icon for a usable station;
- button hidden for an unusable `(0,0)` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
