### PR TITLE
fix(obd2): bound the trajet trip-start so a slow adapter can't hang 'initializing' forever (#3382)

### DIFF
--- a/lib/features/obd2/data/obd2_trip_start_budgets.dart
+++ b/lib/features/obd2/data/obd2_trip_start_budgets.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// #3382 — time budgets that bound the OBD2 trip-START sequence so a slow /
+/// silent adapter (or a Hive stall) can never leave the recording stuck in
+/// "initializing" forever — the field "must restart the app" report.
+///
+/// Two layers:
+///  - per-step budgets ([kObd2TripStartOdometerBudget],
+///    [kObd2TripStartVinBudget]) on the best-effort identity reads in
+///    `TripRecordingController.start`. Both DEGRADE TO NULL on timeout (a null
+///    odometer / VIN is already a supported degraded start), so the trip still
+///    starts instead of hanging on a slow read.
+///  - an overall watchdog ([kObd2TripStartWatchdog]) + a Hive baseline-load
+///    bound ([kObd2TripStartBaselinesBudget]) in `Obd2RecordingPipeline.start`.
+///    A timeout there ABORTS cleanly: tear down the half-open link + surface a
+///    recoverable error so the user can retry immediately, no app restart.
+///
+/// The watchdog comfortably exceeds the sum of the per-step budgets + the
+/// baseline load, so it only fires on a genuine stall, never a slow-but-ok car.
+library;
+
+/// Odometer read budget — its PID-A6 → PID-31 → Mode-22 fallback is otherwise
+/// unbounded.
+const Duration kObd2TripStartOdometerBudget = Duration(seconds: 6);
+
+/// VIN (0902) read budget — a silent adapter mid-handshake can stall it.
+const Duration kObd2TripStartVinBudget = Duration(seconds: 4);
+
+/// Hive baseline-load budget — guards against storage stall / lock contention.
+const Duration kObd2TripStartBaselinesBudget = Duration(seconds: 8);
+
+/// Hard backstop on the whole blocking init (baseline load + controller start).
+const Duration kObd2TripStartWatchdog = Duration(seconds: 25);
+
+/// Bound a best-effort trip-start identity read ([read]) by [budget],
+/// degrading to `null` on timeout so a slow/silent adapter can't stall the
+/// start. The caller treats a null result as "unknown" — a normal degraded
+/// start — so the trip proceeds regardless.
+Future<T?> boundedStartRead<T>(Future<T?> read, Duration budget) =>
+    read.timeout(budget, onTimeout: () => null);

--- a/lib/features/obd2/data/trip_recording_controller.dart
+++ b/lib/features/obd2/data/trip_recording_controller.dart
@@ -23,6 +23,7 @@ import 'gps_only_sample_builder.dart';
 import 'live_sample_snapshot.dart';
 import 'obd2_breadcrumb_collector.dart';
 import 'obd2_connection_errors.dart';
+import 'obd2_trip_start_budgets.dart';
 import 'obd2_debug_session.dart';
 import 'obd2_service.dart';
 import 'paused_trip_repository.dart';
@@ -765,15 +766,12 @@ class TripRecordingController {
     _stopped = false;
     _startedAt = _now();
     _sessionId = _startedAt!.toIso8601String();
-    _odometerStartKm = await _service.readOdometerKm();
+    // #3382 — odometer + VIN (#814) reads time-bounded (obd2_trip_start_budgets)
+    // so a slow/silent adapter degrades them to null and the trip still starts.
+    _odometerStartKm = await boundedStartRead(
+        _service.readOdometerKm(), kObd2TripStartOdometerBudget);
     _odometerLatestKm = _odometerStartKm;
-
-    // One-shot VIN read (#814). VIN is Mode 09 PID 02 — it never
-    // changes mid-trip, so subscribing it to the 0.1 Hz tier would
-    // just waste one Bluetooth round-trip per 10 s on a value we
-    // already have. Best-effort: a car that can't answer 0902 simply
-    // leaves [_vin] null.
-    _vin = await _readVinOnce();
+    _vin = await boundedStartRead(_readVinOnce(), kObd2TripStartVinBudget);
 
     _scheduler = _schedulerOverride ?? _buildScheduler();
     _liveSampleSnapshot.subscribeAllTiers(_scheduler!);

--- a/lib/features/obd2/providers/obd2_recording_pipeline.dart
+++ b/lib/features/obd2/providers/obd2_recording_pipeline.dart
@@ -9,7 +9,9 @@ import '../../../core/logging/error_logger.dart';
 import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../driving/providers/live_harsh_event_bus_provider.dart';
 import '../../../core/domain/vehicle_profile.dart';
+import '../data/obd2_connection_errors.dart';
 import '../data/obd2_service.dart';
+import '../data/obd2_trip_start_budgets.dart';
 import '../data/obd2_session_context_block.dart';
 import '../data/trip_recording_controller.dart';
 import '../../consumption/domain/entities/gps_sample_diagnostic.dart';
@@ -55,6 +57,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     required VehicleProfile? Function() readActiveVehicle,
     required bool Function() readOemPidsFlag,
     required bool Function() readDiagnosticCaptureFlag,
+    Duration startWatchdog = kObd2TripStartWatchdog, // #3382, overridable in tests
+    Duration baselinesBudget = kObd2TripStartBaselinesBudget,
   })  : _ref = ref,
         _host = host,
         _haptics = haptics,
@@ -63,7 +67,9 @@ class Obd2RecordingPipeline implements RecordingPipeline {
         _oemFuel = oemFuel,
         _readActiveVehicle = readActiveVehicle,
         _readOemPidsFlag = readOemPidsFlag,
-        _readDiagnosticCaptureFlag = readDiagnosticCaptureFlag;
+        _readDiagnosticCaptureFlag = readDiagnosticCaptureFlag,
+        _startWatchdog = startWatchdog,
+        _baselinesBudget = baselinesBudget;
 
   final Ref _ref;
   final Obd2RecordingPipelineHost _host;
@@ -75,6 +81,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
   final bool Function() _readOemPidsFlag;
   // #2459 — per-trip diagnostic-capture flag (Feature.debugMode).
   final bool Function() _readDiagnosticCaptureFlag;
+  final Duration _startWatchdog; // #3382 trip-start abort budgets
+  final Duration _baselinesBudget;
 
   Obd2Service? _service;
   TripRecordingController? _controller;
@@ -180,11 +188,17 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     );
     _controller = ctl;
 
-    // #769 — resolve the active vehicle + fuel family and load its
-    // learned baselines from Hive (delegated to TripBaselineRecorder).
-    await _baselines.load();
-
-    await ctl.start();
+    // #769 load baselines + #3382 watchdog-bound the blocking init (see
+    // obd2_trip_start_budgets): on a stall ABORT cleanly (drop controller,
+    // disconnect, surface a recoverable error) instead of hanging forever.
+    try {
+      await _baselines.load().timeout(_baselinesBudget);
+      await ctl.start().timeout(_startWatchdog);
+    } on TimeoutException {
+      _controller = null;
+      unawaited(service.disconnect());
+      throw const Obd2AdapterUnresponsive();
+    }
     // #1374 / #1981 — GPS trip-path sampling, default-on; fire-and-forget so
     // the permission round-trip never blocks trip-start.
     unawaited(_gps.start(ctl));

--- a/test/features/obd2/data/obd2_trip_start_budgets_test.dart
+++ b/test/features/obd2/data/obd2_trip_start_budgets_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_trip_start_budgets.dart';
+
+/// #3382 — [boundedStartRead] is the primitive that keeps a slow/silent
+/// adapter from hanging the trajet trip-start: the best-effort odometer / VIN
+/// reads are wrapped in it so a stall DEGRADES TO NULL (a normal degraded
+/// start) instead of leaving the recording stuck in "initializing" forever.
+void main() {
+  group('boundedStartRead (#3382)', () {
+    test('a stalled read degrades to null at the budget — never hangs', () async {
+      final neverLands = Completer<int?>(); // the "silent adapter" read
+      final result = await boundedStartRead<int>(
+        neverLands.future,
+        const Duration(milliseconds: 20),
+      ).timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => fail('boundedStartRead hung — the budget did not fire'),
+      );
+
+      expect(result, isNull,
+          reason: 'a timed-out start read degrades to null so the trip still '
+              'starts in a degraded state');
+      neverLands.complete(null); // release the dangling read
+    });
+
+    test('a read that lands within the budget returns its value untouched',
+        () async {
+      expect(
+        await boundedStartRead<int>(Future.value(42), const Duration(seconds: 1)),
+        42,
+      );
+    });
+
+    test('a null in-time result is passed through (genuine "unknown")',
+        () async {
+      expect(
+        await boundedStartRead<String>(
+            Future.value(null), const Duration(seconds: 1)),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/obd2/providers/obd2_recording_pipeline_test.dart
+++ b/test/features/obd2/providers/obd2_recording_pipeline_test.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_connection_errors.dart';
 import 'package:tankstellen/features/obd2/data/obd2_service.dart';
 import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
@@ -153,8 +156,76 @@ void main() {
       expect(h.pipeline.resume(), isTrue);
       expect(h.pipeline.controller!.isPaused, isFalse);
     });
+
+    test(
+        'a stalled blocking init aborts trip-start cleanly — throws + '
+        'disconnects the link, no infinite "initializing" (#3382)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final host = _FakeWalHost();
+      final service = Obd2Service(FakeObd2Transport(_elmOk()))
+        ..adapterMac = _Harness.fakeMac;
+      await service.connect();
+      service.adapterMac = _Harness.fakeMac;
+      expect(service.isConnected, isTrue);
+
+      // The baseline load never lands; the tiny injected watchdog must fire.
+      final gate = Completer<void>();
+      final pipeline = container.read(
+        _hangingBaselinesPipelineProvider((host: host, gate: gate.future)),
+      );
+
+      await expectLater(
+        pipeline.start(service),
+        throwsA(isA<Obd2AdapterUnresponsive>()),
+        reason: 'a stalled init must ABORT with a recoverable error, not hang',
+      );
+      // The half-open link is torn down (fire-and-forget) so a retry is clean.
+      await _pump();
+      await _pump();
+      expect(service.isConnected, isFalse,
+          reason: 'the watchdog must disconnect the link so a retry starts '
+              'fresh — and the user never has to restart the app');
+      expect(pipeline.controller, isNull,
+          reason: 'the half-started controller is dropped on abort');
+
+      gate.complete(); // release the dangling load so no work is left pending
+    });
   });
 }
+
+/// #3382 — a [TripBaselineRecorder] whose Hive-backed [load] never lands
+/// (a storage stall / lock), so the pipeline's start-watchdog must fire.
+class _HangingBaselines extends TripBaselineRecorder {
+  _HangingBaselines(super.ref, this._gate);
+
+  final Future<void> _gate;
+
+  @override
+  Future<void> load() => _gate;
+}
+
+/// Builds a pipeline whose baseline load hangs, with tiny abort budgets so the
+/// #3382 watchdog fires fast in-test.
+final _hangingBaselinesPipelineProvider = Provider.family<Obd2RecordingPipeline,
+    ({Obd2RecordingPipelineHost host, Future<void> gate})>(
+  (ref, args) => Obd2RecordingPipeline(
+    ref: ref,
+    host: args.host,
+    haptics: TripHapticController(),
+    gps: TripGpsStreamController(
+      ref: ref,
+      lifecycleState: () => AppLifecycleState.resumed,
+    ),
+    baselines: _HangingBaselines(ref, args.gate),
+    oemFuel: TripOemFuelLevelController(),
+    readActiveVehicle: () => null,
+    readOemPidsFlag: () => false,
+    readDiagnosticCaptureFlag: () => false,
+    baselinesBudget: const Duration(milliseconds: 50),
+    startWatchdog: const Duration(milliseconds: 50),
+  ),
+);
 
 Future<void> _pump() => Future<void>.delayed(Duration.zero);
 


### PR DESCRIPTION
## Symptom (field)

Starting a Trajet recording with OBD2 **sometimes** never initializes — the UI stays stuck "initializing" and the user must **restart the app**.

## Root cause

Connect itself is well-guarded (per-command transport timeouts, 15s protocol-search budget). But the trip-**START** sequence was not: `Obd2RecordingPipeline.start()` awaited `_baselines.load()` (Hive, no timeout) then `TripRecordingController.start()`'s identity reads — `readOdometerKm()` (an **unbounded** A6→31→Mode-22 fallback) and `_readVinOnce()` — none time-bounded, and the UI sat in `TripRecordingPhase.connecting` with no terminal deadline. A slow/silent adapter mid-handshake (or a Hive stall) left it awaiting forever.

## Fix — two layers (budgets centralised in `obd2_trip_start_budgets.dart`)

- **Per-step:** the best-effort odometer + VIN reads go through `boundedStartRead()`, which **degrades to null** on timeout. A null odometer/VIN is already a supported degraded start, so the trip **still starts** instead of hanging on a slow read.
- **Overall watchdog:** `Obd2RecordingPipeline.start()` wraps the blocking init in a watchdog. On timeout it tears down the half-open link (disconnect) and throws a recoverable `Obd2AdapterUnresponsive` — the start coordinator's existing `catch` rolls the connecting card back to idle and surfaces a retry message. **No app restart needed.**

## Tests
- `boundedStartRead` degrades a stalled read to null (fast, no real wait) + passes a value/null through when it lands in time.
- Pipeline watchdog: a stalled baseline load → clean abort (`throwsA(Obd2AdapterUnresponsive)`) + the link is disconnected, via an injected tiny budget.

Full OBD2 suite + file_length / catch_no_st / no_silent_catch gates green; pre-push passed. Budgets extracted to a new file to keep the pipeline ≤400 and avoid bumping the grandfathered controller (#3140).

Closes #3382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)