### PR TITLE
fix(fr): de-noise transient upstream 5xx from Prix-Carburants (#3395)

### DIFF
--- a/lib/core/network/dio_offline.dart
+++ b/lib/core/network/dio_offline.dart
@@ -100,6 +100,41 @@ bool isOfflineError(Object error) {
   return false;
 }
 
+/// Whether [error] is a TRANSIENT UPSTREAM failure — the server (or a gateway
+/// in front of it) couldn't fulfil an otherwise-valid request *right now*, as
+/// opposed to a malformed request (4xx) or a genuine app/connection fault.
+///
+/// #3395 — a country feed having a bad few minutes (the FR data.economie.gouv.fr
+/// gateway returned **502** 50× in 7 min during a real outage) is upstream's
+/// problem, not an app bug, and must NOT spool 50 full ERROR traces that bury
+/// real faults. A site that already degrades to "empty results" on this can
+/// breadcrumb it instead. Deliberately scoped to the unambiguous "retry later"
+/// statuses so a real **500** (which can mean our request broke the server) and
+/// every 4xx still persist as a trace:
+///   - **502 / 503 / 504** — bad gateway / service unavailable / gateway timeout
+///     (infra/proxy transient, never a request-shape problem);
+///   - **429** — rate limited (back off, not a bug);
+///   - connect / send / receive **timeouts** — the upstream was too slow.
+/// Offline / no-network shapes are NOT included here — those are
+/// [isOfflineError]'s job; a caller typically checks offline first.
+bool isTransientUpstreamError(Object error) {
+  if (error is! DioException) return false;
+  switch (error.type) {
+    case DioExceptionType.connectionTimeout:
+    case DioExceptionType.sendTimeout:
+    case DioExceptionType.receiveTimeout:
+      return true;
+    case DioExceptionType.badResponse:
+      final code = error.response?.statusCode;
+      return code == 502 || code == 503 || code == 504 || code == 429;
+    case DioExceptionType.connectionError:
+    case DioExceptionType.badCertificate:
+    case DioExceptionType.cancel:
+    case DioExceptionType.unknown:
+      return false;
+  }
+}
+
 /// True when [message] carries one of the offline / no-network / failed
 /// host-lookup substrings. Matched case-insensitively. Kept in sync with
 /// `friendlyAuthError`'s network-family substrings (#2745).

--- a/lib/features/station_services/france/prix_carburants_queries.dart
+++ b/lib/features/station_services/france/prix_carburants_queries.dart
@@ -90,6 +90,20 @@ Future<List<Map<String, dynamic>>> queryPrixCarburantsByGeo(
       debugPrint('Prix-Carburants geo fetch skipped — offline ($e)');
       return [];
     }
+    // #3395 — a transient UPSTREAM blip (the gov gateway returned 502 50× in
+    // 7 min during a real outage) is not an app fault. Breadcrumb it instead of
+    // spooling 50 ERROR traces that bury real faults; the service already
+    // degrades to empty results and the next poll retries. A genuine fault
+    // (500 / 4xx / unexpected shape) still ERROR-logs below.
+    if (isTransientUpstreamError(e)) {
+      BreadcrumbCollector.add(
+        'Prix-Carburants geo fetch — transient upstream error',
+        detail: 'status=${e.response?.statusCode ?? e.type} '
+            'lat=$lat lng=$lng',
+      );
+      debugPrint('Prix-Carburants geo fetch — transient upstream ($e)');
+      return [];
+    }
     unawaited(errorLogger.log(ErrorLayer.other, e, st,
         context: const {'where': 'Prix-Carburants geo fetch failed'}));
     return [];

--- a/test/core/network/dio_offline_test.dart
+++ b/test/core/network/dio_offline_test.dart
@@ -128,4 +128,55 @@ void main() {
       expect(isOfflineError(Exception('parse failed')), isFalse);
     });
   });
+
+  group('isTransientUpstreamError — retry-later statuses only (#3395)', () {
+    DioException badResponse(int code) => DioException(
+          requestOptions: RequestOptions(path: '/'),
+          type: DioExceptionType.badResponse,
+          response: Response(
+              requestOptions: RequestOptions(path: '/'), statusCode: code),
+        );
+
+    test('502 / 503 / 504 (gateway/unavailable) are transient', () {
+      for (final code in [502, 503, 504]) {
+        expect(isTransientUpstreamError(badResponse(code)), isTrue,
+            reason: '$code is an infra/proxy transient');
+      }
+    });
+
+    test('429 (rate limited) is transient', () {
+      expect(isTransientUpstreamError(badResponse(429)), isTrue);
+    });
+
+    test('connect/send/receive timeouts are transient (upstream too slow)', () {
+      for (final t in [
+        DioExceptionType.connectionTimeout,
+        DioExceptionType.sendTimeout,
+        DioExceptionType.receiveTimeout,
+      ]) {
+        expect(
+          isTransientUpstreamError(
+              DioException(requestOptions: RequestOptions(path: '/'), type: t)),
+          isTrue,
+        );
+      }
+    });
+
+    test('500 is NOT transient — it can mean our request broke the server', () {
+      expect(isTransientUpstreamError(badResponse(500)), isFalse);
+    });
+
+    test('4xx are NOT transient — a malformed/forbidden request is a real bug',
+        () {
+      for (final code in [400, 401, 403, 404, 422]) {
+        expect(isTransientUpstreamError(badResponse(code)), isFalse,
+            reason: '$code is a request-shape problem, not retry-later');
+      }
+    });
+
+    test('a non-Dio error is never transient-upstream', () {
+      expect(isTransientUpstreamError(Exception('boom')), isFalse);
+      expect(isTransientUpstreamError(const SocketException('x')), isFalse);
+    });
+  });
 }

--- a/test/features/station_services/france/prix_carburants_denoise_test.dart
+++ b/test/features/station_services/france/prix_carburants_denoise_test.dart
@@ -108,17 +108,57 @@ void main() {
       );
     });
 
-    test('a GENUINE API error (5xx) STILL ERROR-logs (the guard)', () async {
+    test(
+        'a transient UPSTREAM 502 (field: gov gateway 50x in 7 min) is a '
+        'breadcrumb, NOT an ERROR (#3395)', () async {
       final svc = _serviceThrowing((o) => DioException(
             requestOptions: o,
             type: DioExceptionType.badResponse,
-            response: Response(requestOptions: o, statusCode: 503),
+            response: Response(requestOptions: o, statusCode: 502),
+          ));
+
+      final result = await svc.searchStations(_geoParams);
+
+      expect(result.data, isEmpty, reason: 'transient blip degrades to empty');
+      expect(recorder.calls, isEmpty,
+          reason: 'a transient gateway 502/503/504 must NOT spool an ERROR '
+              'trace (#3395) — it buries real faults');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('Prix-Carburants geo fetch — transient upstream error'),
+      );
+    });
+
+    test('503 and 504 are also transient-upstream breadcrumbs (#3395)',
+        () async {
+      for (final code in [503, 504]) {
+        errorLogger.resetForTest();
+        recorder = _CapturingRecorder();
+        errorLogger.testRecorderOverride = recorder;
+        final svc = _serviceThrowing((o) => DioException(
+              requestOptions: o,
+              type: DioExceptionType.badResponse,
+              response: Response(requestOptions: o, statusCode: code),
+            ));
+        await svc.searchStations(_geoParams);
+        expect(recorder.calls, isEmpty, reason: '$code must breadcrumb');
+      }
+    });
+
+    test(
+        'a GENUINE server error (500) or 4xx STILL ERROR-logs — only transient '
+        'gateway statuses are de-noised (#3395 guard)', () async {
+      // 500 can mean OUR request broke the server — keep it loud.
+      final svc = _serviceThrowing((o) => DioException(
+            requestOptions: o,
+            type: DioExceptionType.badResponse,
+            response: Response(requestOptions: o, statusCode: 500),
           ));
 
       await svc.searchStations(_geoParams);
 
       expect(recorder.calls, hasLength(1),
-          reason: 'a real 5xx is a genuine failure and must persist');
+          reason: 'a 500 is a genuine failure and must persist as a trace');
       expect(recorder.calls.single.toString(),
           contains('Prix-Carburants geo fetch failed'));
     });


### PR DESCRIPTION
## Field evidence

Error log from the **production** build `6.0.0+2026061691` (2026‑06‑24, 20:11–20:18): **50 identical ERROR traces in 7 minutes**, all `DioException 502 … {where: Prix-Carburants geo fetch failed}`. The French gov open‑data gateway (`data.economie.gouv.fr`) had a bad few minutes — an **upstream outage**, not an app fault — but each 502 spooled a full ERROR trace, burying any real fault in the report.

## Fix

The FR geo‑fetch already breadcrumbs **offline** failures (#2524/#2745), but a transient gateway 5xx isn't "offline" and fell through to `errorLogger.log`. Adds a reusable `isTransientUpstreamError` classifier (`dio_offline.dart`) scoped to the unambiguous **retry‑later** cases — **502/503/504**, **429**, and connect/send/receive **timeouts** — and breadcrumbs those at the FR site instead.

Conservative by design: a **500** (which can mean *our* request broke the server) and every **4xx** still ERROR‑log, so request‑shape bugs stay loud. The classifier is shared so other country services can adopt it.

## Tests
- Classifier: 502/503/504/429/timeouts → transient; 500/4xx/non‑Dio → not.
- FR site: 502/503/504 → breadcrumb (no ERROR); 500 → still ERROR. Updated the prior test that asserted "503 still ERROR‑logs" — that premise is exactly what this changes.

Closes #3395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)