### PR TITLE
fix(storage): swallow the mid-await 'File closed' settings race (#3377)

### DIFF
--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
@@ -135,15 +138,39 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   dynamic getSetting(String key) => _settings.get(key);
 
   @override
-  Future<void> putSetting(String key, dynamic value) async {
-    // #3370 — best-effort: a settings write racing app teardown (the box is
-    // already closed — e.g. a fire-and-forget `markKnownGood` during an OBD2
-    // disconnect at shutdown) must NOT throw an uncaught
-    // `FileSystemException: File closed` to PlatformDispatcher.onError. The
-    // value is simply dropped — the app is going away. This is the root of the
-    // recurring "File closed, settings.hive" field reports.
+  Future<void> putSetting(String key, dynamic value) =>
+      _guardedWrite('putSetting', () => _settings.put(key, value));
+
+  /// Run [write] against the settings box, swallowing the benign teardown
+  /// race where the box is (or becomes) closed.
+  ///
+  /// #3370 — a settings write racing app teardown (the box already closed —
+  /// e.g. a fire-and-forget `markKnownGood` during an OBD2 disconnect at
+  /// shutdown) must NOT throw an uncaught `FileSystemException: File closed`
+  /// to PlatformDispatcher.onError. The value is simply dropped — the app is
+  /// going away. This is the root of the recurring "File closed, settings.hive"
+  /// field reports.
+  ///
+  /// #3377 — the [Hive.isBoxOpen] guard alone is a point-in-time check: the
+  /// box can still close DURING the awaited file write (a background-scan
+  /// `HiveBoxes.closeIsolateBoxes` interleaving the async append), so we also
+  /// catch the `FileSystemException` the write itself can throw — the same
+  /// belt-and-braces degrade `CacheManager.put` uses (#2670).
+  Future<void> _guardedWrite(
+    String label,
+    Future<void> Function() write,
+  ) async {
     if (!Hive.isBoxOpen(HiveBoxes.settings)) return;
-    await _settings.put(key, value);
+    try {
+      await write();
+      // Benign teardown race — the box closed mid-write and the app is going
+      // away, so the stack is useless; we only drop the value.
+      // ignore: catch_no_st
+    } on FileSystemException catch (e) {
+      debugPrint(
+          'SettingsHiveStore.$label: settings box closed mid-write, '
+          'dropping ($e)');
+    }
   }
 
   // Setup completion — tracks whether the onboarding wizard has been completed
@@ -158,10 +185,10 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   bool get isSetupSkipped => _settings.get(StorageKeys.setupSkipped) == true;
 
   @override
-  Future<void> skipSetup() =>
-      _settings.put(StorageKeys.setupSkipped, true);
+  Future<void> skipSetup() => _guardedWrite(
+      'skipSetup', () => _settings.put(StorageKeys.setupSkipped, true));
 
   @override
-  Future<void> resetSetupSkip() =>
-      _settings.delete(StorageKeys.setupSkipped);
+  Future<void> resetSetupSkip() => _guardedWrite(
+      'resetSetupSkip', () => _settings.delete(StorageKeys.setupSkipped));
 }

--- a/test/core/storage/stores/settings_hive_store_test.dart
+++ b/test/core/storage/stores/settings_hive_store_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/stores/settings_hive_store.dart';
 
@@ -148,6 +149,31 @@ void main() {
       await store.setEvApiKey('ev-custom');
       expect(store.getEvApiKey(), 'ev-custom');
       expect(store.hasCustomEvApiKey(), isTrue);
+    });
+  });
+
+  group('Resilience — settings box closed (#3370 / #3377)', () {
+    // A write racing app teardown (background-scan `closeIsolateBoxes`, OBD2
+    // disconnect at shutdown) must NEVER surface a `FileSystemException: File
+    // closed` to PlatformDispatcher.onError — it is dropped silently because
+    // the app is going away. These guard the never-throw contract.
+
+    test('putSetting drops silently when the box is closed (no throw)',
+        () async {
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
+      await expectLater(store.putSetting('k', 'v'), completes);
+    });
+
+    test('skipSetup drops silently when the box is closed (no throw)',
+        () async {
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
+      await expectLater(store.skipSetup(), completes);
+    });
+
+    test('resetSetupSkip drops silently when the box is closed (no throw)',
+        () async {
+      await Hive.box<dynamic>(HiveBoxes.settings).close();
+      await expectLater(store.resetSetupSkip(), completes);
     });
   });
 


### PR DESCRIPTION
## Analysis (field error logs, build `2026061601`)

Two posted error logs showed three recurring error classes:

| signature | count | status |
|---|---|---|
| `FileSystemException: File closed … settings.hive` | 37× | fixed by #3370 (stale build) + residual, see below |
| `PostgrestException 22P02 invalid uuid … AlertsSync.merge` | 8× | fixed by #3370 (composite alert-id partition) |
| `ApiException: Detail not available … Luxembourg` | 5× | fixed by #3370 (breadcrumb, not error) |

The build was cut **before** #3370 (dc771d642) merged (2026-06-17 13:30 UTC), so all three are stale-build artifacts that clear in the next Open-Testing build. Verified the AlertsSync value is a `[REDACTED_TOKEN]`-shaped composite alert id (the PiiScrubber token regex explicitly redacts station-id composites), and that the Luxembourg `throwDetailUnavailable` → `FailureKind.unsupported` → breadcrumb path is complete.

## What this PR adds

One genuine residual gap #3370 left open: `putSetting`'s `isBoxOpen` guard is a point-in-time check. The box can still close *during* the awaited file write (a background-scan `closeIsolateBoxes` interleaving the async append), so the `FileSystemException` still escaped uncaught to `PlatformDispatcher.onError` — the tail of the "File closed" reports.

- Route `putSetting`, `skipSetup`, `resetSetupSkip` through one `_guardedWrite` helper: keep the `isBoxOpen` fast-path **and** catch `FileSystemException`, degrading quietly (same #2670 `CacheManager.put` precedent).
- `skipSetup` / `resetSetupSkip` previously wrote the box with **no** guard at all.
- +3 regression tests asserting each write completes without throwing on a closed box.

No ARB / schema impact. Closes #3377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)