### PR TITLE
feat(radar): always-on radar health counters — make 'radar never fired' answerable (#3257 pt1)

### DIFF
--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -8,6 +8,7 @@ import 'package:geolocator/geolocator.dart';
 import '../domain/fuel_type.dart';
 import '../domain/station.dart';
 import '../logging/error_logger.dart';
+import '../telemetry/health_counters.dart';
 import '../utils/geo_utils.dart' as geo;
 import '../utils/num_extensions.dart';
 import '../utils/station_extensions.dart';
@@ -240,6 +241,9 @@ class ApproachDetector {
       _schedulePoll();
       return;
     }
+    // #3257 — always-on radar health counters (#3146): make the silent
+    // "radar never fired" causes answerable in a field export.
+    healthCounters.increment('radar.polls');
     try {
       final stations = await _fetchStations(
         gps.latitude,
@@ -269,7 +273,14 @@ class ApproachDetector {
         final price = p.$1.priceFor(fuel);
         return price != null && price > 0;
       }).toList();
+      if (inRadius.isNotEmpty) healthCounters.increment('radar.inRadiusEnters');
       if (priced.isEmpty) {
+        // #3257 — distinguish "no station in radius" from "all in-radius
+        // stations were dropped by the #2601 priced-only filter" — the latter
+        // is a silent reason the radar never fires despite a forecourt ahead.
+        if (inRadius.isNotEmpty) {
+          healthCounters.increment('radar.unpricedFiltered');
+        }
         _onNoStationInRadius(gps);
       } else {
         _onStationsInRadius(priced);

--- a/lib/core/services/radar/corridor_location_cache.dart
+++ b/lib/core/services/radar/corridor_location_cache.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import '../../domain/station.dart';
+import '../../telemetry/health_counters.dart';
 import 'corridor_geo.dart';
 import 'geo_tile.dart';
 
@@ -266,6 +267,9 @@ class CorridorLocationCache {
     final inFlight = _inFlight;
     if (inFlight != null && _inFlightTile == targetTile) return inFlight;
 
+    // #3257 — count corridor (re)fetches so a field export shows whether the
+    // radar's location set is being fed (a stalled corridor = silent radar).
+    healthCounters.increment('radar.corridorRefetches');
     final future = _doFetch(lat, lng, replace: true);
     _inFlight = future;
     _inFlightTile = targetTile;

--- a/test/core/services/approach_detector_test.dart
+++ b/test/core/services/approach_detector_test.dart
@@ -8,7 +8,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/telemetry/health_counters.dart';
 import '../../helpers/silence_error_logger.dart';
+
+/// Sum a #3146 HealthCounters value across all day-rows of the snapshot
+/// (the in-memory pending deltas are folded under today's key).
+int _counterTotal(String name) {
+  final days = (healthCounters.exportSnapshot()['days'] as Map?) ?? const {};
+  var total = 0;
+  for (final row in days.values) {
+    total += ((row as Map)[name] as int?) ?? 0;
+  }
+  return total;
+}
 
 Position _pos(double lat, double lng, {double speedMps = 0}) => Position(
       latitude: lat,
@@ -410,6 +422,46 @@ void main() {
         unawaited(sub.cancel());
         unawaited(det.dispose());
         unawaited(gps.close());
+      });
+    });
+
+    test(
+        '#3257 — a poll over an in-radius UNPRICED forecourt bumps radar.polls '
+        '+ radar.inRadiusEnters + radar.unpricedFiltered (the silent #2601 '
+        'cause is now answerable in a field export)', () {
+      fakeAsync((async) {
+        healthCounters.resetForTest();
+        // In radius (~500 m N) but NO e10 price → dropped by the #2601 filter.
+        final unpriced = _station(id: 'U', lat: 48.0045, lng: 2.0);
+        final gps = StreamController<Position>.broadcast();
+        final det = ApproachDetector(
+          gpsStream: gps.stream,
+          fetchStations: (_, _, _, _, {headingDegrees}) async => [unpriced],
+          config: const ApproachDetectorConfig(
+            radiusMeters: 1000,
+            priceMode: ApproachPriceMode.nearest,
+            minPollSeconds: 5,
+            fuelTypeApiValue: 'e10',
+          ),
+        );
+        final sub = det.state.listen((_) {});
+
+        gps.add(_pos(48.0, 2.0, speedMps: 10));
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        expect(_counterTotal('radar.polls'), greaterThanOrEqualTo(1));
+        expect(_counterTotal('radar.inRadiusEnters'), greaterThanOrEqualTo(1));
+        expect(_counterTotal('radar.unpricedFiltered'), greaterThanOrEqualTo(1),
+            reason: 'all in-radius stations were unpriced — the radar cannot '
+                'fire, and that reason must be countable');
+
+        unawaited(sub.cancel());
+        unawaited(det.dispose());
+        unawaited(gps.close());
+        async.flushMicrotasks();
+        healthCounters.resetForTest();
       });
     });
   });


### PR DESCRIPTION
A field export couldn't distinguish the silent reasons the radar never fires (overlay gate off, every in-radius station dropped by the #2601 priced-only filter, empty corridor, starved polls). Adds #3146 HealthCounters at the decision sites:

- `radar.polls` — each approach poll ran
- `radar.inRadiusEnters` — a station was within the approach radius
- `radar.unpricedFiltered` — in-radius stations existed but **all** were dropped as unpriced (#2601) — the key "looked dead but wasn't" signal
- `radar.corridorRefetches` — the location corridor was (re)fetched

+fakeAsync test proving an in-radius-but-unpriced poll bumps `polls` / `inRadiusEnters` / `unpricedFiltered`.

**Decision:** part 2 of #3257 (the radar-lead price **freshness disclosure** on the radar card / PiP / Live Activity) is a multi-surface UX change — deferred to a focused follow-up so this lands the high-value diagnostics now. Issue stays open for part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)