### PR TITLE
fix(ios): re-register the state-restoration pending connect after every disconnect (#3242)

### DIFF
--- a/lib/features/obd2/data/ios_background_adapter_listener.dart
+++ b/lib/features/obd2/data/ios_background_adapter_listener.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import '../../../core/logging/error_logger.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import 'background_adapter_listener.dart';
 import 'ios_state_restoration_service.dart';
 
@@ -170,6 +171,31 @@ class IosBackgroundAdapterListener implements BackgroundAdapterListener {
     _emit(connected
         ? AdapterConnected(mac: id, at: _now())
         : AdapterDisconnected(mac: id, at: _now()));
+    // #3242 — FBP's `disconnect()` (our session teardown ALWAYS calls it:
+    // channel close, pre-connect stale-GATT teardown, coordinator session
+    // close) removes the remoteId from FBP's auto-connect set, and the
+    // background re-pend is gated on set membership — so the #3167 hands-free
+    // pending connect would survive only until the FIRST trip of each process
+    // ends, with no trace/UI signal. Re-issue the pend on every real
+    // disconnect so the NEXT adapter power-on still relaunches the app.
+    if (!connected) unawaited(_repend(id));
+  }
+
+  /// #3242 — re-arm the OS-level pending connect after a disconnect cleared it.
+  /// `registerPersistedAdapter` only ISSUES a pending connect (it never tears a
+  /// channel down or stops a scan), so re-issuing it is idempotent + safe. Best
+  /// effort: a restoration-service fault is logged, never thrown.
+  Future<void> _repend(String mac) async {
+    try {
+      await _restoration.registerPersistedAdapter(mac);
+      BreadcrumbCollector.add('obd2-restoration: restoration-repend',
+          detail: 'mac=$mac');
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.background, e, st, context: {
+        'where': 'IosBackgroundAdapterListener._repend',
+        'deviceId': mac,
+      }));
+    }
   }
 
   void _emit(BackgroundAdapterEvent event) {

--- a/test/features/obd2/data/ios_background_adapter_listener_test.dart
+++ b/test/features/obd2/data/ios_background_adapter_listener_test.dart
@@ -158,6 +158,36 @@ void main() {
   });
 
   test(
+      '#3242 — a real disconnect RE-PENDS the persisted adapter (FBP clears '
+      'its auto-connect set on disconnect, killing the hands-free re-pend)',
+      () async {
+    await listener.start(mac: uuid);
+    expect(restoration.registeredUuids, [uuid],
+        reason: 'start() issues the initial pending connect');
+
+    // A real connect → disconnect cycle (trip runs, then teardown calls
+    // device.disconnect(), which removes the id from FBP\'s auto-connect set).
+    stateControllers[uuid]!.add(true);
+    stateControllers[uuid]!.add(false);
+    await pumpEventQueue();
+
+    expect(restoration.registeredUuids, [uuid, uuid],
+        reason: 'the disconnect must re-arm the pend so the NEXT adapter '
+            'power-on still relaunches the app (#3242) — otherwise hands-free '
+            'connect dies after the first trip of the process');
+  });
+
+  test(
+      'the initial replayed "disconnected" does NOT re-pend (it is not a '
+      'transition)', () async {
+    await listener.start(mac: uuid);
+    stateControllers[uuid]!.add(false); // FBP replays current state
+    await pumpEventQueue();
+    expect(restoration.registeredUuids, [uuid],
+        reason: 'only a real disconnect transition re-pends');
+  });
+
+  test(
       'initial replayed "disconnected" is swallowed — a normal launch '
       'must not arm the disconnect-save debounce', () async {
     await listener.start(mac: uuid);


### PR DESCRIPTION
**CRITICAL** (BLE audit, verified against flutter_blue_plus 1.36.8).

FBP's `disconnect()` removes the remoteId from its auto-connect set unconditionally, and the background re-pend is gated on set membership. Our session teardown **always** calls `device.disconnect()` (channel close, pre-connect stale-GATT teardown, coordinator session close), so the #3167 hands-free pending connect survived only until the **first trip of each process** ended — the next adapter power-on did not relaunch the app, with no trace/UI signal. `IosBackgroundAdapterListener.start` also early-returns on the same watched id, so a re-arm never re-invoked `registerPersistedAdapter`.

**Fix:** re-issue the pending connect on every **real** `AdapterDisconnected` transition (`registerPersistedAdapter` only ISSUES a pend — never tears down a channel or stops a scan, so it's idempotent + safe), stamping a `restoration-repend` breadcrumb. The replayed initial "disconnected" is not a transition and does not re-pend.

**Tests:** a disconnect re-pends the adapter; the initial replay does not.

Closes #3242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)