### PR TITLE
chore(android): enable the GPS foreground service on Play builds (#3358)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -99,7 +99,12 @@ jobs:
         run: flutter pub get
 
       - name: Build AAB (play flavor, run-counter build number)
-        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }}
+        # #3173 — FGS_FORM_APPROVED=true ships the GPS foreground service: the
+        # Dart flag hands geolocator the ForegroundNotificationConfig AND the
+        # gradle overlay re-declares FOREGROUND_SERVICE*. Requires the Play
+        # "Foreground Service Use" form to be approved (#1498), else this upload
+        # 403s.
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }} --dart-define=FGS_FORM_APPROVED=true
 
       - name: Clean up decoded keystore
         if: always()

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -154,6 +154,7 @@ jobs:
         run: |
           flutter build appbundle --release --flavor play \
             --build-number=${{ needs.pre-check.outputs.build_number }} \
+            --dart-define=FGS_FORM_APPROVED=true \
             --obfuscate --split-debug-info=build/symbols
 
       # Per-ABI APKs were dropped from the public nightly release on


### PR DESCRIPTION
Closes #3358.

Flips the Play **appbundle** builds (`daily-beta.yml` Open-Testing upload + `daily-github-release.yml`) to `--dart-define=FGS_FORM_APPROVED=true`. In lockstep (#3173):
- **Dart** — `kGpsRecordingForegroundServiceEnabled` → true → geolocator gets the `ForegroundNotificationConfig` (un-throttled 1 s background GPS).
- **Manifest** — gradle swaps to `src/play/AndroidManifestFgsApproved.xml`, re-declaring `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_CONNECTED_DEVICE` + the foreground service.

F-Droid/dev builds stay on the default Play-compliant shape.

### ⚠️ Merge when the Play form is approved
Once merged, the next Open-Testing upload **requires the Google Play "Foreground Service Use" form to be approved** (#1498) — otherwise Play **403s** the upload. **Auto-merge intentionally NOT armed**: merge this the moment your form clears (or now if already submitted/approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)