### PR TITLE
fix(obd2): de-noise benign Classic link-drop (#3379) + self-test transport-aware-on-no-hint (#3380)

### DIFF
--- a/lib/features/obd2/data/classic_elm_channel.dart
+++ b/lib/features/obd2/data/classic_elm_channel.dart
@@ -14,6 +14,7 @@ import 'obd2_connect_trace.dart';
 import 'obd2_connect_trace_log.dart';
 import 'obd2_connection_errors.dart';
 import '../../../core/logging/error_logger.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
 /// Classic-SPP ELM327 adapter (vLinker FS, OBDLink LX, generic
@@ -192,8 +193,24 @@ class ClassicElmChannel implements ElmByteChannel {
         // transient, not a local-storage fault. Tag it `other` to match
         // [FlutterBluePlusElmChannel]'s #2379 convention (the two channels
         // were inconsistent: BLE used `other`, Classic used `storage`).
-        unawaited(errorLogger.log(ErrorLayer.other, e, st,
-            context: const {'where': 'ClassicElmChannel notify error'}));
+        //
+        // #3379 — but the COMMON case here is the EXPECTED end-of-session drop:
+        // an RFCOMM reader surfaces a closed link as `bt socket closed,
+        // read return: -1` on engine-off / drive-away / navigate-away. That is
+        // not a fault — `_signalDrop` above already kicked the reconnect
+        // controller (visible as the `obd2-reconnect: drop-received`
+        // breadcrumb). ERROR-logging it on every session end buried real faults
+        // (it was the SOLE trace in field log 064a9d4c). Breadcrumb the benign
+        // drop; only an UNEXPECTED socket error still ERROR-logs.
+        if (isBenignClassicLinkDrop(e)) {
+          BreadcrumbCollector.add(
+            'obd2: classic link dropped',
+            detail: e.toString(),
+          );
+        } else {
+          unawaited(errorLogger.log(ErrorLayer.other, e, st,
+              context: const {'where': 'ClassicElmChannel notify error'}));
+        }
       },
       onDone: () {
         _open = false;
@@ -282,4 +299,23 @@ class ClassicElmChannel implements ElmByteChannel {
     }
     await _incoming.close();
   }
+}
+
+/// #3379 — whether [e] is the EXPECTED Classic-SPP link-drop signature, as
+/// opposed to an unexpected fault worth an ERROR trace.
+///
+/// An RFCOMM reader stream surfaces a closed link as `bt socket closed,
+/// read return: -1` (or `… not connected`) on every normal session end —
+/// engine off, drive away, navigate off the trip screen, adapter unplugged.
+/// That drop is already handled (the channel `_signalDrop`s it to the
+/// reconnect controller), so it is breadcrumbed rather than ERROR-logged;
+/// only a NON-matching socket error keeps the full error trace.
+///
+/// Pure + case-insensitive substring match — the message text is the only
+/// stable signal the platform layer carries across OEM BT stacks.
+bool isBenignClassicLinkDrop(Object e) {
+  final m = e.toString().toLowerCase();
+  return m.contains('socket closed') ||
+      m.contains('read ret') || // "read ret: -1" and "read return: -1"
+      m.contains('not connected');
 }

--- a/lib/features/obd2/data/obd2_self_test_driver.dart
+++ b/lib/features/obd2/data/obd2_self_test_driver.dart
@@ -221,8 +221,10 @@ Obd2SelfTestStepStatus statusForResponseClass(ResponseClass cls) {
 /// pinned connect + reconnect over the inferred transport — Classic takes the
 /// RFCOMM path (`connectByMacClassicDirect`) instead of the BLE GATT direct
 /// path, which can ONLY 4 s-timeout for a Classic-SPP adapter (the real vLinker
-/// FS trap). A null hint defaults to BLE but records `no-hint-defaulted-ble` on
-/// the trace — visible, not silent.
+/// FS trap). A null hint no longer defaults to BLE (#3380): it routes through
+/// the production `connectByMacTransportAware` resolver (scan-classify +
+/// cross-transport fallback) and records `no-hint-transport-aware` on the
+/// trace — visible, not silent.
 Future<Obd2SelfTestReport> runObd2SelfTest(
   Obd2ConnectionService connection, {
   void Function(Obd2SelfTestStepResult step)? onStep,
@@ -243,11 +245,13 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
   Obd2ConnectTransport? transportHint,
   String? adapterName,
 }) async {
-  final isClassic = transportHint == Obd2ConnectTransport.classic;
+  // #3380 — a null/unknown hint no longer hard-defaults to BLE; it routes
+  // through the production transport-aware resolver (see [_selfTestConnect]),
+  // so the decision reason reflects that, not a doomed BLE default.
   final decisionReason = switch (transportHint) {
     Obd2ConnectTransport.classic => 'name-matched-classic',
     Obd2ConnectTransport.ble => 'name-matched-ble',
-    Obd2ConnectTransport.unknown || null => 'no-hint-defaulted-ble',
+    Obd2ConnectTransport.unknown || null => 'no-hint-transport-aware',
   };
   final diag = Obd2CommDiagnostics.instance;
   final priorEnabled = diag.enabled;
@@ -282,7 +286,7 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
       // connect step gets its OWN longer budget ([connectDeadline]).
       service = pinnedMac != null
           ? await _selfTestConnect(connection, pinnedMac,
-                  isClassic: isClassic,
+                  transport: transportHint,
                   decisionReason: decisionReason,
                   adapterName: adapterName)
               .timeout(connectDeadline)
@@ -352,7 +356,7 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
       final mac = pinnedMac ?? service.adapterMac;
       final reconnected = await _reconnectStep(
           connection, service, diag, mac, stepDeadline,
-          isClassic: isClassic,
+          transport: transportHint,
           decisionReason: decisionReason,
           adapterName: adapterName,
           connectDeadline: connectDeadline);

--- a/lib/features/obd2/data/obd2_self_test_steps.dart
+++ b/lib/features/obd2/data/obd2_self_test_steps.dart
@@ -12,19 +12,25 @@ Obd2SelfTestStepResult _step(
         Obd2SelfTestStepId id, Obd2SelfTestStepStatus status, int? latencyMs) =>
     Obd2SelfTestStepResult(id: id, status: status, latencyMs: latencyMs);
 
-/// #2969 — transport-aware pinned connect for the self-test, stamping
+/// #2969 / #3380 — transport-aware pinned connect for the self-test, stamping
 /// `origin:selfTest` + the transport decision reason on the connect trace the
-/// service opens. A Classic adapter takes the RFCOMM direct path
-/// (`connectByMacClassicDirect`) — the BLE direct path can ONLY 4 s-timeout for
-/// a Classic-SPP adapter (the real vLinker FS trap), so this is the reliability
-/// fix that makes the self-test actually connect to the user's hardware. When
-/// the transport could NOT be inferred ([isClassic] false from a null hint) the
-/// run defaults to BLE but records `no-hint-defaulted-ble` — visible, not
-/// silent.
+/// service opens. Routes by the inferred [transport]:
+///
+/// - **classic** → the RFCOMM direct path (`connectByMacClassicDirect`) — the
+///   BLE direct path can ONLY 4 s-timeout for a Classic-SPP adapter (the real
+///   vLinker FS trap), so this is the reliability fix that makes the self-test
+///   actually connect to the user's hardware.
+/// - **ble** → the BLE GATT direct path (`connectByMacDirect`).
+/// - **null / unknown** → #3380: NO blind BLE default. Take the SAME
+///   production resolver the picker uses (`connectByMacTransportAware`), which
+///   scan-classifies the MAC + cross-transport falls back — so a Classic
+///   adapter whose stored profile lacks a name (→ no inferable hint) still
+///   connects over RFCOMM instead of burning a doomed 4 s BLE timeout. Recorded
+///   as `no-hint-transport-aware` — visible, not silent.
 Future<Obd2Service?> _selfTestConnect(
   Obd2ConnectionService connection,
   String pinnedMac, {
-  required bool isClassic,
+  required Obd2ConnectTransport? transport,
   required String decisionReason,
   String? adapterName,
 }) =>
@@ -34,10 +40,17 @@ Future<Obd2Service?> _selfTestConnect(
       // #3014 — thread the resolved adapter NAME down so the self-test trace
       // headline reads the human name (e.g. `SmartOBD`) instead of just the
       // redacted MAC — the maintainer's #1 trace-tool complaint.
-      () => isClassic
-          ? connection.connectByMacClassicDirect(pinnedMac,
-              adapterName: adapterName)
-          : connection.connectByMacDirect(pinnedMac, adapterName: adapterName),
+      () => switch (transport) {
+        Obd2ConnectTransport.classic => connection.connectByMacClassicDirect(
+            pinnedMac,
+            adapterName: adapterName),
+        Obd2ConnectTransport.ble =>
+          connection.connectByMacDirect(pinnedMac, adapterName: adapterName),
+        Obd2ConnectTransport.unknown ||
+        null =>
+          connection.connectByMacTransportAware(pinnedMac,
+              adapterName: adapterName),
+      },
     );
 
 /// Info step: AT@1 (device description) + ATRV (battery voltage) are sent
@@ -188,8 +201,8 @@ Future<({Obd2SelfTestStepResult result, Obd2Service? service})> _reconnectStep(
   Obd2CommDiagnostics diag,
   String? mac,
   Duration deadline, {
-  bool isClassic = false,
-  String decisionReason = 'no-hint-defaulted-ble',
+  Obd2ConnectTransport? transport,
+  String decisionReason = 'no-hint-transport-aware',
   String? adapterName,
   Duration connectDeadline = const Duration(seconds: 15),
 }) async {
@@ -211,7 +224,7 @@ Future<({Obd2SelfTestStepResult result, Obd2Service? service})> _reconnectStep(
     // #2969 — transport-aware reconnect (Classic → RFCOMM) on its OWN connect
     // budget, mirroring the initial connect step.
     final reconnected = await _selfTestConnect(connection, mac,
-            isClassic: isClassic,
+            transport: transport,
             decisionReason: decisionReason,
             adapterName: adapterName)
         .timeout(connectDeadline);

--- a/lib/features/obd2/providers/obd2_self_test_controller.dart
+++ b/lib/features/obd2/providers/obd2_self_test_controller.dart
@@ -54,8 +54,9 @@ class Obd2SelfTestController extends _$Obd2SelfTestController {
   /// (`connectByMacClassicDirect`) instead of the BLE GATT direct path. The
   /// panel infers it from the selected adapter's stored name via the registry
   /// name matchers — for a Classic-SPP adapter (vLinker FS) the BLE path can
-  /// ONLY 4 s-timeout, so this is the reliability fix. A null hint defaults to
-  /// BLE but records `no-hint-defaulted-ble` on the trace.
+  /// ONLY 4 s-timeout, so this is the reliability fix. A null hint no longer
+  /// blindly defaults to BLE (#3380): it routes through the production
+  /// `connectByMacTransportAware` resolver and records `no-hint-transport-aware`.
   Future<void> run({
     String? targetMac,
     Obd2ConnectTransport? transportHint,

--- a/test/features/obd2/data/classic_elm_channel_test.dart
+++ b/test/features/obd2/data/classic_elm_channel_test.dart
@@ -519,6 +519,36 @@ void main() {
       await sub.cancel();
     });
   });
+
+  group('isBenignClassicLinkDrop (#3379)', () {
+    test('the field RFCOMM-drop signature is benign (breadcrumb, not ERROR)',
+        () {
+      // The exact field-log shape: PlatformException(io, bt socket closed,
+      // read return: -1, null, null) — the normal end-of-session drop.
+      expect(
+        isBenignClassicLinkDrop(
+          'PlatformException(io, bt socket closed, read return: -1, null, null)',
+        ),
+        isTrue,
+      );
+    });
+
+    test('the older "read ret: -1" + "not connected" shapes are benign', () {
+      expect(isBenignClassicLinkDrop('read failed, socket might closed or '
+          'timeout, read ret: -1'), isTrue);
+      expect(
+        isBenignClassicLinkDrop(
+            'PlatformException(state, not connected, null, null)'),
+        isTrue,
+      );
+    });
+
+    test('an UNEXPECTED socket error is NOT benign (keeps the ERROR trace)',
+        () {
+      expect(isBenignClassicLinkDrop('GATT_ERROR 133'), isFalse);
+      expect(isBenignClassicLinkDrop('some unrelated failure'), isFalse);
+    });
+  });
 }
 
 // --- debugPrint override helpers ---------------------------------------

--- a/test/features/obd2/data/obd2_self_test_driver_test.dart
+++ b/test/features/obd2/data/obd2_self_test_driver_test.dart
@@ -371,30 +371,30 @@ void main() {
     });
 
     test(
-        'the SAME classic adapter with NO hint defaults to BLE and FAILS to '
-        'connect — proving the transport-blind bug (RED-on-master signature)',
-        () async {
+        'the SAME classic adapter with NO hint routes through the '
+        'transport-aware resolver and still CONNECTS over RFCOMM (#3380 — no '
+        'blind BLE 4 s-timeout)', () async {
       final conn = _FakeConnection(
         transportFor: () => FakeObd2Transport(Map.of(_happyPathResponses)),
         adapterIsClassic: true,
       );
 
-      // No transportHint → defaults to the BLE direct path, which a Classic
-      // adapter can never answer → the connect step fails / aborts.
+      // #3380 — a null transportHint NO LONGER defaults to the doomed BLE
+      // direct path; it takes the production `connectByMacTransportAware`
+      // resolver, which scan-classifies the Classic adapter → RFCOMM.
       final report = await runObd2SelfTest(conn, pinnedMac: 'AA:BB:CC:DD:EE:FF');
 
-      expect(report.passed, isFalse);
-      // No connect ever landed on either path (the BLE path returned null).
-      expect(conn.pathsTaken, isEmpty);
+      expect(report.passed, isTrue);
+      // Every connect resolved to the Classic RFCOMM path, not blind BLE.
+      expect(conn.pathsTaken, everyElement('classic'));
     });
 
     test(
-        'a null transportHint records origin:selfTest + no-hint-defaulted-ble '
-        'on the trace the REAL service opens', () async {
-      // Drive the REAL Obd2ConnectionService (the fake here overrides
-      // connectByMacDirect and so never opens a trace — the trace lives in the
-      // real `_traced` wrapper). The BLE direct open throws, so the run fails,
-      // but the trace is the artefact under test.
+        'a null transportHint records origin:selfTest + no-hint-transport-aware '
+        'on the trace the REAL service opens (#3380)', () async {
+      // Drive the REAL Obd2ConnectionService. With no hint the run takes the
+      // transport-aware resolver; the facade's direct open throws + the scan is
+      // empty, so the connect fails — but the trace is the artefact under test.
       final service = Obd2ConnectionService(
         registry: Obd2AdapterRegistry.defaults(),
         permissions: _GrantedPermissions(),
@@ -407,11 +407,11 @@ void main() {
       final traces = Obd2ConnectTraceLog.snapshot();
       expect(traces, isNotEmpty,
           reason: 'a FAILED self-test connect must leave a trace');
-      // The self-test stamped its origin + the explicit BLE-default decision.
+      // The self-test stamped its origin + the no-blind-BLE decision (#3380).
       expect(traces.first.origin, Obd2ConnectOrigin.selfTest);
       expect(
         traces.first.transportDecisionReason,
-        'no-hint-defaulted-ble',
+        'no-hint-transport-aware',
       );
     });
   });
@@ -526,6 +526,21 @@ class _FakeConnection extends Obd2ConnectionService {
     // being absent / wrong for a BLE adapter).
     if (!adapterIsClassic) return null;
     return _open('classic');
+  }
+
+  /// #3380 — models the production transport-aware resolver the self-test now
+  /// takes when it has NO hint: it scan-classifies the MAC and routes to the
+  /// correct transport (Classic → RFCOMM), so a hint-less Classic adapter still
+  /// connects instead of burning a doomed BLE 4 s-timeout.
+  @override
+  Future<Obd2Service?> connectByMacTransportAware(
+    String mac, {
+    String? adapterName,
+    bool fallbackToScan = true,
+  }) async {
+    reconnectCalls++;
+    if (reconnectCalls > 1 && reconnectReturnsNull) return null;
+    return adapterIsClassic ? _open('classic') : _open('ble-direct');
   }
 }
 


### PR DESCRIPTION
Analysis of two posted OBD2 field exports (build `2026061611`). The two driving JSONs were healthy (scores 89/92, sensible penalties); the OBD2 logs surfaced two distinct, live bugs.

## #3379 — benign Classic link-drop logged as an ERROR

Error log `064a9d4c` contained **exactly one** trace:
> `PlatformException(io, bt socket closed, read return: -1) [where: ClassicElmChannel notify error]`

…with the breadcrumb `obd2-reconnect: drop-received transport=classic` at the **same millisecond**. So the drop was already detected and handed to the reconnect controller — the ERROR trace is pure noise that buries real faults.

`ClassicElmChannel.onError` ERROR-logged **every** RFCOMM socket error, but `bt socket closed, read return: -1` is the **normal end-of-session signal** (engine off, drive away, navigate away). Now classified: a benign disconnect signature (`socket closed` / `read ret: -1` / `not connected`) → **breadcrumb**; an unexpected error still ERROR-logs. Mirrors the BLE channel's existing disconnect branch + the #3312/#3370 de-noise approach. +unit test.

## #3380 — self-test burns a 4s BLE timeout on a known-Classic adapter

OBD2 connect traces `53875256` — a `selfTest` against a Classic vLinker FS (`pid: vlinker-fs-classic`, dozens of prior `rtx: classic` successes):
- `tdr: no-hint-defaulted-ble`, `rtx: ble`, `ztx: classic`
- `scan-seed: timeout (3.3s)` → `channel-open: fail (Timed out after 4s)` → `direct-connect-failed` → only then recovers via ATZ.

~7s wasted + two spurious failure steps. The hint was absent because the paired vehicle profile stored the MAC but not the adapter name (`transportForName(null)` → null), and the driver hard-defaulted a null hint to **blind BLE** (`connectByMacDirect`), which can only 4s-timeout for a Classic-SPP adapter.

Fix: route the **no-hint** case through the production `connectByMacTransportAware` resolver (scan-classify + cross-transport fallback), the same path the picker uses — so a hint-less Classic adapter resolves over RFCOMM instead of a doomed BLE timeout. Explicit hints keep their fast direct paths. `no-hint-defaulted-ble` → `no-hint-transport-aware`.

Notably, `obd2_self_test_driver_test.dart:382` previously **encoded the bug as expected** ("no hint → BLE → fails") — rewritten to assert the correct behavior (hint-less Classic now resolves + passes).

## Tests
Full OBD2 suite (1936 tests) + catch_no_st / no_silent_catch / file_length / never_throws gates all green. Pre-push hook passed.

Closes #3379, #3380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)