### PR TITLE
fix(consumption): gate GPS distance + altitude on real motion so jitter can't inflate meanSpeed/climb (#3412)

### DIFF
--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -30,6 +30,12 @@ const double kSharpCornerYawRateRadPerSec = 0.30;
 /// (HDOP > 2.5–3.0 / accuracy > 10 m, per the GNSS telematics guidance).
 const double kCornerAccuracyGateM = 10.0;
 
+/// Doppler-speed floor (km/h) below which the car is stationary, so
+/// position-derived integration (distance + altitude) is skipped: at a
+/// standstill the fix wanders 5–30 m/sample and an ungated integrator
+/// manufactures phantom distance/climb (#3412). Mirrors the idle band cutoff.
+const double kStationarySpeedKmh = 5.0;
+
 /// Driving-style aggregate derived from a stream of [TripSample]s
 /// **without** any OBD2 telemetry — the lean feature set the GPS
 /// calibration matrix (ADR 0010 / #2057 / Epic #2055) is fit against.
@@ -194,7 +200,7 @@ class GpsDrivingFeatures {
   /// elapsed time to the next sample (rectangle rule — fine for
   /// 1 Hz GPS streams).
   ///
-  /// Distance prefers great-circle math (`_haversineMeters`) when
+  /// Distance prefers great-circle math ([geo.distanceMeters]) when
   /// both samples carry lat/lng, falling back to `speedKmh × dt`
   /// for segments where either side is GPS-unfixed.
   ///
@@ -245,7 +251,7 @@ class GpsDrivingFeatures {
 
       // Speed-band integration on the leading sample (rectangle rule).
       final v = prev.speedKmh;
-      if (v < 5) {
+      if (v < kStationarySpeedKmh) {
         idle += dt;
       } else if (v < 50) {
         low += dt;
@@ -255,14 +261,27 @@ class GpsDrivingFeatures {
         high += dt;
       }
 
-      // Distance — prefer haversine when both samples have a fix.
+      // #3412 — integrate position-derived metrics (distance + altitude) only
+      // over GENUINE motion with a usable fix; a standstill/jittery fix
+      // otherwise piles GPS wander into phantom distance/climb. Accuracy
+      // ceiling mirrors the corner/accel gates.
+      final pAcc = prev.hAccuracyM, cAcc = cur.hAccuracyM;
+      final accurateFix = (pAcc == null || pAcc <= kCornerAccuracyGateM) &&
+          (cAcc == null || cAcc <= kCornerAccuracyGateM);
+      final moving = v >= kStationarySpeedKmh && accurateFix;
+
+      // Distance: haversine when fixed else speed-integrated, capped by what
+      // the (more reliable) Doppler speed allows so a position jump can't leak.
       final pLat = prev.latitude, pLng = prev.longitude;
       final cLat = cur.latitude, cLng = cur.longitude;
-      if (pLat != null && pLng != null && cLat != null && cLng != null) {
-        distM += _haversineMeters(pLat, pLng, cLat, cLng);
-      } else {
-        // m = (km/h × 1000/3600) × s
-        distM += v / 3.6 * dt;
+      if (moving) {
+        final segM =
+            (pLat != null && pLng != null && cLat != null && cLng != null)
+                ? geo.distanceMeters(pLat, pLng, cLat, cLng)
+                : v / 3.6 * dt;
+        final speedCapM =
+            (math.max(prev.speedKmh, cur.speedKmh) / 3.6) * dt * 1.5;
+        distM += math.min(segM, speedCapM);
       }
 
       // Peak |acceleration| in g, sample-to-sample (a quick sanity ceiling
@@ -301,9 +320,10 @@ class GpsDrivingFeatures {
         coastSeconds += dt;
       }
 
-      // Altitude delta.
+      // Altitude delta — only while moving (#3412): standstill altitude noise
+      // would otherwise become phantom climb (a bogus "29% gradient" lesson).
       final pAlt = prev.altitudeM, cAlt = cur.altitudeM;
-      if (pAlt != null && cAlt != null) {
+      if (moving && pAlt != null && cAlt != null) {
         final dAlt = cAlt - pAlt;
         if (dAlt > 0) {
           climb += dAlt;
@@ -320,10 +340,8 @@ class GpsDrivingFeatures {
       // out (a noisy bearing manufactures phantom corners — a bad fix is
       // worse than no fix).
       final pBear = prev.bearingDeg, cBear = cur.bearingDeg;
-      final pAcc = prev.hAccuracyM, cAcc = cur.hAccuracyM;
-      final accurate = (pAcc == null || pAcc <= kCornerAccuracyGateM) &&
-          (cAcc == null || cAcc <= kCornerAccuracyGateM);
-      if (pBear != null && cBear != null && accurate) {
+      // Reuses accurateFix (pAcc/cAcc) computed above for the distance gate.
+      if (pBear != null && cBear != null && accurateFix) {
         // Signed minimal angular delta — handles the 0/360 wrap so a
         // 350°→10° step is +20°, not −340° ((d+540) mod 360) − 180.
         final dBearingDeg = ((cBear - pBear + 540.0) % 360.0) - 180.0;
@@ -378,14 +396,4 @@ class GpsDrivingFeatures {
       climbEnergyPerKm: climbPerKm,
     );
   }
-
-  /// Great-circle distance between two WGS-84 coordinates in metres.
-  /// Delegates to the shared [geo.distanceMeters] (#2169).
-  static double _haversineMeters(
-    double lat1,
-    double lng1,
-    double lat2,
-    double lng2,
-  ) =>
-      geo.distanceMeters(lat1, lng1, lat2, lng2);
 }

--- a/test/features/consumption/domain/gps_driving_features_test.dart
+++ b/test/features/consumption/domain/gps_driving_features_test.dart
@@ -538,5 +538,68 @@ void main() {
         expect(f.steadyShare, 0);
       });
     });
+
+    group('stationary GPS jitter must not inflate distance/meanSpeed/climb '
+        '(#3412)', () {
+      // A parked phone: Doppler speed ≈ 0 (idle) but the fix wanders ~22 m
+      // (0.0002°) back and forth every second and the altitude bounces ±15 m.
+      // Pre-fix the ungated haversine + altitude integrators piled this jitter
+      // into ~km of phantom distance (meanSpeed 276 km/h on a 0.3 km trip) and
+      // ~100 m of phantom climb.
+      Iterable<TripSample> stationaryJitter({required int seconds}) sync* {
+        for (var i = 0; i <= seconds; i++) {
+          final wob = i.isEven ? 0.0002 : -0.0002; // ~22 m east/west wobble
+          final altWob = i.isEven ? 15.0 : -15.0; // ±15 m altitude noise
+          yield _s(
+            t0.add(Duration(seconds: i)),
+            i.isEven ? 0.0 : 1.5, // Doppler speed stays sub-5 km/h (idle)
+            lat: 48.85 + wob,
+            lng: 2.35,
+            altM: 100.0 + altWob,
+            hAccuracyM: 8, // an "accurate" fix — the wander is real GPS noise
+          );
+        }
+      }
+
+      test('a standstill with jittering lat/lon yields ~0 distance and a sane '
+          'meanSpeedKmh', () {
+        final f = GpsDrivingFeatures.from(stationaryJitter(seconds: 120))!;
+        // All time is idle (speed < 5).
+        expect(f.idleSeconds, closeTo(120.0, 0.5));
+        // The wander must NOT have accumulated into distance.
+        expect(f.distanceKm, lessThan(0.05),
+            reason: 'standstill jitter must not become real distance');
+        // And meanSpeed must stay physically sane (was 276 km/h).
+        expect(f.meanSpeedKmh, lessThan(5.0),
+            reason: 'a parked car cannot average tens of km/h');
+      });
+
+      test('a standstill with altitude noise yields ~0 phantom climb', () {
+        final f = GpsDrivingFeatures.from(stationaryJitter(seconds: 120))!;
+        expect(f.gradeClimbMeters, lessThan(2.0),
+            reason: 'altitude jitter at a standstill must not become climb');
+      });
+
+      test('a genuinely moving trip with accurate fixes still measures '
+          'distance (no over-gating)', () {
+        // ~30 km/h east: each 1 s step advances ~8.3 m. Over 60 s ≈ 500 m.
+        Iterable<TripSample> moving() sync* {
+          for (var i = 0; i <= 60; i++) {
+            yield _s(
+              t0.add(Duration(seconds: i)),
+              30,
+              lat: 48.85,
+              lng: 2.35 + i * 0.0001, // ~7.3 m/step east at this latitude
+              hAccuracyM: 6,
+            );
+          }
+        }
+
+        final f = GpsDrivingFeatures.from(moving())!;
+        expect(f.distanceKm, greaterThan(0.3),
+            reason: 'real motion must still accumulate distance');
+        expect(f.meanSpeedKmh, greaterThan(15.0));
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes #3412.

## Symptom
A `drivingAnalysis` export of a near-stationary **0.303 km / 1083 s** trip reported `meanSpeedKmh: 276.5` (actual ≈ 1 km/h) — internally inconsistent with its own speed bands (idle 794 s + low 97 s, zero cruise/high) — plus a phantom "Montée à 29% de pente (76% du trajet) : 0.6 L gaspillés" lesson.

## Root cause — `gps_driving_features.dart`
`meanSpeed = distKm / (total/3600)`; 276.5 km/h × 0.2475 h ⇒ the integrator accumulated **~68 km**. Two ungated position integrators in the per-sample loop:
- **distance** (`distM += haversine(prev,cur)`) — no accuracy/movement gate, so 5–30 m of standstill GPS wander × ~3500 samples = ~68 km phantom distance;
- **altitude** (`climb += dAlt`) — same, ~100 m phantom climb (the 29%-gradient lesson).

The accel-event (#2895) and corner-load integrals already gate on fix accuracy; these two were missed. Fixing distance alone would make `climbPerKm = climb/distKm` explode the other way, so **both** are gated together.

## Fix
- `moving = v >= kStationarySpeedKmh (5) && accurateFix` — Doppler speed is the movement truth (it already classifies the bands); accuracy ceiling reuses `kCornerAccuracyGateM`.
- Distance accumulates only while `moving`, and is **speed-capped** (`min(haversine, max(v)/3.6·dt·1.5)`) so a residual position jump can't exceed what the speed allows.
- Climb/descent accumulate only while `moving`.
- Speed-only KPIs (RPA/PKE/VAPOS/coast) untouched. Dropped the redundant private `_haversineMeters` (now calls `geo.distanceMeters` directly).

## Tests (RED on master)
- Stationary lat/lon + altitude jitter → ~0 distance, sane meanSpeed, ~0 climb.
- A genuinely moving trip still measures distance (no over-gating).
- Full consumption suite (1799) green; file ≤400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
