### PR TITLE
feat(consumption): surface real OBD2 telemetry in the driving-analysis export (#3402)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import '../../domain/driving_score.dart';
 import '../../domain/gps_driving_features.dart';
 import '../../domain/lessons/driving_lesson.dart';
+import '../../domain/obd2_trip_features.dart';
 import '../../domain/trip_summary.dart';
 
 /// A self-contained, JSON-serialisable snapshot of a single trip's
@@ -31,6 +32,15 @@ class DrivingAnalysisTrace {
 
   final TripSummary summary;
   final GpsDrivingFeatures? gpsFeatures;
+
+  /// Per-trip OBD2 telemetry aggregate (#3402). Null when the trip carried no
+  /// engine signal — a GPS-only trip, or an OBD2 trip whose link kept dropping
+  /// so every read fell back to GPS. A null section is the export's explicit
+  /// "0 % OBD2 coverage" marker; a present section surfaces the real RPM /
+  /// engine-load / throttle distribution and whether the fuel figure was
+  /// measured or estimated.
+  final Obd2TripFeatures? obd2Features;
+
   final DrivingScore score;
   final List<DrivingLesson> lessons;
 
@@ -40,6 +50,7 @@ class DrivingAnalysisTrace {
     required this.score,
     required this.lessons,
     this.gpsFeatures,
+    this.obd2Features,
     this.comment = kDrivingAnalysisCommentPrompt,
   });
 
@@ -88,6 +99,11 @@ class DrivingAnalysisTrace {
                   'high': _round(gpsFeatures!.highSpeedSeconds, 0),
                 },
               },
+        // #3402 — the real OBD2 telemetry the trip captured (RPM / engine-load
+        // / throttle / pedal distribution, measured-vs-estimated fuel, and a
+        // per-signal coverage map). Null when no engine signal landed, which
+        // makes a broken-link GPS-fallback trip read as `obd2Features: null`.
+        'obd2Features': obd2Features?.toJson(),
         'score': {
           'overall': score.score,
           'styleClass': score.styleClass.name,

--- a/lib/features/consumption/domain/obd2_trip_features.dart
+++ b/lib/features/consumption/domain/obd2_trip_features.dart
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'trip_sample.dart';
+
+/// Per-trip aggregate of the **OBD2** telemetry a trip actually captured —
+/// the engine-side counterpart to [GpsDrivingFeatures] (#3402 child 1).
+///
+/// The driving-analysis export historically surfaced only GPS-derived KPIs,
+/// so a trip whose adapter streamed RPM / engine-load / throttle / fuel rate
+/// showed none of it, and a reader could not tell whether the trip's
+/// `avgLPer100Km` was a *measured* fuel-PID figure or a GPS-physics estimate.
+/// This aggregate makes the real engine signal — and how much of it the
+/// adapter exposed — explicit per trip.
+///
+/// Pure transform, no I/O. [fromSamples] returns `null` when the trip carried
+/// **no** engine signal at all (a GPS-only trip, or an OBD2 trip whose link
+/// failed so every read fell back to GPS — see the classic-RFCOMM reconnect
+/// hang). A `null` here is therefore the export's honest "0 % OBD2 coverage"
+/// marker, not a missing field.
+class Obd2TripFeatures {
+  /// Total samples in the trip (GPS + OBD2).
+  final int sampleCount;
+
+  /// Samples carrying at least one engine signal (RPM / engine-load /
+  /// throttle / measured fuel rate). [obd2Coverage] is this over
+  /// [sampleCount].
+  final int obd2SampleCount;
+
+  /// Fraction of samples with an engine signal — 1.0 on a clean OBD2 trip,
+  /// near 0 when the adapter kept dropping and reads fell back to GPS.
+  final double obd2Coverage;
+
+  /// Where the trip's fuel figure came from:
+  /// - `measured` — at least one real fuel PID landed (PID 5E / MAF / MAP).
+  /// - `estimated` — no fuel PID; the GPS-physics fallback supplied it.
+  /// - `none` — neither; no per-distance fuel figure is meaningful.
+  final Obd2FuelSource fuelSource;
+
+  /// RPM distribution (null-RPM samples excluded). All null on a trip that
+  /// never saw PID 0x0C.
+  final Obd2SignalDistribution rpm;
+
+  /// Calculated engine load %, PID 0x04 (the captured-but-previously-unused
+  /// "uphill vs flat at the same speed" signal).
+  final Obd2SignalDistribution engineLoadPercent;
+
+  /// Throttle position %, PID 0x11.
+  final Obd2SignalDistribution throttlePercent;
+
+  /// Accelerator-pedal position %, PIDs 0x49/0x4A/0x4B — driver intent.
+  final Obd2SignalDistribution pedalPercent;
+
+  /// Absolute load %, PID 0x43 — boosted-engine high-load proxy (>100 % ok).
+  final Obd2SignalDistribution absLoadPercent;
+
+  /// Share of RPM samples above 3000 — the high-RPM band the score penalises.
+  final double rpmShareAbove3000;
+
+  /// Share of samples idling (engine on, RPM in (0, 1100], speed < 3 km/h).
+  final double idleShare;
+
+  /// Peak coolant temperature °C, PID 0x05 (null if never seen).
+  final double? coolantMaxC;
+
+  /// Whether coolant reached operating temperature (≥ 80 °C) — a cold trip
+  /// burns proportionally more fuel for warm-up.
+  final bool reachedOperatingTemp;
+
+  /// Per-signal capture fraction: for each OBD2 field, the share of samples
+  /// that carried it. This is the at-a-glance "what did this adapter / ECU
+  /// actually expose" map — a `0.0` means the PID is unsupported (or the link
+  /// was down), a `1.0` a fully-streamed signal.
+  final Map<String, double> signalCoverage;
+
+  const Obd2TripFeatures({
+    required this.sampleCount,
+    required this.obd2SampleCount,
+    required this.obd2Coverage,
+    required this.fuelSource,
+    required this.rpm,
+    required this.engineLoadPercent,
+    required this.throttlePercent,
+    required this.pedalPercent,
+    required this.absLoadPercent,
+    required this.rpmShareAbove3000,
+    required this.idleShare,
+    required this.coolantMaxC,
+    required this.reachedOperatingTemp,
+    required this.signalCoverage,
+  });
+
+  /// Build the aggregate from a trip's samples, or `null` when no sample
+  /// carried any engine signal (pure-GPS / failed-link trip).
+  static Obd2TripFeatures? fromSamples(List<TripSample> samples) {
+    if (samples.isEmpty) return null;
+
+    bool hasEngine(TripSample s) =>
+        s.rpm != null ||
+        s.engineLoadPercent != null ||
+        s.throttlePercent != null ||
+        s.fuelRateLPerHour != null;
+
+    final obd2Count = samples.where(hasEngine).length;
+    if (obd2Count == 0) return null;
+
+    final n = samples.length;
+
+    final rpms = <double>[];
+    var rpmAbove3000 = 0;
+    var idle = 0;
+    for (final s in samples) {
+      final r = s.rpm;
+      if (r != null) {
+        rpms.add(r);
+        if (r > 3000) rpmAbove3000++;
+        if (r > 0 && r <= 1100 && s.speedKmh < 3) idle++;
+      }
+    }
+
+    final hasMeasuredFuel = samples.any((s) => s.fuelRateLPerHour != null);
+    final hasEstimatedFuel =
+        samples.any((s) => s.estimatedFuelRateLPerHour != null);
+    final fuelSource = hasMeasuredFuel
+        ? Obd2FuelSource.measured
+        : hasEstimatedFuel
+            ? Obd2FuelSource.estimated
+            : Obd2FuelSource.none;
+
+    final coolants = [for (final s in samples) s.coolantTempC]
+        .whereType<double>()
+        .toList();
+    final coolantMax = coolants.isEmpty
+        ? null
+        : coolants.reduce((a, b) => a > b ? a : b);
+
+    return Obd2TripFeatures(
+      sampleCount: n,
+      obd2SampleCount: obd2Count,
+      obd2Coverage: obd2Count / n,
+      fuelSource: fuelSource,
+      rpm: Obd2SignalDistribution.from(rpms),
+      engineLoadPercent: _distOf(samples, (s) => s.engineLoadPercent),
+      throttlePercent: _distOf(samples, (s) => s.throttlePercent),
+      pedalPercent: _distOf(samples, (s) => s.pedalPercent),
+      absLoadPercent: _distOf(samples, (s) => s.absLoadPercent),
+      rpmShareAbove3000: rpms.isEmpty ? 0.0 : rpmAbove3000 / rpms.length,
+      idleShare: idle / n,
+      coolantMaxC: coolantMax,
+      reachedOperatingTemp: coolantMax != null && coolantMax >= 80,
+      signalCoverage: {
+        'rpm': _coverage(samples, (s) => s.rpm),
+        'fuelRate': _coverage(samples, (s) => s.fuelRateLPerHour),
+        'engineLoadPercent': _coverage(samples, (s) => s.engineLoadPercent),
+        'absLoadPercent': _coverage(samples, (s) => s.absLoadPercent),
+        'throttlePercent': _coverage(samples, (s) => s.throttlePercent),
+        'pedalPercent': _coverage(samples, (s) => s.pedalPercent),
+        'lambda': _coverage(samples, (s) => s.lambda),
+        'baroKpa': _coverage(samples, (s) => s.baroKpa),
+        'maf': _coverage(samples, (s) => s.mafGramsPerSecond),
+        'map': _coverage(samples, (s) => s.mapKpa),
+        'stft': _coverage(samples, (s) => s.stft),
+        'ltft': _coverage(samples, (s) => s.ltft),
+        'coolantTempC': _coverage(samples, (s) => s.coolantTempC),
+        'oilTempC': _coverage(samples, (s) => s.oilTempC),
+        'ambientTempC': _coverage(samples, (s) => s.ambientTempC),
+      },
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'sampleCount': sampleCount,
+        'obd2SampleCount': obd2SampleCount,
+        'obd2Coverage': _r(obd2Coverage, 3),
+        'fuelSource': fuelSource.name,
+        'rpm': rpm.toJson(),
+        'rpmShareAbove3000': _r(rpmShareAbove3000, 3),
+        'idleShare': _r(idleShare, 3),
+        'engineLoadPercent': engineLoadPercent.toJson(),
+        'throttlePercent': throttlePercent.toJson(),
+        'pedalPercent': pedalPercent.toJson(),
+        'absLoadPercent': absLoadPercent.toJson(),
+        'coolantMaxC': coolantMaxC == null ? null : _r(coolantMaxC!, 1),
+        'reachedOperatingTemp': reachedOperatingTemp,
+        'signalCoverage': {
+          for (final e in signalCoverage.entries) e.key: _r(e.value, 3),
+        },
+      };
+
+  static Obd2SignalDistribution _distOf(
+    List<TripSample> samples,
+    double? Function(TripSample) pick,
+  ) =>
+      Obd2SignalDistribution.from(
+        [for (final s in samples) pick(s)].whereType<double>().toList(),
+      );
+
+  static double _coverage(
+    List<TripSample> samples,
+    double? Function(TripSample) pick,
+  ) {
+    if (samples.isEmpty) return 0.0;
+    final present = samples.where((s) => pick(s) != null).length;
+    return present / samples.length;
+  }
+}
+
+/// Provenance of a trip's fuel figure (see [Obd2TripFeatures.fuelSource]).
+enum Obd2FuelSource { measured, estimated, none }
+
+/// A minimal mean / p95 / coverage summary of one optional signal.
+/// `null` fields when the signal was never present so the export omits a
+/// fabricated zero.
+class Obd2SignalDistribution {
+  final double? mean;
+  final double? p95;
+
+  /// Fraction of the supplied (already non-null) values — 0.0 when the signal
+  /// was absent across the whole trip.
+  final double coverage;
+
+  const Obd2SignalDistribution({this.mean, this.p95, required this.coverage});
+
+  /// Build from the non-null values of one signal. [coverage] here is whether
+  /// any value was present (1.0) or none (0.0); the per-trip fraction lives in
+  /// [Obd2TripFeatures.signalCoverage].
+  factory Obd2SignalDistribution.from(List<double> values) {
+    if (values.isEmpty) {
+      return const Obd2SignalDistribution(coverage: 0.0);
+    }
+    final sum = values.fold<double>(0, (a, b) => a + b);
+    final sorted = [...values]..sort();
+    final p95Index = ((sorted.length - 1) * 0.95).ceil();
+    return Obd2SignalDistribution(
+      mean: sum / values.length,
+      p95: sorted[p95Index],
+      coverage: 1.0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'mean': mean == null ? null : _r(mean!, 1),
+        'p95': p95 == null ? null : _r(p95!, 1),
+        'coverage': _r(coverage, 3),
+      };
+}
+
+double _r(double v, int places) {
+  var f = 1.0;
+  for (var i = 0; i < places; i++) {
+    f *= 10;
+  }
+  return (v * f).round() / f;
+}

--- a/lib/features/consumption/presentation/widgets/driving_analysis_trace_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_analysis_trace_card.dart
@@ -12,6 +12,8 @@ import '../../data/analysis/driving_analysis_trace_export.dart';
 import '../../domain/driving_score.dart';
 import '../../domain/gps_driving_features.dart';
 import '../../domain/lessons/driving_lesson.dart';
+import '../../domain/obd2_trip_features.dart';
+import '../../domain/trip_sample.dart';
 import '../../domain/trip_summary.dart';
 
 /// Dev-only and self-hiding: renders nothing unless [Feature.debugMode] is on
@@ -28,6 +30,7 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
     required this.summary,
     required this.score,
     required this.lessons,
+    required this.samples,
     this.gpsFeatures,
   });
 
@@ -35,6 +38,10 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
   final DrivingScore score;
   final List<DrivingLesson> lessons;
   final GpsDrivingFeatures? gpsFeatures;
+
+  /// The trip's raw samples — the source of the OBD2 telemetry aggregate
+  /// folded into the export (#3402).
+  final List<TripSample> samples;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -79,6 +86,7 @@ class DrivingAnalysisTraceCard extends ConsumerWidget {
       score: score,
       lessons: lessons,
       gpsFeatures: gpsFeatures,
+      obd2Features: Obd2TripFeatures.fromSamples(samples),
     );
     final ok = await DrivingAnalysisTraceExport.export(trace);
     if (!context.mounted) return;

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -120,6 +120,12 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
         isEv: widget.isEv,
       );
 
+  /// The trip's samples in the domain shape, memoised so the O(n) conversion
+  /// runs once (not per rebuild). Feeds the driving-analysis trace's OBD2
+  /// telemetry aggregate (#3402).
+  late final List<TripSample> _tripSamples =
+      widget.samples.map(tripDetailToTripSample).toList(growable: false);
+
   List<DrivingInsight> _computeInsights() {
     if (widget.samples.isEmpty) return const [];
     // Insights are only meaningful for combustion trips — EV trips
@@ -332,6 +338,7 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
             score: _score,
             lessons: lessons,
             gpsFeatures: _gpsFeatures,
+            samples: _tripSamples,
           ),
         // #1895 — the per-trip telemetry charts, folded into one
         // collapsed-by-default section. Extracted to its own widget (#2804)

--- a/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
+++ b/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
@@ -8,6 +8,8 @@ import 'package:tankstellen/features/consumption/data/analysis/driving_analysis_
 import 'package:tankstellen/features/consumption/domain/driving_score.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
 import 'package:tankstellen/features/consumption/domain/lessons/driving_lesson.dart';
+import 'package:tankstellen/features/consumption/domain/obd2_trip_features.dart';
+import 'package:tankstellen/features/consumption/domain/trip_sample.dart';
 import 'package:tankstellen/features/consumption/domain/trip_summary.dart';
 
 TripSummary _summary() => TripSummary(
@@ -206,6 +208,50 @@ void main() {
         lessons: const [],
       );
       expect(trace.toJson()['gpsFeatures'], isNull);
+    });
+
+    test('obd2Features is null when no engine signal landed — the broken-link '
+        '/ GPS-only marker (#3402)', () {
+      final trace = DrivingAnalysisTrace(
+        capturedAt: DateTime.utc(2026, 6, 3, 11),
+        summary: _summary(),
+        score: _score,
+        lessons: const [],
+      );
+      expect(trace.toJson()['obd2Features'], isNull);
+    });
+
+    test('obd2Features surfaces real engine telemetry + fuel provenance '
+        '(#3402)', () {
+      final obd2 = Obd2TripFeatures.fromSamples([
+        TripSample(
+          timestamp: DateTime.utc(2026, 6, 3, 10),
+          speedKmh: 50,
+          rpm: 1800,
+          fuelRateLPerHour: 2.4,
+          engineLoadPercent: 42,
+        ),
+        TripSample(
+          timestamp: DateTime.utc(2026, 6, 3, 10, 0, 1),
+          speedKmh: 55,
+          rpm: 2200,
+          fuelRateLPerHour: 2.8,
+          engineLoadPercent: 48,
+        ),
+      ]);
+      final json = DrivingAnalysisTrace(
+        capturedAt: DateTime.utc(2026, 6, 3, 11),
+        summary: _summary(),
+        score: _score,
+        lessons: const [],
+        obd2Features: obd2,
+      ).toJson();
+
+      final block = json['obd2Features'] as Map<String, dynamic>;
+      expect(block['fuelSource'], 'measured');
+      expect(block['obd2Coverage'], 1.0);
+      expect((block['rpm'] as Map)['mean'], 2000.0);
+      expect((block['signalCoverage'] as Map)['engineLoadPercent'], 1.0);
     });
 
     test('formatDrivingAnalysisTraceJson is valid, round-trippable JSON', () {

--- a/test/features/consumption/domain/obd2_trip_features_test.dart
+++ b/test/features/consumption/domain/obd2_trip_features_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/obd2_trip_features.dart';
+import 'package:tankstellen/features/consumption/domain/trip_sample.dart';
+
+TripSample _s({
+  required int sec,
+  double speedKmh = 50,
+  double? rpm,
+  double? fuelRateLPerHour,
+  double? estimatedFuelRateLPerHour,
+  double? throttlePercent,
+  double? engineLoadPercent,
+  double? absLoadPercent,
+  double? pedalPercent,
+  double? coolantTempC,
+  double? lambda,
+}) =>
+    TripSample(
+      timestamp: DateTime(2026, 1, 1, 0, 0, sec),
+      speedKmh: speedKmh,
+      rpm: rpm,
+      fuelRateLPerHour: fuelRateLPerHour,
+      estimatedFuelRateLPerHour: estimatedFuelRateLPerHour,
+      throttlePercent: throttlePercent,
+      engineLoadPercent: engineLoadPercent,
+      absLoadPercent: absLoadPercent,
+      pedalPercent: pedalPercent,
+      coolantTempC: coolantTempC,
+      lambda: lambda,
+    );
+
+void main() {
+  group('Obd2TripFeatures.fromSamples', () {
+    test('returns null for an empty trip', () {
+      expect(Obd2TripFeatures.fromSamples(const []), isNull);
+    });
+
+    test('returns null for a pure-GPS trip (no engine signal) — the explicit '
+        '0% OBD2-coverage marker', () {
+      final gpsOnly = [
+        _s(sec: 0, speedKmh: 30),
+        _s(sec: 1, speedKmh: 32),
+        _s(sec: 2, speedKmh: 35),
+      ];
+      expect(Obd2TripFeatures.fromSamples(gpsOnly), isNull);
+    });
+
+    test('computes coverage, RPM bands and idle share on a real OBD2 trip', () {
+      final samples = [
+        // idle: engine on, low rpm, stationary
+        _s(sec: 0, speedKmh: 0, rpm: 800, throttlePercent: 0),
+        _s(sec: 1, speedKmh: 40, rpm: 2000, throttlePercent: 30),
+        _s(sec: 2, speedKmh: 60, rpm: 3500, throttlePercent: 80),
+        // a GPS-fallback sample with no engine signal (link blip)
+        _s(sec: 3, speedKmh: 62),
+      ];
+
+      final f = Obd2TripFeatures.fromSamples(samples)!;
+      expect(f.sampleCount, 4);
+      expect(f.obd2SampleCount, 3);
+      expect(f.obd2Coverage, closeTo(0.75, 1e-9));
+      // 1 of 3 RPM samples above 3000
+      expect(f.rpmShareAbove3000, closeTo(1 / 3, 1e-9));
+      // 1 of 4 samples idling
+      expect(f.idleShare, closeTo(0.25, 1e-9));
+      expect(f.rpm.mean, closeTo((800 + 2000 + 3500) / 3, 1e-6));
+    });
+
+    test('fuelSource = measured when any real fuel PID landed', () {
+      final f = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500, fuelRateLPerHour: 2.1),
+        _s(sec: 1, rpm: 1600, estimatedFuelRateLPerHour: 3.0),
+      ])!;
+      expect(f.fuelSource, Obd2FuelSource.measured);
+    });
+
+    test('fuelSource = estimated when only the GPS-physics estimate exists', () {
+      final f = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500, estimatedFuelRateLPerHour: 3.0),
+        _s(sec: 1, rpm: 1600, estimatedFuelRateLPerHour: 3.2),
+      ])!;
+      expect(f.fuelSource, Obd2FuelSource.estimated);
+    });
+
+    test('fuelSource = none when neither measured nor estimated fuel exists',
+        () {
+      final f = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500),
+        _s(sec: 1, rpm: 1600),
+      ])!;
+      expect(f.fuelSource, Obd2FuelSource.none);
+    });
+
+    test('signalCoverage reflects which PIDs the adapter exposed', () {
+      final f = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500, engineLoadPercent: 40, lambda: 0.99),
+        _s(sec: 1, rpm: 1600, engineLoadPercent: 45),
+      ])!;
+      expect(f.signalCoverage['rpm'], closeTo(1.0, 1e-9));
+      expect(f.signalCoverage['engineLoadPercent'], closeTo(1.0, 1e-9));
+      expect(f.signalCoverage['lambda'], closeTo(0.5, 1e-9));
+      // never present → 0.0, the "PID unsupported / link down" marker
+      expect(f.signalCoverage['maf'], 0.0);
+      expect(f.signalCoverage['absLoadPercent'], 0.0);
+    });
+
+    test('coolant operating-temperature flag', () {
+      final cold = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500, coolantTempC: 40),
+        _s(sec: 1, rpm: 1500, coolantTempC: 60),
+      ])!;
+      expect(cold.coolantMaxC, 60);
+      expect(cold.reachedOperatingTemp, isFalse);
+
+      final warm = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 1500, coolantTempC: 70),
+        _s(sec: 1, rpm: 1500, coolantTempC: 88),
+      ])!;
+      expect(warm.reachedOperatingTemp, isTrue);
+    });
+
+    test('toJson is stable and rounds', () {
+      final json = Obd2TripFeatures.fromSamples([
+        _s(sec: 0, rpm: 800, engineLoadPercent: 20, throttlePercent: 10),
+        _s(sec: 1, rpm: 2500, engineLoadPercent: 55, throttlePercent: 60),
+      ])!.toJson();
+      expect(json['fuelSource'], 'none');
+      expect(json['obd2Coverage'], 1.0);
+      expect((json['rpm'] as Map)['mean'], 1650.0);
+      expect((json['signalCoverage'] as Map)['rpm'], 1.0);
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/driving_analysis_trace_card_test.dart
+++ b/test/features/consumption/presentation/widgets/driving_analysis_trace_card_test.dart
@@ -40,6 +40,7 @@ Widget _host(Set<Feature> features) => ProviderScope(
             summary: _summary(),
             score: _score,
             lessons: const [],
+            samples: const [],
           ),
         ),
       ),


### PR DESCRIPTION
Closes #3402 (child 1).

## Context

A user exported two `drivingAnalysis` traces (both `tripKind: gpsPlusObd2`) and noted the analysis "is not using a lot" of the OBD2 adapter data. Investigation found two threads:

- **Thread A (these specific trips):** the error log shows the **vLinker FS** classic adapter dropping mid-trip and failing to re-open its RFCOMM channel (`rfcomm open failed … socket might closed`, one rescan stuck 22 min). Every read fell back to GPS → no engine data existed. Known classic-RFCOMM reconnect hang; tracked under existing OBD2-reliability work.
- **Thread B (this PR):** even when OBD2 **is** connected, the driving-analysis export carried only GPS KPIs. `engineLoadPercent`, `absLoadPercent`, MAF/MAP, trims, throttle distribution were captured but never surfaced, and `avgLPer100Km` didn't say whether it was a measured fuel-PID figure or a GPS-physics estimate.

## Change

New `Obd2TripFeatures` pure aggregate over the trip samples, folded into `DrivingAnalysisTrace` as an `obd2Features` section:
- OBD2 coverage (% of samples with an engine signal)
- RPM distribution + `rpmShareAbove3000` + `idleShare`
- engine-load / throttle / pedal / abs-load distributions (mean / p95)
- `fuelSource: measured | estimated | none`
- a per-signal coverage map — exactly which PIDs the adapter/ECU exposed
- coolant peak + reached-operating-temp flag

**Null when no engine signal landed** — so a broken-link trip (Thread A) reads as `obd2Features: null`, making the 0%-OBD2-coverage case explicit instead of silently absent.

This is the calibration substrate for **child 2** (follow-up in #3402): fusing engine-load/throttle into harsh-event detection and the score, with thresholds tuned against the data this export now captures rather than guessed.

## Tests
- `obd2_trip_features_test.dart` — null on GPS-only/empty, coverage/RPM-band/idle math, all three `fuelSource` cases, signal-coverage map, coolant flag, `toJson` rounding.
- `driving_analysis_trace_test.dart` — `obd2Features` null marker + present-telemetry contract.
- Dev-only export (Feature.debugMode); no UI strings, no codegen, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
