### PR TITLE
fix(deploy): default promote-rollout to beta + guard against promoting an older versionCode (#3407)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,14 @@ on:
         description: 'Source track (for promote-rollout)'
         required: false
         type: choice
+        # beta (open testing) is the real release track and is kept current by
+        # the daily build; internal is rarely updated and defaulting to it
+        # silently promotes a stale, lower-versionCode build (#3407).
         options:
-          - internal
-          - alpha
           - beta
-        default: internal
+          - alpha
+          - internal
+        default: beta
       aab_run_id:
         description: 'CI run ID to download AAB from (for deploy-internal, leave empty for latest)'
         required: false

--- a/scripts/promote_play_store.sh
+++ b/scripts/promote_play_store.sh
@@ -98,6 +98,34 @@ version_codes = latest.get('versionCodes', [])
 release_name = latest.get('name', 'Unknown')
 print(f"Found release '{release_name}' with version codes: {version_codes}")
 
+# Guard (#3407): never promote a build OLDER than what production already
+# has. Promoting a lower versionCode can only fail — and Play returns an
+# opaque error (e.g. a stale build's missing permission-declaration 403)
+# that hides the real "wrong/stale source track" cause. Compare the
+# candidate's max versionCode against production's current max (across
+# completed AND in-progress releases). Equal (re-promote to bump rollout %)
+# and higher (new release) stay allowed; a first-ever production release
+# (no existing prod release) is unaffected.
+def _max_code(codes):
+    nums = [int(c) for c in codes if str(c).isdigit()]
+    return max(nums) if nums else None
+
+candidate_max = _max_code(version_codes)
+prod = service.edits().tracks().get(
+    packageName=package_name, editId=edit_id, track='production'
+).execute()
+prod_codes = [c for r in prod.get('releases', []) for c in r.get('versionCodes', [])]
+prod_max = _max_code(prod_codes)
+if candidate_max is not None and prod_max is not None and candidate_max < prod_max:
+    print(
+        f"ERROR: refusing to promote versionCode {candidate_max} from "
+        f"'{track_from}' — production already has {prod_max}. The source "
+        f"track is stale; promote from the track holding the current build "
+        f"(usually 'beta').",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 # Build production track update
 if rollout_pct >= 100:
     status = 'completed'


### PR DESCRIPTION
Closes #3407.

## Why
A `Deploy to Play Store` → `promote-rollout` run failed: it defaulted to `track_from=internal`, whose top release was the **stale May build `20260508`** (pre #3375/#3376 FGS/permission fix). Google rejected the commit with an opaque permission-declaration **403**, hiding the real cause — the wrong, older build was selected. (Resolved operationally by re-promoting from beta → `2026061761` now rolling out to production at 5%.)

## Change
- **`deploy.yml`** — `track_from` default `internal` → **`beta`** (the real release track, kept current by the daily build; `internal` is rarely updated).
- **`scripts/promote_play_store.sh`** — before updating production, read production's current releases and **refuse to promote when the candidate's max `versionCode` < production's max** (across completed + in-progress), with a clear message instead of an opaque Play 403. Equal codes (re-promote to bump rollout %) and higher codes (new release) stay allowed; a first-ever production release is unaffected.

## Validation
- `bash -n` (shell), `py_compile` (embedded Python), and YAML parse all pass.
- Behaviour verified against the live failure: candidate `20260508` < production `2026061691` → would now fail fast with `refusing to promote versionCode 20260508 — production already has 2026061691`.

No Dart / app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
