### PR TITLE
feat(obd2): comprehensive tracing of the auto-reconnect path (#3346)

### DIFF
--- a/lib/features/obd2/data/classic_elm_channel.dart
+++ b/lib/features/obd2/data/classic_elm_channel.dart
@@ -182,7 +182,7 @@ class ClassicElmChannel implements ElmByteChannel {
         // rather than the drop being discovered only LAZILY on the next
         // `write()` (which never comes when idle / between trips). The in-trip
         // typed-disconnect handling below is unchanged.
-        _signalDrop();
+        _signalDrop(reason: 'classic-socket-error'); // #3346
         // #2295 — forward the socket error onto the byte stream so the
         // transport's pending `sendCommand` completer fails IMMEDIATELY
         // (via `_failPending`) instead of waiting out the read timeout,
@@ -199,7 +199,7 @@ class ClassicElmChannel implements ElmByteChannel {
         _open = false;
         // #3019 — a clean socket `done` is also a drop (some stacks close the
         // reader instead of erroring it). Same proactive signal.
-        _signalDrop();
+        _signalDrop(reason: 'classic-socket-done'); // #3346
       },
     );
     _open = true;
@@ -232,7 +232,7 @@ class ClassicElmChannel implements ElmByteChannel {
       // must ALSO emit the #3019 proactive link-drop signal, or the
       // trip-independent reconnect controller stays asleep until the next
       // write that never comes. The reader onError/onDone paths already do.
-      _signalDrop();
+      _signalDrop(reason: 'classic-write-failed'); // #3346
       debugPrint('ClassicElmChannel: write failed — reclassifying as a '
           'recoverable disconnect (#2671): $e\n$st');
       throw const Obd2DisconnectedException(
@@ -257,12 +257,14 @@ class ClassicElmChannel implements ElmByteChannel {
 
   /// #3019 — emit the proactive Classic link-drop signal once per unexpected
   /// drop. A deliberate [close] (the `_closing` guard) is a normal teardown,
-  /// not a drop, so it never reaches here.
-  void _signalDrop() {
+  /// not a drop, so it never reaches here. #3346 — [reason] tags WHICH edge
+  /// noticed the drop (socket error / socket done / lazy write failure) so the
+  /// reconnect-episode breadcrumb records it.
+  void _signalDrop({required String reason}) {
     if (_closing || _dropSignalled) return;
     _dropSignalled = true;
     Obd2LinkDropSignal.instance
-        .notifyDrop(transportKind: 'classic', mac: address);
+        .notifyDrop(transportKind: 'classic', mac: address, reason: reason);
   }
 
   @override

--- a/lib/features/obd2/data/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/obd2/data/flutter_blue_plus_elm_channel.dart
@@ -208,8 +208,11 @@ class FlutterBluePlusElmChannel
     // disconnect is never misread as a drop.
     if (!_closing && !_dropSignalled) {
       _dropSignalled = true;
-      Obd2LinkDropSignal.instance
-          .notifyDrop(transportKind: 'ble', mac: _device.remoteId.str);
+      Obd2LinkDropSignal.instance.notifyDrop(
+        transportKind: 'ble',
+        mac: _device.remoteId.str,
+        reason: 'ble-disconnect-edge', // #3346
+      );
     }
     if (_incoming.isClosed) return;
     _incoming.addError(const Obd2DisconnectedException());

--- a/lib/features/obd2/data/obd2_link_drop_signal.dart
+++ b/lib/features/obd2/data/obd2_link_drop_signal.dart
@@ -42,9 +42,23 @@ class Obd2LinkDropSignal {
   /// onError / onDone / disconnect-edge handlers. Best-effort: a closed
   /// controller (only in a torn-down test) is ignored silently — a drop
   /// signal is advisory, never load-bearing on its own.
-  void notifyDrop({required String transportKind, String? mac}) {
+  ///
+  /// #3346 — [reason] is a stable, low-cardinality tag for WHY the link
+  /// dropped (`ble-disconnect-edge`, `classic-socket-error`,
+  /// `classic-socket-done`, `classic-write-failed`). It is carried into the
+  /// reconnect-episode breadcrumb so a field export answers the first
+  /// question — *what killed the link* — without a debugger attached.
+  void notifyDrop({
+    required String transportKind,
+    String? mac,
+    String reason = 'unspecified',
+  }) {
     if (_controller.isClosed) return;
-    _controller.add(Obd2LinkDropEvent(transportKind: transportKind, mac: mac));
+    _controller.add(Obd2LinkDropEvent(
+      transportKind: transportKind,
+      mac: mac,
+      reason: reason,
+    ));
   }
 }
 
@@ -56,9 +70,17 @@ class Obd2LinkDropEvent {
   /// MAC of the link that dropped, when the channel knows it.
   final String? mac;
 
-  const Obd2LinkDropEvent({required this.transportKind, this.mac});
+  /// #3346 — a stable, low-cardinality tag for WHY the link dropped, set at
+  /// the channel drop site. Defaults to `'unspecified'` for older callers.
+  final String reason;
+
+  const Obd2LinkDropEvent({
+    required this.transportKind,
+    this.mac,
+    this.reason = 'unspecified',
+  });
 
   @override
-  String toString() =>
-      'Obd2LinkDropEvent(transportKind: $transportKind, mac: $mac)';
+  String toString() => 'Obd2LinkDropEvent(transportKind: $transportKind, '
+      'mac: $mac, reason: $reason)';
 }

--- a/lib/features/obd2/data/obd2_reconnect_controller.dart
+++ b/lib/features/obd2/data/obd2_reconnect_controller.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'last_good_adapter_store.dart';
+import 'obd2_reconnect_episode_tracer.dart';
 
 /// Coarse lifecycle state of the trip-INDEPENDENT auto-reconnect
 /// controller (#3019 / Epic #3013 phase 3).
@@ -120,11 +121,17 @@ class Obd2ReconnectController {
   /// Emitted on every state transition so a notifier / widget can react.
   void Function(Obd2ReconnectState state)? onState;
 
+  /// #3346 — owns the episode breadcrumb emission + timing. The provider wires
+  /// its sink to [BreadcrumbCollector] + [Obd2CommDiagnostics] in production.
+  final Obd2ReconnectEpisodeTracer _tracer;
+
   Obd2ReconnectController({
     required LastGoodAdapterStore pinStore,
     required PinnedConnectAttempt pinnedConnect,
     required RescanConnectAttempt rescanConnect,
     this.onState,
+    Obd2ReconnectTraceSink? onTrace,
+    DateTime Function()? now,
     int maxAttempts = 6,
     Duration initialBackoff = const Duration(seconds: 2),
     Duration maxBackoff = const Duration(seconds: 60),
@@ -133,11 +140,15 @@ class Obd2ReconnectController {
         _pinStore = pinStore,
         _pinnedConnect = pinnedConnect,
         _rescanConnect = rescanConnect,
+        _tracer = Obd2ReconnectEpisodeTracer(onTrace: onTrace, now: now),
         _maxAttempts = maxAttempts,
         _initialBackoff = initialBackoff,
         _maxBackoff = maxBackoff,
         _firstAttemptDelay = firstAttemptDelay,
         _currentBackoff = initialBackoff;
+
+  /// #3346 — wire / detach the episode breadcrumb sink after construction.
+  set onTrace(Obd2ReconnectTraceSink? sink) => _tracer.onTrace = sink;
 
   Obd2ReconnectState _state = Obd2ReconnectState.idle;
   Duration _currentBackoff;
@@ -173,6 +184,7 @@ class Obd2ReconnectController {
   /// reconnect). Cancels any in-flight loop and clears the counters so the
   /// next drop starts a clean episode.
   void notifyConnected() {
+    _tracer.connected(_attempts + 1);
     _timer?.cancel();
     _timer = null;
     _attempts = 0;
@@ -185,10 +197,26 @@ class Obd2ReconnectController {
   /// point. Starts the bounded backoff loop. Idempotent: a second call
   /// while already reconnecting is a no-op so the (possibly multiple) drop
   /// signals a single physical disconnect raises don't stack loops.
-  void notifyDropped() {
-    if (_state == Obd2ReconnectState.reconnecting) return;
+  void notifyDropped({
+    String reason = 'unspecified',
+    String? transportKind,
+    String? mac,
+  }) {
+    if (_state == Obd2ReconnectState.reconnecting) {
+      // A second drop signal for the same physical disconnect — record it so
+      // a field export shows the channels fired more than once, but don't
+      // restart the episode (idempotent, #3019).
+      _tracer.dropIgnored(reason: reason, transport: transportKind);
+      return;
+    }
     _attempts = 0;
     _currentBackoff = _initialBackoff;
+    _tracer.dropReceived(
+      reason: reason,
+      transport: transportKind,
+      mac: mac,
+      hadPin: _pinStore.recall() != null,
+    );
     _transition(Obd2ReconnectState.reconnecting);
     _scheduleNext(_firstAttemptDelay);
   }
@@ -206,6 +234,7 @@ class Obd2ReconnectController {
     }
     _attempts = 0;
     _currentBackoff = _initialBackoff;
+    _tracer.retry(_state.name);
     _transition(Obd2ReconnectState.reconnecting);
     _scheduleNext(_firstAttemptDelay);
   }
@@ -233,24 +262,47 @@ class Obd2ReconnectController {
     // which it isn't built for. Cheap guard (mirrors the in-trip scanner).
     if (_cycleInFlight || _state != Obd2ReconnectState.reconnecting) return;
     _cycleInFlight = true;
+    final attemptNo = _attempts + 1;
     try {
       final pinned = _pinStore.recall();
+      _tracer.attemptStart(
+        attempt: attemptNo,
+        maxAttempts: _maxAttempts,
+        hasPin: pinned != null,
+      );
       // 1) PINNED FAST PATH (transport-correct direct connect, no scan).
-      var result = pinned == null
-          ? Obd2ReconnectAttemptResult.notFound
-          : await _safely(() => _pinnedConnect(pinned));
+      var result = Obd2ReconnectAttemptResult.notFound;
+      if (pinned == null) {
+        _tracer.pinnedSkipped(attemptNo);
+      } else {
+        final t0 = _tracer.now();
+        result = await _safely(() => _pinnedConnect(pinned));
+        _tracer.pinnedResult(
+          attempt: attemptNo,
+          result: result.name,
+          start: t0,
+          transport: pinned.transportKind,
+        );
+      }
       if (_state != Obd2ReconnectState.reconnecting) return; // stop() raced
       // #3035 — a CONFIRMED engine-off on the pinned path is terminal: the
       // adapter re-connected fine, the ECU is just silent. Re-scanning can't
       // wake a parked car, so STOP here (no rescan, no backoff burst) rather
       // than looping reconnect→engine-off→teardown.
       if (result == Obd2ReconnectAttemptResult.engineOff) {
+        _tracer.terminal('terminal-engine-off', attemptNo);
         _transition(Obd2ReconnectState.terminalEngineOff);
         return;
       }
       // 2) RE-SCAN FALLBACK — only when the pinned path didn't land.
       if (result != Obd2ReconnectAttemptResult.connected) {
+        final t0 = _tracer.now();
         result = await _safely(() => _rescanConnect(pinned));
+        _tracer.rescanResult(
+          attempt: attemptNo,
+          result: result.name,
+          start: t0,
+        );
         if (_state != Obd2ReconnectState.reconnecting) return;
       }
       if (result == Obd2ReconnectAttemptResult.connected) {
@@ -259,6 +311,7 @@ class Obd2ReconnectController {
       }
       // #3035 — the re-scan path can also land on a confirmed engine-off.
       if (result == Obd2ReconnectAttemptResult.engineOff) {
+        _tracer.terminal('terminal-engine-off', attemptNo);
         _transition(Obd2ReconnectState.terminalEngineOff);
         return;
       }
@@ -275,9 +328,14 @@ class Obd2ReconnectController {
     if (_attempts >= _maxAttempts) {
       _timer?.cancel();
       _timer = null;
+      _tracer.terminal('terminal-failed', _attempts);
       _transition(Obd2ReconnectState.terminalFailed);
       return;
     }
+    _tracer.backoffScheduled(
+      nextAttempt: _attempts + 1,
+      delayMs: _currentBackoff.inMilliseconds,
+    );
     _scheduleNext(_currentBackoff);
     _doubleBackoff();
   }
@@ -313,5 +371,6 @@ class Obd2ReconnectController {
     _timer?.cancel();
     _timer = null;
     onState = null;
+    _tracer.dispose();
   }
 }

--- a/lib/features/obd2/data/obd2_reconnect_episode_tracer.dart
+++ b/lib/features/obd2/data/obd2_reconnect_episode_tracer.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+/// Structured breadcrumb sink for the reconnect EPISODE (#3346). The
+/// controller fires this at every lifecycle point — drop received, each
+/// attempt's path + outcome + latency, backoff, terminal / connected — so the
+/// orchestration the per-attempt connect-trace ring can't see lands in an
+/// exported channel. [event] is a stable, low-cardinality tag; [data] is a
+/// flat map of Hive-safe primitives.
+typedef Obd2ReconnectTraceSink = void Function(
+  String event,
+  Map<String, Object?> data,
+);
+
+/// Owns the reconnect-episode breadcrumb emission + timing for
+/// `Obd2ReconnectController` (#3346), kept separate so the controller stays a
+/// lean state machine. Stamps `episodeMs` (whole-episode duration) and per-
+/// attempt latencies off an injectable clock, and guards the sink so a buggy
+/// collector can never wedge the reconnect loop (#1103).
+class Obd2ReconnectEpisodeTracer {
+  Obd2ReconnectEpisodeTracer({this.onTrace, DateTime Function()? now})
+      : _now = now ?? DateTime.now;
+
+  /// The breadcrumb sink. Mutable so the owner can wire / detach it after
+  /// construction; null disables tracing entirely.
+  Obd2ReconnectTraceSink? onTrace;
+
+  final DateTime Function() _now;
+
+  /// When the current episode began (a fresh drop / retry), used to stamp
+  /// `episodeMs` on the terminal / connected breadcrumb.
+  DateTime? _startedAt;
+
+  /// A timestamp for the caller to bracket a connect-seam latency.
+  DateTime now() => _now();
+
+  void dropReceived({
+    required String reason,
+    String? transport,
+    String? mac,
+    required bool hadPin,
+  }) {
+    _startedAt = _now();
+    _emit('drop-received', {
+      'reason': reason,
+      'transport': transport,
+      'mac': mac,
+      'hadPin': hadPin,
+    });
+  }
+
+  void dropIgnored({required String reason, String? transport}) => _emit(
+        'drop-ignored-already-reconnecting',
+        {'reason': reason, 'transport': transport},
+      );
+
+  void retry(String from) {
+    _startedAt = _now();
+    _emit('retry', {'from': from});
+  }
+
+  void attemptStart({
+    required int attempt,
+    required int maxAttempts,
+    required bool hasPin,
+  }) =>
+      _emit('attempt-start', {
+        'attempt': attempt,
+        'maxAttempts': maxAttempts,
+        'hasPin': hasPin,
+      });
+
+  void pinnedSkipped(int attempt) =>
+      _emit('pinned-skipped', {'attempt': attempt, 'reason': 'no-pin'});
+
+  void pinnedResult({
+    required int attempt,
+    required String result,
+    required DateTime start,
+    String? transport,
+  }) =>
+      _emit('pinned-result', {
+        'attempt': attempt,
+        'result': result,
+        'ms': _sinceMs(start),
+        'transport': transport,
+      });
+
+  void rescanResult({
+    required int attempt,
+    required String result,
+    required DateTime start,
+  }) =>
+      _emit('rescan-result', {
+        'attempt': attempt,
+        'result': result,
+        'ms': _sinceMs(start),
+      });
+
+  void connected(int attempts) {
+    _emit('connected', {'attempts': attempts, 'episodeMs': _episodeMs()});
+    _startedAt = null;
+  }
+
+  /// Emit a terminal breadcrumb (`terminal-failed` / `terminal-engine-off`)
+  /// stamping the attempts spent + whole-episode duration, then clear the
+  /// episode clock.
+  void terminal(String event, int attempts) {
+    _emit(event, {'attempts': attempts, 'episodeMs': _episodeMs()});
+    _startedAt = null;
+  }
+
+  void backoffScheduled({required int nextAttempt, required int delayMs}) =>
+      _emit('backoff-scheduled',
+          {'nextAttempt': nextAttempt, 'delayMs': delayMs});
+
+  int? _episodeMs() {
+    final start = _startedAt;
+    return start == null ? null : _sinceMs(start);
+  }
+
+  int _sinceMs(DateTime from) => _now().difference(from).inMilliseconds;
+
+  /// Fire the sink defensively — observability must NEVER derail the reconnect
+  /// loop (#1103).
+  void _emit(String event, Map<String, Object?> data) {
+    final sink = onTrace;
+    if (sink == null) return;
+    try {
+      sink(event, data);
+    } catch (e, st) {
+      debugPrint(
+          'Obd2ReconnectEpisodeTracer: onTrace sink threw (ignored) — $e\n$st');
+    }
+  }
+
+  /// Detach the sink for good.
+  void dispose() => onTrace = null;
+}

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -8,7 +8,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/data/storage_repository.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_providers.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../data/last_good_adapter_store.dart';
+import '../data/obd2_comm_diagnostics.dart';
+import '../data/obd2_connect_trace.dart';
+import '../data/obd2_connect_trace_log.dart';
 import '../data/obd2_connection_service.dart';
 import '../data/obd2_link_drop_signal.dart';
 import '../data/obd2_reconnect_controller.dart';
@@ -51,8 +55,14 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     // #3019 — subscribe to the PROACTIVE link-drop signal both channels emit
     // the instant a link dies (BLE disconnect edge / Classic socket close), so
     // a drop while idle / between trips still starts the bounded backoff loop.
-    _dropSub = Obd2LinkDropSignal.instance.drops.listen((_) {
-      _controller?.notifyDropped();
+    _dropSub = Obd2LinkDropSignal.instance.drops.listen((e) {
+      // #3346 — carry WHY the link dropped (and on which transport) into the
+      // controller so the reconnect-episode breadcrumb records it.
+      _controller?.notifyDropped(
+        reason: e.reason,
+        transportKind: e.transportKind,
+        mac: e.mac,
+      );
     });
     ref.onDispose(() {
       unawaited(_dropSub?.cancel());
@@ -91,8 +101,44 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     );
     // Republish every transition into the Riverpod state so the UI rebuilds.
     controller.onState = (s) => state = s;
+    // #3346 — route the reconnect-EPISODE breadcrumbs (drop reason, each
+    // attempt's path/outcome/latency, backoff, terminal) into the exported
+    // channels: the always-on BreadcrumbCollector (rides every error trace)
+    // + the developer-mode comm-diagnostics reconnect reservoir.
+    controller.onTrace = _trace;
     return controller;
   }
+
+  /// #3346 — fan one reconnect-episode event out to the exported telemetry
+  /// channels. Best-effort: the controller already guards this against throws.
+  void _trace(String event, Map<String, Object?> data) {
+    BreadcrumbCollector.add('obd2-reconnect: $event', detail: _fmt(data));
+    // Feed the gated comm-diagnostics reconnect counters so the developer-mode
+    // health screen's reservoir reflects real reconnect activity, not just
+    // first-connects.
+    final diag = Obd2CommDiagnostics.instance;
+    if (!diag.enabled) return;
+    switch (event) {
+      case 'attempt-start':
+        diag.noteConnectionEvent(attempt: true);
+      case 'connected':
+        final ms = data['episodeMs'];
+        diag.noteConnectionEvent(
+          success: true,
+          visibleReconnect: true,
+          timeToReconnectMs: ms is int ? ms : null,
+        );
+      case 'terminal-failed':
+        diag.noteConnectionEvent(failureReason: 'reconnect-exhausted');
+      case 'terminal-engine-off':
+        diag.noteConnectionEvent(failureReason: 'reconnect-engine-off');
+    }
+  }
+
+  /// Render a flat breadcrumb map as a compact `k=v` string (stable key
+  /// order is not required — a field reader scans for the tokens).
+  static String _fmt(Map<String, Object?> data) =>
+      data.entries.map((e) => '${e.key}=${e.value}').join(' ');
 
   /// Report a detected connection drop — the trip-INDEPENDENT entry point.
   /// Safe to call from anywhere a drop is observed (the proactive Classic
@@ -118,9 +164,17 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     LastGoodAdapter pinned,
   ) async {
     try {
-      final svc = pinned.isClassic
-          ? await connection.connectByMacClassicDirect(pinned.mac)
-          : await connection.connectByMacDirect(pinned.mac, fallbackToScan: false);
+      // #3346 — stamp the per-attempt connect trace as a liveReconnect (not a
+      // firstConnect), so the persisted, exported connect-trace ring tells a
+      // silent mid-drive reconnect apart from a user-driven first connect.
+      final svc = await Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.liveReconnect,
+        () => pinned.isClassic
+            ? connection.connectByMacClassicDirect(pinned.mac)
+            : connection.connectByMacDirect(pinned.mac, fallbackToScan: false),
+        transportDecisionReason:
+            pinned.isClassic ? 'reconnect-pinned-classic' : 'reconnect-pinned-ble',
+      );
       return _onResult(svc);
     } catch (e, st) {
       _logSeam('pinned', e, st);
@@ -137,9 +191,13 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     LastGoodAdapter? pinned,
   ) async {
     try {
-      final svc = pinned != null
-          ? await connection.connectByMac(pinned.mac)
-          : await connection.connectBest();
+      final svc = await Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.liveReconnect,
+        () => pinned != null
+            ? connection.connectByMac(pinned.mac)
+            : connection.connectBest(),
+        transportDecisionReason: 'reconnect-rescan',
+      );
       return _onResult(svc);
     } catch (e, st) {
       _logSeam('rescan', e, st);

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'054270a7bf402d0fcabe698a1d1b5ec13d324ceb';
+String _$obd2ReconnectHash() => r'8b3ab217a16af7fce3da7394f731e93a093736b6';
 
 /// App-wide owner of the trip-INDEPENDENT auto-reconnect controller (#3019 /
 /// Epic #3013 phase 3).

--- a/test/features/obd2/data/obd2_link_drop_signal_test.dart
+++ b/test/features/obd2/data/obd2_link_drop_signal_test.dart
@@ -22,6 +22,27 @@ void main() {
       await sub.cancel();
     });
 
+    test('#3346 — the drop event carries the WHY (reason) when given',
+        () async {
+      final events = <Obd2LinkDropEvent>[];
+      final sub = Obd2LinkDropSignal.instance.drops.listen(events.add);
+
+      Obd2LinkDropSignal.instance.notifyDrop(
+        transportKind: 'classic',
+        mac: 'AA:BB',
+        reason: 'classic-socket-error',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events.single.reason, 'classic-socket-error');
+      await sub.cancel();
+    });
+
+    test('#3346 — reason defaults to "unspecified" for older callers', () {
+      const event = Obd2LinkDropEvent(transportKind: 'ble');
+      expect(event.reason, 'unspecified');
+    });
+
     test('multiple listeners both receive a drop (broadcast)', () async {
       var a = 0;
       var b = 0;

--- a/test/features/obd2/data/obd2_reconnect_controller_trace_test.dart
+++ b/test/features/obd2/data/obd2_reconnect_controller_trace_test.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/obd2/data/last_good_adapter_store.dart';
+import 'package:tankstellen/features/obd2/data/obd2_reconnect_controller.dart';
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3346 — pins the reconnect-EPISODE breadcrumb sink on
+/// [Obd2ReconnectController]. The orchestration the per-attempt connect-trace
+/// ring can't see (drop reason, each attempt's path/outcome/latency, backoff,
+/// terminal) must reach `onTrace` so the provider can fan it into the exported
+/// telemetry channels.
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+  @override
+  dynamic getSetting(String key) => data[key];
+  @override
+  Future<void> putSetting(String key, dynamic value) async => data[key] = value;
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+Future<void> _waitFor(
+  bool Function() cond, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!cond() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 4));
+  }
+}
+
+const _fast = Duration(milliseconds: 6);
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late _FakeSettingsStorage storage;
+  late LastGoodAdapterStore pinStore;
+  late List<({String event, Map<String, Object?> data})> events;
+
+  setUp(() {
+    storage = _FakeSettingsStorage();
+    pinStore = LastGoodAdapterStore(storage);
+    events = [];
+  });
+
+  Obd2ReconnectController build({
+    required Future<Obd2ReconnectAttemptResult> Function(LastGoodAdapter) pinned,
+    required Future<Obd2ReconnectAttemptResult> Function(LastGoodAdapter?)
+        rescan,
+    int maxAttempts = 4,
+  }) {
+    return Obd2ReconnectController(
+      pinStore: pinStore,
+      pinnedConnect: pinned,
+      rescanConnect: rescan,
+      onTrace: (e, d) => events.add((event: e, data: d)),
+      maxAttempts: maxAttempts,
+      initialBackoff: _fast,
+      maxBackoff: const Duration(milliseconds: 40),
+      firstAttemptDelay: _fast,
+    );
+  }
+
+  List<String> names() => events.map((e) => e.event).toList();
+
+  group('Obd2ReconnectController episode breadcrumbs (#3346)', () {
+    test('a successful pinned reconnect traces drop→attempt→connected, '
+        'carrying the drop reason', () async {
+      await pinStore
+          .record(const LastGoodAdapter(mac: 'AA', transportKind: 'classic'));
+      final c = build(
+        pinned: (_) async => Obd2ReconnectAttemptResult.connected,
+        rescan: (_) async => Obd2ReconnectAttemptResult.notFound,
+      );
+
+      c.notifyDropped(reason: 'classic-socket-error', transportKind: 'classic');
+      await _waitFor(() => c.state == Obd2ReconnectState.connected);
+
+      expect(names(),
+          containsAllInOrder(['drop-received', 'attempt-start', 'connected']));
+      final drop = events.firstWhere((e) => e.event == 'drop-received');
+      expect(drop.data['reason'], 'classic-socket-error');
+      expect(drop.data['transport'], 'classic');
+      expect(drop.data['hadPin'], isTrue);
+      // The pinned hit must record a pinned-result, and never a rescan-result.
+      expect(names(), contains('pinned-result'));
+      expect(names(), isNot(contains('rescan-result')));
+      c.stop();
+    });
+
+    test('a pinned miss records both pinned-result and rescan-result', () async {
+      await pinStore
+          .record(const LastGoodAdapter(mac: 'AA', transportKind: 'classic'));
+      final c = build(
+        pinned: (_) async => Obd2ReconnectAttemptResult.notFound,
+        rescan: (_) async => Obd2ReconnectAttemptResult.connected,
+      );
+
+      c.notifyDropped(reason: 'classic-socket-done');
+      await _waitFor(() => c.state == Obd2ReconnectState.connected);
+
+      final pinnedRes = events.firstWhere((e) => e.event == 'pinned-result');
+      expect(pinnedRes.data['result'], 'notFound');
+      expect(pinnedRes.data['transport'], 'classic');
+      final rescanRes = events.firstWhere((e) => e.event == 'rescan-result');
+      expect(rescanRes.data['result'], 'connected');
+      c.stop();
+    });
+
+    test('exhausting the bound traces backoff-scheduled then terminal-failed',
+        () async {
+      final c = build(
+        pinned: (_) async => Obd2ReconnectAttemptResult.notFound,
+        rescan: (_) async => Obd2ReconnectAttemptResult.notFound,
+        maxAttempts: 2,
+      );
+
+      c.notifyDropped(reason: 'ble-disconnect-edge');
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalFailed);
+
+      expect(names(), contains('backoff-scheduled'));
+      final terminal = events.firstWhere((e) => e.event == 'terminal-failed');
+      expect(terminal.data['attempts'], 2);
+      expect(terminal.data['episodeMs'], isA<int>());
+      c.stop();
+    });
+
+    test('a confirmed engine-off traces terminal-engine-off', () async {
+      await pinStore
+          .record(const LastGoodAdapter(mac: 'AA', transportKind: 'ble'));
+      final c = build(
+        pinned: (_) async => Obd2ReconnectAttemptResult.engineOff,
+        rescan: (_) async => Obd2ReconnectAttemptResult.notFound,
+      );
+
+      c.notifyDropped(reason: 'ble-disconnect-edge');
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalEngineOff);
+
+      expect(names(), contains('terminal-engine-off'));
+      c.stop();
+    });
+
+    test('a second drop while reconnecting is traced but does not restart',
+        () async {
+      final c = build(
+        pinned: (_) async => Obd2ReconnectAttemptResult.notFound,
+        rescan: (_) async => Obd2ReconnectAttemptResult.notFound,
+        maxAttempts: 6,
+      );
+
+      c.notifyDropped(reason: 'ble-disconnect-edge');
+      c.notifyDropped(reason: 'ble-disconnect-edge'); // duplicate signal
+      await _waitFor(() => c.attempts >= 1);
+
+      expect(names().where((e) => e == 'drop-received'), hasLength(1),
+          reason: 'only the first drop starts an episode');
+      expect(names(), contains('drop-ignored-already-reconnecting'));
+      c.stop();
+    });
+
+    test('a throwing onTrace sink never wedges the loop', () async {
+      await pinStore
+          .record(const LastGoodAdapter(mac: 'AA', transportKind: 'ble'));
+      final c = Obd2ReconnectController(
+        pinStore: pinStore,
+        pinnedConnect: (_) async => Obd2ReconnectAttemptResult.connected,
+        rescanConnect: (_) async => Obd2ReconnectAttemptResult.notFound,
+        onTrace: (_, _) => throw StateError('buggy collector'),
+        initialBackoff: _fast,
+        firstAttemptDelay: _fast,
+      );
+
+      c.notifyDropped(reason: 'classic-socket-error');
+      await _waitFor(() => c.state == Obd2ReconnectState.connected);
+
+      expect(c.state, Obd2ReconnectState.connected,
+          reason: 'observability must never derail the reconnect');
+      c.stop();
+    });
+  });
+}


### PR DESCRIPTION
Closes #3346.

Reconnection complaints were undiagnosable: the per-attempt connect-trace ring is rich, but the reconnect **orchestration** was blind. Three additive, no-behaviour-change seams close that:

1. **Drop reason** — `Obd2LinkDropEvent` now carries *why* the link died, set at each channel drop site (`ble-disconnect-edge`, `classic-socket-error`, `classic-socket-done`, `classic-write-failed`).
2. **Labeled attempts** — the trip-independent reconnect provider wraps its pinned + rescan seams in `runWithOrigin(liveReconnect, …)`, so persisted/exported connect traces stop masquerading as `firstConnect` and carry a transport-decision reason.
3. **Episode breadcrumbs** — a new `Obd2ReconnectEpisodeTracer` emits the whole timeline (`drop-received`, `attempt-start`, `pinned`/`rescan-result` with latency, `backoff-scheduled`, `connected`, `terminal-failed`/`-engine-off`, each with attempt index + `episodeMs`) into the always-on `BreadcrumbCollector` (rides every error trace) + the dev-mode comm-diagnostics reconnect reservoir.

The tracer is its own file so the controller stays a lean state machine under the 400-line cap; a throwing sink can never wedge the loop.

### Field evidence already collected (informs the follow-up fix)
A user export shows the adapter (`vLinker FS`, Bluetooth **Classic**) self-tests fine in ~3s, but every **reconnect** is `rfcommOpenFail` — *"read failed, socket might closed or timeout, read ret: -1"* — each burning **83–120s**. The native plugin cycles 3 secure + 1 insecure + 1 reflection blocking `socket.connect()` calls while the adapter hasn't released its single SPP channel. The instrumentation here will confirm pinned-vs-rescan path on the next capture; the fast-fail/settle fix is a follow-up.

### Tests
`Obd2ReconnectEpisodeTracer` via the controller (drop reason carried, pinned/rescan result + latency, backoff→terminal, engine-off, duplicate-drop idempotency, throwing-sink safety); drop-signal reason; full obd2 suite (1921) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
