### PR TITLE
feat(radar): landscape full-bleed scope/list, pinch-zoom, 100% fill, slower sweep (#3372)

### DIFF
--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -326,56 +326,64 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               const <String>{})
         : const <String>{};
 
+    // #3372 — in LANDSCAPE (the two-pane layout) while the radar owns the
+    // results, hide the source/summary/position bars so the radar scope (or
+    // list) fills the whole left pane — the bars stole most of the short
+    // landscape height and left the scope tiny. Portrait keeps them.
+    final hideChromeForLandscapeRadar =
+        isWideScreen(context) && ref.watch(radarSearchProvider).active;
     return Column(
       children: [
-        DemoModeBanner(country: country, corridorCountryCodes: corridorCodes),
-        // #3361 — honest "no coverage for your country" notice (replaces the
-        // silent fall-back to Germany that read as a geo-restriction).
-        const UnsupportedRegionNotice(),
-        // Compact summary bar — top-level entry point for editing criteria.
-        const SearchSummaryBar(),
-        UserPositionBar(
-          onUpdatePosition: () async {
-            final settings = ref.read(settingsStorageProvider);
-            // #3159 — capture before the consent/GPS awaits; ref.read on an
-            // unmounted element throws a StateError under Riverpod 3.
-            final positionNotifier = ref.read(userPositionProvider.notifier);
-            if (!LocationConsentDialog.hasConsent(settings)) {
-              if (!mounted) return;
-              final consented = await LocationConsentDialog.show(context);
-              if (!consented) return;
-              await LocationConsentDialog.recordConsent(settings);
-            }
-            try {
-              await positionNotifier.updateFromGps();
-              if (!mounted) return;
-              final state = ref.read(searchStateProvider);
-              if (state.hasValue && state.value!.data.isNotEmpty) {
-                unawaited(_performGpsSearch());
+        if (!hideChromeForLandscapeRadar) ...[
+          DemoModeBanner(country: country, corridorCountryCodes: corridorCodes),
+          // #3361 — honest "no coverage for your country" notice (replaces the
+          // silent fall-back to Germany that read as a geo-restriction).
+          const UnsupportedRegionNotice(),
+          // Compact summary bar — top-level entry point for editing criteria.
+          const SearchSummaryBar(),
+          UserPositionBar(
+            onUpdatePosition: () async {
+              final settings = ref.read(settingsStorageProvider);
+              // #3159 — capture before the consent/GPS awaits; ref.read on an
+              // unmounted element throws a StateError under Riverpod 3.
+              final positionNotifier = ref.read(userPositionProvider.notifier);
+              if (!LocationConsentDialog.hasConsent(settings)) {
+                if (!mounted) return;
+                final consented = await LocationConsentDialog.show(context);
+                if (!consented) return;
+                await LocationConsentDialog.recordConsent(settings);
               }
-            } catch (e, st) {
-              // #1692 — never surface a raw exception toString() to the
-              // user; show a localized, actionable message instead.
-              // #2146 — route to the exportable log so the cause is
-              // recoverable from a bug report.
-              unawaited(
-                errorLogger.log(
-                  ErrorLayer.ui,
-                  e,
-                  st,
-                  context: const {
-                    'where': 'SearchScreen: userPosition.updateFromGps',
-                  },
-                ),
-              );
-              if (!context.mounted) return;
-              SnackBarHelper.showError(
-                context,
-                AppLocalizations.of(context).searchFailedSnackbar,
-              );
-            }
-          },
-        ),
+              try {
+                await positionNotifier.updateFromGps();
+                if (!mounted) return;
+                final state = ref.read(searchStateProvider);
+                if (state.hasValue && state.value!.data.isNotEmpty) {
+                  unawaited(_performGpsSearch());
+                }
+              } catch (e, st) {
+                // #1692 — never surface a raw exception toString() to the
+                // user; show a localized, actionable message instead.
+                // #2146 — route to the exportable log so the cause is
+                // recoverable from a bug report.
+                unawaited(
+                  errorLogger.log(
+                    ErrorLayer.ui,
+                    e,
+                    st,
+                    context: const {
+                      'where': 'SearchScreen: userPosition.updateFromGps',
+                    },
+                  ),
+                );
+                if (!context.mounted) return;
+                SnackBarHelper.showError(
+                  context,
+                  AppLocalizations.of(context).searchFailedSnackbar,
+                );
+              }
+            },
+          ),
+        ],
         // Results dominate the remaining vertical space.
         Expanded(
           child: Semantics(

--- a/lib/features/search/presentation/widgets/radar_scope_view.dart
+++ b/lib/features/search/presentation/widgets/radar_scope_view.dart
@@ -70,7 +70,7 @@ class _RadarScopeViewState extends ConsumerState<RadarScopeView>
     with SingleTickerProviderStateMixin {
   late final AnimationController _sweep = AnimationController(
     vsync: this,
-    duration: const Duration(seconds: 4),
+    duration: const Duration(seconds: 8), // #3372 — slower, calmer sweep
   )..repeat();
 
   // Scope palette — a dark-green PPI face so the green grid/chips and the

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -10,6 +10,7 @@ import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/widgets/responsive_layout.dart';
 import '../../../../core/utils/geo_utils.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -100,41 +101,56 @@ class SearchResultsContent extends ConsumerWidget {
           final userPos = ref.watch(userPositionProvider);
           final canScope =
               userPos != null && isUsableCoord(userPos.lat, userPos.lng);
+          // #3372 — in landscape the list drops its sort/filter rows for room.
+          final wide = isWideScreen(context);
           void toggleScope() =>
               ref.read(radarScopeModeProvider.notifier).toggle();
           final list = SearchResultsList(
             result: radarResult,
             onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
             onRadarToggle: canScope ? toggleScope : null,
+            hideSortAndFilter: wide,
           );
           final Widget body;
           if (scopeMode && canScope) {
-            body = SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Stack(
-                children: [
-                  RadarScopeView(
-                    stations: stations,
-                    centerLat: userPos.lat,
-                    centerLng: userPos.lng,
-                    rangeKm: ref.watch(searchRadiusProvider),
-                    fuelType: ref.watch(selectedFuelTypeProvider),
-                    gpsCourseDeg: radar.heading,
-                    onStationTap: (s) =>
-                        unawaited(StationDetailRoute(s.id).push<void>(context)),
-                  ),
-                  Positioned(
-                    top: 0,
-                    right: 0,
-                    child: IconButton.filledTonal(
-                      key: const Key('radar_view_to_list'),
-                      tooltip: l10n.radarScopeShowList,
-                      icon: const Icon(Icons.list, size: 20),
-                      onPressed: toggleScope,
+            // #3372 — the scope fills the whole pane (centred AspectRatio in
+            // the bounded area, so it's the largest square that fits — 100% of
+            // the short dimension), and is pinch-zoom + pan-able. The "back to
+            // list" icon floats top-right over the pane.
+            body = Stack(
+              children: [
+                Positioned.fill(
+                  child: InteractiveViewer(
+                    minScale: 1,
+                    maxScale: 4,
+                    child: Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(wide ? 8 : 16),
+                        child: RadarScopeView(
+                          stations: stations,
+                          centerLat: userPos.lat,
+                          centerLng: userPos.lng,
+                          rangeKm: ref.watch(searchRadiusProvider),
+                          fuelType: ref.watch(selectedFuelTypeProvider),
+                          gpsCourseDeg: radar.heading,
+                          onStationTap: (s) => unawaited(
+                              StationDetailRoute(s.id).push<void>(context)),
+                        ),
+                      ),
                     ),
                   ),
-                ],
-              ),
+                ),
+                Positioned(
+                  top: 4,
+                  right: 4,
+                  child: IconButton.filledTonal(
+                    key: const Key('radar_view_to_list'),
+                    tooltip: l10n.radarScopeShowList,
+                    icon: const Icon(Icons.list, size: 20),
+                    onPressed: toggleScope,
+                  ),
+                ),
+              ],
             );
           } else {
             body = list;

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -59,11 +59,17 @@ class SearchResultsList extends ConsumerStatefulWidget {
   /// Null for an ordinary search (no scope to offer).
   final VoidCallback? onRadarToggle;
 
+  /// #3372 — hide the sort selector + brand/mixed filter rows (the landscape
+  /// radar list wants maximum vertical room — just the count/view header + the
+  /// station cards). The header row (count + view-mode + radar toggle) stays.
+  final bool hideSortAndFilter;
+
   const SearchResultsList({
     super.key,
     required this.result,
     required this.onRefresh,
     this.onRadarToggle,
+    this.hideSortAndFilter = false,
   });
 
   @override
@@ -184,19 +190,23 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
         // #494 — same swipe-hint banner as the favorites screen. Shows
         // once until the user taps "Got it", then stays dismissed.
         const SwipeTutorialBanner(),
-        SortSelector(
-          selected: sortMode,
-          onChanged: (mode) =>
-              ref.read(selectedSortModeProvider.notifier).set(mode),
-        ),
-        _CollapsibleBrandFilters(
-          stations: _fuelStationsFrom(result.data)
-              .where((s) => !ignoredIds.contains(s.id))
-              .toList(),
-        ),
-        // #1784 — Fuel/EV/Both kind selector + EV connector & power
-        // filters. Renders nothing for a fuel-only result set.
-        const MixedResultsFilterChips(),
+        // #3372 — the landscape radar list drops the sort + filter rows for
+        // vertical room (the header keeps the radar/list/map toggles).
+        if (!widget.hideSortAndFilter) ...[
+          SortSelector(
+            selected: sortMode,
+            onChanged: (mode) =>
+                ref.read(selectedSortModeProvider.notifier).set(mode),
+          ),
+          _CollapsibleBrandFilters(
+            stations: _fuelStationsFrom(result.data)
+                .where((s) => !ignoredIds.contains(s.id))
+                .toList(),
+          ),
+          // #1784 — Fuel/EV/Both kind selector + EV connector & power
+          // filters. Renders nothing for a fuel-only result set.
+          const MixedResultsFilterChips(),
+        ],
         Expanded(
           child: RefreshIndicator(
             onRefresh: () async => onRefresh(),


### PR DESCRIPTION
Closes #3372.

In landscape (two-pane) the radar scope was tiny — the source/fuel/position bars ate the short landscape height. For the **horizontal** radar:
- `search_screen` **hides the three info bars** (source, summary, position) when the radar owns the results in the wide layout → the scope/list fills the whole left pane.
- `SearchResultsList.hideSortAndFilter` — the landscape list **drops the sort + filter rows** (the count/view header with the radar/list/map toggles stays).
- The scope **fills the pane**: a centred `AspectRatio` in the bounded area = the largest square that fits (**100% of the short dimension**).

General polish (both orientations):
- **Pinch-zoom + pan** the scope (`InteractiveViewer`, 1–4×).
- **Slower sweep** (4 s → 8 s).
- **Verified** distance recalcs on every GPS fix (`_onFix` → `RadarRanking.rank`); the sweep is cosmetic, the live re-rank drives distances — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
