### PR TITLE
fix(reliability): settings write-after-close crash, alerts UUID 22P02, Luxembourg detail-unavailable noise (#3370)

### DIFF
--- a/lib/core/services/station_api_failure_log.dart
+++ b/lib/core/services/station_api_failure_log.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../error/exceptions.dart';
+import '../logging/error_logger.dart';
+import '../telemetry/collectors/breadcrumb_collector.dart';
+
+/// #3370 — classify a station-service API failure for logging.
+///
+/// An `unsupported` [ApiException] is an EXPECTED, permanent capability gap (a
+/// country whose regulated-prices feed exposes no per-station detail, e.g.
+/// Luxembourg — `throwDetailUnavailable`), not an outage. Breadcrumb it instead
+/// of ERROR-logging it on every detail tap (recurring field noise). Any other
+/// failure is a real fault and keeps the #2296 error trace (with its stack).
+void logStationApiFailure(
+  Object error,
+  StackTrace stackTrace, {
+  required String countryCode,
+  required String cacheKey,
+}) {
+  if (error is ApiException && error.kind == FailureKind.unsupported) {
+    BreadcrumbCollector.add(
+      'service: detail unavailable ($countryCode)',
+      detail: error.toString(),
+    );
+    return;
+  }
+  unawaited(errorLogger.log(ErrorLayer.services, error, stackTrace, context: {
+    'where': 'StationServiceChain.apiCall',
+    'country': countryCode,
+    'key': cacheKey,
+  }));
+}

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -11,12 +11,12 @@ import '../domain/station.dart';
 import '../background/provider_request_budget.dart';
 import '../cache/cache_manager.dart';
 import '../error/exceptions.dart';
-import '../logging/error_logger.dart';
 import 'diagnostics/data_access_event.dart';
 import 'diagnostics/data_access_recorder.dart';
 import 'fuel_service_policy.dart';
 import 'mixins/station_service_helpers.dart';
 import 'service_result.dart';
+import 'station_api_failure_log.dart';
 import 'station_failure_classifier.dart';
 import 'station_service.dart';
 import 'station_service_chain_codec.dart';
@@ -207,13 +207,9 @@ class StationServiceChain implements StationService {
       return result;
     } on Exception catch (e, st) {
       recordDataAccessFailure(countryCode); // #3146 — always-on tally
-      // #2296 — log the API-failure path (stack was previously discarded)
-      // so a sustained upstream outage leaves a breadcrumb. Non-fatal.
-      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
-        'where': 'StationServiceChain.apiCall',
-        'country': countryCode,
-        'key': cacheKey,
-      }));
+      // #3370/#2296 — breadcrumb an EXPECTED `unsupported` gap (e.g. Luxembourg
+      // has no per-station detail); ERROR-log any real failure (with stack).
+      logStationApiFailure(e, st, countryCode: countryCode, cacheKey: cacheKey);
       errors.add(ServiceError(
         source: _errorSource,
         message: e.toString(),

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -135,8 +135,16 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   dynamic getSetting(String key) => _settings.get(key);
 
   @override
-  Future<void> putSetting(String key, dynamic value) =>
-      _settings.put(key, value);
+  Future<void> putSetting(String key, dynamic value) async {
+    // #3370 — best-effort: a settings write racing app teardown (the box is
+    // already closed — e.g. a fire-and-forget `markKnownGood` during an OBD2
+    // disconnect at shutdown) must NOT throw an uncaught
+    // `FileSystemException: File closed` to PlatformDispatcher.onError. The
+    // value is simply dropped — the app is going away. This is the root of the
+    // recurring "File closed, settings.hive" field reports.
+    if (!Hive.isBoxOpen(HiveBoxes.settings)) return;
+    await _settings.put(key, value);
+  }
 
   // Setup completion — tracks whether the onboarding wizard has been completed
   // or explicitly skipped. Must NOT depend on hasApiKey() because the bundled

--- a/lib/core/sync/alerts_sync.dart
+++ b/lib/core/sync/alerts_sync.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import '../../features/alerts/data/models/price_alert.dart';
+import '../telemetry/collectors/breadcrumb_collector.dart';
 import '../utils/json_extensions.dart';
 import 'entity_sync.dart';
 import 'sync_transport.dart';
@@ -66,11 +67,40 @@ class AlertsSync {
   /// deleted alert can't resurrect through the launch pull or another
   /// device's still-local copy (#3121, same seam as favorites #3078).
   /// [transport] is injectable for tests.
+  /// #3370 — the `alerts.id` column is a Postgres `uuid`, but two creation
+  /// paths historically minted non-UUID ids (a `stationId_fuel_ts` composite
+  /// in the create-alert dialog; the bare station id in the station-info
+  /// section), so syncing them hit `22P02 invalid input syntax for type uuid`
+  /// on every merge (recurring field reports). Such alerts can never round-trip
+  /// to Supabase, so partition them out of the SERVER sync and keep them
+  /// local-only — the user still sees them; they simply don't sync until they
+  /// carry a valid UUID. No data loss (they were erroring, not syncing).
+  static final RegExp _uuidPattern = RegExp(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+    r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+  );
+
   static Future<List<PriceAlert>> merge(
     List<PriceAlert> localAlerts, {
     SyncTransport? transport,
-  }) =>
-      _sync.merge(localAlerts, transport: transport);
+  }) async {
+    final syncable = <PriceAlert>[];
+    final localOnly = <PriceAlert>[];
+    for (final a in localAlerts) {
+      (_uuidPattern.hasMatch(a.id) ? syncable : localOnly).add(a);
+    }
+    if (localOnly.isNotEmpty) {
+      BreadcrumbCollector.add(
+        'alerts sync: ${localOnly.length} alert(s) kept local — non-UUID id',
+        detail: 'legacy station/composite ids cannot round-trip the uuid '
+            'column (#3370); they stay on this device.',
+      );
+    }
+    final merged = await _sync.merge(syncable, transport: transport);
+    // Union: server-merged UUID alerts + the local-only non-UUID ones, so the
+    // user keeps seeing every alert regardless of whether it can sync.
+    return [...merged, ...localOnly];
+  }
 
   /// Delete a single alert row from the server and tombstone the id
   /// (#3121). Called only when the user explicitly removes an alert on

--- a/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
+++ b/lib/features/alerts/presentation/widgets/create_alert_dialog.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
 import '../../background/fuel_price_fields.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/utils/price_formatter.dart';
@@ -185,7 +186,11 @@ class _CreateAlertDialogState extends State<CreateAlertDialog> {
     final price = double.parse(_priceController.text.replaceAll(',', '.'));
 
     final alert = PriceAlert(
-      id: '${widget.stationId}_${_selectedFuelType.apiValue}_${DateTime.now().millisecondsSinceEpoch}',
+      // #3370 — a real UUID so the alert round-trips the Supabase `alerts.id`
+      // uuid column. The old `stationId_fuel_ts` composite failed sync with
+      // 22P02 (the id is just an identifier — stationId/fuelType live in their
+      // own fields — so a uuid is a safe swap).
+      id: const Uuid().v4(),
       stationId: widget.stationId,
       stationName: widget.stationName,
       fuelType: _selectedFuelType,

--- a/test/core/sync/alerts_sync_test.dart
+++ b/test/core/sync/alerts_sync_test.dart
@@ -35,5 +35,29 @@ void main() {
       final result = await AlertsSync.merge(const <PriceAlert>[]);
       expect(result, isEmpty);
     });
+
+    test('#3370 — a non-UUID (legacy) alert is KEPT local-only, never dropped',
+        () async {
+      final uuidAlert = PriceAlert(
+        id: '11111111-1111-4111-8111-111111111111',
+        stationId: 'st-1',
+        stationName: 'UUID Station',
+        fuelType: FuelType.e10,
+        targetPrice: 1.70,
+        createdAt: DateTime(2026, 4, 21),
+      );
+      final legacy = PriceAlert(
+        id: 'st-2_e10_1718000000000', // old composite id — not a uuid
+        stationId: 'st-2',
+        stationName: 'Legacy Station',
+        fuelType: FuelType.e10,
+        targetPrice: 1.65,
+        createdAt: DateTime(2026, 4, 21),
+      );
+      final result = await AlertsSync.merge([uuidAlert, legacy]);
+      // Both survive the merge — the legacy non-UUID alert can't sync to the
+      // uuid column, but it must stay visible on this device (#3370).
+      expect(result.map((a) => a.id), containsAll([uuidAlert.id, legacy.id]));
+    });
   });
 }

--- a/test/features/alerts/presentation/widgets/create_alert_dialog_test.dart
+++ b/test/features/alerts/presentation/widgets/create_alert_dialog_test.dart
@@ -186,8 +186,15 @@ void main() {
       expect(returned!.stationName, 'Shell 42');
       expect(returned!.fuelType, FuelType.diesel);
       expect(returned!.targetPrice, 1.500);
-      expect(returned!.id, contains('shell-42'));
-      expect(returned!.id, contains(FuelType.diesel.apiValue));
+      // #3370 — the id is now a UUID (so it round-trips the Supabase uuid
+      // column); the station + fuel live in their own fields, not the id.
+      expect(
+        returned!.id,
+        matches(RegExp(
+          r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+          r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+        )),
+      );
     });
 
     testWidgets('Cancel returns null', (tester) async {


### PR DESCRIPTION
Closes #3370. Three recurring error-log offenders from field exports:

1. **`FileSystemException: File closed` on `settings.hive`** (~37×) — a fire-and-forget settings write (e.g. `markKnownGood` during an OBD2 disconnect) races app teardown after Hive closed the box, surfacing uncaught at `PlatformDispatcher.onError`. `SettingsHiveStore.putSetting` now **no-ops when the box is closed** (best-effort; the app is going away).
2. **`AlertsSync.merge` → `22P02 invalid input syntax for type uuid`** (~8×) — the `alerts.id` column is a Postgres `uuid`, but `create_alert_dialog` minted a `stationId_fuel_ts` composite id. Now mints a real `Uuid().v4()` at creation (root), and `AlertsSync.merge` **partitions non-UUID ids out of the server sync but keeps them local-only** (covers legacy alerts; no data loss).
3. **`ApiException: Detail not available from Luxembourg`** (~5×) — an *expected* `FailureKind.unsupported` capability gap ERROR-logged on every detail tap. Now **breadcrumbed** (extracted to `logStationApiFailure`); real outages still ERROR-log with a stack.

### Tests
non-UUID alert kept local-only (not dropped); create-dialog mints a UUID; chain failure paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
