### PR TITLE
revert(ci): drop FGS define from Play uploads until the Foreground Service form is approved (#3375)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -99,12 +99,13 @@ jobs:
         run: flutter pub get
 
       - name: Build AAB (play flavor, run-counter build number)
-        # #3173 — FGS_FORM_APPROVED=true ships the GPS foreground service: the
-        # Dart flag hands geolocator the ForegroundNotificationConfig AND the
-        # gradle overlay re-declares FOREGROUND_SERVICE*. Requires the Play
-        # "Foreground Service Use" form to be approved (#1498), else this upload
-        # 403s.
-        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }} --dart-define=FGS_FORM_APPROVED=true
+        # #3375 — ship DARK: NO --dart-define=FGS_FORM_APPROVED here. The GPS
+        # foreground service (#3173) stays code-merged but gated off, because
+        # the Play "Foreground Service Use" form (#1498) is not yet approved —
+        # uploading the FGS bundle before then 403s ("you must let us know
+        # whether your app uses any Foreground Service permissions"). Re-add the
+        # define once the form clears.
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }}
 
       - name: Clean up decoded keystore
         if: always()

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -154,7 +154,6 @@ jobs:
         run: |
           flutter build appbundle --release --flavor play \
             --build-number=${{ needs.pre-check.outputs.build_number }} \
-            --dart-define=FGS_FORM_APPROVED=true \
             --obfuscate --split-debug-info=build/symbols
 
       # Per-ABI APKs were dropped from the public nightly release on


### PR DESCRIPTION
## Why

Daily Open-Testing Build #162 **built fine** but the **Play upload 403'd**:

> You must let us know whether your app uses any Foreground Service permissions.

#3359 added `--dart-define=FGS_FORM_APPROVED=true` to the two Play-build
workflows, which ships the GPS foreground service (#3173). Play refuses that
bundle until the **"Foreground Service Use" declaration form** (#1498) is
approved in the Play Console — which it is not yet.

## What

Ship **dark**, exactly as #3173 intended:

- `daily-beta.yml` — drop the FGS define from the Open-Testing AAB build.
- `daily-github-release.yml` — drop it from the nightly release AAB build.

The FGS code stays merged but gated off, so uploads succeed again. Re-add the
define (one line per workflow) once the Play form clears.

Closes #3375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)