### PR TITLE
fix(obd2): stop the perpetual reconnect war — #3019 stands down while a recording owns the adapter (#3386)

### DIFF
--- a/lib/features/obd2/data/obd2_recording_link_ownership.dart
+++ b/lib/features/obd2/data/obd2_recording_link_ownership.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+/// #3386 — single-authority gate for OBD2 reconnect.
+///
+/// Two reconnect authorities existed for the one adapter:
+///  * the in-trip [DroppedSessionManager] (#2188) — the reconnect owner WHILE a
+///    recording is active;
+///  * the app-wide, trip-INDEPENDENT [Obd2Reconnect] (#3019) — documented as
+///    the owner for a drop "while idle / between trips".
+///
+/// But #3019 subscribed to the link-drop signal UNCONDITIONALLY, so during a
+/// recording BOTH reconnected the single adapter. Establishing a second RFCOMM
+/// socket tears down the first (one SPP channel), the first sees a socket-close
+/// drop and reconnects, tearing down the second — a perpetual reconnect WAR
+/// that never let the link settle, leaving the trip stuck on GPS-estimated
+/// consumption (field: "Enregistrement via GPS — reconnexion OBD2" all drive).
+///
+/// This latch lets the OBD2 recording pipeline CLAIM the adapter so #3019
+/// stands down (and stops any in-flight loop) for the trip's lifetime; the
+/// trip's own [DroppedSessionManager] is then the sole in-trip authority, as
+/// the design always intended. Releasing it hands the idle/between-trips role
+/// back to #3019.
+///
+/// A process-wide singleton (not a Riverpod provider) so the data-layer
+/// reconnect controller and the recording pipeline coordinate WITHOUT a
+/// cross-feature provider dependency; the [recordingOwnsLink] notifier lets
+/// #3019 react the instant a recording claims the link.
+class Obd2RecordingLinkOwnership {
+  Obd2RecordingLinkOwnership._();
+
+  /// Process-wide instance.
+  static final Obd2RecordingLinkOwnership instance =
+      Obd2RecordingLinkOwnership._();
+
+  /// True while a trip recording owns the adapter. Notifies on every change.
+  final ValueNotifier<bool> recordingOwnsLink = ValueNotifier<bool>(false);
+
+  /// Whether a recording currently owns the adapter (the in-trip
+  /// [DroppedSessionManager] is the reconnect authority).
+  bool get active => recordingOwnsLink.value;
+
+  /// A recording now owns the adapter — #3019 stands down.
+  void claim() => recordingOwnsLink.value = true;
+
+  /// The recording released the adapter — #3019 resumes the idle role.
+  void release() => recordingOwnsLink.value = false;
+
+  /// Reset to the unowned state (tests).
+  @visibleForTesting
+  void resetForTest() => recordingOwnsLink.value = false;
+}

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -15,6 +15,7 @@ import '../data/obd2_connect_trace.dart';
 import '../data/obd2_connect_trace_log.dart';
 import '../data/obd2_connection_service.dart';
 import '../data/obd2_link_drop_signal.dart';
+import '../data/obd2_recording_link_ownership.dart';
 import '../data/obd2_reconnect_controller.dart';
 import '../data/obd2_service.dart';
 import 'obd2_connection_state_provider.dart';
@@ -56,6 +57,12 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     // the instant a link dies (BLE disconnect edge / Classic socket close), so
     // a drop while idle / between trips still starts the bounded backoff loop.
     _dropSub = Obd2LinkDropSignal.instance.drops.listen((e) {
+      // #3386 — STAND DOWN while a trip recording owns the adapter: the trip's
+      // own DroppedSessionManager (#2188) is the sole in-trip reconnect
+      // authority. Two reconnectors on one adapter ping-pong the single RFCOMM
+      // socket forever (the field "permanently reconnecting" war). #3019 only
+      // handles drops while idle / between trips — exactly its #3013 charter.
+      if (Obd2RecordingLinkOwnership.instance.active) return;
       // #3346 — carry WHY the link dropped (and on which transport) into the
       // controller so the reconnect-episode breadcrumb records it.
       _controller?.notifyDropped(
@@ -64,7 +71,16 @@ class Obd2Reconnect extends _$Obd2Reconnect {
         mac: e.mac,
       );
     });
+    // #3386 — if a recording CLAIMS the link while #3019 is mid-loop (an idle
+    // drop that was recovering when the user hit Start), hand over immediately:
+    // stop the loop so it can't tear down the recording's freshly-owned socket.
+    final ownership = Obd2RecordingLinkOwnership.instance.recordingOwnsLink;
+    void onOwnershipChanged() {
+      if (ownership.value) _controller?.stop();
+    }
+    ownership.addListener(onOwnershipChanged);
     ref.onDispose(() {
+      ownership.removeListener(onOwnershipChanged);
       unawaited(_dropSub?.cancel());
       _dropSub = null;
       controller.dispose();

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'8b3ab217a16af7fce3da7394f731e93a093736b6';
+String _$obd2ReconnectHash() => r'865da60113c9d5aeeaa9040e5d3faf2720c8db3b';
 
 /// App-wide owner of the trip-INDEPENDENT auto-reconnect controller (#3019 /
 /// Epic #3013 phase 3).

--- a/lib/features/obd2/providers/obd2_recording_pipeline.dart
+++ b/lib/features/obd2/providers/obd2_recording_pipeline.dart
@@ -10,6 +10,7 @@ import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../driving/providers/live_harsh_event_bus_provider.dart';
 import '../../../core/domain/vehicle_profile.dart';
 import '../data/obd2_connection_errors.dart';
+import '../data/obd2_recording_link_ownership.dart';
 import '../data/obd2_service.dart';
 import '../data/obd2_trip_start_budgets.dart';
 import '../data/obd2_session_context_block.dart';
@@ -188,9 +189,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     );
     _controller = ctl;
 
-    // #769 load baselines + #3382 watchdog-bound the blocking init (see
-    // obd2_trip_start_budgets): on a stall ABORT cleanly (drop controller,
-    // disconnect, surface a recoverable error) instead of hanging forever.
+    // #769 baselines + #3382 watchdog-bound init (obd2_trip_start_budgets): on
+    // a stall ABORT cleanly (disconnect + recoverable error), never hang.
     try {
       await _baselines.load().timeout(_baselinesBudget);
       await ctl.start().timeout(_startWatchdog);
@@ -270,8 +270,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       // #1303 — phase transitions force an immediate snapshot.
       unawaited(_host.flushActiveSnapshot(force: true));
     });
-    // #2274 concern 2 — going live clears any connecting stage so the
-    // recording screen swaps the progress card for live metrics that frame.
+    Obd2RecordingLinkOwnership.instance.claim(); // #3386 — #3019 stands down
+    // #2274 — going live clears the connecting stage for the live-metrics frame.
     _host.state = _host.state.copyWith(
       phase: TripRecordingPhase.recording,
       clearConnectStage: true,
@@ -296,6 +296,7 @@ class Obd2RecordingPipeline implements RecordingPipeline {
 
   @override
   Future<StoppedTripResult> stop({bool automatic = false}) async {
+    Obd2RecordingLinkOwnership.instance.release(); // #3386 — #3019 resumes idle
     final ctl = _controller;
     final svc = _service;
     if (ctl == null || svc == null) {

--- a/test/features/obd2/data/obd2_recording_link_ownership_test.dart
+++ b/test/features/obd2/data/obd2_recording_link_ownership_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_recording_link_ownership.dart';
+
+/// #3386 — the latch that lets a trip recording claim the adapter so the
+/// app-wide #3019 reconnect controller stands down (single in-trip authority).
+void main() {
+  setUp(Obd2RecordingLinkOwnership.instance.resetForTest);
+  tearDown(Obd2RecordingLinkOwnership.instance.resetForTest);
+
+  test('defaults to unowned', () {
+    expect(Obd2RecordingLinkOwnership.instance.active, isFalse);
+  });
+
+  test('claim() / release() flip active and notify listeners', () {
+    final seen = <bool>[];
+    void listener() =>
+        seen.add(Obd2RecordingLinkOwnership.instance.recordingOwnsLink.value);
+    Obd2RecordingLinkOwnership.instance.recordingOwnsLink.addListener(listener);
+    addTearDown(() => Obd2RecordingLinkOwnership.instance.recordingOwnsLink
+        .removeListener(listener));
+
+    Obd2RecordingLinkOwnership.instance.claim();
+    expect(Obd2RecordingLinkOwnership.instance.active, isTrue);
+    Obd2RecordingLinkOwnership.instance.release();
+    expect(Obd2RecordingLinkOwnership.instance.active, isFalse);
+
+    expect(seen, [true, false]);
+  });
+}

--- a/test/features/obd2/providers/obd2_reconnect_provider_test.dart
+++ b/test/features/obd2/providers/obd2_reconnect_provider_test.dart
@@ -3,12 +3,17 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
+import 'package:tankstellen/features/obd2/data/obd2_recording_link_ownership.dart';
 import 'package:tankstellen/features/obd2/data/obd2_reconnect_controller.dart';
 import 'package:tankstellen/features/obd2/providers/obd2_reconnect_provider.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 void main() {
   silenceErrorLoggerSpool();
+
+  setUp(Obd2RecordingLinkOwnership.instance.resetForTest);
+  tearDown(Obd2RecordingLinkOwnership.instance.resetForTest);
 
   group('Obd2Reconnect provider (#3019 / Epic #3013 phase 3)', () {
     test(
@@ -40,6 +45,58 @@ void main() {
         () => container.read(obd2ReconnectProvider.notifier).reportDropped(),
         returnsNormally,
       );
+    });
+
+    test(
+        '#3386 — STANDS DOWN while a recording owns the adapter: a drop signal '
+        'does NOT start the reconnect loop (the trip DroppedSessionManager '
+        'owns it)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      // A recording owns the link → #3019 must ignore the drop signal.
+      Obd2RecordingLinkOwnership.instance.claim();
+      Obd2LinkDropSignal.instance
+          .notifyDrop(transportKind: 'classic', reason: 'classic-socket-error');
+      await pumpEventQueue();
+
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
+          reason: 'two reconnectors on one adapter ping-pong forever — #3019 '
+              'must defer to the in-trip DroppedSessionManager');
+
+      // Release: the very next idle drop is handled again as before.
+      Obd2RecordingLinkOwnership.instance.release();
+      Obd2LinkDropSignal.instance
+          .notifyDrop(transportKind: 'classic', reason: 'classic-socket-error');
+      await pumpEventQueue();
+
+      expect(container.read(obd2ReconnectProvider),
+          Obd2ReconnectState.reconnecting,
+          reason: 'an idle / between-trips drop still recovers (#3019 charter)');
+    });
+
+    test(
+        '#3386 — claiming the link mid-loop hands over immediately: an '
+        'in-flight reconnect is stopped so it can\'t tear down the recording\'s '
+        'socket', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      // Read once so the keepAlive provider builds + subscribes to the signal.
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      // An idle drop starts the loop (no recording yet).
+      Obd2LinkDropSignal.instance
+          .notifyDrop(transportKind: 'classic', reason: 'classic-socket-error');
+      await pumpEventQueue();
+      expect(container.read(obd2ReconnectProvider),
+          Obd2ReconnectState.reconnecting);
+
+      // The user hits Start: the recording claims the link → #3019 stops.
+      Obd2RecordingLinkOwnership.instance.claim();
+      await pumpEventQueue();
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
+          reason: 'a recording claiming the link must stop the app-wide loop');
     });
   });
 }

--- a/test/features/obd2/providers/obd2_recording_pipeline_test.dart
+++ b/test/features/obd2/providers/obd2_recording_pipeline_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/obd2/data/obd2_connection_errors.dart';
+import 'package:tankstellen/features/obd2/data/obd2_recording_link_ownership.dart';
 import 'package:tankstellen/features/obd2/data/obd2_service.dart';
 import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
@@ -54,6 +55,21 @@ void main() {
       expect(h.host.seedCount, 1,
           reason: 'start must seed the active-trip WAL snapshot exactly '
               'once (#1303), as the inline path did');
+    });
+
+    test('#3386 — start() CLAIMS the adapter (so #3019 stands down) and stop() '
+        'RELEASES it', () async {
+      Obd2RecordingLinkOwnership.instance.resetForTest();
+      addTearDown(Obd2RecordingLinkOwnership.instance.resetForTest);
+
+      final h = await _Harness.started();
+      expect(Obd2RecordingLinkOwnership.instance.active, isTrue,
+          reason: 'a live OBD2 recording owns the adapter — the app-wide #3019 '
+              'reconnect controller must stand down to avoid the reconnect war');
+
+      await h.dispose(); // calls pipeline.stop()
+      expect(Obd2RecordingLinkOwnership.instance.active, isFalse,
+          reason: 'stop() hands the idle reconnect role back to #3019');
     });
 
     test('a live sample flows through to the host state + drives the '


### PR DESCRIPTION
## Symptom (your screenshots)

During an OBD2 trip the banner stays on **"Enregistrement via GPS — reconnexion OBD2"** the entire drive and consumption is GPS-**estimated** ("~ estimé", "~0.83 L", "~10.6 L/100 km"). The adapter connects but **never holds** — it's permanently reconnecting — so the app only ever gets a fraction of the live data (which is why the fuel chart is an estimate, not measured).

## Root cause

The connect-trace ring is conclusive: **~20 connect cycles in 70 s, each starting 0–1 ms after the previous ends**, alternating between two reconnect authorities on the *single* adapter:
- `firstConnect` `connectByMacClassicDirect` → the trip's `DroppedSessionManager` (#2188), via `reconnect_connector`.
- `liveReconnect` `connectBest`/pinned → the app-wide `Obd2Reconnect` (#3019).

A single backoff controller produces *increasing* gaps; 0 ms back-to-back alternation = **two independent authorities**. #3019's own charter (#3013) is *"a drop while idle / between trips"*, but it subscribed to the link-drop signal **unconditionally**. So during a recording **both** reconnect the one adapter: establishing a second RFCOMM socket tears down the first (one SPP channel), the first sees a socket-close drop and reconnects, tearing down the second… a **perpetual war** that never lets the link settle → the trip stays in `degradedGpsOnly` → fuel is GPS-estimated.

The PID coverage is actually comprehensive (5E → MAF → speed-density MAP+IAT+RPM) — it was never the problem. The link instability was.

## Fix — one in-trip reconnect authority

A small `Obd2RecordingLinkOwnership` latch (obd2 data layer, no feature dependency) the OBD2 recording pipeline **claims on go-live / releases on stop**. While claimed, `Obd2Reconnect` (#3019) **ignores drop signals and stops any in-flight loop** (so it can't tear down the recording's freshly-owned socket). The trip's `DroppedSessionManager` is then the sole in-trip authority — exactly as designed — so the link settles and real PIDs stream. #3019 resumes the idle/between-trips role when the trip ends.

UI is unaffected: the degraded-GPS banner is driven by the trip's own `degradedGpsOnly` phase, and #3019's banner only renders when no trip is active.

## Tests
- The gate: a drop is ignored while a recording owns the link; an idle drop still recovers; claiming the link mid-loop stops the in-flight reconnect.
- The pipeline claim/release lifecycle (start claims, stop releases).
- Full OBD2 suite (2210 tests) + file_length gate green; clean-codegen committed.

Closes #3386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)