### PR TITLE
chore(ci): read-only Play track status workflow to confirm a publish

### DIFF
--- a/.github/workflows/play-status.yml
+++ b/.github/workflows/play-status.yml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: Play track status (read-only)
+
+# Manual-only. Reports what is currently live on each Play Store track so a
+# promotion can be confirmed as actually PUBLISHED (an API edit commit succeeds
+# even when Managed Publishing holds the change, or a first production release
+# is still in Google review). Read-only: the script creates an edit only to
+# READ the track resources and deletes it without committing.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: play-store-deploy
+  cancel-in-progress: false
+
+env:
+  PACKAGE_NAME: de.tankstellen.fuelprices
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install google-api-python-client
+        run: pip install google-api-python-client google-auth
+
+      - name: Report track status
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+        run: bash scripts/play_track_status.sh | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/play_track_status.sh
+++ b/scripts/play_track_status.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+#
+# play_track_status.sh — READ-ONLY report of what is currently live on each
+# Play Store track (production / beta / alpha / internal). Used to confirm a
+# promotion actually published — an API edit commit succeeds even when the
+# Console has Managed Publishing on (the change then waits for a manual
+# "Publish") or when a first production release is still in Google review.
+#
+# It creates an edit ONLY to read the track resources, then DELETES the edit
+# without committing — it never changes anything.
+#
+# Required env:
+#   PLAY_STORE_SERVICE_ACCOUNT_JSON — service account JSON (contents)
+#   PACKAGE_NAME                    — e.g. de.tankstellen.fuelprices
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ -z "${PLAY_STORE_SERVICE_ACCOUNT_JSON:-}" ]] && die "PLAY_STORE_SERVICE_ACCOUNT_JSON is not set"
+[[ -z "${PACKAGE_NAME:-}" ]] && die "PACKAGE_NAME is not set"
+
+SA_FILE="$(mktemp)"
+trap 'rm -f "$SA_FILE"' EXIT
+echo "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$SA_FILE"
+
+python3 - "$SA_FILE" "$PACKAGE_NAME" << 'PYTHON_EOF'
+import sys
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+sa_file, package_name = sys.argv[1], sys.argv[2]
+
+creds = service_account.Credentials.from_service_account_file(
+    sa_file, scopes=['https://www.googleapis.com/auth/androidpublisher'])
+service = build('androidpublisher', 'v3', credentials=creds)
+
+edit = service.edits().insert(body={}, packageName=package_name).execute()
+edit_id = edit['id']
+try:
+    print(f"== Play track status for {package_name} ==\n")
+    for track in ('production', 'beta', 'alpha', 'internal'):
+        try:
+            t = service.edits().tracks().get(
+                packageName=package_name, editId=edit_id, track=track).execute()
+        except Exception as e:  # noqa: BLE001 — a missing track is normal
+            print(f"[{track}] (no track / not accessible): {e}")
+            continue
+        releases = t.get('releases', [])
+        if not releases:
+            print(f"[{track}] no releases")
+            continue
+        for r in releases:
+            status = r.get('status', '?')
+            codes = r.get('versionCodes', [])
+            name = r.get('name', '?')
+            frac = r.get('userFraction')
+            frac_s = f" userFraction={frac}" if frac is not None else ""
+            print(f"[{track}] status={status} versionCodes={codes} "
+                  f"name={name}{frac_s}")
+    print()
+    # Explicit production verdict for the confirmation question.
+    prod = service.edits().tracks().get(
+        packageName=package_name, editId=edit_id, track='production').execute()
+    prod_releases = prod.get('releases', [])
+    completed = [r for r in prod_releases if r.get('status') == 'completed']
+    if completed:
+        c = completed[0]
+        print(f"PRODUCTION VERDICT: PUBLISHED — versionCodes="
+              f"{c.get('versionCodes')} status=completed "
+              f"(userFraction={c.get('userFraction', 'full/1.0')})")
+    elif prod_releases:
+        r = prod_releases[0]
+        print(f"PRODUCTION VERDICT: PRESENT but not completed — "
+              f"status={r.get('status')} versionCodes={r.get('versionCodes')} "
+              f"(may be draft / awaiting Managed-Publishing publish / in review)")
+    else:
+        print("PRODUCTION VERDICT: NO production release found")
+finally:
+    # READ-ONLY: discard the edit without committing — changes nothing.
+    service.edits().delete(packageName=package_name, editId=edit_id).execute()
+    print("\n(read-only: edit discarded, nothing changed)")
+PYTHON_EOF


### PR DESCRIPTION
A promote/upload API edit commit succeeds even when the Play Console has **Managed Publishing** on (the change then waits for a manual Publish) or a **first production release** is still in Google review — so a green `deploy.yml` run does not by itself prove the build is live.

Adds a manual, **read-only** workflow + script that reports the current release on each track (production / beta / alpha / internal) and an explicit **production verdict**. It creates an edit only to READ track resources and discards it without committing — it changes nothing.

Used right now to confirm the 100% production promotion (run 27933537136) actually published vs. waiting on review/managed-publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)