### PR TITLE
fix(trips): GPS-only fuel litres consistent with the displayed distance (#3252)

### DIFF
--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -331,7 +331,7 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
         if (est != null) {
           summary = summary.copyWith(
             avgLPer100Km: est.lPer100Km,
-            fuelLitersConsumed: est.litersConsumed,
+            fuelLitersConsumed: est.lPer100Km * summary.distanceKm / 100, // #3252
           );
         }
       }

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -236,6 +236,39 @@ void main() {
       ]);
     });
 
+    test(
+        '#3252 — imputed fuel litres are CONSISTENT with the displayed '
+        'distance: litres ≈ avg × km / 100', () async {
+      final harness = _Harness(
+        vehicle: const VehicleProfile(id: 'v1', name: 'Peugeot 107'),
+      );
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      // A noisy-ish moving GPS-only run → non-zero distance + a fuel estimate.
+      final t0 = DateTime(2026, 5, 29, 8);
+      for (var i = 0; i < 8; i++) {
+        harness.geo.emit(_pos(43.40 + i * 0.006, 3.50 + i * 0.004,
+            speedMps: 20.0, at: t0.add(Duration(seconds: i))));
+        await _pump();
+      }
+      await harness.pipeline.stop(automatic: true);
+
+      final s = harness.host.saved.single.summary;
+      expect(s.avgLPer100Km, isNotNull,
+          reason: 'the #2080 GPS-fuel imputation must fire with an active '
+              'vehicle');
+      expect(s.fuelLitersConsumed, isNotNull);
+      // The invariant the trip UI relies on (#3252): the displayed litres are
+      // the displayed average applied to the displayed distance.
+      expect(
+        s.fuelLitersConsumed!,
+        closeTo(s.avgLPer100Km! * s.distanceKm / 100, 1e-9),
+        reason: 'displayed litres must equal avg × shown-km / 100 — not a '
+            'separate un-gated haversine that disagrees with the shown km',
+      );
+    });
+
     test('appendObd2Sample mid-trip flips the finalised kind to '
         'gpsPlusObd2', () async {
       final harness = _Harness();
@@ -316,8 +349,12 @@ Future<void> _pump() => Future<void>.delayed(Duration.zero);
 
 /// Wires a [GpsOnlyRecordingPipeline] to a fake host + fake Geolocator.
 class _Harness {
-  _Harness({String? activeVehicleId, bool vehicleProviderThrows = false})
-      : host = _FakeHost(activeVehicleId: activeVehicleId) {
+  _Harness({
+    String? activeVehicleId,
+    bool vehicleProviderThrows = false,
+    VehicleProfile? vehicle,
+  }) : host = _FakeHost(activeVehicleId: activeVehicleId) {
+    _vehicle = vehicle;
     container = ProviderContainer(overrides: [
       geolocatorWrapperProvider.overrideWithValue(geo),
       // #2760 — the pipeline now attaches IMU fusion in start(); stub it with
@@ -335,13 +372,18 @@ class _Harness {
       // [vehicleProviderThrows] is set, the read throws instead — the
       // #2228 regression: the stop path must degrade gracefully.
       activeVehicleProfileProvider.overrideWith(
-        () => vehicleProviderThrows ? _ThrowingActiveVehicle() : _NoActiveVehicle(),
+        () => vehicleProviderThrows
+            ? _ThrowingActiveVehicle()
+            : (_vehicle != null
+                ? _RealActiveVehicle(_vehicle!)
+                : _NoActiveVehicle()),
       ),
     ]);
     // A tiny capturing provider hands us a real Ref to feed the pipeline.
     pipeline = container.read(_pipelineProvider(host));
   }
 
+  VehicleProfile? _vehicle;
   final _FakeHost host;
   final _RecordingGeolocator geo = _RecordingGeolocator();
   late final ProviderContainer container;
@@ -367,6 +409,13 @@ final _pipelineProvider =
 class _FixedActiveLanguage extends ActiveLanguage {
   @override
   AppLanguage build() => const AppLanguage('en', 'English', 'English');
+}
+
+class _RealActiveVehicle extends ActiveVehicleProfile {
+  _RealActiveVehicle(this._v);
+  final VehicleProfile _v;
+  @override
+  VehicleProfile? build() => _v;
 }
 
 class _NoActiveVehicle extends ActiveVehicleProfile {


### PR DESCRIPTION
The GPS-only save persisted the recorder's ∫speed·dt as the displayed distance, but the #2080 fuel imputation took its **litres** from the estimator's separate **un-gated haversine**. So `fuelLitersConsumed = lPer100Km × haversineKm/100` while the displayed distance was the integral — `litres ÷ shown-km ≠ shown average` whenever they diverge (tunnels, batching, parked scatter).

**Fix:** derive litres from the estimator's **rate** × the **displayed** distance, so `litres ÷ shown-km × 100 == shown avg` holds by construction. Left `distanceSource` as `'virtual'` on purpose — relabeling it `'gps'` would wrongly disable the #3368 phantom-harsh suppression that keys on `'virtual'`.

**Test:** invariant assertion (`litres ≈ avg × km/100`) on a moving GPS-only fixture with an active vehicle.

Part of the recording-audit cluster; the fuller "route through the gated GpsTrackDistance + stamp 'gps'" remains a follow-up (#3252 mentions it). Closes #3252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)