### PR TITLE
fix(trips): WAL correctness — zombie resurrection (#3250) + fabricated distance/provenance (#3251)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -176,6 +176,9 @@ class TripRecording extends _$TripRecording {
   /// after a [reset] / fresh [build].
   String? _lastTripVehicleId;
   DateTime? _lastTripStartedAt;
+  // #3251 — the live trip's auto-record provenance, so the WAL seed stamps it
+  // (the recovery badge + saved entry then know it was hands-free).
+  bool _lastTripAutomatic = false;
 
   // ---------------------------------------------------------------------------
   // #1303 — write-through persistence of the in-progress trip
@@ -387,6 +390,7 @@ class TripRecording extends _$TripRecording {
     bool automatic = false,
   }) async {
     _lastTripStartedAt ??= DateTime.now();
+    _lastTripAutomatic = automatic; // #3251 — stamp the WAL seed honestly.
     // #769 — record the vehicle id the trip is scoped to up-front so the
     // fill-up auto-link window resolves it even if the baseline load
     // races. Cheap Riverpod cache hit.
@@ -602,7 +606,7 @@ class TripRecording extends _$TripRecording {
       id: id,
       vehicleId: _lastTripVehicleId ?? _baselines.vehicleId,
       vin: ctl.vin,
-      automatic: false, // refined on every flush via _buildSnapshotFor
+      automatic: _lastTripAutomatic, // #3251 — real auto-record provenance
       phase: 'recording',
       summary: const TripSummary(
         distanceKm: 0,
@@ -690,32 +694,25 @@ class TripRecording extends _$TripRecording {
         harshAccelerations: 0,
       );
     }
-    var distanceKm = 0.0;
     var maxRpm = 0.0;
-    for (var i = 0; i < samples.length; i++) {
-      final s = samples[i];
+    for (final s in samples) {
       if ((s.rpm ?? 0) > maxRpm) maxRpm = s.rpm ?? 0; // #2692 C4-G null→0
-      if (i == 0) continue;
-      final prev = samples[i - 1];
-      final dtSec = s.timestamp
-              .difference(prev.timestamp)
-              .inMicroseconds /
-          Duration.microsecondsPerSecond;
-      if (dtSec <= 0) continue;
-      final avgSpeed = (prev.speedKmh + s.speedKmh) / 2.0;
-      distanceKm += avgSpeed * dtSec / 3600.0;
     }
-    final startedAt = samples.first.timestamp;
-    final endedAt = samples.last.timestamp;
+    // #3251 — use the controller's OWN gap-capped distance + provenance, not a
+    // re-integration of the raw buffer. Re-integrating bridged dropout gaps and
+    // fabricated ~10 km across a 20-min hole (the #1927 bug on the recovery
+    // path); `currentDistanceKm` already applies `maxIntegrationGapSeconds`, and
+    // `distanceSource` keeps the real provenance instead of defaulting 'virtual'.
     return TripSummary(
-      distanceKm: distanceKm,
+      distanceKm: ctl.currentDistanceKm,
       maxRpm: maxRpm,
       highRpmSeconds: 0,
       idleSeconds: 0,
       harshBrakes: 0,
       harshAccelerations: 0,
-      startedAt: startedAt,
-      endedAt: endedAt,
+      startedAt: samples.first.timestamp,
+      endedAt: samples.last.timestamp,
+      distanceSource: ctl.distanceSource,
     );
   }
 

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'59a3c0bbc2ff91e919f92d369e9e1bb367db4d27';
+String _$tripRecordingHash() => r'9fce0a58c2049948f2cb13b38dc3ab2bd7e019ae';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/obd2/data/active_trip_recovery_service.dart
+++ b/lib/features/obd2/data/active_trip_recovery_service.dart
@@ -115,6 +115,26 @@ class ActiveTripRecoveryService {
       return ActiveTripRecoveryOutcome.none;
     }
 
+    // #3250 — a snapshot whose phase is already terminal was finalised to
+    // history (the grace-window auto-finalise, or the stop-transition flush)
+    // but the WAL was left behind. Recovering it resurrects an already-saved
+    // trip as a `pausedDueToDrop` banner, and End/Resume re-puts the SAME Hive
+    // id — overwriting the good saved entry with a gutted recovery summary.
+    // Drop it: it is NOT a live trip to resume.
+    if (snapshot.phase == 'stopped' || snapshot.phase == 'saved') {
+      try {
+        await _activeRepo.clearSnapshot();
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+          'where': 'ActiveTripRecoveryService clear finalised failed'
+        }));
+        return ActiveTripRecoveryOutcome.failed;
+      }
+      debugPrint('ActiveTripRecoveryService: discarded already-finalised '
+          'snapshot id=${snapshot.id} phase=${snapshot.phase}');
+      return ActiveTripRecoveryOutcome.discarded;
+    }
+
     final now = _now();
     final stale = ActiveTripRepository.isStale(
       snapshot,

--- a/lib/features/obd2/data/active_trip_repository.dart
+++ b/lib/features/obd2/data/active_trip_repository.dart
@@ -214,6 +214,11 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       if (s.latitude != null) 'la': s.latitude,
       if (s.longitude != null) 'lo': s.longitude,
       if (s.altitudeM != null) 'al': s.altitudeM,
+      // #3251 — GPS accuracy + bearing were dropped on the WAL codec, so a
+      // recovered GPS trip lost its jitter-gating + map-arrow data. Same keys
+      // as trip_sample_codec.dart so a recovered trip round-trips identically.
+      if (s.hAccuracyM != null) 'ha': s.hAccuracyM,
+      if (s.bearingDeg != null) 'be': s.bearingDeg,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -232,6 +237,9 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       longitude: (j['lo'] as num?)?.toDouble(),
       // #1935 child A — GPS altitude mirror key.
       altitudeM: (j['al'] as num?)?.toDouble(),
+      // #3251 — GPS accuracy + bearing (legacy snapshots have neither → null).
+      hAccuracyM: (j['ha'] as num?)?.toDouble(),
+      bearingDeg: (j['be'] as num?)?.toDouble(),
     );
 
 /// Hive-backed singleton store for the live, in-progress trip

--- a/lib/features/obd2/data/dropped_session_repo_resolver.dart
+++ b/lib/features/obd2/data/dropped_session_repo_resolver.dart
@@ -8,6 +8,7 @@ import 'package:hive/hive.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../consumption/data/trip_history_repository.dart';
+import 'active_trip_repository.dart';
 import 'dropped_session_host.dart';
 import 'paused_trip_repository.dart';
 
@@ -23,11 +24,14 @@ class DroppedSessionRepoResolver {
   DroppedSessionRepoResolver({
     PausedTripRepository? pausedOverride,
     TripHistoryRepository? historyOverride,
+    ActiveTripRepository? activeOverride,
   })  : _pausedOverride = pausedOverride,
-        _historyOverride = historyOverride;
+        _historyOverride = historyOverride,
+        _activeOverride = activeOverride;
 
   final PausedTripRepository? _pausedOverride;
   final TripHistoryRepository? _historyOverride;
+  final ActiveTripRepository? _activeOverride;
 
   PausedTripRepository? resolvePaused() {
     final override = _pausedOverride;
@@ -54,6 +58,24 @@ class DroppedSessionRepoResolver {
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
           context: const {'where': 'DroppedSessionManager history repo'}));
+      return null;
+    }
+  }
+
+  /// #3250 — the active-trip WAL box, so the grace-window finalise can CLEAR
+  /// the WAL after writing to history (else next launch resurrects an
+  /// already-saved trip).
+  ActiveTripRepository? resolveActive() {
+    final override = _activeOverride;
+    if (override != null) return override;
+    if (!Hive.isBoxOpen(ActiveTripRepository.boxName)) return null;
+    try {
+      return ActiveTripRepository(
+        box: Hive.box<String>(ActiveTripRepository.boxName),
+      );
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'DroppedSessionManager active repo'}));
       return null;
     }
   }
@@ -110,5 +132,8 @@ class DroppedSessionRepoResolver {
       }
     }
     deletePausedRow(id);
+    // #3250 — clear the active-trip WAL: this trip is now in history, so the
+    // launch-time recovery must not resurrect it as a paused session.
+    unawaited(resolveActive()?.clearSnapshot());
   }
 }

--- a/test/features/obd2/data/active_trip_recovery_service_test.dart
+++ b/test/features/obd2/data/active_trip_recovery_service_test.dart
@@ -135,6 +135,42 @@ void main() {
       expect(activeRepo.loadSnapshot(), isNotNull);
     });
 
+    test(
+        '#3250 — a fresh snapshot whose phase is already terminal '
+        '(stopped/saved) is DISCARDED + cleared, not resurrected', () async {
+      for (final phase in ['stopped', 'saved']) {
+        await activeRepo.clearSnapshot();
+        // Fresh by timestamp, but the trip was already finalised to history —
+        // recovering it would re-surface a saved trip + overwrite it on End.
+        await activeRepo.saveSnapshot(
+          ActiveTripSnapshot(
+            id: 'session-$phase',
+            vehicleId: 'veh-1',
+            vin: 'VIN',
+            automatic: false,
+            phase: phase,
+            summary: summary(),
+            samples: const [],
+            odometerStartKm: 100.0,
+            odometerLatestKm: 105.0,
+            startedAt: fakeNow.subtract(const Duration(minutes: 30)),
+            lastFlushedAt: fakeNow.subtract(const Duration(minutes: 2)),
+          ),
+        );
+        final svc = ActiveTripRecoveryService(
+          activeRepo: activeRepo,
+          historyRepo: historyRepo,
+          now: () => fakeNow,
+        );
+        final outcome = await svc.recover();
+        expect(outcome, ActiveTripRecoveryOutcome.discarded,
+            reason: 'phase=$phase is already finalised — never recovered');
+        expect(svc.recoveredSnapshot, isNull);
+        expect(activeRepo.loadSnapshot(), isNull,
+            reason: 'the zombie WAL must be cleared (phase=$phase)');
+      }
+    });
+
     test('stale snapshot is discarded and cleared from disk', () async {
       final snap = staleSnapshot();
       await activeRepo.saveSnapshot(snap);

--- a/test/features/obd2/data/active_trip_repository_test.dart
+++ b/test/features/obd2/data/active_trip_repository_test.dart
@@ -121,6 +121,39 @@ void main() {
       expect(restored.samples.first.coolantTempC, 80.0);
     });
 
+    test('#3251 — GPS accuracy + bearing round-trip (were dropped before)',
+        () async {
+      await repo.saveSnapshot(
+        ActiveTripSnapshot(
+          id: 'gps-1',
+          vehicleId: 'veh-1',
+          vin: null,
+          automatic: false,
+          phase: 'recording',
+          summary: summary(),
+          samples: [
+            TripSample(
+              timestamp: start,
+              speedKmh: 42.0,
+              latitude: 43.4,
+              longitude: 3.5,
+              hAccuracyM: 4.2,
+              bearingDeg: 117.5,
+            ),
+          ],
+          odometerStartKm: null,
+          odometerLatestKm: null,
+          startedAt: start,
+          lastFlushedAt: start.add(const Duration(minutes: 1)),
+        ),
+      );
+      final s = repo.loadSnapshot()!.samples.single;
+      expect(s.hAccuracyM, closeTo(4.2, 1e-9),
+          reason: 'jitter-gating data must survive recovery');
+      expect(s.bearingDeg, closeTo(117.5, 1e-9),
+          reason: 'map-arrow bearing must survive recovery');
+    });
+
     test('loadSnapshot returns null on an empty box', () {
       expect(repo.loadSnapshot(), isNull);
     });


### PR DESCRIPTION
Two related active-trip WAL (write-ahead-log) correctness bugs from the recording audit.

## #3250 — grace-finalised trip resurrects as a zombie WAL
The grace-window auto-finalise wrote the trip to history but never cleared the active WAL, and `recover()` checked only staleness, never phase. So a finalised trip came back on next launch (≤24h) as a `pausedDueToDrop` banner, and End/Resume re-put the **same Hive id** — overwriting the good saved entry with a gutted recovery summary.
- `recover()` discards + clears a snapshot whose phase is terminal (`stopped`/`saved`).
- The grace-finalise resolver clears the active WAL after writing to history.

## #3251 — recovery fabricates distance + drops provenance/GPS fields
`_summaryFromCtl` re-integrated the raw buffer with **no** `maxIntegrationGapSeconds` cap → a 20-min dropout hole fabricated ~10 km (the #1927 bug on the recovery path), and defaulted `distanceSource` to `'virtual'`. The WAL codec also dropped GPS `hAccuracyM`/`bearingDeg`, and seeded `automatic:false` regardless.
- Use the controller's own **gap-capped** `currentDistanceKm` + real `distanceSource`.
- WAL codec round-trips `hAccuracyM` (`'ha'`) + `bearingDeg` (`'be'`).
- WAL seed stamps the real `automatic` flag.

One commit per issue. +tests (terminal-phase discard; GPS accuracy/bearing round-trip). Existing WAL suite non-regressive.

Closes #3250, #3251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)