### PR TITLE
fix(android): no phantom FGS arm when the foreground service isn't registered (#3246)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
@@ -105,10 +105,31 @@ object BackgroundAdapterChannel {
                     putExtra(AutoRecordForegroundService.EXTRA_MAC, mac)
                 }
                 try {
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                        ctx.startForegroundService(intent)
-                    } else {
-                        ctx.startService(intent)
+                    val component =
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                            ctx.startForegroundService(intent)
+                        } else {
+                            ctx.startService(intent)
+                        }
+                    // #3246 — shipped builds gate the <service> OUT of the manifest
+                    // (FGS_FORM_APPROVED off, #3173). Starting an undeclared service
+                    // does NOT throw — it logs "Unable to start service … not found"
+                    // and resolves to a null ComponentName. Report the honest failure
+                    // instead of a phantom "armed", so Dart degrades to GPS-only rather
+                    // than believing a foreground service is running that isn't.
+                    if (component == null) {
+                        Log.w(
+                            TAG,
+                            "start: AutoRecordForegroundService is not registered " +
+                                "(FGS gated out of the manifest) — not armed",
+                        )
+                        running = false
+                        result.error(
+                            "unavailable",
+                            "foreground service not registered",
+                            null,
+                        )
+                        return
                     }
                     running = true
                     result.success(true)

--- a/lib/features/obd2/data/android_background_adapter_listener.dart
+++ b/lib/features/obd2/data/android_background_adapter_listener.dart
@@ -94,7 +94,25 @@ class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
           },
         );
 
-    await _methods.invokeMethod<bool>('start', <String, Object?>{'mac': mac});
+    // #3246 — the native arm can legitimately fail: shipped builds gate the
+    // foreground <service> out of the manifest (FGS_FORM_APPROVED off, #3173)
+    // so it is `unavailable`, or it `cannot start fgs from background`. The
+    // native side now reports those honestly instead of a phantom success;
+    // degrade silently here (recording falls back to the GPS-only / foreground
+    // path) rather than crashing the auto-record coordinator.
+    try {
+      final armed =
+          await _methods.invokeMethod<bool>('start', <String, Object?>{'mac': mac});
+      if (armed != true) {
+        debugPrint('AndroidBackgroundAdapterListener: FGS not armed (native '
+            'returned $armed)');
+      }
+      // Benign degrade — the channel code/message is the only useful signal.
+      // ignore: catch_no_st
+    } on PlatformException catch (e) {
+      debugPrint('AndroidBackgroundAdapterListener: FGS arm failed '
+          '(${e.code}): ${e.message} — degrading to no-FGS recording');
+    }
   }
 
   @override

--- a/test/features/obd2/data/android_background_adapter_listener_test.dart
+++ b/test/features/obd2/data/android_background_adapter_listener_test.dart
@@ -61,6 +61,27 @@ void main() {
       expect(calls.single.arguments, {'mac': 'AA:BB:CC:DD:EE:01'});
     });
 
+    test(
+        '#3246 — a native arm FAILURE (FGS not registered in a shipped build) '
+        'degrades silently: start() does NOT throw', () async {
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        // The native side now reports the honest failure instead of a phantom
+        // success when the <service> is gated out of the manifest (#3173).
+        throw PlatformException(
+            code: 'unavailable', message: 'foreground service not registered');
+      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(onListen: (_, _) {}),
+      );
+
+      // Must not crash the auto-record coordinator — recording falls back to
+      // the GPS-only / foreground path.
+      await expectLater(
+          listener.start(mac: 'AA:BB:CC:DD:EE:01'), completes);
+    });
+
     test('events from the EventChannel are translated to typed events',
         () async {
       messenger.setMockMethodCallHandler(


### PR DESCRIPTION
Shipped builds gate the `AutoRecordForegroundService` `<service>` **out of the manifest** (FGS_FORM_APPROVED off, #3173). Starting an undeclared service does **not** throw — Android logs "Unable to start service … not found" and resolves to a `null` ComponentName — but `start()` flipped `running=true` and returned `success(true)` regardless, so Dart believed a foreground service was running that wasn't.

- **Kotlin**: capture the `startForegroundService`/`startService` ComponentName; a `null` result → `result.error("unavailable", …)` with `running=false` instead of a phantom success.
- **Dart**: `AndroidBackgroundAdapterListener.start()` catches the `PlatformException` (`unavailable` / cannot-start-from-background) and degrades silently — recording falls back to the GPS-only / foreground path rather than crashing the auto-record coordinator. +regression test.

Kotlin compiles (`compilePlayDebugKotlin`); lint/test green.

Closes #3246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)