### PR TITLE
fix(radar): orient the scope by the device compass, not GPS course (#3364)

### DIFF
--- a/lib/core/sensors/compass_heading.dart
+++ b/lib/core/sensors/compass_heading.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math';
+
+/// #3364 — tilt-compensated compass azimuth from raw accelerometer (gravity)
+/// + magnetometer vectors. Pure math (no sensors_plus) so it is unit-testable
+/// without a device.
+///
+/// Mirrors Android `SensorManager.getRotationMatrix` + `getOrientation`:
+/// the cross products build the device→world rotation and the azimuth is
+/// `atan2(R[1], R[4])` — the angle, clockwise from magnetic north, that the
+/// device's +Y axis (its "top") points toward. Returns degrees in `[0, 360)`,
+/// or `null` when the vectors are degenerate (free-fall / no usable field).
+///
+/// [ax]/[ay]/[az] is the RAW accelerometer (gravity included, m/s²) — NOT the
+/// gravity-removed `userAccelerometer` the harsh-event detector uses.
+double? azimuthFromVectors(
+  double ax,
+  double ay,
+  double az,
+  double mx,
+  double my,
+  double mz,
+) {
+  // H = M × A  (points device-east), then normalise.
+  final hx = my * az - mz * ay;
+  final hy = mz * ax - mx * az;
+  final hz = mx * ay - my * ax;
+  final normH = sqrt(hx * hx + hy * hy + hz * hz);
+  if (normH < 0.1) return null; // device tilted into the field / free-fall
+  final invH = 1 / normH;
+  final ehx = hx * invH;
+  final ehy = hy * invH;
+  final ehz = hz * invH;
+
+  final normA = sqrt(ax * ax + ay * ay + az * az);
+  if (normA < 0.1) return null;
+  final invA = 1 / normA;
+  final eax = ax * invA;
+  final eaz = az * invA;
+
+  // M (device-north) = A × H, using the normalised vectors; only the
+  // Y component feeds the azimuth.
+  final my2 = eaz * ehx - eax * ehz;
+
+  // azimuth = atan2(R[1], R[4]) = atan2(Hy, My).
+  final deg = atan2(ehy, my2) * 180 / pi;
+  return (deg + 360) % 360;
+}
+
+/// #3364 — exponential low-pass smoother for a *circular* heading (deg), so a
+/// noisy magnetometer doesn't make the scope jitter and the 359°→0° wrap is
+/// handled (filtering the unit vector, not the raw angle). [alpha] in (0,1];
+/// higher = snappier, lower = smoother.
+class CompassSmoother {
+  CompassSmoother({this.alpha = 0.18});
+
+  final double alpha;
+  double? _x;
+  double? _y;
+
+  /// Fold [headingDeg] in and return the smoothed heading in `[0, 360)`.
+  double add(double headingDeg) {
+    final r = headingDeg * pi / 180;
+    final cx = cos(r);
+    final cy = sin(r);
+    _x = _x == null ? cx : _x! + alpha * (cx - _x!);
+    _y = _y == null ? cy : _y! + alpha * (cy - _y!);
+    final out = atan2(_y!, _x!) * 180 / pi;
+    return (out + 360) % 360;
+  }
+
+  /// Smallest absolute difference between two headings, in `[0, 180]`.
+  static double delta(double a, double b) {
+    final d = ((a - b) % 360 + 540) % 360 - 180;
+    return d.abs();
+  }
+}

--- a/lib/core/sensors/imu_sensor_source.dart
+++ b/lib/core/sensors/imu_sensor_source.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 
+import 'compass_heading.dart';
 import 'imu_sample.dart';
 
 part 'imu_sensor_source.g.dart';
@@ -29,6 +30,15 @@ part 'imu_sensor_source.g.dart';
 ImuSensorSource imuSensorSource(Ref ref) {
   return ImuSensorSource();
 }
+
+/// #3364 — the device compass heading (degrees clockwise from magnetic north),
+/// smoothed + throttled. autoDispose: the magnetometer only spins while a
+/// consumer (the radar scope) is on screen, so it costs nothing otherwise.
+/// Degrades to a quiet stream when the device has no magnetometer / the plugin
+/// isn't bound (unit tests), so the scope just falls back to North-up.
+@riverpod
+Stream<double> compassHeading(Ref ref) =>
+    ref.watch(imuSensorSourceProvider).compassHeadingStream();
 
 class ImuSensorSource {
   /// A fused ~50 Hz stream of gravity-removed linear acceleration +
@@ -108,6 +118,83 @@ class ImuSensorSource {
           await gyroSub?.cancel();
         } catch (_) {
           // ignore: silent_catch — A subscription that failed to set up cleanly may also throw on
+          // cancel; nothing to recover.
+        }
+        if (!out.isClosed) await out.close();
+      },
+    );
+    return out.stream;
+  }
+
+  /// #3364 — the device compass heading (degrees clockwise from magnetic
+  /// north), tilt-compensated by fusing the RAW accelerometer (gravity) with
+  /// the magnetometer. Smoothed ([CompassSmoother]) so the scope doesn't
+  /// jitter, and throttled to emit at most ~every [_emitGapMs] and only when
+  /// the heading moved ≥ [_emitDeltaDeg] — bounding the rebuilds the scope does.
+  ///
+  /// Degrades to a quiet stream when the sensors / plugin are unavailable
+  /// (a device with no magnetometer, or a unit-test host), exactly like
+  /// [stream]: the caller then falls back to North-up.
+  Stream<double> compassHeadingStream() {
+    const emitGapMs = 100;
+    const emitDeltaDeg = 1.0;
+    final smoother = CompassSmoother();
+    var lastAx = 0.0, lastAy = 0.0, lastAz = 0.0;
+    var hasAccel = false;
+    double? lastEmit;
+    var lastEmitMs = 0;
+    StreamSubscription<AccelerometerEvent>? accelSub;
+    StreamSubscription<MagnetometerEvent>? magSub;
+
+    // ignore: close_sinks
+    late final StreamController<double> out;
+    out = StreamController<double>(
+      onListen: () {
+        try {
+          // RAW accelerometer (gravity included) — the compass needs the
+          // gravity vector, unlike the harsh-event stream's userAccelerometer.
+          accelSub = accelerometerEventStream(
+            samplingPeriod: SensorInterval.uiInterval,
+          ).listen((e) {
+            lastAx = e.x;
+            lastAy = e.y;
+            lastAz = e.z;
+            hasAccel = true;
+          }, onError: (Object _) {});
+          magSub = magnetometerEventStream(
+            samplingPeriod: SensorInterval.uiInterval,
+          ).listen(
+            (e) {
+              if (out.isClosed || !hasAccel) return;
+              final az =
+                  azimuthFromVectors(lastAx, lastAy, lastAz, e.x, e.y, e.z);
+              if (az == null) return;
+              final heading = smoother.add(az);
+              final nowMs = DateTime.now().millisecondsSinceEpoch;
+              if (lastEmit != null &&
+                  nowMs - lastEmitMs < emitGapMs &&
+                  CompassSmoother.delta(heading, lastEmit!) < emitDeltaDeg) {
+                return;
+              }
+              lastEmit = heading;
+              lastEmitMs = nowMs;
+              out.add(heading);
+            },
+            onError: (Object err, StackTrace st) {
+              if (!out.isClosed) out.addError(err, st);
+            },
+          );
+        } catch (_) {
+          // ignore: silent_catch — magnetometer unavailable; stay quiet so the
+          // scope falls back to North-up rather than crashing.
+        }
+      },
+      onCancel: () async {
+        try {
+          await accelSub?.cancel();
+          await magSub?.cancel();
+        } catch (_) {
+          // ignore: silent_catch — a half-set-up subscription may throw on
           // cancel; nothing to recover.
         }
         if (!out.isClosed) await out.close();

--- a/lib/core/sensors/imu_sensor_source.g.dart
+++ b/lib/core/sensors/imu_sensor_source.g.dart
@@ -96,3 +96,53 @@ final class ImuSensorSourceProvider
 }
 
 String _$imuSensorSourceHash() => r'0df5d3689f54a0056b9cd4adf97a0146aa3ee606';
+
+/// #3364 — the device compass heading (degrees clockwise from magnetic north),
+/// smoothed + throttled. autoDispose: the magnetometer only spins while a
+/// consumer (the radar scope) is on screen, so it costs nothing otherwise.
+/// Degrades to a quiet stream when the device has no magnetometer / the plugin
+/// isn't bound (unit tests), so the scope just falls back to North-up.
+
+@ProviderFor(compassHeading)
+final compassHeadingProvider = CompassHeadingProvider._();
+
+/// #3364 — the device compass heading (degrees clockwise from magnetic north),
+/// smoothed + throttled. autoDispose: the magnetometer only spins while a
+/// consumer (the radar scope) is on screen, so it costs nothing otherwise.
+/// Degrades to a quiet stream when the device has no magnetometer / the plugin
+/// isn't bound (unit tests), so the scope just falls back to North-up.
+
+final class CompassHeadingProvider
+    extends $FunctionalProvider<AsyncValue<double>, double, Stream<double>>
+    with $FutureModifier<double>, $StreamProvider<double> {
+  /// #3364 — the device compass heading (degrees clockwise from magnetic north),
+  /// smoothed + throttled. autoDispose: the magnetometer only spins while a
+  /// consumer (the radar scope) is on screen, so it costs nothing otherwise.
+  /// Degrades to a quiet stream when the device has no magnetometer / the plugin
+  /// isn't bound (unit tests), so the scope just falls back to North-up.
+  CompassHeadingProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'compassHeadingProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$compassHeadingHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<double> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<double> create(Ref ref) {
+    return compassHeading(ref);
+  }
+}
+
+String _$compassHeadingHash() => r'3c0e3dcfe8d0ece12ec1353e1cce953ba095728b';

--- a/lib/features/search/presentation/widgets/radar_scope_view.dart
+++ b/lib/features/search/presentation/widgets/radar_scope_view.dart
@@ -4,9 +4,11 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
+import '../../../../core/sensors/imu_sensor_source.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/station_extensions.dart';
 import 'radar_scope_geometry.dart';
@@ -18,9 +20,15 @@ import 'radar_scope_geometry.dart';
 ///
 /// #3354 — the scope shows the PRICE for the active fuel type instead of a bare
 /// dot (overlapping chips collapse to the cheapest), the cheapest in view is
-/// highlighted, and the whole scope orients HEADING-UP: a station ahead of the
-/// driver sits at the top. Falls back to North-up when no course is known.
-class RadarScopeView extends StatefulWidget {
+/// highlighted, and the whole scope orients HEADING-UP: the direction you face
+/// is at the top.
+///
+/// #3364 — the orientation now follows the DEVICE COMPASS
+/// ([compassHeadingProvider], magnetometer) so it tracks the phone pointing in
+/// different directions even at a standstill — a real radar. GPS course
+/// ([gpsCourseDeg]) is the fallback when no compass is available (it only
+/// exists while moving), and North-up the last resort.
+class RadarScopeView extends ConsumerStatefulWidget {
   const RadarScopeView({
     super.key,
     required this.stations,
@@ -28,7 +36,7 @@ class RadarScopeView extends StatefulWidget {
     required this.centerLng,
     required this.rangeKm,
     required this.fuelType,
-    this.headingDeg,
+    this.gpsCourseDeg,
     this.onStationTap,
   });
 
@@ -40,9 +48,9 @@ class RadarScopeView extends StatefulWidget {
   /// Active fuel type — the price shown per station (#3354).
   final FuelType fuelType;
 
-  /// Live GPS course (deg clockwise from North); when non-null the scope
-  /// rotates so this direction points up. Null → North-up (#3354).
-  final double? headingDeg;
+  /// Live GPS course (deg clockwise from North) — the FALLBACK orientation when
+  /// the device has no compass reading yet. Null → North-up (#3364).
+  final double? gpsCourseDeg;
 
   final void Function(Station station)? onStationTap;
 
@@ -55,10 +63,10 @@ class RadarScopeView extends StatefulWidget {
   static const double clusterSeparation = 0.18;
 
   @override
-  State<RadarScopeView> createState() => _RadarScopeViewState();
+  ConsumerState<RadarScopeView> createState() => _RadarScopeViewState();
 }
 
-class _RadarScopeViewState extends State<RadarScopeView>
+class _RadarScopeViewState extends ConsumerState<RadarScopeView>
     with SingleTickerProviderStateMixin {
   late final AnimationController _sweep = AnimationController(
     vsync: this,
@@ -95,7 +103,10 @@ class _RadarScopeViewState extends State<RadarScopeView>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final blips = _blips();
-    final heading = widget.headingDeg ?? 0;
+    // #3364 — compass-first (tracks the phone pointing), GPS course as the
+    // fallback (driving), North-up the last resort.
+    final heading =
+        ref.watch(compassHeadingProvider).value ?? widget.gpsCourseDeg ?? 0;
     // The cheapest priced station in view — highlighted on the scope.
     double? cheapest;
     for (final b in blips) {

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -112,7 +112,7 @@ class SearchResultsContent extends ConsumerWidget {
                 centerLng: userPos.lng,
                 rangeKm: ref.watch(searchRadiusProvider),
                 fuelType: ref.watch(selectedFuelTypeProvider),
-                headingDeg: radar.heading,
+                gpsCourseDeg: radar.heading,
                 onStationTap: (s) =>
                     unawaited(StationDetailRoute(s.id).push<void>(context)),
               ),

--- a/test/core/sensors/compass_heading_test.dart
+++ b/test/core/sensors/compass_heading_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sensors/compass_heading.dart';
+
+/// #3364 — the tilt-compensated compass azimuth math + circular smoother.
+/// Phone held flat (gravity on +Z); the magnetometer's horizontal component
+/// points toward magnetic north (with a downward dip in the N hemisphere).
+void main() {
+  const g = 9.81;
+
+  group('azimuthFromVectors', () {
+    test('flat phone, field toward +Y (top) → ~0° (north)', () {
+      final az = azimuthFromVectors(0, 0, g, 0, 30, -40);
+      expect(az, isNotNull);
+      expect(CompassSmoother.delta(az!, 0), lessThan(1));
+    });
+
+    test('flat phone rotated so the top faces east → ~90°', () {
+      // North is now to the device's left (−X).
+      final az = azimuthFromVectors(0, 0, g, -30, 0, -40);
+      expect(CompassSmoother.delta(az!, 90), lessThan(1));
+    });
+
+    test('flat phone, top faces south → ~180°', () {
+      final az = azimuthFromVectors(0, 0, g, 0, -30, -40);
+      expect(CompassSmoother.delta(az!, 180), lessThan(1));
+    });
+
+    test('flat phone, top faces west → ~270°', () {
+      final az = azimuthFromVectors(0, 0, g, 30, 0, -40);
+      expect(CompassSmoother.delta(az!, 270), lessThan(1));
+    });
+
+    test('degenerate gravity → null', () {
+      expect(azimuthFromVectors(0, 0, 0, 0, 30, -40), isNull);
+    });
+
+    test('always in [0,360)', () {
+      final az = azimuthFromVectors(0, 0, g, 0, -1, -40);
+      expect(az, inInclusiveRange(0, 360));
+      expect(az, lessThan(360));
+    });
+  });
+
+  group('CompassSmoother', () {
+    test('converges toward a constant heading', () {
+      final s = CompassSmoother(alpha: 0.5);
+      double out = 0;
+      for (var i = 0; i < 40; i++) {
+        out = s.add(120);
+      }
+      expect(CompassSmoother.delta(out, 120), lessThan(0.5));
+    });
+
+    test('handles the 360→0 wrap (averages 350 & 10 near 0, not 180)', () {
+      final s = CompassSmoother(alpha: 0.5);
+      s.add(350);
+      final out = s.add(10);
+      // Must be near 0/360, never near 180.
+      expect(CompassSmoother.delta(out, 0), lessThan(20));
+    });
+
+    test('delta is the shortest circular distance', () {
+      expect(CompassSmoother.delta(350, 10), closeTo(20, 0.001));
+      expect(CompassSmoother.delta(10, 350), closeTo(20, 0.001));
+      expect(CompassSmoother.delta(0, 180), closeTo(180, 0.001));
+      expect(CompassSmoother.delta(90, 90), 0);
+    });
+  });
+}

--- a/test/features/search/presentation/widgets/radar_scope_view_test.dart
+++ b/test/features/search/presentation/widgets/radar_scope_view_test.dart
@@ -95,7 +95,8 @@ void main() {
             centerLng: 13.0,
             rangeKm: 20,
             fuelType: FuelType.e10,
-            headingDeg: 90, // driving east → North rotates to the left
+            // No compass override in tests → falls back to this GPS course.
+            gpsCourseDeg: 90, // driving east → North rotates to the left
             onStationTap: (s) => tapped = s,
           ),
         ),


### PR DESCRIPTION
Closes #3364.

Field screenshots ("Stop & go", minutes apart) showed the radar scope frozen **North-up** no matter which way the phone pointed. The heading-up rotation (#3354) was driven by **GPS course-over-ground**, which only exists while *moving* — at a standstill it's null, so the scope never rotates. A real radar tracks where the **device** points: the magnetometer.

- `compass_heading.dart` — pure tilt-compensated azimuth (raw accelerometer + magnetometer, Android `getRotationMatrix`/`getOrientation` math) + a circular low-pass `CompassSmoother`. Unit-tested (N/E/S/W, degenerate, 360→0 wrap).
- `ImuSensorSource.compassHeadingStream()` (the single `sensors_plus` site) — fuses raw accel + magnetometer, smooths + throttles (~10 Hz, ≥1° change). `compassHeadingProvider` is **autoDispose**: the magnetometer only spins while the scope is on screen.
- `RadarScopeView` watches the compass heading; GPS course (`gpsCourseDeg`) is the fallback (mounted/driving), North-up the last resort. Handheld phone now rotates the scope as you turn; a driving phone still gets forward-up.

Declination (~0–2° in France) left uncorrected for v1. **Sensor stream needs on-device validation** (CI can't exercise the magnetometer); the azimuth math is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
