### PR TITLE
feat(radar): price chips + lowest-price aggregation + heading-up orientation (#3354)

### DIFF
--- a/lib/features/search/presentation/widgets/radar_scope_geometry.dart
+++ b/lib/features/search/presentation/widgets/radar_scope_geometry.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:math';
+import 'dart:ui' show Offset;
 
 import '../../../../core/domain/station.dart';
 import '../../../../core/utils/geo_utils.dart';
@@ -15,6 +16,8 @@ class RadarBlip {
     required this.bearingDeg,
     required this.distanceKm,
     required this.beyondRange,
+    this.price,
+    this.aggregatedCount = 1,
   });
 
   final Station station;
@@ -23,7 +26,8 @@ class RadarBlip {
   /// (= the search radius). Out-of-range stations clamp to 1.
   final double fraction;
 
-  /// Bearing from the user, degrees clockwise from North (which is "up").
+  /// Bearing from the user, degrees clockwise from North (which is "up" on a
+  /// North-up scope). The view applies the heading rotation for display.
   final double bearingDeg;
 
   final double distanceKm;
@@ -32,22 +36,52 @@ class RadarBlip {
   /// rim (so the UI can render it dimmer / on the edge).
   final bool beyondRange;
 
-  /// Unit-scope x (centre = 0, rim = ±1), screen coords (East = +x).
-  double get unitDx => fraction * sin(bearingDeg * pi / 180);
+  /// Price for the active fuel type (#3354), or null when unpriced. The view
+  /// renders this instead of a plain dot, and clustering keeps the lowest.
+  final double? price;
 
-  /// Unit-scope y (screen coords, down = +y; North = up = −y).
-  double get unitDy => -fraction * cos(bearingDeg * pi / 180);
+  /// #3354 — how many overlapping stations this blip stands in for after
+  /// [aggregateOverlapping] collapsed a cluster to its cheapest member. 1 when
+  /// it represents only itself.
+  final int aggregatedCount;
+
+  /// Unit-scope offset (centre = origin, rim = ±1) in screen coords (East =
+  /// +x, North = −y), rotated so [headingDeg] points UP (#3354). A station
+  /// dead ahead of the driver then sits at the top of the scope. Pass 0 for
+  /// the North-up default.
+  Offset unitOffset({double headingDeg = 0}) {
+    final a = (bearingDeg - headingDeg) * pi / 180;
+    return Offset(fraction * sin(a), -fraction * cos(a));
+  }
+
+  /// North-up x (kept for the existing tests / default orientation).
+  double get unitDx => unitOffset().dx;
+
+  /// North-up y.
+  double get unitDy => unitOffset().dy;
+
+  RadarBlip _asAggregate(int count) => RadarBlip(
+        station: station,
+        fraction: fraction,
+        bearingDeg: bearingDeg,
+        distanceKm: distanceKm,
+        beyondRange: beyondRange,
+        price: price,
+        aggregatedCount: count,
+      );
 }
 
 /// Map [stations] to scope blips around `(centerLat, centerLng)`, with the
 /// outer ring at [rangeKm]. Stations beyond the range clamp to the rim.
+/// [priceOf] resolves each station's price for the active fuel type (#3354).
 /// Returns empty when the range is non-positive or the centre is unusable.
 List<RadarBlip> radarScopeBlips(
   List<Station> stations,
   double centerLat,
   double centerLng,
-  double rangeKm,
-) {
+  double rangeKm, {
+  double? Function(Station station)? priceOf,
+}) {
   if (rangeKm <= 0 || !isUsableCoord(centerLat, centerLng)) {
     return const <RadarBlip>[];
   }
@@ -63,8 +97,53 @@ List<RadarBlip> radarScopeBlips(
         bearingDeg: bearingDegrees(centerLat, centerLng, s.lat, s.lng),
         distanceKm: dKm,
         beyondRange: beyond,
+        price: priceOf?.call(s),
       ),
     );
   }
   return blips;
+}
+
+/// #3354 — collapse blips whose scope positions are within [minSeparation]
+/// (unit-scope distance) into a single representative carrying the LOWEST
+/// price, so overlapping price labels don't pile up. Pairwise distances are
+/// rotation-invariant, so clustering on the North-up offsets matches the
+/// rotated (heading-up) display. Greedy, cheapest-first: the cheapest blip
+/// seeds a cluster and absorbs every still-unclaimed neighbour within
+/// [minSeparation]; the representative keeps the seed's (cheapest) price and an
+/// [RadarBlip.aggregatedCount] of the cluster size. Unpriced blips sort last so
+/// a real price always wins a cluster.
+List<RadarBlip> aggregateOverlapping(
+  List<RadarBlip> blips, {
+  double minSeparation = 0.16,
+}) {
+  if (blips.length < 2) return blips;
+  // Cheapest first; unpriced (null) last, then nearer-first as a tiebreak.
+  final order = [...blips]..sort((a, b) {
+      final pa = a.price, pb = b.price;
+      if (pa != null && pb != null && pa != pb) return pa.compareTo(pb);
+      if (pa == null && pb != null) return 1;
+      if (pa != null && pb == null) return -1;
+      return a.fraction.compareTo(b.fraction);
+    });
+  final claimed = List<bool>.filled(order.length, false);
+  final out = <RadarBlip>[];
+  final minSepSq = minSeparation * minSeparation;
+  for (var i = 0; i < order.length; i++) {
+    if (claimed[i]) continue;
+    claimed[i] = true;
+    final seed = order[i];
+    final seedPos = seed.unitOffset();
+    var count = 1;
+    for (var j = i + 1; j < order.length; j++) {
+      if (claimed[j]) continue;
+      final d = order[j].unitOffset() - seedPos;
+      if (d.dx * d.dx + d.dy * d.dy <= minSepSq) {
+        claimed[j] = true;
+        count++;
+      }
+    }
+    out.add(count > 1 ? seed._asAggregate(count) : seed);
+  }
+  return out;
 }

--- a/lib/features/search/presentation/widgets/radar_scope_view.dart
+++ b/lib/features/search/presentation/widgets/radar_scope_view.dart
@@ -5,17 +5,21 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/station_extensions.dart';
 import 'radar_scope_geometry.dart';
 
 /// #3342 — a PPI ("plan position indicator") radar-scope view of nearby fuel
 /// stations: concentric range rings + crosshair, a rotating light-blue sweep
-/// (the refresh), and a green blip per station placed by distance (radius,
-/// clamped to the rim = the search radius) and bearing (angle, North up).
+/// (the refresh), and a green PRICE chip per station placed by distance
+/// (radius, clamped to the rim = the search radius) and bearing.
 ///
-/// A second visualization of the same radar station set — the caller toggles
-/// between this and the distance-sorted list.
+/// #3354 — the scope shows the PRICE for the active fuel type instead of a bare
+/// dot (overlapping chips collapse to the cheapest), the cheapest in view is
+/// highlighted, and the whole scope orients HEADING-UP: a station ahead of the
+/// driver sits at the top. Falls back to North-up when no course is known.
 class RadarScopeView extends StatefulWidget {
   const RadarScopeView({
     super.key,
@@ -23,6 +27,8 @@ class RadarScopeView extends StatefulWidget {
     required this.centerLat,
     required this.centerLng,
     required this.rangeKm,
+    required this.fuelType,
+    this.headingDeg,
     this.onStationTap,
   });
 
@@ -30,11 +36,23 @@ class RadarScopeView extends StatefulWidget {
   final double centerLat;
   final double centerLng;
   final double rangeKm;
+
+  /// Active fuel type — the price shown per station (#3354).
+  final FuelType fuelType;
+
+  /// Live GPS course (deg clockwise from North); when non-null the scope
+  /// rotates so this direction points up. Null → North-up (#3354).
+  final double? headingDeg;
+
   final void Function(Station station)? onStationTap;
 
   /// Padding (px) between the outer ring and the widget edge — shared by the
-  /// painter and the tap hit-test so blip positions line up.
-  static const double pad = 16.0;
+  /// painter and the tap hit-test so chip positions line up.
+  static const double pad = 22.0;
+
+  /// Min on-scope separation (unit-radius) below which chips collapse to the
+  /// cheapest, so price labels never pile up (#3354).
+  static const double clusterSeparation = 0.18;
 
   @override
   State<RadarScopeView> createState() => _RadarScopeViewState();
@@ -47,11 +65,12 @@ class _RadarScopeViewState extends State<RadarScopeView>
     duration: const Duration(seconds: 4),
   )..repeat();
 
-  // Scope palette — a dark-green PPI face so the green grid/blips and the
+  // Scope palette — a dark-green PPI face so the green grid/chips and the
   // light-blue sweep read as a radar, independent of the app's light theme.
   static const Color _backdrop = Color(0xFF0A2A14);
   static const Color _grid = Color(0xFF3DDC84);
   static const Color _blip = Color(0xFF6EF2A6);
+  static const Color _cheapest = Color(0xFFB9FF66);
   static const Color _sweepColor = Color(0xFF40C4FF);
 
   @override
@@ -60,15 +79,29 @@ class _RadarScopeViewState extends State<RadarScopeView>
     super.dispose();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final blips = radarScopeBlips(
+  List<RadarBlip> _blips() {
+    final raw = radarScopeBlips(
       widget.stations,
       widget.centerLat,
       widget.centerLng,
       widget.rangeKm,
+      priceOf: (s) => s.priceFor(widget.fuelType),
     );
+    return aggregateOverlapping(raw,
+        minSeparation: RadarScopeView.clusterSeparation);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final blips = _blips();
+    final heading = widget.headingDeg ?? 0;
+    // The cheapest priced station in view — highlighted on the scope.
+    double? cheapest;
+    for (final b in blips) {
+      final p = b.price;
+      if (p != null && (cheapest == null || p < cheapest)) cheapest = p;
+    }
     final rangeLabel = PriceFormatter.formatDistance(widget.rangeKm);
 
     return AspectRatio(
@@ -78,7 +111,8 @@ class _RadarScopeViewState extends State<RadarScopeView>
           final side = min(constraints.maxWidth, constraints.maxHeight);
           final size = Size(side, side);
           return GestureDetector(
-            onTapUp: (details) => _handleTap(details.localPosition, size, blips),
+            onTapUp: (details) =>
+                _handleTap(details.localPosition, size, blips, heading),
             child: AnimatedBuilder(
               animation: _sweep,
               builder: (_, _) => CustomPaint(
@@ -86,13 +120,18 @@ class _RadarScopeViewState extends State<RadarScopeView>
                 painter: _RadarScopePainter(
                   blips: blips,
                   sweepT: _sweep.value,
+                  headingDeg: heading,
+                  cheapest: cheapest,
                   backdrop: _backdrop,
                   grid: _grid,
                   blip: _blip,
+                  cheapestColor: _cheapest,
                   sweep: _sweepColor,
                   rangeLabel: rangeLabel,
-                  labelStyle: theme.textTheme.labelSmall
-                          ?.copyWith(color: _grid) ??
+                  labelStyle: theme.textTheme.labelSmall?.copyWith(
+                        color: _grid,
+                        fontWeight: FontWeight.w600,
+                      ) ??
                       const TextStyle(color: _grid, fontSize: 10),
                 ),
               ),
@@ -103,15 +142,16 @@ class _RadarScopeViewState extends State<RadarScopeView>
     );
   }
 
-  void _handleTap(Offset pos, Size size, List<RadarBlip> blips) {
+  void _handleTap(
+      Offset pos, Size size, List<RadarBlip> blips, double heading) {
     final cb = widget.onStationTap;
     if (cb == null || blips.isEmpty) return;
     final center = Offset(size.width / 2, size.height / 2);
     final radius = size.shortestSide / 2 - RadarScopeView.pad;
     RadarBlip? nearest;
-    var bestDist = 28.0; // px hit tolerance
+    var bestDist = 32.0; // px hit tolerance
     for (final b in blips) {
-      final p = center + Offset(b.unitDx * radius, b.unitDy * radius);
+      final p = center + b.unitOffset(headingDeg: heading) * radius;
       final d = (p - pos).distance;
       if (d < bestDist) {
         bestDist = d;
@@ -126,9 +166,12 @@ class _RadarScopePainter extends CustomPainter {
   _RadarScopePainter({
     required this.blips,
     required this.sweepT,
+    required this.headingDeg,
+    required this.cheapest,
     required this.backdrop,
     required this.grid,
     required this.blip,
+    required this.cheapestColor,
     required this.sweep,
     required this.rangeLabel,
     required this.labelStyle,
@@ -136,9 +179,12 @@ class _RadarScopePainter extends CustomPainter {
 
   final List<RadarBlip> blips;
   final double sweepT;
+  final double headingDeg;
+  final double? cheapest;
   final Color backdrop;
   final Color grid;
   final Color blip;
+  final Color cheapestColor;
   final Color sweep;
   final String rangeLabel;
   final TextStyle labelStyle;
@@ -154,7 +200,8 @@ class _RadarScopePainter extends CustomPainter {
     // Trailing sweep wedge — a SweepGradient rotated to the current angle.
     final sweepAngle = sweepT * 2 * pi;
     canvas.save();
-    canvas.clipPath(Path()..addOval(Rect.fromCircle(center: center, radius: radius)));
+    canvas.clipPath(
+        Path()..addOval(Rect.fromCircle(center: center, radius: radius)));
     canvas.drawCircle(
       center,
       radius,
@@ -193,14 +240,17 @@ class _RadarScopePainter extends CustomPainter {
         ..strokeWidth = 2,
     );
 
-    // Station blips.
-    for (final b in blips) {
-      final p = center + Offset(b.unitDx * radius, b.unitDy * radius);
-      final a = b.beyondRange ? 0.5 : 1.0;
-      canvas.drawCircle(p, 7, Paint()..color = blip.withValues(alpha: 0.18 * a));
-      canvas.drawCircle(
-          p, b.beyondRange ? 3 : 4, Paint()..color = blip.withValues(alpha: a));
+    // Station price chips, drawn farthest-first so nearer (more relevant)
+    // chips paint on top.
+    final ordered = [...blips]
+      ..sort((a, b) => b.distanceKm.compareTo(a.distanceKm));
+    for (final b in ordered) {
+      _paintChip(canvas, center, radius, b);
     }
+
+    // "Ahead" marker — a fixed up-pointing caret at the centre showing the
+    // driving direction is UP, plus the rotating North tick (#3354).
+    _paintHeadingMarkers(canvas, center, radius);
 
     // Range label at the top of the outer ring.
     final tp = TextPainter(
@@ -210,7 +260,99 @@ class _RadarScopePainter extends CustomPainter {
     tp.paint(canvas, Offset(center.dx + 6, center.dy - radius - tp.height));
   }
 
+  void _paintChip(Canvas canvas, Offset center, double radius, RadarBlip b) {
+    final pos = center + b.unitOffset(headingDeg: headingDeg) * radius;
+    final isCheapest =
+        b.price != null && cheapest != null && b.price == cheapest;
+    final a = b.beyondRange ? 0.55 : 1.0;
+    final label = b.price == null
+        ? '?'
+        : PriceFormatter.formatPriceCompact(b.price);
+
+    final tp = TextPainter(
+      text: TextSpan(
+        text: label,
+        style: TextStyle(
+          color: isCheapest ? const Color(0xFF06210F) : _ink(a),
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    const padX = 5.0, padY = 2.0;
+    final w = tp.width + padX * 2;
+    final h = tp.height + padY * 2;
+    final rect = RRect.fromRectAndRadius(
+      Rect.fromCenter(center: pos, width: w, height: h),
+      const Radius.circular(7),
+    );
+    final fill = isCheapest ? cheapestColor : blip.withValues(alpha: 0.16 * a);
+    canvas.drawRRect(rect, Paint()..color = fill);
+    if (!isCheapest) {
+      canvas.drawRRect(
+        rect,
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1
+          ..color = blip.withValues(alpha: 0.6 * a),
+      );
+    }
+    tp.paint(canvas, pos - Offset(tp.width / 2, tp.height / 2));
+
+    // A small "+N" when this chip stands in for an overlapping cluster.
+    if (b.aggregatedCount > 1) {
+      final badge = TextPainter(
+        text: TextSpan(
+          text: '+${b.aggregatedCount - 1}',
+          style: TextStyle(
+            color: _ink(a),
+            fontSize: 8,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      badge.paint(canvas, Offset(rect.right - 2, rect.top - badge.height + 2));
+    }
+  }
+
+  Color _ink(double a) => cheapestColor.withValues(alpha: a);
+
+  void _paintHeadingMarkers(Canvas canvas, Offset center, double radius) {
+    // Fixed up-caret at the centre — "ahead" is always the top.
+    final caret = Path()
+      ..moveTo(center.dx, center.dy - 11)
+      ..lineTo(center.dx - 6, center.dy + 4)
+      ..lineTo(center.dx + 6, center.dy + 4)
+      ..close();
+    canvas.drawPath(caret, Paint()..color = sweep.withValues(alpha: 0.9));
+
+    // Rotating "N" tick — North sits at screen angle (0 − heading) from up.
+    final nAngle = (-headingDeg) * pi / 180;
+    final nPos = Offset(
+      center.dx + (radius - 8) * sin(nAngle),
+      center.dy - (radius - 8) * cos(nAngle),
+    );
+    final nTp = TextPainter(
+      text: TextSpan(
+        text: 'N',
+        style: TextStyle(
+          color: grid.withValues(alpha: 0.8),
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    nTp.paint(canvas, nPos - Offset(nTp.width / 2, nTp.height / 2));
+  }
+
   @override
   bool shouldRepaint(covariant _RadarScopePainter old) =>
-      old.sweepT != sweepT || !identical(old.blips, blips);
+      old.sweepT != sweepT ||
+      old.headingDeg != headingDeg ||
+      !identical(old.blips, blips);
 }

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -111,6 +111,8 @@ class SearchResultsContent extends ConsumerWidget {
                 centerLat: userPos.lat,
                 centerLng: userPos.lng,
                 rangeKm: ref.watch(searchRadiusProvider),
+                fuelType: ref.watch(selectedFuelTypeProvider),
+                headingDeg: radar.heading,
                 onStationTap: (s) =>
                     unawaited(StationDetailRoute(s.id).push<void>(context)),
               ),

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -33,6 +33,7 @@ class RadarSearchState {
     required this.active,
     this.locating = false,
     required this.stations,
+    this.heading,
   });
 
   /// `true` once a radar run has resolved and the results list should render
@@ -48,6 +49,13 @@ class RadarSearchState {
   /// The radar's distance-sorted, priced station list (loading/data/error).
   final AsyncValue<List<Station>> stations;
 
+  /// #3354 — the latest live GPS course (degrees clockwise from North),
+  /// `null` until the first moving fix. The radar-scope view rotates so this
+  /// direction points UP ("heading-up"). Kept last-known when the user stops
+  /// (a standstill fix has no course), so the scope holds the travel direction
+  /// instead of snapping back to North.
+  final double? heading;
+
   static const RadarSearchState idle = RadarSearchState(
     active: false,
     locating: false,
@@ -58,11 +66,14 @@ class RadarSearchState {
     bool? active,
     bool? locating,
     AsyncValue<List<Station>>? stations,
+    double? heading,
   }) =>
       RadarSearchState(
         active: active ?? this.active,
         locating: locating ?? this.locating,
         stations: stations ?? this.stations,
+        // Keep-last: a standstill fix (null course) holds the travel direction.
+        heading: heading ?? this.heading,
       );
 }
 
@@ -317,7 +328,11 @@ class RadarSearch extends _$RadarSearch {
     final fuel = ref.read(selectedFuelTypeProvider);
     final ranked = RadarRanking.rank(_lastRaw, lat: lat, lng: lng, fuel: fuel);
     unawaited(carWriter.writeRadar(ranked, fuel));
-    state = state.copyWith(stations: AsyncData<List<Station>>(ranked));
+    // #3354 — stamp the live course so the scope can orient heading-up.
+    state = state.copyWith(
+      stations: AsyncData<List<Station>>(ranked),
+      heading: geo.sanitizedHeading(_lastFix?.heading),
+    );
   }
 
   /// Dismiss the radar result and hand the results list back to the regular

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'6915d5a189620edc8479072f08a23d7eecddd521';
+String _$radarSearchHash() => r'1aebbdcc66b59606cd957d916336782ba663c648';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/test/features/search/presentation/widgets/radar_scope_geometry_test.dart
+++ b/test/features/search/presentation/widgets/radar_scope_geometry_test.dart
@@ -94,5 +94,67 @@ void main() {
       expect(blip.unitDx, closeTo(0, 0.02));
       expect(blip.unitDy, lessThan(0)); // North = up = negative y
     });
+
+    test('#3354 — priceOf stamps each blip with its fuel price', () {
+      final blips = radarScopeBlips(
+        [station('a', 52.1, 13.0)],
+        52.0,
+        13.0,
+        20,
+        priceOf: (s) => 1.799,
+      );
+      expect(blips.single.price, 1.799);
+    });
+  });
+
+  group('#3354 — heading-up rotation', () {
+    test('driving north keeps a due-north blip at the top (−y)', () {
+      final blip =
+          radarScopeBlips([station('a', 52.1, 13.0)], 52.0, 13.0, 20).single;
+      final o = blip.unitOffset(headingDeg: 0);
+      expect(o.dx, closeTo(0, 0.02));
+      expect(o.dy, lessThan(0));
+    });
+
+    test('driving east rotates a due-north blip to the LEFT (−x)', () {
+      final blip =
+          radarScopeBlips([station('a', 52.1, 13.0)], 52.0, 13.0, 20).single;
+      final o = blip.unitOffset(headingDeg: 90);
+      expect(o.dx, lessThan(0)); // North is now to the driver's left
+      expect(o.dy, closeTo(0, 0.02));
+    });
+  });
+
+  group('#3354 — aggregateOverlapping (lowest price wins)', () {
+    test('overlapping blips collapse to the cheapest, with a count', () {
+      final blips = radarScopeBlips(
+        [
+          station('pricey', 52.100, 13.0),
+          station('cheap', 52.1005, 13.0001), // ~essentially the same spot
+        ],
+        52.0,
+        13.0,
+        20,
+        priceOf: (s) => s.id == 'cheap' ? 1.599 : 1.899,
+      );
+      final agg = aggregateOverlapping(blips, minSeparation: 0.2);
+      expect(agg, hasLength(1));
+      expect(agg.single.station.id, 'cheap');
+      expect(agg.single.price, 1.599);
+      expect(agg.single.aggregatedCount, 2);
+    });
+
+    test('well-separated blips are NOT merged', () {
+      final blips = radarScopeBlips(
+        [station('n', 52.15, 13.0), station('s', 51.85, 13.0)],
+        52.0,
+        13.0,
+        40,
+        priceOf: (s) => 1.7,
+      );
+      final agg = aggregateOverlapping(blips, minSeparation: 0.16);
+      expect(agg, hasLength(2));
+      expect(agg.every((b) => b.aggregatedCount == 1), isTrue);
+    });
   });
 }

--- a/test/features/search/presentation/widgets/radar_scope_view_test.dart
+++ b/test/features/search/presentation/widgets/radar_scope_view_test.dart
@@ -3,16 +3,18 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/core/domain/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/radar_scope_view.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Smoke-tests the PPI radar-scope widget (#3342): it paints without throwing
-/// and a tap near a blip routes to that station. The sweep animation runs
-/// forever, so pumps use `settle: false`.
+/// Smoke-tests the PPI radar-scope widget (#3342/#3354): it paints price chips
+/// without throwing, a tap near a chip routes to that station, and the heading
+/// rotates placement. The sweep animation runs forever, so pumps use
+/// `settle: false`.
 void main() {
-  Station station(String id, double lat, double lng) => Station(
+  Station station(String id, double lat, double lng, {double? e10}) => Station(
         id: id,
         name: 'Station $id',
         brand: 'TEST',
@@ -22,18 +24,23 @@ void main() {
         lat: lat,
         lng: lng,
         dist: 1,
+        e10: e10,
         isOpen: true,
       );
 
-  testWidgets('paints a scope for nearby stations without throwing',
+  testWidgets('paints a scope for nearby priced stations without throwing',
       (tester) async {
     await pumpApp(
       tester,
       RadarScopeView(
-        stations: [station('a', 52.1, 13.0), station('b', 52.0, 13.1)],
+        stations: [
+          station('a', 52.1, 13.0, e10: 1.799),
+          station('b', 52.0, 13.1, e10: 1.659),
+        ],
         centerLat: 52.0,
         centerLng: 13.0,
         rangeKm: 20,
+        fuelType: FuelType.e10,
       ),
       settle: false,
     );
@@ -43,7 +50,8 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('tapping near a blip invokes onStationTap', (tester) async {
+  testWidgets('tapping near a chip invokes onStationTap (North-up)',
+      (tester) async {
     Station? tapped;
     await pumpApp(
       tester,
@@ -52,10 +60,11 @@ void main() {
           width: 300,
           height: 300,
           child: RadarScopeView(
-            stations: [station('north', 52.1, 13.0)],
+            stations: [station('north', 52.1, 13.0, e10: 1.799)],
             centerLat: 52.0,
             centerLng: 13.0,
             rangeKm: 20,
+            fuelType: FuelType.e10,
             onStationTap: (s) => tapped = s,
           ),
         ),
@@ -63,10 +72,40 @@ void main() {
       settle: false,
     );
 
-    // The single station is due north, so its blip sits above centre. Tapping
-    // the upper-middle of the scope should hit it.
+    // Due north + no heading → North-up → chip sits above centre.
     final box = tester.getRect(find.byType(RadarScopeView));
-    await tester.tapAt(Offset(box.center.dx, box.top + box.height * 0.30));
+    await tester.tapAt(Offset(box.center.dx, box.top + box.height * 0.32));
+    await tester.pump();
+
+    expect(tapped?.id, 'north');
+  });
+
+  testWidgets('heading-up: driving east puts a due-north station on the LEFT',
+      (tester) async {
+    Station? tapped;
+    await pumpApp(
+      tester,
+      Center(
+        child: SizedBox(
+          width: 300,
+          height: 300,
+          child: RadarScopeView(
+            stations: [station('north', 52.1, 13.0, e10: 1.799)],
+            centerLat: 52.0,
+            centerLng: 13.0,
+            rangeKm: 20,
+            fuelType: FuelType.e10,
+            headingDeg: 90, // driving east → North rotates to the left
+            onStationTap: (s) => tapped = s,
+          ),
+        ),
+      ),
+      settle: false,
+    );
+
+    final box = tester.getRect(find.byType(RadarScopeView));
+    // The due-north station should now be on the left half, vertically centred.
+    await tester.tapAt(Offset(box.left + box.width * 0.18, box.center.dy));
     await tester.pump();
 
     expect(tapped?.id, 'north');
@@ -80,6 +119,7 @@ void main() {
         centerLat: 52.0,
         centerLng: 13.0,
         rangeKm: 20,
+        fuelType: FuelType.e10,
       ),
       settle: false,
     );


### PR DESCRIPTION
Closes #3354. Follow-up to the PPI radar-scope view (#3342).

- **Price chips** — each station shows its price for the active fuel type (`station.priceFor(fuelType)`, compact format) instead of a bare dot; the **cheapest in view is highlighted**.
- **Lowest-price aggregation** — overlapping chips collapse to the cheapest (greedy cheapest-first within a unit-scope separation) with a `+N` badge, so labels never pile up. Pairwise distances are rotation-invariant → clustering on the North-up offsets matches the rotated display.
- **Heading-up orientation** — a station ahead of the driver sits at the top. Uses the radar's existing live GPS course (`RadarSearchState.heading`, from the fix already kept for the corridor prefetch); holds the last travel direction at a standstill, falls back to North-up until the first moving fix. A rotating "N" tick shows where North is.

### Tests
geometry: price stamping, heading rotation (north→top, east→left), aggregation (cheapest wins + count, separated stay split); widget: paints priced chips, tap routes (North-up and heading-up east→left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
