### PR TITLE
feat(ocr): label-anchored value ROIs — read 7-seg pumps on hand-held photos (implements Epic #2823) (#3397)

### DIFF
--- a/assets/ocr_config/index.json
+++ b/assets/ocr_config/index.json
@@ -42,6 +42,12 @@
         "volumeLabel":  "VOLUME",
         "pricePerLitre":      { "left": 0.44, "top": 0.31, "width": 0.10, "height": 0.10 },
         "pricePerLitreLabel": "PRIX DU LITRE"
+      },
+      "valueAnchor": {
+        "direction":    "above",
+        "gap":          0.15,
+        "widthFactor":  1.4,
+        "heightFactor": 2.4
       }
     }
   ]

--- a/lib/features/consumption/data/ocr/label_anchored_roi.dart
+++ b/lib/features/consumption/data/ocr/label_anchored_roi.dart
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '_pump_label_table.dart';
+import 'ocr_geometry.dart';
+import 'pump_ocr_config.dart';
+import 'recognized_text_block.dart';
+
+/// The direction the 7-segment LCD value sits relative to its printed label
+/// on the pump (#3397). On a Tokheim vertical display the digits are directly
+/// ABOVE each "PRIX" / "VOLUME" / "PRIX DU LITRE" label.
+enum ValueAnchorDirection {
+  above,
+  below,
+  left,
+  right;
+
+  static ValueAnchorDirection fromJson(Object? raw) {
+    switch (raw) {
+      case 'below':
+        return ValueAnchorDirection.below;
+      case 'left':
+        return ValueAnchorDirection.left;
+      case 'right':
+        return ValueAnchorDirection.right;
+      case 'above':
+      default:
+        return ValueAnchorDirection.above;
+    }
+  }
+}
+
+/// How to place a 7-segment value ROI relative to the label box ML Kit
+/// located for that field (#3397 / Epic #2823).
+///
+/// The fixed template ROIs assumed the user framed the display canonically;
+/// on a hand-held photo the LCD lands at a different position/scale and the
+/// fixed rectangle samples the wrong pixels. ML Kit DOES reliably read the
+/// printed labels (with boxes), so the value ROI is derived from its label's
+/// box instead — wherever the label landed, the value ROI follows.
+///
+/// The multipliers are deliberately GENEROUS: the [SevenSegmentRecognizer]
+/// row/column-segments WITHIN the ROI, so the ROI only has to CONTAIN the
+/// digits (with margin), not bound them tightly. That tolerance is what makes
+/// label anchoring robust without pixel-perfect per-pump tuning.
+class OcrValueAnchor {
+  /// Where the value sits relative to its label.
+  final ValueAnchorDirection direction;
+
+  /// Separation between the label edge and the value ROI, as a fraction of
+  /// the label's extent along [direction].
+  final double gap;
+
+  /// Value ROI width ÷ label width.
+  final double widthFactor;
+
+  /// Value ROI height ÷ label height.
+  final double heightFactor;
+
+  const OcrValueAnchor({
+    this.direction = ValueAnchorDirection.above,
+    this.gap = 0.15,
+    this.widthFactor = 1.4,
+    this.heightFactor = 2.4,
+  });
+
+  /// Parse a `{direction, gap, widthFactor, heightFactor}` map. Returns null
+  /// (anchoring disabled → fixed template ROIs) when the key is absent, so
+  /// every template without it is byte-for-byte unchanged.
+  static OcrValueAnchor? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    double f(Object? v, double dflt) =>
+        v is num ? v.toDouble() : (v is String ? double.tryParse(v) ?? dflt : dflt);
+    return OcrValueAnchor(
+      direction: ValueAnchorDirection.fromJson(raw['direction']),
+      gap: f(raw['gap'], 0.15),
+      widthFactor: f(raw['widthFactor'], 1.4),
+      heightFactor: f(raw['heightFactor'], 2.4),
+    );
+  }
+}
+
+/// The field ROIs to feed the recognizer, plus which of them were
+/// label-anchored (vs. left at the fixed template fallback) — recorded on the
+/// trace so a field export answers "did the recognizer aim at the digits".
+class AnchoredFieldSpec {
+  final OcrPumpFieldSpec fields;
+  final Set<PumpField> anchored;
+  const AnchoredFieldSpec(this.fields, this.anchored);
+
+  int get anchoredCount => anchored.length;
+}
+
+/// Derive the 7-segment value ROIs from the labels ML Kit located, instead of
+/// the fixed template rectangles (#3397, the missing core of Epic #2823).
+///
+/// For each field: find the heaviest-classified, largest matching label block
+/// ("PRIX DU LITRE" outranks bare "PRIX" via [classifyPumpLabel]'s weights),
+/// then place the value ROI relative to that label per [anchor]. A field whose
+/// label ML Kit did not find keeps its fixed [template] ROI, so the result is
+/// never worse than today.
+///
+/// [blocks] boxes and the recognizer frame share pixel coordinates (both are
+/// `cropToRoi(bakeOrientation(decode), roi)` with no resize), so block boxes
+/// are normalised by [frameWidth]/[frameHeight] into the 0..1 ROI space.
+AnchoredFieldSpec resolveLabelAnchoredFields({
+  required OcrPumpFieldSpec template,
+  required List<RecognizedTextBlock> blocks,
+  required int frameWidth,
+  required int frameHeight,
+  required OcrValueAnchor anchor,
+}) {
+  if (frameWidth <= 0 || frameHeight <= 0 || blocks.isEmpty) {
+    return AnchoredFieldSpec(template, const {});
+  }
+
+  // Best (largest-area) label block per field.
+  final labelBoxes = <PumpField, OcrBox>{};
+  for (final b in blocks) {
+    final field = classifyPumpLabel(b.text);
+    if (field == null) continue;
+    final prev = labelBoxes[field];
+    final area = b.box.width * b.box.height;
+    if (prev == null || area > prev.width * prev.height) {
+      labelBoxes[field] = b.box;
+    }
+  }
+
+  final anchored = <PumpField>{};
+  OcrNormalizedRect pick(PumpField field, OcrNormalizedRect fallback) {
+    final label = labelBoxes[field];
+    if (label == null) return fallback;
+    final roi = _valueRoiFromLabel(label, frameWidth, frameHeight, anchor);
+    if (roi == null) return fallback;
+    anchored.add(field);
+    return roi;
+  }
+
+  return AnchoredFieldSpec(
+    OcrPumpFieldSpec(
+      total: pick(PumpField.total, template.total),
+      volume: pick(PumpField.volume, template.volume),
+      pricePerLitre: pick(PumpField.pricePerLitre, template.pricePerLitre),
+      displayLabels: template.displayLabels,
+    ),
+    anchored,
+  );
+}
+
+/// Place a value ROI relative to a (pixel-space) [label] box per [anchor],
+/// returning a normalised 0..1 rect clamped to the frame, or null when it
+/// collapses to a degenerate sliver (the caller then keeps the fixed ROI).
+OcrNormalizedRect? _valueRoiFromLabel(
+  OcrBox label,
+  int frameWidth,
+  int frameHeight,
+  OcrValueAnchor anchor,
+) {
+  // Normalise the label box to 0..1.
+  final lLeft = label.left / frameWidth;
+  final lTop = label.top / frameHeight;
+  final lW = label.width / frameWidth;
+  final lH = label.height / frameHeight;
+  if (lW <= 0 || lH <= 0) return null;
+  final lCx = lLeft + lW / 2;
+  final lCy = lTop + lH / 2;
+
+  final w = lW * anchor.widthFactor;
+  final h = lH * anchor.heightFactor;
+  double cx;
+  double cy;
+  switch (anchor.direction) {
+    case ValueAnchorDirection.above:
+      cx = lCx;
+      cy = lTop - anchor.gap * lH - h / 2;
+    case ValueAnchorDirection.below:
+      cx = lCx;
+      cy = (lTop + lH) + anchor.gap * lH + h / 2;
+    case ValueAnchorDirection.left:
+      cy = lCy;
+      cx = lLeft - anchor.gap * lW - w / 2;
+    case ValueAnchorDirection.right:
+      cy = lCy;
+      cx = (lLeft + lW) + anchor.gap * lW + w / 2;
+  }
+
+  final left = (cx - w / 2).clamp(0.0, 1.0);
+  final top = (cy - h / 2).clamp(0.0, 1.0);
+  final right = (cx + w / 2).clamp(0.0, 1.0);
+  final bottom = (cy + h / 2).clamp(0.0, 1.0);
+  final cw = right - left;
+  final ch = bottom - top;
+  // A useful ROI must retain real area after clamping.
+  if (cw < 0.03 || ch < 0.03) return null;
+  return OcrNormalizedRect(left: left, top: top, width: cw, height: ch);
+}

--- a/lib/features/consumption/data/ocr/pump_display_orchestrator.dart
+++ b/lib/features/consumption/data/ocr/pump_display_orchestrator.dart
@@ -5,6 +5,7 @@ import 'package:image/image.dart' as img;
 
 import '../pump_display_parser.dart';
 import 'label_anchored_extractor.dart';
+import 'label_anchored_roi.dart';
 import 'ocr_trace_recorder.dart';
 import 'pump_ocr_config.dart';
 import 'pump_ocr_recognizer.dart';
@@ -44,6 +45,7 @@ PumpDisplayParseResult orchestratePumpDisplayParse({
   OcrTraceRecorder? trace,
   img.Image? frame,
   OcrPumpFieldSpec? recognizerFields,
+  OcrValueAnchor? valueAnchor,
   PumpOcrRecognizer recognizer = const PumpOcrRecognizer(),
 }) {
   // The #2830 3rd source is reachable only when a ROI template matched
@@ -59,6 +61,10 @@ PumpDisplayParseResult orchestratePumpDisplayParse({
       recognizer: recognizer,
       gate: gate,
       trace: trace,
+      // #3397 — pass ML Kit's label blocks + the brand's value-anchor so the
+      // recognizer aims its ROIs at the labels it actually found.
+      blocks: blocks,
+      anchor: valueAnchor,
     ).result;
   }
 

--- a/lib/features/consumption/data/ocr/pump_ocr_config.dart
+++ b/lib/features/consumption/data/ocr/pump_ocr_config.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import 'label_anchored_roi.dart';
 import 'ocr_geometry.dart';
 
 /// The physical orientation of a pump display readout (#2276).
@@ -198,12 +199,19 @@ class OcrBrandTemplate {
   /// without the key continue to work unchanged.
   final OcrDisplayOrientation displayOrientation;
 
+  /// #3397 — when present, the 7-segment recognizer derives each value ROI
+  /// from the label ML Kit located (label-anchored) instead of the fixed
+  /// [pumpDisplay] rectangles, so a hand-held shot still reads. Null ⇒ the
+  /// legacy fixed-ROI sweep, so every template without the key is unchanged.
+  final OcrValueAnchor? valueAnchor;
+
   const OcrBrandTemplate({
     required this.brand,
     required this.country,
     required this.label,
     this.pumpDisplay,
     this.displayOrientation = OcrDisplayOrientation.horizontal,
+    this.valueAnchor,
   });
 
   static OcrBrandTemplate? fromJson(Object? raw) {
@@ -220,6 +228,7 @@ class OcrBrandTemplate {
       pumpDisplay: OcrPumpFieldSpec.fromJson(raw['pumpDisplay']),
       displayOrientation:
           OcrDisplayOrientation.fromJson(raw['displayOrientation']),
+      valueAnchor: OcrValueAnchor.fromJson(raw['valueAnchor']),
     );
   }
 }

--- a/lib/features/consumption/data/ocr/pump_recognizer_source.dart
+++ b/lib/features/consumption/data/ocr/pump_recognizer_source.dart
@@ -8,11 +8,13 @@ import 'package:image/image.dart' as img;
 
 import '../../../../core/logging/error_logger.dart';
 import '../pump_display_parse_result.dart';
+import 'label_anchored_roi.dart';
 import 'ocr_image_preprocessor.dart';
 import 'ocr_trace_recorder.dart';
 import 'pump_ocr_config.dart';
 import 'pump_ocr_recognizer.dart';
 import 'pump_validation_gate.dart';
+import 'recognized_text_block.dart';
 
 /// Resolves the #2830 recognizer-source inputs for the pump-display scan.
 ///
@@ -27,7 +29,8 @@ import 'pump_validation_gate.dart';
 ///
 /// Best-effort: any decode error logs and degrades to `(null, null)` so
 /// a quirky image still completes via the existing two sources.
-Future<({img.Image? frame, OcrPumpFieldSpec? fields})> resolveRecognizerSource(
+Future<({img.Image? frame, OcrPumpFieldSpec? fields, OcrValueAnchor? anchor})>
+    resolveRecognizerSource(
   String path,
   String? country,
   String? brand,
@@ -35,22 +38,22 @@ Future<({img.Image? frame, OcrPumpFieldSpec? fields})> resolveRecognizerSource(
   required PumpOcrConfig config,
   OcrImagePreprocessor preprocessor = const OcrImagePreprocessor(),
 }) async {
-  if (country == null) return (frame: null, fields: null);
+  if (country == null) return (frame: null, fields: null, anchor: null);
   await config.load();
   final template = config.templateFor(country: country, brand: brand);
   final fields = template?.pumpDisplay;
-  if (fields == null) return (frame: null, fields: null);
+  if (fields == null) return (frame: null, fields: null, anchor: null);
   try {
     final bytes = await File(path).readAsBytes();
     final decoded = img.decodeJpg(bytes);
-    if (decoded == null) return (frame: null, fields: null);
+    if (decoded == null) return (frame: null, fields: null, anchor: null);
     final upright = img.bakeOrientation(decoded);
     final frame = roi != null ? preprocessor.cropToRoi(upright, roi) : upright;
-    return (frame: frame, fields: fields);
+    return (frame: frame, fields: fields, anchor: template?.valueAnchor);
   } catch (e, st) {
     unawaited(errorLogger.log(ErrorLayer.storage, e, st,
         context: const {'where': 'pump recognizer-source decode failed'}));
-    return (frame: null, fields: null);
+    return (frame: null, fields: null, anchor: null);
   }
 }
 
@@ -85,8 +88,30 @@ Future<({img.Image? frame, OcrPumpFieldSpec? fields})> resolveRecognizerSource(
   PumpOcrRecognizer recognizer = const PumpOcrRecognizer(),
   PumpValidationGate gate = const PumpValidationGate(),
   OcrTraceRecorder? trace,
+  // #3397 — when [anchor] is set and ML Kit found ≥2 labels, the value ROIs are
+  // derived from those label boxes (label-anchored) and read in the labels'
+  // own upright orientation (no blind sweep needed — the labels define it);
+  // otherwise the legacy fixed-ROI 4-way sweep runs, so production is unchanged.
+  List<RecognizedTextBlock> blocks = const [],
+  OcrValueAnchor? anchor,
 }) {
-  final read = recognizer.recognizeWithSweep(frame, fields);
+  final PumpOcrResult read;
+  if (anchor != null) {
+    final anchored = resolveLabelAnchoredFields(
+      template: fields,
+      blocks: blocks,
+      frameWidth: frame.width,
+      frameHeight: frame.height,
+      anchor: anchor,
+    );
+    trace?.brand(null,
+        'recognizer: label-anchored ${anchored.anchoredCount}/3 fields');
+    read = anchored.anchoredCount >= 2
+        ? recognizer.recognize(frame, anchored.fields)
+        : recognizer.recognizeWithSweep(frame, fields);
+  } else {
+    read = recognizer.recognizeWithSweep(frame, fields);
+  }
   if (read.glareRejected || read.fieldCount < 2) {
     return (result: existing, recognizerWon: false);
   }

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -239,7 +239,8 @@ class ReceiptScanService {
             gate: _pumpGate,
             trace: trace,
             frame: src.frame,
-            recognizerFields: src.fields);
+            recognizerFields: src.fields,
+            valueAnchor: src.anchor);
     var parse = parseFor(recognised);
 
     // #2798 — the #2275 binarization can dissolve faint 7-seg digits; when

--- a/test/features/consumption/data/ocr/label_anchored_roi_test.dart
+++ b/test/features/consumption/data/ocr/label_anchored_roi_test.dart
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ocr/_pump_label_table.dart';
+import 'package:tankstellen/features/consumption/data/ocr/label_anchored_roi.dart';
+import 'package:tankstellen/features/consumption/data/ocr/ocr_geometry.dart';
+import 'package:tankstellen/features/consumption/data/ocr/pump_ocr_config.dart';
+import 'package:tankstellen/features/consumption/data/ocr/recognized_text_block.dart';
+
+/// #3397 / Epic #2823 — label-anchored value ROIs. The fixed template ROIs
+/// can't track where the LCD lands in a hand-held photo; deriving each value
+/// ROI from the label box ML Kit located is what makes the 7-segment read
+/// aim at the actual digits. These are pure-geometry tests (no platform).
+
+RecognizedTextBlock _label(String text,
+        {required double l, required double t, required double r, required double b}) =>
+    RecognizedTextBlock(text: text, box: OcrBox(left: l, top: t, right: r, bottom: b));
+
+// A fixed template whose ROIs are deliberately in the WRONG place (top-left
+// corner) — the failure mode this fix addresses. Anchoring must override them.
+const _wrongFixed = OcrPumpFieldSpec(
+  total: OcrNormalizedRect(left: 0.0, top: 0.0, width: 0.1, height: 0.05),
+  volume: OcrNormalizedRect(left: 0.0, top: 0.05, width: 0.1, height: 0.05),
+  pricePerLitre: OcrNormalizedRect(left: 0.0, top: 0.10, width: 0.1, height: 0.05),
+);
+
+const _anchor = OcrValueAnchor(); // above, gap .15, w×1.4, h×2.4
+
+void main() {
+  group('resolveLabelAnchoredFields (#3397)', () {
+    test('a PRIX label anchors the total ROI ABOVE it, centred on it', () {
+      // 1000×1000 frame; "PRIX" low in the frame (digits above it).
+      final out = resolveLabelAnchoredFields(
+        template: _wrongFixed,
+        blocks: [_label('PRIX', l: 300, t: 600, r: 400, b: 640)],
+        frameWidth: 1000,
+        frameHeight: 1000,
+        anchor: _anchor,
+      );
+
+      expect(out.anchored, contains(PumpField.total));
+      final roi = out.fields.total;
+      // Sits ABOVE the label (bottom edge above the label's top at 0.60).
+      expect(roi.bottom, lessThanOrEqualTo(0.60),
+          reason: 'the value is above its label on a Tokheim display');
+      // Horizontally centred on the label centre (0.35).
+      final roiCx = roi.left + roi.width / 2;
+      expect(roiCx, closeTo(0.35, 1e-9));
+      // Scaled from the label (width 0.1 × 1.4).
+      expect(roi.width, closeTo(0.14, 1e-9));
+      expect(roi.height, closeTo(0.096, 1e-9));
+      // It is NOT the wrong fixed corner ROI.
+      expect(roi.top, greaterThan(0.2));
+    });
+
+    test(
+        'the SAME label framed bigger + shifted moves the ROI with it — the '
+        'robustness property the fixed ROIs lacked', () {
+      OcrNormalizedRect totalRoiFor(double l, double t, double r, double b) =>
+          resolveLabelAnchoredFields(
+            template: _wrongFixed,
+            blocks: [_label('PRIX', l: l, t: t, r: r, b: b)],
+            frameWidth: 1000,
+            frameHeight: 1000,
+            anchor: _anchor,
+          ).fields.total;
+
+      final near = totalRoiFor(300, 600, 400, 640); // small, low
+      final zoomed = totalRoiFor(150, 300, 450, 460); // 2× wider/taller, higher
+
+      // Both stay above + centred on their label; the zoomed one is bigger and
+      // higher in the frame — it tracked the label instead of a fixed rect.
+      expect(zoomed.width, greaterThan(near.width));
+      expect((zoomed.left + zoomed.width / 2), closeTo(0.30, 1e-9));
+      expect(zoomed.bottom, lessThanOrEqualTo(0.30));
+    });
+
+    test('a field whose label ML Kit did NOT find keeps its fixed ROI', () {
+      final out = resolveLabelAnchoredFields(
+        template: _wrongFixed,
+        blocks: [_label('PRIX', l: 300, t: 600, r: 400, b: 640)], // only total
+        frameWidth: 1000,
+        frameHeight: 1000,
+        anchor: _anchor,
+      );
+      expect(out.anchored, equals({PumpField.total}));
+      // volume + price untouched (the fixed fallback).
+      expect(out.fields.volume, same(_wrongFixed.volume));
+      expect(out.fields.pricePerLitre, same(_wrongFixed.pricePerLitre));
+    });
+
+    test('"PRIX DU LITRE" anchors the price field, not the bare-PRIX total', () {
+      final out = resolveLabelAnchoredFields(
+        template: _wrongFixed,
+        blocks: [
+          _label('PRIX', l: 300, t: 600, r: 400, b: 640),
+          _label('VOLUME', l: 300, t: 660, r: 460, b: 700),
+          _label('PRIX DU LITRE', l: 460, t: 610, r: 640, b: 650),
+        ],
+        frameWidth: 1000,
+        frameHeight: 1000,
+        anchor: _anchor,
+      );
+      expect(out.anchoredCount, 3);
+      // The price ROI is anchored to the PRIX-DU-LITRE block (centre ~0.55),
+      // NOT to the bare PRIX block (centre 0.35) — the #2478 collision.
+      final priceCx = out.fields.pricePerLitre.left + out.fields.pricePerLitre.width / 2;
+      expect(priceCx, closeTo(0.55, 1e-9));
+    });
+
+    test('empty blocks or a zero frame returns the template unchanged', () {
+      expect(
+        resolveLabelAnchoredFields(
+                template: _wrongFixed,
+                blocks: const [],
+                frameWidth: 1000,
+                frameHeight: 1000,
+                anchor: _anchor)
+            .anchoredCount,
+        0,
+      );
+      expect(
+        resolveLabelAnchoredFields(
+                template: _wrongFixed,
+                blocks: [_label('PRIX', l: 0, t: 0, r: 10, b: 10)],
+                frameWidth: 0,
+                frameHeight: 0,
+                anchor: _anchor)
+            .fields,
+        same(_wrongFixed),
+      );
+    });
+
+    test('direction:below places the value UNDER the label', () {
+      final out = resolveLabelAnchoredFields(
+        template: _wrongFixed,
+        blocks: [_label('PRIX', l: 300, t: 200, r: 400, b: 240)],
+        frameWidth: 1000,
+        frameHeight: 1000,
+        anchor: const OcrValueAnchor(direction: ValueAnchorDirection.below),
+      ).fields.total;
+      expect(out.top, greaterThanOrEqualTo(0.24),
+          reason: 'value sits below the label (label bottom 0.24)');
+    });
+  });
+
+  group('OcrValueAnchor.fromJson (#3397)', () {
+    test('parses direction + factors', () {
+      final a = OcrValueAnchor.fromJson({
+        'direction': 'right',
+        'gap': 0.2,
+        'widthFactor': 1.1,
+        'heightFactor': 1.9,
+      })!;
+      expect(a.direction, ValueAnchorDirection.right);
+      expect(a.gap, 0.2);
+      expect(a.widthFactor, 1.1);
+      expect(a.heightFactor, 1.9);
+    });
+
+    test('absent / non-map ⇒ null (anchoring disabled, fixed ROIs)', () {
+      expect(OcrValueAnchor.fromJson(null), isNull);
+      expect(OcrValueAnchor.fromJson('nope'), isNull);
+    });
+
+    test('unknown direction defaults to above; missing factors default', () {
+      final a = OcrValueAnchor.fromJson(const <String, Object?>{})!;
+      expect(a.direction, ValueAnchorDirection.above);
+      expect(a.widthFactor, 1.4);
+      expect(a.heightFactor, 2.4);
+    });
+  });
+}

--- a/test/features/consumption/data/ocr/pump_ocr_config_test.dart
+++ b/test/features/consumption/data/ocr/pump_ocr_config_test.dart
@@ -4,6 +4,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ocr/label_anchored_roi.dart';
 import 'package:tankstellen/features/consumption/data/ocr/pump_ocr_config.dart';
 
 /// Coverage for the per-country/brand OCR config registry (#2275): JSON
@@ -98,6 +99,11 @@ void main() {
       expect(tokheim, isNotNull);
       expect(tokheim!.pumpDisplay, isNotNull,
           reason: 'FR/Tokheim must carry pump-display field ROIs');
+      // #3397 — FR/Tokheim opts into label-anchored value ROIs (digits above
+      // their labels), the capability that makes a hand-held read work.
+      expect(tokheim.valueAnchor, isNotNull,
+          reason: 'FR/Tokheim must enable label anchoring (#3397)');
+      expect(tokheim.valueAnchor!.direction, ValueAnchorDirection.above);
     });
   });
 }


### PR DESCRIPTION
## Problem (real field captures)

Three real Tokheim/E85 pump captures returned **confidence 0 / `flat-string-fallback`** and read nothing. ML Kit structurally can't read 7-segment LCDs, and the dedicated `SevenSegmentRecognizer` (wired by Epic #2823) was fed the brand template's **fixed normalized ROI rectangles** — which assume a canonical framing. On a hand-held, off-centre, rotated shot they sample the wrong pixels → garbage → fall back to ML Kit text → nothing. The recognizer's own docstring promised label-anchoring; it was never implemented.

## Fix — derive the value ROIs from the labels ML Kit *does* read

ML Kit reliably reads the printed labels (PRIX / VOLUME / PRIX DU LITRE) **with boxes**. New `resolveLabelAnchoredFields` (pure geometry) places each value ROI relative to its label's box — wherever the label landed, the value ROI follows (Tokheim: digits above). A field whose label wasn't found keeps its fixed ROI → never worse than today.

- `OcrValueAnchor` (direction + gap + size factors), **opt-in** per template via a `valueAnchor` JSON key. Absent ⇒ legacy fixed-ROI sweep, so every other path is byte-identical. Enabled for FR/Tokheim.
- ≥2 labels anchored → read in the labels' upright orientation (no blind sweep); else legacy sweep.
- Verified the block boxes and recognizer frame share pixel coordinates (both `cropToRoi(bakeOrientation(decode), roi)`, no resize), so normalize-by-frame-dims is sound.
- Recognizer-source decision now recorded on the trace (`label-anchored N/3`), fixing the empty `input:{}` that made field exports uninformative.

**Why it's robust without per-pump tuning:** the ssocr decoder segments *within* the ROI, so a generous label-anchored ROI just has to *contain* the digits.

## Tests
Pure-geometry: anchor above + centred; the **same** label framed bigger/shifted moves the ROI with it (the property fixed ROIs lacked); missing label → fixed fallback; PRIX-DU-LITRE vs bare PRIX; direction:below; JSON parse/defaults; shipped FR/Tokheim asset enables anchoring. Full existing OCR suite non-regressive (153 pass).

## Scope
Implements Epic #2823's missing core (the capability to aim ROIs at the digits). Whether the decoder survives real glare on a given pump still needs the maintainer's reticle-cropped fixture capture — that's the remaining #2831, now actually enabled.

Closes #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)