### PR TITLE
ci: turnkey FGS switch — repo-variable gate for Play, ship the FGS on F-Droid + dev-APK now (#3434, #3435)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -99,13 +99,15 @@ jobs:
         run: flutter pub get
 
       - name: Build AAB (play flavor, run-counter build number)
-        # #3375 — ship DARK: NO --dart-define=FGS_FORM_APPROVED here. The GPS
-        # foreground service (#3173) stays code-merged but gated off, because
-        # the Play "Foreground Service Use" form (#1498) is not yet approved —
-        # uploading the FGS bundle before then 403s ("you must let us know
-        # whether your app uses any Foreground Service permissions"). Re-add the
-        # define once the form clears.
-        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }}
+        # #3434 — the FGS define is gated on the repo variable
+        # FGS_FORM_APPROVED (Settings → Secrets and variables → Actions →
+        # Variables). While unset/false the GPS foreground service (#3173)
+        # ships DARK (#3375): uploading an FGS bundle before the Play
+        # "Foreground services" declaration (#3436) is approved 403s
+        # ("you must let us know whether your app uses any Foreground
+        # Service permissions"). Once the declaration clears, set the
+        # variable to `true` — no workflow edit needed.
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }} ${{ vars.FGS_FORM_APPROVED == 'true' && '--dart-define=FGS_FORM_APPROVED=true' || '' }}
 
       - name: Clean up decoded keystore
         if: always()

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -151,10 +151,13 @@ jobs:
         # #1777 — `--obfuscate` strips Dart symbol names from the
         # release binary; `--split-debug-info` writes the symbol files
         # needed to de-obfuscate later crash reports (uploaded below).
+        # #3434 — FGS define gated on the FGS_FORM_APPROVED repo variable;
+        # see daily-beta.yml for the full rationale.
         run: |
           flutter build appbundle --release --flavor play \
             --build-number=${{ needs.pre-check.outputs.build_number }} \
-            --obfuscate --split-debug-info=build/symbols
+            --obfuscate --split-debug-info=build/symbols \
+            ${{ vars.FGS_FORM_APPROVED == 'true' && '--dart-define=FGS_FORM_APPROVED=true' || '' }}
 
       # Per-ABI APKs were dropped from the public nightly release on
       # purpose — Play App Signing re-signs every Play install with

--- a/.github/workflows/dev-apk.yml
+++ b/.github/workflows/dev-apk.yml
@@ -86,9 +86,14 @@ jobs:
         # single ABI the modern Samsung device cares about — smaller
         # download, faster CI (~5-6 min instead of ~13 for split-per-
         # abi).
+        # #3435 — sideload artifacts never pass Play review, so they always
+        # ship the GPS foreground service (#3173): this is the build used to
+        # validate background recording on-device before the Play declaration
+        # (#3436) clears.
         run: |
           flutter build apk --release --flavor play \
-            --target-platform android-arm64
+            --target-platform android-arm64 \
+            --dart-define=FGS_FORM_APPROVED=true
 
       - name: Clean up decoded keystore
         if: always() && env.ANDROID_KEYSTORE_PATH != ''

--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -98,7 +98,11 @@ jobs:
           echo "FDROID_REPO_KEY_PASSWORD=$FDROID_REPO_KEY_PASSWORD" >> "$GITHUB_ENV"
 
       - name: Build signed fdroid release APK
-        run: flutter build apk --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true
+        # #3435 — the Play "Foreground services" declaration does not apply to
+        # F-Droid, so the fdroid flavor ships the GPS foreground service
+        # unconditionally (src/fdroid/AndroidManifestFgsApproved.xml overlay:
+        # FGS + FGS_LOCATION + battery-exemption only — no play-only services).
+        run: flutter build apk --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
 
       - name: Audit — no GMS / MLKit
         run: bash scripts/audit_no_gms.sh build/app/outputs/flutter-apk/app-fdroid-release.apk

--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -61,8 +61,10 @@ jobs:
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       # Build the unsigned DEBUG fdroid APK with the GMS-free runtime config.
+      # #3435 — FGS define matches fdroid-publish.yml so the GMS audit runs
+      # against the same artifact shape F-Droid actually ships.
       - name: Build fdroid debug APK
-        run: flutter build apk --debug --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true
+        run: flutter build apk --debug --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
       # Layer A (dependency graph) ALWAYS runs; layer B (dex) runs on the
       # debug APK just produced. dexdump comes from the runner's Android SDK
       # build-tools (ANDROID_HOME is set on ubuntu-latest); the script falls


### PR DESCRIPTION
## Why

Background trip recording is architecturally complete but ships dark in every Android build: the Play upload API 403s an FGS-declaring bundle until the Play Console "Foreground services" declaration is approved, so #3376 stripped the define from Play builds — and F-Droid (where no Play form applies at all) was collateral damage.

## What

- **#3434** — `daily-beta.yml` + `daily-github-release.yml` gate `--dart-define=FGS_FORM_APPROVED=true` on the **repo variable** `vars.FGS_FORM_APPROVED`. After the declaration (#3436) clears, flipping one variable ships the FGS everywhere — no workflow edit, no code change (the #3173 restore is already mechanised in Gradle + manifest overlays).
- **#3435** — `fdroid-publish.yml` and `dev-apk.yml` build with the define **now**: F-Droid gets full 1 s background GPS recording today (fdroid overlay = FGS + FGS_LOCATION + battery exemption only), and dev-APK sideload artifacts become the on-device validation build for #3439. `fdroid.yml`'s GMS audit builds with the same define so it audits the shipped artifact shape.

While the variable is unset, Play AABs are define-free — byte-identical FGS content to today (pin test `recording_location_settings_test.dart` unchanged).

Part of Epic #3417.
Closes #3434
Closes #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
