### PR TITLE
fix(consumption): driving-score export reports the count that drove the penalty (#3350)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace.dart
@@ -91,15 +91,16 @@ class DrivingAnalysisTrace {
         'score': {
           'overall': score.score,
           'styleClass': score.styleClass.name,
-          // #3029 — the harsh counts that ACTUALLY drive the penalties
-          // (`summary.harshAccelerations`/`harshBrakes` — IMU when it ran,
-          // else the now-suppressed direct-speed value), so a non-zero
-          // penalty always has a visible matching count. The `imu.*Count`
-          // block above stays the inertial-sensor truth; before this, a
-          // GPS-sourced trip could show a penalty>0 while `imu.*Count==0`,
-          // reading as a phantom with no source.
-          'hardAccelCount': summary.harshAccelerations,
-          'hardBrakeCount': summary.harshBrakes,
+          // #3350 — the counts the penalties were ACTUALLY computed from,
+          // read straight off the score so they can never disagree with the
+          // penalty. #3029 sourced these from `summary.harshAccelerations`,
+          // but on an OBD2 trip with the IMU inactive the score's penalty is
+          // driven by the sample-derived gate, not the (suppressed→0) summary
+          // figure — so a 15-pt penalty showed alongside count 0 (the phantom
+          // this fixes). The `imu.*Count` block above stays the inertial-sensor
+          // truth.
+          'hardAccelCount': score.hardAccelEvents,
+          'hardBrakeCount': score.hardBrakeEvents,
           'hardAccelPenalty': _round(score.hardAccelPenalty, 2),
           'hardBrakePenalty': _round(score.hardBrakePenalty, 2),
           'idlingPenalty': _round(score.idlingPenalty, 2),

--- a/lib/features/consumption/data/driving_score_accumulators.dart
+++ b/lib/features/consumption/data/driving_score_accumulators.dart
@@ -199,6 +199,10 @@ class _Accumulators {
       idlingPenalty: idlingPenalty,
       hardAccelPenalty: hardAccelPenalty,
       hardBrakePenalty: hardBrakePenalty,
+      // #3350 — carry the EXACT episode counts these penalties were computed
+      // from, so the breakdown/export can never show a mismatched count.
+      hardAccelEvents: hardAccelEvents,
+      hardBrakeEvents: hardBrakeEvents,
       highRpmPenalty: highRpmPenalty,
       fullThrottlePenalty: fullThrottlePenalty,
       pedalVelocityPenalty: pedalVelocityPenalty,

--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -274,6 +274,9 @@ DrivingScore computeDrivingScoreFromSummary(
     idlingPenalty: idlingPenalty,
     hardAccelPenalty: hardAccelPenalty,
     hardBrakePenalty: hardBrakePenalty,
+    // #3350 — the summary path's penalties come straight from these counts.
+    hardAccelEvents: summary.harshAccelerations,
+    hardBrakeEvents: summary.harshBrakes,
     highRpmPenalty: highRpmPenalty,
     fullThrottlePenalty: 0,
     luggingPenalty: luggingPenalty,

--- a/lib/features/consumption/domain/driving_score.dart
+++ b/lib/features/consumption/domain/driving_score.dart
@@ -68,6 +68,18 @@ class DrivingScore {
   /// (≤ -3.5 m/s²), per 100 km.
   final double hardBrakePenalty;
 
+  /// #3350 — the hard-acceleration episode COUNT that actually produced
+  /// [hardAccelPenalty] (the resolved `hardAccelEventsOverride ?? sample-gate`
+  /// figure). Carried on the score so a breakdown / export always shows the
+  /// count that drove the penalty — never a different source that could read
+  /// as a phantom (penalty>0 with count 0). The inertial-sensor truth lives
+  /// separately on the summary's `imuHardAccelCount`.
+  final int hardAccelEvents;
+
+  /// #3350 — the hard-braking episode COUNT that produced [hardBrakePenalty].
+  /// See [hardAccelEvents].
+  final int hardBrakeEvents;
+
   /// Score-points subtracted because of time spent at full throttle
   /// (pedal — else throttle — ≥ 90 %). **Now fires** (#2460): the
   /// persisted pedal/throttle drives it. Capped.
@@ -135,6 +147,8 @@ class DrivingScore {
     required this.hardBrakePenalty,
     required this.highRpmPenalty,
     required this.fullThrottlePenalty,
+    this.hardAccelEvents = 0,
+    this.hardBrakeEvents = 0,
     this.pedalVelocityPenalty = 0,
     this.luggingPenalty = 0,
     this.hardShiftPenalty = 0,
@@ -168,6 +182,8 @@ class DrivingScore {
         other.idlingPenalty == idlingPenalty &&
         other.hardAccelPenalty == hardAccelPenalty &&
         other.hardBrakePenalty == hardBrakePenalty &&
+        other.hardAccelEvents == hardAccelEvents &&
+        other.hardBrakeEvents == hardBrakeEvents &&
         other.highRpmPenalty == highRpmPenalty &&
         other.fullThrottlePenalty == fullThrottlePenalty &&
         other.pedalVelocityPenalty == pedalVelocityPenalty &&
@@ -186,6 +202,8 @@ class DrivingScore {
         idlingPenalty,
         hardAccelPenalty,
         hardBrakePenalty,
+        hardAccelEvents,
+        hardBrakeEvents,
         highRpmPenalty,
         fullThrottlePenalty,
         pedalVelocityPenalty,
@@ -203,8 +221,8 @@ class DrivingScore {
       'score: $score, '
       'class: ${styleClass.name}, '
       'idling: ${idlingPenalty.toStringAsFixed(1)}, '
-      'hardAccel: ${hardAccelPenalty.toStringAsFixed(1)}, '
-      'hardBrake: ${hardBrakePenalty.toStringAsFixed(1)}, '
+      'hardAccel: ${hardAccelPenalty.toStringAsFixed(1)} (${hardAccelEvents}x), '
+      'hardBrake: ${hardBrakePenalty.toStringAsFixed(1)} (${hardBrakeEvents}x), '
       'highRpm: ${highRpmPenalty.toStringAsFixed(1)}, '
       'fullThrottle: ${fullThrottlePenalty.toStringAsFixed(1)}, '
       'pedalVel: ${pedalVelocityPenalty.toStringAsFixed(1)}, '

--- a/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
+++ b/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
@@ -54,6 +54,8 @@ const DrivingScore _score = DrivingScore(
   idlingPenalty: 2,
   hardAccelPenalty: 6,
   hardBrakePenalty: 4,
+  hardAccelEvents: 2,
+  hardBrakeEvents: 1,
   highRpmPenalty: 0,
   fullThrottlePenalty: 0,
 );
@@ -127,11 +129,10 @@ void main() {
       expect(score['styleClass'], _score.styleClass.name);
       expect(score['hardAccelPenalty'], 6);
       expect(score['hardBrakePenalty'], 4);
-      // #3029 — the score block now exports the counts that DRIVE the
-      // penalties (summary.harshAccelerations/harshBrakes), so a penalty
-      // always has a visible matching count.
-      expect(score['hardAccelCount'], 0);
-      expect(score['hardBrakeCount'], 0);
+      // #3350 — the score block exports the counts the penalties were computed
+      // from, read straight off the score so they always match.
+      expect(score['hardAccelCount'], 2);
+      expect(score['hardBrakeCount'], 1);
 
       final lessons = json['lessons'] as List<dynamic>;
       expect(lessons, hasLength(1));
@@ -140,34 +141,38 @@ void main() {
     });
 
     test(
-        '#3029 — the score block\'s harsh counts are the penalty drivers '
-        '(non-zero penalty ⟺ non-zero count)', () {
-      // A real-OBD2-speed trip with genuine harsh events: the exported
-      // score-block counts must match summary.harshAccelerations/harshBrakes
-      // (what the penalty is computed from), NOT the imu.*Count scalars —
-      // so the export is internally consistent (penalty>0 has a count>0).
+        '#3350 — the score block\'s harsh counts are the penalty drivers '
+        '(read off the score), even when the summary figure is a suppressed 0',
+        () {
+      // Reproduces the field bug: an OBD2 trip with the IMU INACTIVE. The
+      // summary's harshAccelerations fell back to the recorder's
+      // GPS-suppressed HarshEventDetector → 0, but the SCORE's penalty was
+      // driven by the sample-derived gate (12 accel / 5 brake episodes). Before
+      // #3350 the export read the summary (0), so a 15-pt penalty showed
+      // alongside count 0 — a phantom. Now it reads the score's own resolved
+      // counts, so count ⟺ penalty by construction.
       final summary = TripSummary(
-        distanceKm: 20,
+        distanceKm: 109,
         maxRpm: 3000,
         highRpmSeconds: 0,
         idleSeconds: 0,
-        harshBrakes: 2,
-        harshAccelerations: 3,
+        harshBrakes: 0, // suppressed → would contradict the penalty
+        harshAccelerations: 0,
         startedAt: DateTime.utc(2026, 6, 3, 10),
-        endedAt: DateTime.utc(2026, 6, 3, 10, 25),
-        distanceSource: 'real',
+        endedAt: DateTime.utc(2026, 6, 3, 11),
+        distanceSource: 'gps',
         kind: TripKind.gpsPlusObd2,
-        // IMU never ran — its scalars are 0 and would CONTRADICT the
-        // penalty if the export used them as the count.
         imuActive: false,
         imuHardAccelCount: 0,
         imuHardBrakeCount: 0,
       );
       const score = DrivingScore(
-        score: 70,
+        score: 33,
         idlingPenalty: 0,
-        hardAccelPenalty: 9,
-        hardBrakePenalty: 6,
+        hardAccelPenalty: 15,
+        hardBrakePenalty: 15,
+        hardAccelEvents: 12, // the count that ACTUALLY drove the penalty
+        hardBrakeEvents: 5,
         highRpmPenalty: 0,
         fullThrottlePenalty: 0,
       );
@@ -180,15 +185,15 @@ void main() {
 
       final scoreBlock = json['score'] as Map<String, dynamic>;
       final imu = json['imu'] as Map<String, dynamic>;
-      // The penalty drivers are the harsh counts, not the IMU scalars.
-      expect(scoreBlock['hardAccelCount'], 3);
-      expect(scoreBlock['hardBrakeCount'], 2);
-      expect(scoreBlock['hardAccelPenalty'], 9);
-      expect(scoreBlock['hardBrakePenalty'], 6);
+      // The score block reports the penalty-driving counts, NOT the summary 0.
+      expect(scoreBlock['hardAccelCount'], 12);
+      expect(scoreBlock['hardBrakeCount'], 5);
+      expect(scoreBlock['hardAccelPenalty'], 15);
+      expect(scoreBlock['hardBrakePenalty'], 15);
       // The IMU truth block is unchanged (still the inertial scalars).
       expect(imu['hardAccelCount'], 0);
       expect(imu['hardBrakeCount'], 0);
-      // Invariant: a non-zero penalty has a non-zero score-block count.
+      // Invariant: a non-zero penalty always has a non-zero score-block count.
       expect(scoreBlock['hardAccelCount'], greaterThan(0));
       expect(scoreBlock['hardBrakeCount'], greaterThan(0));
     });

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -126,6 +126,31 @@ void main() {
       expect(result.score, lessThanOrEqualTo(85));
     });
 
+    test('#3350 — the score carries the SAME count that drove the penalty', () {
+      // 5 sample-derived hard accels, no override (the OBD2 / IMU-inactive
+      // path). The penalty caps at 15, and the score must report the count it
+      // used (5) — so a downstream export can never show penalty>0 with count 0.
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2500));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      final derived = computeDrivingScore(samples);
+      expect(derived.hardAccelPenalty, greaterThan(0));
+      expect(derived.hardAccelEvents, 5,
+          reason: 'the stored count is the one the penalty was computed from');
+
+      // An explicit override wins and is the count reported, too.
+      final overridden =
+          computeDrivingScore(samples, hardAccelEventsOverride: 2);
+      expect(overridden.hardAccelEvents, 2);
+    });
+
     test('hardAccelPenalty caps at 15 even with 10 events', () {
       var t = start;
       final samples = <TripSample>[];


### PR DESCRIPTION
Closes #3350.

## Bug (field export)
A 109 km `gpsPlusObd2` trip exported a self-contradicting score: `hardAccelPenalty: 15.0` **and** `hardBrakePenalty: 15.0` (the cap) alongside `score.hardAccelCount: 0` / `hardBrakeCount: 0`, while the lesson said **"12 accélérations brusques"**. Penalty, count field, and lesson all disagreed.

## Root cause
`computeDrivingScore` drives the penalty from `hardAccelEventsOverride ?? accelCounts.accelEvents` — the sample-derived gate (12 events) when no override. The override is only passed `useImu ? summary.harshAccelerations : null`, so on an **IMU-inactive** trip it's null → penalty uses the 12-event gate. But the export reported the count from `summary.harshAccelerations`, which on an IMU-inactive trip falls back to the recorder's `HarshEventDetector` — **suppressed to 0 on GPS-distance trips**. Penalty source ≠ count source → phantom.

## Fix
Carry the resolved `hardAccelEvents`/`hardBrakeEvents` (the exact counts each penalty was computed from) on the `DrivingScore` value object — set in both the per-sample `build()` and the summary-only path — and read them in the export. **Count ⟺ penalty by construction**, for every trip type. The `imu.*Count` block stays the separate inertial-sensor truth.

## Tests
- calculator: the score carries the same count the penalty used (sample-derived 5, and an explicit override 2);
- trace export: reproduces the exact field bug (summary count 0, penalty from 12/5) and asserts the export now shows 12/5 matching the penalty; the IMU block stays 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
