### PR TITLE
fix(consumption): suppress phantom harsh events on virtual-distance trips (#3368)

### DIFF
--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -92,6 +92,7 @@ const int _topN = 3;
 List<DrivingInsight> analyzeTrip(
   List<TripSample> samples, {
   int? enginePowerKw,
+  bool suppressSpeedHarsh = false,
 }) {
   if (samples.length < 2) return const [];
 
@@ -110,6 +111,9 @@ List<DrivingInsight> analyzeTrip(
 
   // Hard-accel EPISODES via the ONE shared gate (#2667) — same count the
   // harsh detector, the score, and the GPS features report.
+  // #3368 — suppress harsh-event derivation for a `virtual` dead-reckoning
+  // trip (its quantised speed manufactures phantom events), matching the score
+  // + the recorder's HarshEventDetector so the lesson agrees.
   final accelCounts = countAccelEvents([
     for (final s in sorted)
       AccelSamplePoint(
@@ -117,7 +121,7 @@ List<DrivingInsight> analyzeTrip(
         speedKmh: s.speedKmh,
         hAccuracyM: s.hAccuracyM,
       ),
-  ]);
+  ], suppress: suppressSpeedHarsh);
   final hardAccelEvents = accelCounts.accelEvents;
   final hardAccelTotalDt = accelCounts.accelSeconds;
 

--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -157,6 +157,7 @@ DrivingScore computeDrivingScore(
   int? hardAccelEventsOverride,
   int? hardBrakeEventsOverride,
   int? enginePowerKw,
+  bool suppressSpeedHarsh = false,
 }) {
   if (samples.length < 2) return DrivingScore.perfect;
 
@@ -179,6 +180,11 @@ DrivingScore computeDrivingScore(
   // the score agrees with the harsh detector, the insights, and the GPS
   // features on what counts as a single physical event (the accumulator no
   // longer over-counts a multi-interval manoeuvre once per interval).
+  // #3368 — a `virtual` dead-reckoning trip has a 1 km/h-quantised speed whose
+  // derivative manufactures phantom harsh events; the recorder already
+  // suppresses its HarshEventDetector for it, so suppress the score's gate too
+  // rather than re-deriving the same artefacts (23/23 phantom events, field
+  // export). GPS-Doppler trips stay enabled-but-gated (accuracy + plausibility).
   final accelCounts = countAccelEvents([
     for (final s in sorted)
       AccelSamplePoint(
@@ -186,7 +192,7 @@ DrivingScore computeDrivingScore(
         speedKmh: s.speedKmh,
         hAccuracyM: s.hAccuracyM,
       ),
-  ]);
+  ], suppress: suppressSpeedHarsh);
 
   // #2695 C9 — source-aware re-weight. A GPS-only / degraded trip carries
   // no engine signal (every sample's rpm is null, #2692 C4-G), so the

--- a/lib/features/consumption/data/lessons/driving_lesson_registry.dart
+++ b/lib/features/consumption/data/lessons/driving_lesson_registry.dart
@@ -105,8 +105,13 @@ class DrivingLessonRegistry {
       LessonContext(
         summary: summary,
         samples: samples,
-        score: score ?? computeDrivingScore(samples),
-        insights: insights ?? analyzeTrip(samples),
+        // #3368 — a virtual dead-reckoning trip's quantised speed manufactures
+        // phantom harsh events; suppress them in the fallback score + insights.
+        score: score ??
+            computeDrivingScore(samples,
+                suppressSpeedHarsh: summary.isVirtualSource),
+        insights: insights ??
+            analyzeTrip(samples, suppressSpeedHarsh: summary.isVirtualSource),
       ),
       l,
     );

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -38,6 +38,14 @@ class TripSummary {
   /// trips before this flag landed keep that honest label.
   final String distanceSource;
 
+  /// #3368 — true for a `virtual` (dead-reckoning odometer) trip, whose
+  /// 1 km/h-quantised speed manufactures phantom harsh-accel/brake events when
+  /// differentiated. Score + lessons suppress speed-derived harsh events for
+  /// it (mirrors the recorder's HarshEventDetector). Literal mirrors
+  /// `kDistanceSourceVirtual` (kept local to avoid a domain→obd2 import; same
+  /// value as this field's own default above).
+  bool get isVirtualSource => distanceSource == 'virtual';
+
   /// Whether this trip likely paid a cold-start fuel surcharge
   /// (#1262 phase 2). Flipped true when the coolant temperature
   /// telemetry suggests the engine was warming up for a meaningful

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -136,7 +136,11 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // vehicle's engine power (a small engine wastes proportionally more for
     // the same hard pull). Trips aren't tagged with a vehicle, so the
     // currently-active profile is the source; null power → unchanged.
-    return analyzeTrip(tripSamples, enginePowerKw: _activeEnginePowerKw());
+    // #3368 — a virtual dead-reckoning trip's quantised speed manufactures
+    // phantom harsh events; suppress them in the lessons just like the score.
+    return analyzeTrip(tripSamples,
+        enginePowerKw: _activeEnginePowerKw(),
+        suppressSpeedHarsh: widget.entry.summary.isVirtualSource);
   }
 
   /// The active vehicle's engine power (kW) for the power-aware hard-accel
@@ -181,6 +185,9 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
       hardAccelEventsOverride: useImu ? summary.harshAccelerations : null,
       hardBrakeEventsOverride: useImu ? summary.harshBrakes : null,
       enginePowerKw: _activeEnginePowerKw(),
+      // #3368 — suppress the noisy virtual-odometer speed derivative (phantom
+      // harsh events) unless the IMU supplied real counts above.
+      suppressSpeedHarsh: summary.isVirtualSource,
     );
   }
 

--- a/test/accessibility/icon_button_tooltip_coverage_test.dart
+++ b/test/accessibility/icon_button_tooltip_coverage_test.dart
@@ -21,7 +21,13 @@ void main() {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
       final src = entity.readAsStringSync();
 
-      for (final match in RegExp(r'IconButton\s*\(').allMatches(src)) {
+      // #3375 — a LEFT word-boundary so a custom widget whose name merely ENDS
+      // in "IconButton" (e.g. `HeaderIconButton(`) is not false-matched as the
+      // Material `IconButton(`. Real `IconButton(` is always preceded by a
+      // non-identifier char ((, space, comma, =, return…); a preceding letter/
+      // digit/_ means it's a different widget.
+      for (final match
+          in RegExp(r'(?<![A-Za-z0-9_])IconButton\s*\(').allMatches(src)) {
         final start = match.start;
         final int openParen = src.indexOf('(', start);
         int depth = 0;

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -151,6 +151,26 @@ void main() {
       expect(overridden.hardAccelEvents, 2);
     });
 
+    test('#3368 — suppressSpeedHarsh zeroes the speed-derived harsh events '
+        '(virtual dead-reckoning trip)', () {
+      // The SAME 5 hard-accel manoeuvres that cap the penalty above…
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2500));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      // …vanish when the speed signal is unfit (virtual odometer).
+      final suppressed = computeDrivingScore(samples, suppressSpeedHarsh: true);
+      expect(suppressed.hardAccelPenalty, 0);
+      expect(suppressed.hardAccelEvents, 0);
+      expect(suppressed.hardBrakePenalty, 0);
+    });
+
     test('hardAccelPenalty caps at 15 even with 10 events', () {
       var t = start;
       final samples = <TripSample>[];

--- a/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
+++ b/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
@@ -39,6 +39,9 @@ void main() {
         idleSeconds: 0,
         harshBrakes: 0,
         harshAccelerations: 0,
+        // #3368 — a GPS trip (not the `virtual` default), so its GPS-derived
+        // harsh events are NOT suppressed and the hard-accel lesson still fires.
+        distanceSource: 'gps',
         secondsBelowOptimalGear: secondsBelowOptimalGear,
       );
 
@@ -317,6 +320,7 @@ void main() {
         harshBrakes: 0,
         harshAccelerations: 2, // IMU-preferred count (#2895)
         kind: TripKind.gpsOnly,
+        distanceSource: 'gps', // #3368 — GPS trip, harsh events not suppressed
         imuHardAccelCount: 2,
         imuActive: true,
       );
@@ -339,6 +343,7 @@ void main() {
         harshBrakes: 0,
         harshAccelerations: 2, // ignored — IMU did not run
         kind: TripKind.gpsOnly,
+        distanceSource: 'gps', // #3368 — GPS trip, harsh events not suppressed
         imuActive: false,
       );
       final reg = DrivingLessonRegistry.standard();


### PR DESCRIPTION
Closes #3368.

A field export (9 km / 31 min, `distanceSource: "virtual"`) scored **23 hard accels + 23 hard brakes** (both penalties capped at 15) with a *"23 accélérations brusques: 2.1 L gaspillés"* lesson — phantom events from the 1 km/h-quantised dead-reckoning speed being differentiated.

The shared accel-event gate already supports `suppress: true` for exactly this (the recorder's `HarshEventDetector` passes it for `virtual`/`gps`), but `computeDrivingScore` + `analyzeTrip` called `countAccelEvents(...)` **without** it — re-deriving the artefacts in the score and lessons.

- Thread `suppressSpeedHarsh` through `computeDrivingScore` + `analyzeTrip` → `countAccelEvents(suppress:)`.
- The trip-detail score/insights calls + the lesson registry pass it for a virtual trip via the new `TripSummary.isVirtualSource`.
- GPS-Doppler trips stay enabled-but-gated (accuracy + plausibility ceilings unchanged).

Regression test: the same 5 manoeuvres that cap the penalty drop to 0 events/penalty under `suppressSpeedHarsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
