### PR TITLE
feat(radar): compact radar-scope toggle icon, replacing the big 'Radar view' button (#3366)

### DIFF
--- a/lib/features/search/presentation/widgets/header_icon_button.dart
+++ b/lib/features/search/presentation/widgets/header_icon_button.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_radius.dart';
+
+/// #3366 — a small primary-tinted icon button used in the search-results
+/// header row (list/map view, radar-scope toggle, fuel calculator). Extracted
+/// so the three siblings share one definition (and the [AppRadius] token)
+/// instead of repeating the Semantics + InkWell + Padding + Icon scaffold.
+class HeaderIconButton extends StatelessWidget {
+  const HeaderIconButton({
+    super.key,
+    required this.icon,
+    required this.semanticsLabel,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String semanticsLabel;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: AppRadius.lg,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          child: Icon(icon,
+              size: 18, color: Theme.of(context).colorScheme.primary),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -89,32 +89,51 @@ class SearchResultsContent extends ConsumerWidget {
             source: ServiceSource.cache,
             fetchedAt: DateTime.now(),
           );
-          final list = SearchResultsList(
-            result: radarResult,
-            onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
-          );
           // #3342 — a second visualization of the SAME station set: a green
-          // PPI radar scope (rotating sweep + a blip per station by distance
-          // and bearing). The toggle only swaps the view, it never re-scans,
-          // and is only offered when we have a usable centre to place blips
-          // around. Defaults to the list.
+          // PPI radar scope (rotating sweep + a chip per station by distance
+          // and bearing). The toggle only swaps the view, never re-scans, and
+          // is offered only when we have a usable centre to place blips around.
+          // #3366 — the toggle is now a small icon: into the list's header
+          // (next to list/map), and a "back to list" icon on the scope itself,
+          // replacing the space-hungry "Radar view" text button.
           final scopeMode = ref.watch(radarScopeModeProvider);
           final userPos = ref.watch(userPositionProvider);
           final canScope =
               userPos != null && isUsableCoord(userPos.lat, userPos.lng);
+          void toggleScope() =>
+              ref.read(radarScopeModeProvider.notifier).toggle();
+          final list = SearchResultsList(
+            result: radarResult,
+            onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
+            onRadarToggle: canScope ? toggleScope : null,
+          );
           final Widget body;
           if (scopeMode && canScope) {
             body = SingleChildScrollView(
               padding: const EdgeInsets.all(16),
-              child: RadarScopeView(
-                stations: stations,
-                centerLat: userPos.lat,
-                centerLng: userPos.lng,
-                rangeKm: ref.watch(searchRadiusProvider),
-                fuelType: ref.watch(selectedFuelTypeProvider),
-                gpsCourseDeg: radar.heading,
-                onStationTap: (s) =>
-                    unawaited(StationDetailRoute(s.id).push<void>(context)),
+              child: Stack(
+                children: [
+                  RadarScopeView(
+                    stations: stations,
+                    centerLat: userPos.lat,
+                    centerLng: userPos.lng,
+                    rangeKm: ref.watch(searchRadiusProvider),
+                    fuelType: ref.watch(selectedFuelTypeProvider),
+                    gpsCourseDeg: radar.heading,
+                    onStationTap: (s) =>
+                        unawaited(StationDetailRoute(s.id).push<void>(context)),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton.filledTonal(
+                      key: const Key('radar_view_to_list'),
+                      tooltip: l10n.radarScopeShowList,
+                      icon: const Icon(Icons.list, size: 20),
+                      onPressed: toggleScope,
+                    ),
+                  ),
+                ],
               ),
             );
           } else {
@@ -126,7 +145,6 @@ class SearchResultsContent extends ConsumerWidget {
           // lands and the list re-ranks.
           return Column(
             children: [
-              if (canScope) _RadarViewToggle(scopeMode: scopeMode),
               if (radar.locating)
                 _RadarUpdatingBanner(message: l10n.radarUpdatingLocation),
               Expanded(child: body),
@@ -182,34 +200,6 @@ class SearchResultsContent extends ConsumerWidget {
         stackTrace: stackTrace,
         searchContext:
             'Station search (${ref.read(selectedFuelTypeProvider).apiValue})',
-      ),
-    );
-  }
-}
-
-/// #3342 — a right-aligned button toggling the radar results between the
-/// distance-sorted list and the green PPI radar-scope view. Only shown when a
-/// usable centre exists (so the scope can place blips). Reads the toggle so its
-/// icon/label reflect the current view.
-class _RadarViewToggle extends ConsumerWidget {
-  const _RadarViewToggle({required this.scopeMode});
-
-  final bool scopeMode;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context);
-    final label = scopeMode ? l10n.radarScopeShowList : l10n.radarScopeShowScope;
-    return Align(
-      alignment: Alignment.centerRight,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: TextButton.icon(
-          key: const Key('radar_view_toggle'),
-          onPressed: () => ref.read(radarScopeModeProvider.notifier).toggle(),
-          icon: Icon(scopeMode ? Icons.list : Icons.radar, size: 20),
-          label: Text(label),
-        ),
       ),
     );
   }

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/widgets/responsive_layout.dart';
 import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/service_result.dart';
+import 'header_icon_button.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/price_utils.dart';
@@ -52,10 +53,17 @@ class SearchResultsList extends ConsumerStatefulWidget {
   final ServiceResult<List<SearchResultItem>> result;
   final VoidCallback onRefresh;
 
+  /// #3366 — when non-null, a small radar-scope toggle icon appears in the
+  /// header next to the list/map icons (the Fuel Station Radar is active and a
+  /// usable centre exists). Tapping it switches to the PPI radar-scope view.
+  /// Null for an ordinary search (no scope to offer).
+  final VoidCallback? onRadarToggle;
+
   const SearchResultsList({
     super.key,
     required this.result,
     required this.onRefresh,
+    this.onRadarToggle,
   });
 
   @override
@@ -127,59 +135,44 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
               ),
               _ViewToggleButton(),
               const SizedBox(width: 4),
-              Semantics(
-                label: l10n.showOnMapSemanticLabel,
-                button: true,
-                child: InkWell(
-                  onTap: () => context.go(RoutePaths.map),
-                  borderRadius: BorderRadius.circular(12),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                    child: Icon(Icons.map, size: 18,
-                        color: Theme.of(context).colorScheme.primary),
-                  ),
-                ),
+              HeaderIconButton(
+                icon: Icons.map,
+                semanticsLabel: l10n.showOnMapSemanticLabel,
+                onTap: () => context.go(RoutePaths.map),
               ),
               const SizedBox(width: 4),
-              // #2682 — the Fuel Station Radar launch affordance moved out of
-              // this header (the cramped #2675 IconButton) to a "Start
-              // recording"-style extended-FAB pill (`RadarSearchFab`) floated
-              // bottom-right by the search screen, clear of the central search
-              // FAB + bottom nav.
-              // #1613 — gated entry point for the fuel-cost Calculator.
-              // The /calculator route exists but had no navigation entry
-              // point anywhere in lib/; this affordance makes it
-              // reachable when Feature.fuelCalculator is enabled.
+              // #3366 — compact radar-scope toggle, sat with the list/map view
+              // icons (replaces the space-hungry "Radar view" text button).
+              // Only present when the caller offers it (radar active + usable
+              // centre).
+              if (widget.onRadarToggle != null) ...[
+                HeaderIconButton(
+                  key: const Key('radar_view_toggle'),
+                  icon: Icons.radar,
+                  semanticsLabel: l10n.radarScopeShowScope,
+                  onTap: widget.onRadarToggle!,
+                ),
+                const SizedBox(width: 4),
+              ],
+              // #2682 — the radar LAUNCH affordance is a bottom-right FAB
+              // (`RadarSearchFab`), not here. #1613 — gated fuel-cost
+              // Calculator entry point (#2543 pre-fills the cheapest price).
               if (ref
                   .watch(enabledFeaturesProvider)
                   .contains(Feature.fuelCalculator)) ...[
-                Semantics(
-                  label: l10n.fuelCostCalculator,
-                  button: true,
-                  child: InkWell(
-                    // #2543 — carry the cheapest visible price for the
-                    // selected fuel into the calculator so it opens
-                    // pre-filled. Null when no station has a price.
-                    onTap: () {
-                      final fuel = ref.read(selectedFuelTypeProvider);
-                      final (minP, _) = priceRange(
-                        _fuelStationsFrom(result.data),
-                        fuel,
-                        requirePositive: true,
-                      );
-                      CalculatorRoute(
-                        initialPrice: minP > 0 ? minP : null,
-                      ).go(context);
-                    },
-                    borderRadius: BorderRadius.circular(12),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 6, vertical: 2),
-                      child: Icon(Icons.calculate,
-                          size: 18,
-                          color: Theme.of(context).colorScheme.primary),
-                    ),
-                  ),
+                HeaderIconButton(
+                  icon: Icons.calculate,
+                  semanticsLabel: l10n.fuelCostCalculator,
+                  onTap: () {
+                    final fuel = ref.read(selectedFuelTypeProvider);
+                    final (minP, _) = priceRange(
+                      _fuelStationsFrom(result.data),
+                      fuel,
+                      requirePositive: true,
+                    );
+                    CalculatorRoute(initialPrice: minP > 0 ? minP : null)
+                        .go(context);
+                  },
                 ),
                 const SizedBox(width: 4),
               ],


### PR DESCRIPTION
Closes #3366.

The full-width "Radar view" text button (#3342) took a whole row above the results. Replaced with:
- a small **radar icon** in the `SearchResultsList` header next to the list/map view icons (only when the radar is active + a usable centre exists), and
- a small **"back to list" icon** on the scope view itself.

Same list↔scope toggle, no wasted vertical space. The repeated map/calculator/radar icon scaffold is extracted to a shared `HeaderIconButton` (routes all three through the `AppRadius` token — also drops the inline-border-radius count). Reuses the existing `radarScopeShowScope`/`radarScopeShowList` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)