### PR TITLE
chore(ci): stop dependabot bumping the pinned riverpod_lint (#3356)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
     ignore:
       - dependency-name: "flutter_blue_plus"
         update-types: ["version-update:semver-major"]
+      # `riverpod_lint` is pinned EXACTLY (pubspec.yaml): each release pins one
+      # riverpod version, and 3.1.4 forces `riverpod: 3.3.2`, which fails
+      # version-solving against the locked riverpod 3.x graph (#3352 — the bump
+      # red-CI'd the whole minor-and-patch group). Hold it until the riverpod
+      # 3.x line is intentionally moved in lockstep.
+      - dependency-name: "riverpod_lint"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes #3356.

Dependabot's weekly `minor-and-patch` group keeps red-CI'ing because it includes `riverpod_lint: 3.1.4`, which forces `riverpod: 3.3.2` → **pub version-solving fails** against the locked riverpod 3.x graph. `riverpod_lint` is pinned exactly in `pubspec.yaml` for exactly this reason.

Adds `riverpod_lint` to the dependabot `ignore` list so the group solves (every other dep in it is fine). The unmergeable #3352 will be closed; dependabot recreates the group without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)