### PR TITLE
fix(android): revert launcher/splash icon background to brand green (#3405)

### DIFF
--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -22,8 +22,9 @@
   the identity is consistent.
 
   Style constraints (see docs/design/ASSET_SPEC.md § 1):
-    * 2-tone only: white glyph on ic_launcher_background (#4059AD, the
-      theme primary — #3270 migrated it off the interim green #2E7D32).
+    * 2-tone only: white glyph on ic_launcher_background (#2E7D32, the
+      brand green — #3405 reverted the #3270 migration to the indigo
+      theme primary because green is the app identity).
     * No gradients, no drop shadow, no text.
     * Keep all geometry inside the 18dp–90dp safe-zone band on each axis.
 -->
@@ -67,6 +68,6 @@
                           C53,62 51.5,62.5 50.5,62
                           C49.8,61.5 49.8,60.8 50,60
                           Z"
-        android:fillColor="#4059AD"
+        android:fillColor="#2E7D32"
         android:fillAlpha="0.25" />
 </vector>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -5,9 +5,10 @@
 -->
 
 <resources>
-    <!-- #3270 — migrated from the interim green (#2E7D32) to the theme
-         primary so the launcher icon + splash match the app brand. -->
-    <color name="ic_launcher_background">#4059AD</color>
+    <!-- #3405 — reverted to the brand green. #3270 had migrated this to the
+         indigo theme primary (#4059AD), but green is the Sparkilo app
+         identity, so the launcher icon + splash stay green. -->
+    <color name="ic_launcher_background">#2E7D32</color>
     <!-- Widget text colors with explicit light/dark variants so dark-mode
          launchers always get readable contrast — `?android:attr/textColorPrimary`
          resolved against the launcher's theme and sometimes stayed dark on


### PR DESCRIPTION
Closes #3405.

## What
The Android launcher icon "suddenly turned blue" for users on the first production release. #3270 (commit 2614a8fa0) had migrated the launcher-icon + splash background from the brand green `#2E7D32` to the indigo theme primary `#4059AD`. Green is the Sparkilo app identity, so this reverts it.

## Change (exact inverse of #3270, 3 references)
- `values/colors.xml` — `ic_launcher_background` `#4059AD` → `#2E7D32`
- `drawable/ic_launcher_foreground.xml` — 25%-alpha inner-shade `fillColor` + doc comment

The splash (`launch_background.xml` + `drawable-v21/`) references `@color/ic_launcher_background`, so it reverts automatically. The white shield/droplet glyph and the **in-app indigo theme are unchanged** — this is launcher icon + splash only.

## Risk
Pure Android resource (XML) change. No Dart, no codegen, no l10n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
