### PR TITLE
feat(obd2): Obd2LinkArbiter — one session-lease authority ends the reconnect war (#3419, #3420)

### DIFF
--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -71,17 +71,24 @@ class RecordingStartCoordinator {
     // GATT. `fallbackToScan: false` — the pre-warm is a fast best-effort warm,
     // not a guaranteed connect; a miss just means the start flow connects
     // normally. A successful warm is held for the start flow to consume.
-    final future = connection.connectByMacTransportAware(
-      mac,
-      adapterName: activeVehicle?.obd2AdapterName,
-      fallbackToScan: false,
+    // #3420 — the pre-warm is an INTERACTIVE link lease: refused outright
+    // (null, a plain pre-warm miss) while a recording or the auto-record
+    // watch owns the adapter, and it silences the #3019 idle loop while it
+    // dials — one connect authority at a time.
+    final future = Obd2LinkArbiter.instance.runInteractive(
+      'prewarm',
+      () => connection.connectByMacTransportAware(
+        mac,
+        adapterName: activeVehicle?.obd2AdapterName,
+        fallbackToScan: false,
+      ),
     );
     _prewarm = future;
     unawaited(future.then((svc) {
       if (!_alive) {
         // Backed out while the warm was in flight — disconnect it so we
         // don't leak an open GATT link.
-        unawaited(svc?.disconnect());
+        unawaited(svc?.disconnectQuietly());
         return;
       }
       _prewarmedService = svc;
@@ -167,7 +174,7 @@ class RecordingStartCoordinator {
       if (service.busProbe == Obd2BusProbeResult.probedSilent) {
         notifier.cancelConnecting();
         onConnectionError(const Obd2EngineOff());
-        unawaited(service.disconnect());
+        unawaited(service.disconnectQuietly());
         return;
       }
       // #3335 — the user may have hit Cancel on the connecting card while
@@ -175,7 +182,7 @@ class RecordingStartCoordinator {
       // connecting, tear the freshly-linked service down and do NOT start a
       // trip they backed out of.
       if (!ref.read(tripRecordingProvider).isConnecting) {
-        unawaited(service.disconnect());
+        unawaited(service.disconnectQuietly());
         return;
       }
       notifier.setConnectStage(TripStartStage.readingVehicleData);
@@ -199,11 +206,13 @@ class RecordingStartCoordinator {
     if (_prewarmConsumed) return;
     final svc = _prewarmedService;
     if (svc != null) {
-      unawaited(svc.disconnect());
+      unawaited(svc.disconnectQuietly());
     } else {
       // The warm may still be in flight — disconnect whatever it
-      // resolves to, since this tab is gone.
-      unawaited(_prewarm?.then((s) => s?.disconnect()));
+      // resolves to, since this tab is gone. #3420 — disconnectQuietly:
+      // the raw disconnect() here leaked teardown PlatformExceptions to
+      // PlatformDispatcher.onError (the 2026-07-02 field log entry).
+      unawaited(_prewarm?.then((s) => s?.disconnectQuietly()));
     }
   }
 }

--- a/lib/features/consumption/providers/reconnect_scanner_factory.dart
+++ b/lib/features/consumption/providers/reconnect_scanner_factory.dart
@@ -70,10 +70,23 @@ AdapterReconnectScanner? Function(
     final scanner = AdapterReconnectScanner(
       pinnedMac: pinnedMac,
       probe: (mac) async => true,
-      connect: connector.attempt,
+      // #3420 — stamp every in-trip reconnect attempt as a liveReconnect:
+      // the connector dials `connectByMacClassicDirect`/direct paths that
+      // default to firstConnect, which made the field trace ring read as
+      // ten user-driven connects during the #3415 war. The origin now
+      // tells the in-trip recovery apart from a real first connect.
+      connect: (mac) => Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.liveReconnect,
+        () => connector.attempt(mac),
+        transportDecisionReason: 'in-trip-reconnect',
+      ),
       // #2261 concern 2 — after the active-scan miss ceiling switch to a
       // passive autoConnect GATT wait for the rest of the 15-min grace.
-      passiveConnect: connector.attemptPassive,
+      passiveConnect: (mac) => Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.liveReconnect,
+        () => connector.attemptPassive(mac),
+        transportDecisionReason: 'in-trip-reconnect-passive',
+      ),
       onReconnect: onReconnect,
     );
     // #2905 — let the connector's per-attempt telemetry rows carry the

--- a/lib/features/obd2/api.dart
+++ b/lib/features/obd2/api.dart
@@ -36,6 +36,8 @@ export 'data/obd2_connect_trace_log.dart';
 export 'data/obd2_connect_trace_persistence.dart';
 export 'data/obd2_connection_errors.dart';
 export 'data/obd2_connection_service.dart';
+export 'data/obd2_disconnect_quietly.dart';
+export 'data/obd2_link_arbiter.dart';
 export 'data/obd2_permissions.dart';
 export 'data/obd2_read_telemetry.dart';
 export 'data/obd2_reconnect_controller.dart';

--- a/lib/features/obd2/data/auto_trip_coordinator.dart
+++ b/lib/features/obd2/data/auto_trip_coordinator.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import '../../../core/logging/error_logger.dart';
 import 'auto_record_trace_log.dart';
 import 'background_adapter_listener.dart';
+import 'obd2_link_arbiter.dart';
 import 'obd2_read_telemetry.dart';
 import 'obd2_service.dart';
 import 'obd2_speed_stream.dart';
@@ -201,6 +202,11 @@ class AutoTripCoordinator {
   /// here). Null when the coordinator is idle, when no opener was
   /// injected, or after a successful hand-off.
   Obd2Service? _session;
+
+  /// #3420 — the auto-record lease on the [Obd2LinkArbiter], held while a
+  /// movement-watch session is open. Released at hand-off (the recorder
+  /// acquires its own recording lease), on teardown, and on preemption.
+  Obd2LinkLease? _linkLease;
 
   AutoTripCoordinator({
     required this.listener,
@@ -447,6 +453,24 @@ class AutoTripCoordinator {
       // we simply have no speed source. Stay idle.
       return;
     }
+    // #3420 — claim the link as the auto-record authority BEFORE any
+    // connect. Refused while a recording (or another holder) owns the
+    // adapter: opening a second RFCOMM session against a live trip tears
+    // down the recording's socket — the #3415 field war's second front.
+    final lease = Obd2LinkArbiter.instance.tryAcquire(
+      'auto-record',
+      Obd2LinkPriority.autoRecord,
+      onPreempted: _onLinkPreempted,
+    );
+    if (lease == null) {
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.sessionOpenFailed,
+        mac: config.mac,
+        detail: 'link-held-by=${Obd2LinkArbiter.instance.holder?.owner}',
+      );
+      return;
+    }
+    _linkLease = lease;
 
     Obd2Service? service;
     try {
@@ -473,19 +497,22 @@ class AutoTripCoordinator {
         mac: config.mac,
         detail: 'opener returned null',
       );
+      _releaseLinkLease(); // #3420 — no session, hand the link back
       return;
     }
 
     // The connect cycle could have been cancelled between awaiting the
-    // opener and now (stop() was called, or a disconnect already fired
-    // and queued ahead of us). Drop the freshly-opened service rather
-    // than wire a dangling subscription.
-    if (!_started || _tripActive || _session != null) {
+    // opener and now (stop() was called, a disconnect already fired and
+    // queued ahead of us, or a recording PREEMPTED the lease mid-open,
+    // #3420). Drop the freshly-opened service rather than wire a dangling
+    // subscription against a link someone else now owns.
+    if (!_started || _tripActive || _session != null || !lease.isActive) {
       try {
         await service.disconnect();
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AutoTripCoordinator: drop-orphan disconnect failed'}));
       }
+      _releaseLinkLease(); // #3420 — the cycle was cancelled under us
       return;
     }
 
@@ -638,8 +665,11 @@ class AutoTripCoordinator {
     await _tuneLinkForRecording(session);
     // Transfer ownership: null out the local pointer so neither
     // `stop()` nor `_onDisconnected()` will try to close a session
-    // the recorder is using.
+    // the recorder is using. #3420 — release the auto-record lease at the
+    // same moment: the recorder's `start()` acquires its own RECORDING
+    // lease, so the hand-off is a clean ownership transfer, not a preempt.
     _session = null;
+    _releaseLinkLease();
     AutoRecordTraceLog.add(
       AutoRecordEventKind.sessionHandedOff,
       mac: config.mac,
@@ -715,8 +745,9 @@ class AutoTripCoordinator {
 
   /// Close [_session] if held, swallowing transport errors. Idempotent
   /// — `_session` is nulled out either way so a follow-up call is a
-  /// no-op.
+  /// no-op. #3420 — also hands the auto-record link lease back.
   Future<void> _closeSessionIfHeld() async {
+    _releaseLinkLease();
     final held = _session;
     if (held == null) return;
     _session = null;
@@ -725,5 +756,25 @@ class AutoTripCoordinator {
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AutoTripCoordinator: session close failed'}));
     }
+  }
+
+  void _releaseLinkLease() {
+    _linkLease?.release();
+    _linkLease = null;
+  }
+
+  /// #3420 — a strictly-higher authority (a manual recording) took the
+  /// link. The lease is already revoked; stop the movement watch and drop
+  /// the held session so the new owner's connect finds a free adapter.
+  void _onLinkPreempted() {
+    _linkLease = null;
+    unawaited(_speedSub?.cancel());
+    _speedSub = null;
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.sessionOpenFailed,
+      mac: config.mac,
+      detail: 'link-preempted: watch stopped, session closing',
+    );
+    unawaited(_closeSessionIfHeld());
   }
 }

--- a/lib/features/obd2/data/obd2_disconnect_quietly.dart
+++ b/lib/features/obd2/data/obd2_disconnect_quietly.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../../core/logging/error_logger.dart';
+import 'obd2_service.dart';
+
+/// #3420 — fire-and-forget-safe teardown for the one leak the 2026-07-02
+/// field log caught at `PlatformDispatcher.onError`:
+/// `PlatformException(io, bt socket closed, read return: -1)`.
+///
+/// [Obd2Service.disconnect] can rethrow a platform teardown error (the
+/// transport's EventChannel cancel / native socket close racing a dying
+/// link). Every `unawaited(service.disconnect())` call site therefore
+/// leaked that error into the zone as an UNHANDLED async error — six such
+/// sites existed (the pre-warm coordinator × 5, the trip-start watchdog
+/// abort × 1). Route them through this wrapper instead.
+extension Obd2DisconnectQuietly on Obd2Service {
+  /// Disconnect, swallowing (and error-logging) any teardown error.
+  /// Never throws — safe under `unawaited(...)`.
+  Future<void> disconnectQuietly() async {
+    try {
+      await disconnect();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'Obd2Service.disconnectQuietly: teardown error (swallowed)',
+      }));
+    }
+  }
+}

--- a/lib/features/obd2/data/obd2_link_arbiter.dart
+++ b/lib/features/obd2/data/obd2_link_arbiter.dart
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'obd2_link_drop_signal.dart';
+
+/// Priority of an [Obd2LinkLease], ordered low → high. A [tryAcquire] with a
+/// STRICTLY higher priority preempts the current holder; an equal-or-lower
+/// request is refused (the caller keeps its existing fallback behaviour).
+///
+/// `idle` is deliberately NOT a lease: the #3019 idle reconnector registers
+/// as the FALLBACK drop policy via [Obd2LinkArbiter.registerIdlePolicy] and
+/// handles drops only while NO lease is held — its #3013 charter ("idle /
+/// between trips") enforced by construction instead of by flag discipline.
+enum Obd2LinkPriority {
+  /// User-interactive one-shot connects: adapter picker, pre-warm, VIN
+  /// read, self-test.
+  interactive(1),
+
+  /// The hands-free auto-record coordinator's movement-watch session.
+  autoRecord(2),
+
+  /// A live trip recording — the highest authority on the adapter.
+  recording(3);
+
+  const Obd2LinkPriority(this.rank);
+
+  /// Numeric rank for comparisons (higher = stronger claim).
+  final int rank;
+}
+
+/// A granted claim on the one physical OBD2 adapter (#3415 / #3420).
+///
+/// While a lease is active, the arbiter routes every proactive
+/// [Obd2LinkDropSignal] drop to [onDrop] (instead of the idle policy), and
+/// [Obd2LinkArbiter.tryAcquire] refuses equal-or-lower rivals — so exactly
+/// one authority can drive connect/reconnect cycles at any moment. The
+/// 2026-07-02 field evidence on #3415 (ten successful ELM inits in 43 s,
+/// alternating firstConnect/liveReconnect) is the war this makes impossible.
+class Obd2LinkLease {
+  Obd2LinkLease._(this.owner, this.priority, this.onDrop, this.onPreempted);
+
+  /// Stable, low-cardinality owner tag for traces (`recording`,
+  /// `auto-record`, `picker`, …).
+  final String owner;
+
+  final Obd2LinkPriority priority;
+
+  /// Invoked with every link-drop event observed while this lease holds.
+  /// Null → the holder relies on its own transport-level drop handling
+  /// (e.g. the in-trip DroppedSessionManager) and the event is dropped.
+  final void Function(Obd2LinkDropEvent event)? onDrop;
+
+  /// Invoked when a strictly-higher-priority acquire revokes this lease.
+  /// The holder must stop driving connects and abandon/tear down its
+  /// session; the lease is already released when this fires.
+  final VoidCallback? onPreempted;
+
+  bool _active = true;
+
+  /// Whether this lease still holds the link.
+  bool get isActive => _active;
+
+  /// Hand the link back. Idempotent.
+  void release() => Obd2LinkArbiter.instance._release(this);
+}
+
+/// One session-lease authority for every OBD2 connect, reconnect and drop
+/// (#3415 / #3420, design #3418).
+///
+/// Root cause of the recurring reconnect war: N independent initiators ×
+/// 1 adapter, reconciled only by a boolean latch (#3387) + a connect-slot
+/// queue (#3185) — both of which serialize WITHOUT deciding who OWNS the
+/// link. The arbiter decides ownership:
+///
+///  * every initiator [tryAcquire]s a lease before driving any connect;
+///  * a strictly-higher priority preempts (the holder is told to stand
+///    down); an equal-or-lower rival is refused outright;
+///  * the arbiter is the SOLE consumer of [Obd2LinkDropSignal] — a drop
+///    reaches the current holder only, or the registered idle policy
+///    (#3019) when no lease is held.
+///
+/// Process-wide singleton for the same reason as the latch it absorbs: the
+/// data-layer channels, the recording pipeline and the providers coordinate
+/// without a cross-feature provider dependency.
+class Obd2LinkArbiter {
+  Obd2LinkArbiter._() {
+    // Held for the process lifetime (never cancelled) — the arbiter IS the
+    // app-wide drop router, alive exactly as long as the process.
+    Obd2LinkDropSignal.instance.drops.listen(_routeDrop);
+  }
+
+  /// Process-wide instance.
+  static final Obd2LinkArbiter instance = Obd2LinkArbiter._();
+
+  Obd2LinkLease? _holder;
+
+  final Set<Obd2LinkIdleRegistration> _idlePolicies =
+      <Obd2LinkIdleRegistration>{};
+
+  /// Mirrors "a recording lease is held" for the #3387 latch shim
+  /// ([Obd2RecordingLinkOwnership]) and its pinned tests. Notifies on every
+  /// recording-ownership transition, exactly like the latch it replaces.
+  final ValueNotifier<bool> recordingOwnsLink = ValueNotifier<bool>(false);
+
+  /// The current lease holder, if any. Exposed for traces + tests.
+  Obd2LinkLease? get holder => _holder;
+
+  /// Whether a recording lease currently holds the link.
+  bool get recordingLeaseHeld =>
+      _holder?.priority == Obd2LinkPriority.recording && _holder!.isActive;
+
+  /// Claim the link. Grants when the link is free; PREEMPTS a
+  /// strictly-lower-priority holder (its [Obd2LinkLease.onPreempted] fires
+  /// after its lease is revoked); returns null when an equal-or-higher
+  /// holder keeps the link — the caller must NOT drive a connect cycle.
+  ///
+  /// Synchronous by design: the recording pipeline claims at the very top
+  /// of `start()` (before its first await) so no drop can land unowned —
+  /// the #3387 claim-after-watchdog race window cannot exist.
+  Obd2LinkLease? tryAcquire(
+    String owner,
+    Obd2LinkPriority priority, {
+    void Function(Obd2LinkDropEvent event)? onDrop,
+    VoidCallback? onPreempted,
+  }) {
+    final current = _holder;
+    if (current != null && current.isActive) {
+      // Interactive-vs-interactive: the LATEST user gesture wins — a hung
+      // earlier attempt (e.g. a native connect blocked for minutes, #3415
+      // trace t8) must not wedge every later tap. All other equal-or-lower
+      // acquires are refused: loops (idle/auto-record) retry on their own
+      // schedule and must never tear down a live holder.
+      final gestureOverGesture = priority == Obd2LinkPriority.interactive &&
+          current.priority == Obd2LinkPriority.interactive;
+      if (priority.rank <= current.priority.rank && !gestureOverGesture) {
+        return null;
+      }
+      // Strictly higher (or gesture-over-gesture) — revoke, then notify the
+      // ousted holder.
+      current._active = false;
+      _holder = null;
+      _afterHolderChanged();
+      try {
+        current.onPreempted?.call();
+        // ignore: silent_catch — a misbehaving onPreempted must not block the grant
+      } catch (_) {}
+    }
+    final lease = Obd2LinkLease._(owner, priority, onDrop, onPreempted);
+    _holder = lease;
+    _afterHolderChanged();
+    return lease;
+  }
+
+  /// Run [body] under a short-lived [Obd2LinkPriority.interactive] lease
+  /// (picker / pre-warm / VIN / self-test). Returns null WITHOUT running
+  /// [body] when the link is held by an equal-or-higher authority — the
+  /// user-facing caller treats it as "adapter busy" exactly like a failed
+  /// connect. The lease is always released when [body] settles.
+  Future<T?> runInteractive<T>(
+    String owner,
+    Future<T> Function() body,
+  ) async {
+    final lease = tryAcquire(owner, Obd2LinkPriority.interactive);
+    if (lease == null) return null;
+    try {
+      return await body();
+    } finally {
+      lease.release();
+    }
+  }
+
+  /// Register the #3019 idle reconnect policy: [onDrop] receives drop
+  /// events only while NO lease is held; [onStandDown] fires the instant
+  /// any lease is granted (so an in-flight idle loop stops before it can
+  /// tear down the new owner's socket). Multiple registrations (one per
+  /// live provider container) all receive the callbacks — mirroring the
+  /// broadcast drop-signal semantics this replaces. Dispose the returned
+  /// registration with the owning provider.
+  Obd2LinkIdleRegistration registerIdlePolicy({
+    required void Function(Obd2LinkDropEvent event) onDrop,
+    required VoidCallback onStandDown,
+  }) {
+    final reg = Obd2LinkIdleRegistration._(this, onDrop, onStandDown);
+    _idlePolicies.add(reg);
+    return reg;
+  }
+
+  void _routeDrop(Obd2LinkDropEvent event) {
+    final current = _holder;
+    if (current != null && current.isActive) {
+      // The holder owns the drop — the idle policy must NOT also react
+      // (that is the #3386/#3415 war). A null onDrop means the holder's
+      // own transport-level handling (DroppedSessionManager) covers it.
+      try {
+        current.onDrop?.call(event);
+        // ignore: silent_catch — a throwing holder must not kill the router
+      } catch (_) {}
+      return;
+    }
+    for (final reg in List<Obd2LinkIdleRegistration>.of(_idlePolicies)) {
+      reg._notifyDrop(event);
+    }
+  }
+
+  void _release(Obd2LinkLease lease) {
+    if (!lease._active && !identical(_holder, lease)) return;
+    lease._active = false;
+    if (identical(_holder, lease)) {
+      _holder = null;
+      _afterHolderChanged();
+    }
+  }
+
+  void _afterHolderChanged() {
+    recordingOwnsLink.value = recordingLeaseHeld;
+    final current = _holder;
+    if (current != null && current.isActive) {
+      // Any granted lease silences the idle loop — not just recording
+      // (the auto-record ↔ #3019 pair was the ungated war the field
+      // breadcrumbs caught 15 ms apart, #3415).
+      for (final reg in List<Obd2LinkIdleRegistration>.of(_idlePolicies)) {
+        reg._notifyStandDown();
+      }
+    }
+  }
+
+  /// Revoke any held lease and reset the recording mirror (tests). Idle
+  /// registrations are NOT cleared — their owning containers dispose them.
+  @visibleForTesting
+  void resetForTest() {
+    _holder?._active = false;
+    _holder = null;
+    recordingOwnsLink.value = false;
+  }
+}
+
+/// Handle for a registered idle policy (#3019). [dispose] with the owning
+/// provider so a torn-down container stops receiving callbacks.
+class Obd2LinkIdleRegistration {
+  Obd2LinkIdleRegistration._(this._arbiter, this._onDrop, this._onStandDown);
+
+  final Obd2LinkArbiter _arbiter;
+  final void Function(Obd2LinkDropEvent event) _onDrop;
+  final VoidCallback _onStandDown;
+  bool _disposed = false;
+
+  void _notifyDrop(Obd2LinkDropEvent event) {
+    if (_disposed) return;
+    try {
+      _onDrop(event);
+      // ignore: silent_catch — one broken policy must not starve the others
+    } catch (_) {}
+  }
+
+  void _notifyStandDown() {
+    if (_disposed) return;
+    try {
+      _onStandDown();
+      // ignore: silent_catch — one broken policy must not starve the others
+    } catch (_) {}
+  }
+
+  /// Stop receiving callbacks. Idempotent.
+  void dispose() {
+    _disposed = true;
+    _arbiter._idlePolicies.remove(this);
+  }
+}

--- a/lib/features/obd2/data/obd2_recording_link_ownership.dart
+++ b/lib/features/obd2/data/obd2_recording_link_ownership.dart
@@ -3,31 +3,22 @@
 
 import 'package:flutter/foundation.dart';
 
-/// #3386 — single-authority gate for OBD2 reconnect.
+import 'obd2_link_arbiter.dart';
+
+/// #3386 → #3420 — THIN SHIM over [Obd2LinkArbiter].
 ///
-/// Two reconnect authorities existed for the one adapter:
-///  * the in-trip [DroppedSessionManager] (#2188) — the reconnect owner WHILE a
-///    recording is active;
-///  * the app-wide, trip-INDEPENDENT [Obd2Reconnect] (#3019) — documented as
-///    the owner for a drop "while idle / between trips".
+/// The original latch let the recording pipeline claim the adapter so the
+/// app-wide #3019 reconnector stood down. #3415's field evidence proved a
+/// boolean latch cannot carry that responsibility (claim/release race
+/// windows at the trip edges; no gate at all between auto-record and
+/// #3019), so ownership moved into the [Obd2LinkArbiter] session lease.
 ///
-/// But #3019 subscribed to the link-drop signal UNCONDITIONALLY, so during a
-/// recording BOTH reconnected the single adapter. Establishing a second RFCOMM
-/// socket tears down the first (one SPP channel), the first sees a socket-close
-/// drop and reconnects, tearing down the second — a perpetual reconnect WAR
-/// that never let the link settle, leaving the trip stuck on GPS-estimated
-/// consumption (field: "Enregistrement via GPS — reconnexion OBD2" all drive).
-///
-/// This latch lets the OBD2 recording pipeline CLAIM the adapter so #3019
-/// stands down (and stops any in-flight loop) for the trip's lifetime; the
-/// trip's own [DroppedSessionManager] is then the sole in-trip authority, as
-/// the design always intended. Releasing it hands the idle/between-trips role
-/// back to #3019.
-///
-/// A process-wide singleton (not a Riverpod provider) so the data-layer
-/// reconnect controller and the recording pipeline coordinate WITHOUT a
-/// cross-feature provider dependency; the [recordingOwnsLink] notifier lets
-/// #3019 react the instant a recording claims the link.
+/// This shim preserves the latch API for its existing tests and any legacy
+/// caller: [claim]/[release] acquire/release a RECORDING lease on the
+/// arbiter, and [active]/[recordingOwnsLink] mirror "a recording lease is
+/// held" (including one acquired directly on the arbiter, e.g. by
+/// `Obd2RecordingPipeline.start`). Scheduled for deletion in #3424 once
+/// the regression suite proves nothing references it.
 class Obd2RecordingLinkOwnership {
   Obd2RecordingLinkOwnership._();
 
@@ -35,20 +26,39 @@ class Obd2RecordingLinkOwnership {
   static final Obd2RecordingLinkOwnership instance =
       Obd2RecordingLinkOwnership._();
 
-  /// True while a trip recording owns the adapter. Notifies on every change.
-  final ValueNotifier<bool> recordingOwnsLink = ValueNotifier<bool>(false);
+  Obd2LinkLease? _legacyLease;
 
-  /// Whether a recording currently owns the adapter (the in-trip
-  /// [DroppedSessionManager] is the reconnect authority).
-  bool get active => recordingOwnsLink.value;
+  /// True while a trip recording owns the adapter. Notifies on every
+  /// change. Owned by the arbiter — reflects ANY recording lease, however
+  /// acquired.
+  ValueNotifier<bool> get recordingOwnsLink =>
+      Obd2LinkArbiter.instance.recordingOwnsLink;
 
-  /// A recording now owns the adapter — #3019 stands down.
-  void claim() => recordingOwnsLink.value = true;
+  /// Whether a recording currently owns the adapter.
+  bool get active => Obd2LinkArbiter.instance.recordingLeaseHeld;
 
-  /// The recording released the adapter — #3019 resumes the idle role.
-  void release() => recordingOwnsLink.value = false;
+  /// A recording now owns the adapter (legacy path — the pipeline itself
+  /// acquires its lease on the arbiter directly).
+  void claim() =>
+      _legacyLease ??= Obd2LinkArbiter.instance.tryAcquire(
+        'legacy-latch',
+        Obd2LinkPriority.recording,
+        onPreempted: () => _legacyLease = null,
+      );
 
-  /// Reset to the unowned state (tests).
+  /// The recording released the adapter.
+  void release() {
+    _legacyLease?.release();
+    _legacyLease = null;
+  }
+
+  /// Reset to the unowned state (tests) — clears any held lease on the
+  /// arbiter, whoever acquired it.
   @visibleForTesting
-  void resetForTest() => recordingOwnsLink.value = false;
+  void resetForTest() {
+    _legacyLease = null;
+    // Shim-to-arbiter delegation: both ends are @visibleForTesting.
+    // ignore: invalid_use_of_visible_for_testing_member
+    Obd2LinkArbiter.instance.resetForTest();
+  }
 }

--- a/lib/features/obd2/data/obd2_self_test_driver.dart
+++ b/lib/features/obd2/data/obd2_self_test_driver.dart
@@ -8,6 +8,7 @@ import 'obd2_connect_trace.dart';
 import 'obd2_connect_trace_log.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_connection_service.dart';
+import 'obd2_link_arbiter.dart';
 import 'obd2_response_class.dart';
 import 'obd2_service.dart';
 
@@ -284,13 +285,18 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
       // #2969 — transport-aware pinned connect: a Classic adapter takes the
       // RFCOMM direct path (the BLE direct path would only 4 s-timeout); the
       // connect step gets its OWN longer budget ([connectDeadline]).
-      service = pinnedMac != null
-          ? await _selfTestConnect(connection, pinnedMac,
-                  transport: transportHint,
-                  decisionReason: decisionReason,
-                  adapterName: adapterName)
-              .timeout(connectDeadline)
-          : await connection.connectBest().timeout(connectDeadline);
+      // #3420 — interactive lease: refused (null → noResponse) while a
+      // recording / auto-record watch owns the adapter; the controller's
+      // no-live-recording guard remains the first line of defence.
+      service = await Obd2LinkArbiter.instance.runInteractive<Obd2Service?>(
+          'self-test',
+          () async => pinnedMac != null
+              ? await _selfTestConnect(connection, pinnedMac,
+                      transport: transportHint,
+                      decisionReason: decisionReason,
+                      adapterName: adapterName)
+                  .timeout(connectDeadline)
+              : await connection.connectBest().timeout(connectDeadline));
     } on TimeoutException {
       connectSw.stop();
       emit(_step(Obd2SelfTestStepId.scan, Obd2SelfTestStepStatus.timeout,

--- a/lib/features/obd2/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/obd2/presentation/widgets/obd2_adapter_picker.dart
@@ -14,6 +14,7 @@ import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/adapter_registry.dart';
 import '../../data/obd2_adapter_identity.dart';
 import '../../data/obd2_connection_errors.dart';
+import '../../data/obd2_link_arbiter.dart';
 import '../../data/obd2_connection_service.dart';
 import '../../data/obd2_pairing_mode.dart';
 import '../../data/obd2_service.dart';
@@ -60,10 +61,11 @@ Future<Obd2Service?> showObd2AdapterPicker(
       // and NEVER opens the BLE GATT that 4 s-times-out + poisons the socket. It
       // still falls back to the merged BLE+Classic scan via `connectByMac`
       // internally for a direct miss, so the existing behaviour is preserved.
-      service = await container.read(obd2ConnectionProvider).connectByMacTransportAware(
-            pinnedMac,
-            adapterName: pinnedAdapterName,
-          );
+      // #3420 — interactive lease; refused (null → sheet) while a recording
+      // or the auto-record watch owns the link.
+      service = await Obd2LinkArbiter.instance.runInteractive<Obd2Service?>(
+          'picker-pinned',
+          () => container.read(obd2ConnectionProvider).connectByMacTransportAware(pinnedMac, adapterName: pinnedAdapterName));
     } on Obd2ConnectionError catch (e, st) {
       // Drop through to the sheet so the user can pick another adapter; the
       // fall-through snackbar surfaces it. #2745 — an expected, user-surfaced
@@ -284,7 +286,13 @@ class _Obd2AdapterPickerSheetState
     unawaited(_sub?.cancel());
     _sub = null;
     try {
-      final service = await connection.connect(candidate);
+      // #3420 — interactive lease (same contract as the pinned path above).
+      final service = await Obd2LinkArbiter.instance
+          .runInteractive('picker-scan', () => connection.connect(candidate));
+      if (service == null) {
+        // Refused: a recording / auto-record watch owns the link (#3420).
+        throw const Obd2AdapterUnresponsive();
+      }
       // #1188 — persist MAC + display name back onto the active vehicle
       // profile so the next session takes the pinned-MAC fast path and skips
       // the picker. Best-effort; uses the pre-await captures (errorlog_30) so

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -14,8 +14,7 @@ import '../data/obd2_comm_diagnostics.dart';
 import '../data/obd2_connect_trace.dart';
 import '../data/obd2_connect_trace_log.dart';
 import '../data/obd2_connection_service.dart';
-import '../data/obd2_link_drop_signal.dart';
-import '../data/obd2_recording_link_ownership.dart';
+import '../data/obd2_link_arbiter.dart';
 import '../data/obd2_reconnect_controller.dart';
 import '../data/obd2_service.dart';
 import 'obd2_connection_state_provider.dart';
@@ -47,42 +46,31 @@ LastGoodAdapterStore lastGoodAdapterStore(Ref ref) =>
 @Riverpod(keepAlive: true)
 class Obd2Reconnect extends _$Obd2Reconnect {
   Obd2ReconnectController? _controller;
-  StreamSubscription<Obd2LinkDropEvent>? _dropSub;
+  Obd2LinkIdleRegistration? _idleReg;
 
   @override
   Obd2ReconnectState build() {
     final controller = _buildController();
     _controller = controller;
-    // #3019 — subscribe to the PROACTIVE link-drop signal both channels emit
-    // the instant a link dies (BLE disconnect edge / Classic socket close), so
-    // a drop while idle / between trips still starts the bounded backoff loop.
-    _dropSub = Obd2LinkDropSignal.instance.drops.listen((e) {
-      // #3386 — STAND DOWN while a trip recording owns the adapter: the trip's
-      // own DroppedSessionManager (#2188) is the sole in-trip reconnect
-      // authority. Two reconnectors on one adapter ping-pong the single RFCOMM
-      // socket forever (the field "permanently reconnecting" war). #3019 only
-      // handles drops while idle / between trips — exactly its #3013 charter.
-      if (Obd2RecordingLinkOwnership.instance.active) return;
-      // #3346 — carry WHY the link dropped (and on which transport) into the
-      // controller so the reconnect-episode breadcrumb records it.
-      _controller?.notifyDropped(
+    // #3420 — register as the arbiter's IDLE policy. The arbiter is the sole
+    // consumer of the proactive link-drop signal: a drop reaches this loop
+    // ONLY while no lease (recording / auto-record / interactive) holds the
+    // link — the #3013 "idle / between trips" charter by construction, where
+    // the #3386 latch left the auto-record ↔ #3019 pair ungated (#3415).
+    // onStandDown fires the instant ANY lease is granted, so an in-flight
+    // idle loop stops before it can tear down the new owner's socket.
+    // #3346 — the drop reason/transport still reach the episode breadcrumb.
+    _idleReg = Obd2LinkArbiter.instance.registerIdlePolicy(
+      onDrop: (e) => _controller?.notifyDropped(
         reason: e.reason,
         transportKind: e.transportKind,
         mac: e.mac,
-      );
-    });
-    // #3386 — if a recording CLAIMS the link while #3019 is mid-loop (an idle
-    // drop that was recovering when the user hit Start), hand over immediately:
-    // stop the loop so it can't tear down the recording's freshly-owned socket.
-    final ownership = Obd2RecordingLinkOwnership.instance.recordingOwnsLink;
-    void onOwnershipChanged() {
-      if (ownership.value) _controller?.stop();
-    }
-    ownership.addListener(onOwnershipChanged);
+      ),
+      onStandDown: () => _controller?.stop(),
+    );
     ref.onDispose(() {
-      ownership.removeListener(onOwnershipChanged);
-      unawaited(_dropSub?.cancel());
-      _dropSub = null;
+      _idleReg?.dispose();
+      _idleReg = null;
       controller.dispose();
       _controller = null;
     });

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'865da60113c9d5aeeaa9040e5d3faf2720c8db3b';
+String _$obd2ReconnectHash() => r'05c72e8a46cb79489470753ad4fefad93620e89e';
 
 /// App-wide owner of the trip-INDEPENDENT auto-reconnect controller (#3019 /
 /// Epic #3013 phase 3).

--- a/lib/features/obd2/providers/obd2_recording_pipeline.dart
+++ b/lib/features/obd2/providers/obd2_recording_pipeline.dart
@@ -10,7 +10,8 @@ import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../driving/providers/live_harsh_event_bus_provider.dart';
 import '../../../core/domain/vehicle_profile.dart';
 import '../data/obd2_connection_errors.dart';
-import '../data/obd2_recording_link_ownership.dart';
+import '../data/obd2_disconnect_quietly.dart';
+import '../data/obd2_link_arbiter.dart';
 import '../data/obd2_service.dart';
 import '../data/obd2_trip_start_budgets.dart';
 import '../data/obd2_session_context_block.dart';
@@ -86,6 +87,7 @@ class Obd2RecordingPipeline implements RecordingPipeline {
   final Duration _baselinesBudget;
 
   Obd2Service? _service;
+  Obd2LinkLease? _lease; // #3420 — the recording's session lease (arbiter)
   TripRecordingController? _controller;
   StreamSubscription<TripLiveReading>? _liveSub;
   StreamSubscription<TripRecordingControllerState>? _stateSub;
@@ -121,6 +123,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
   /// verbatim from `TripRecording._startInternal`; the re-entrancy guard
   /// + `state.isActive` short-circuit stay on the notifier.
   Future<void> start(Obd2Service service, {bool automatic = false}) async {
+    // #3420 — claim the link BEFORE the first await: a drop anywhere in the start window belongs to THIS recording, never the #3019 idle loop.
+    _lease = Obd2LinkArbiter.instance.tryAcquire('recording', Obd2LinkPriority.recording);
     _service = service;
     // #2261 concern 6 — re-arm the deferred capability probe (first sample).
     _capabilityReconcileKicked = false;
@@ -195,8 +199,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       await _baselines.load().timeout(_baselinesBudget);
       await ctl.start().timeout(_startWatchdog);
     } on TimeoutException {
-      _controller = null;
-      unawaited(service.disconnect());
+      _controller = null; _lease?.release(); _lease = null;
+      unawaited(service.disconnectQuietly());
       throw const Obd2AdapterUnresponsive();
     }
     // #1374 / #1981 — GPS trip-path sampling, default-on; fire-and-forget so
@@ -270,7 +274,6 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       // #1303 — phase transitions force an immediate snapshot.
       unawaited(_host.flushActiveSnapshot(force: true));
     });
-    Obd2RecordingLinkOwnership.instance.claim(); // #3386 — #3019 stands down
     // #2274 — going live clears the connecting stage for the live-metrics frame.
     _host.state = _host.state.copyWith(
       phase: TripRecordingPhase.recording,
@@ -296,7 +299,6 @@ class Obd2RecordingPipeline implements RecordingPipeline {
 
   @override
   Future<StoppedTripResult> stop({bool automatic = false}) async {
-    Obd2RecordingLinkOwnership.instance.release(); // #3386 — #3019 resumes idle
     final ctl = _controller;
     final svc = _service;
     if (ctl == null || svc == null) {
@@ -384,7 +386,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st,
           context: obd2DisconnectTraceContext()));
     }
-    _service = null;
+    // #3420 — the lease is held until the disconnect COMPLETED (race 2).
+    _service = null; _lease?.release(); _lease = null;
     // #1303 — trip finalised; clear the WAL so recovery doesn't resurrect it.
     await _host.clearActiveSnapshot();
     _host.state = _host.state.copyWith(phase: TripRecordingPhase.finished);

--- a/lib/features/vehicle/providers/obd2_vin_reader_provider.dart
+++ b/lib/features/vehicle/providers/obd2_vin_reader_provider.dart
@@ -46,7 +46,13 @@ class Obd2VinReaderService implements VinReaderService {
     // owns its own short scan window and short-circuits on the first
     // candidate matching [pairedAdapterMac] — exactly what we want.
     try {
-      final service = await connection.connectByMac(pairedAdapterMac);
+      // #3420 — an INTERACTIVE link lease: refused (null → io failure)
+      // while a recording / auto-record watch owns the adapter, so a VIN
+      // read can never open a rival session against a live trip.
+      final service = await Obd2LinkArbiter.instance.runInteractive(
+        'vin-read',
+        () => connection.connectByMac(pairedAdapterMac),
+      );
       if (service == null) {
         return const ObdVinResult.failure(ObdVinFailureReason.io);
       }

--- a/test/features/obd2/data/obd2_disconnect_quietly_test.dart
+++ b/test/features/obd2/data/obd2_disconnect_quietly_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_disconnect_quietly.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3420 — fault-injection contract test for [Obd2DisconnectQuietly]: the
+/// wrapper's "Never throws" doc is load-bearing, because every call site is
+/// `unawaited(...)` — a rethrow there is an UNHANDLED zone error (the
+/// 2026-07-02 field log's `PlatformDispatcher.onError` PlatformException).
+void main() {
+  silenceErrorLoggerSpool();
+
+  test('disconnectQuietly completes when the transport disconnect throws',
+      () async {
+    final svc = Obd2Service(_ThrowingDisconnectTransport());
+    await svc.connect();
+    await expectLater(svc.disconnectQuietly(), completes);
+  });
+
+  test('disconnectQuietly still performs a clean disconnect', () async {
+    final transport = FakeObd2Transport(const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    });
+    final svc = Obd2Service(transport);
+    await svc.connect();
+    await expectLater(svc.disconnectQuietly(), completes);
+    expect(transport.isConnected, isFalse,
+        reason: 'the quiet wrapper must still close a healthy link');
+  });
+}
+
+/// The fault seam: a transport whose teardown throws the way a dying
+/// platform channel does mid-drop.
+class _ThrowingDisconnectTransport extends FakeObd2Transport {
+  _ThrowingDisconnectTransport()
+      : super(const {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+        });
+
+  @override
+  Future<void> disconnect() async {
+    throw StateError('bt socket closed, read return: -1');
+  }
+}

--- a/test/features/obd2/obd2_link_authority_races_test.dart
+++ b/test/features/obd2/obd2_link_authority_races_test.dart
@@ -170,7 +170,10 @@ void main() {
       addTearDown(coordinator.stop);
       await coordinator.start();
       listener.emitConnected(_mac);
-      await pumpEventQueue();
+      // The opener runs a real (fake-transport) ELM init with wall-clock
+      // settles — poll bounded instead of pumpEventQueue (mirrors the
+      // auto_trip_coordinator_test pumpSpeedTicks approach).
+      await _waitFor(() => coordinator.hasOpenSession);
 
       expect(coordinator.hasOpenSession, isTrue,
           reason: 'the auto-record authority owns the link now');
@@ -265,6 +268,16 @@ AutoRecordConfig _config() => const AutoRecordConfig(
       movementStartThresholdKmh: 5,
       disconnectSaveDelay: Duration(seconds: 60),
     );
+
+/// Bounded real-time wait — the coordinator's opener resolves on wall-clock
+/// timers (ELM init settles), which `pumpEventQueue` cannot advance.
+Future<void> _waitFor(bool Function() done,
+    {Duration timeout = const Duration(seconds: 8)}) async {
+  final sw = Stopwatch()..start();
+  while (!done() && sw.elapsed < timeout) {
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+}
 
 /// A connectable fake session for the coordinator's opener seam.
 Future<Obd2Service?> _openFakeService() async {

--- a/test/features/obd2/obd2_link_authority_races_test.dart
+++ b/test/features/obd2/obd2_link_authority_races_test.dart
@@ -1,0 +1,378 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/entities/trip_save_stage.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/trip_baseline_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/trip_gps_stream_controller.dart';
+import 'package:tankstellen/features/consumption/providers/trip_haptic_controller.dart';
+import 'package:tankstellen/features/consumption/providers/trip_oem_fuel_level_controller.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_state.dart';
+import 'package:tankstellen/features/obd2/data/auto_trip_coordinator.dart';
+import 'package:tankstellen/features/obd2/data/fake_background_adapter_listener.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
+import 'package:tankstellen/features/obd2/data/obd2_recording_link_ownership.dart';
+import 'package:tankstellen/features/obd2/data/obd2_reconnect_controller.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_speed_stream.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+import 'package:tankstellen/features/obd2/providers/obd2_reconnect_provider.dart';
+import 'package:tankstellen/features/obd2/providers/obd2_recording_pipeline.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+/// #3419 (epic #3415 task 2) — integration reproduction tests for the four
+/// diagnosed OBD2 link-authority races. Written at the level the bugs live
+/// (the drop-signal / connect-initiator seams), per the recurring-bug
+/// protocol: each test was verified RED against master's behaviour before
+/// the #3420 [Obd2LinkArbiter] was implemented, and each carries a comment
+/// naming exactly what master does wrong. These tests are the regression
+/// lock that gates the #3424 deletion of the superseded machinery.
+///
+/// Field evidence (#3415, 2026-07-02 export): ten fully-successful ELM
+/// inits in 43 s alternating firstConnect/liveReconnect — the adapter
+/// answered every time, each session destroyed by a rival connect
+/// authority; 1479 connect attempts in one day.
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(Obd2RecordingLinkOwnership.instance.resetForTest);
+  tearDown(Obd2RecordingLinkOwnership.instance.resetForTest);
+
+  group('OBD2 link-authority races (#3415 / #3419)', () {
+    test(
+        'race 1 — a drop INSIDE the trip-start window belongs to the '
+        'recording authority: the idle #3019 machine must not react', () async {
+      // MASTER BUG: Obd2RecordingPipeline.start claims the #3387 latch only
+      // at the END of start (obd2_recording_pipeline.dart:273), AFTER the
+      // baseline load + the 25 s controller-start watchdog window. A drop
+      // that lands inside that window finds the latch unclaimed, so the
+      // app-wide #3019 reconnector starts its loop against the very link the
+      // trip start still owns — two authorities on one adapter (the war).
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      final host = _FakeWalHost();
+      final gate = Completer<void>();
+      final pipeline = container.read(
+        _gatedBaselinesPipelineProvider((host: host, gate: gate.future)),
+      );
+      final service = Obd2Service(FakeObd2Transport(_elmOk()))
+        ..adapterMac = _mac;
+      await service.connect();
+      service.adapterMac = _mac;
+
+      // start() is now parked inside its trip-start window (baseline load).
+      final startF = pipeline.start(service);
+      await _pump();
+
+      // The link drops mid-start (the adapter blipped while initialising).
+      Obd2LinkDropSignal.instance.notifyDrop(
+          transportKind: 'classic', mac: _mac, reason: 'classic-socket-error');
+      await pumpEventQueue();
+
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
+          reason: 'a drop inside the trip-start window must be owned by the '
+              'single recording authority — on master the latch is only '
+              'claimed after the start watchdog window, so the idle #3019 '
+              'loop starts a SECOND reconnect against the starting trip');
+
+      gate.complete();
+      await startF;
+      await pipeline.stop();
+    });
+
+    test(
+        'race 2 — a drop during stop teardown (release→disconnect window) '
+        'must not start an idle reconnect against the closing socket',
+        () async {
+      // MASTER BUG: Obd2RecordingPipeline.stop releases the #3387 latch as
+      // its FIRST statement (obd2_recording_pipeline.dart:299) but only
+      // disconnects the service at the very end (:381). A socket drop inside
+      // that teardown window (engine off while saving) finds the latch
+      // already released, so #3019 fires a reconnect at an adapter the stop
+      // sequence is deliberately closing.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      final host = _FakeWalHost();
+      final transport = _GatedDisconnectTransport(_elmOk());
+      final pipeline = container.read(_pipelineProvider(host));
+      final service = Obd2Service(transport)..adapterMac = _mac;
+      await service.connect();
+      service.adapterMac = _mac;
+      await pipeline.start(service);
+
+      // Gate the disconnect so the teardown window stays open.
+      final gate = Completer<void>();
+      transport.disconnectGate = gate.future;
+      final stopF = pipeline.stop();
+      var spins = 0;
+      while (!transport.disconnectEntered && spins++ < 200) {
+        await _pump();
+      }
+      expect(transport.disconnectEntered, isTrue,
+          reason: 'harness: stop() must have reached svc.disconnect()');
+
+      // The dying socket raises its drop while the teardown is in flight.
+      Obd2LinkDropSignal.instance.notifyDrop(
+          transportKind: 'classic', mac: _mac, reason: 'classic-socket-error');
+      await pumpEventQueue();
+
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
+          reason: 'the recording authority owns the link until its disconnect '
+              'COMPLETES — on master release() precedes svc.disconnect(), so '
+              'the idle #3019 loop reconnects a deliberately-closing session');
+
+      gate.complete();
+      await stopF;
+    });
+
+    test(
+        'race 3 — the auto-record opener and the idle #3019 loop are never '
+        'two interleaved connect authorities', () async {
+      // MASTER BUG: nothing gates the auto-record session opener against the
+      // idle #3019 reconnector (the #3386 latch only covers a live
+      // RECORDING). Field breadcrumbs 2026-06-28: `obd2-reconnect:
+      // backoff-scheduled nextAttempt=2` followed 15 ms later by
+      // `auto_record:connectStarted` — both machines drove connect cycles at
+      // the same adapter. The lower-priority authority must stand down.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      // An idle drop starts the #3019 loop (no recording, no session).
+      Obd2LinkDropSignal.instance.notifyDrop(
+          transportKind: 'classic', mac: _mac, reason: 'classic-socket-error');
+      await pumpEventQueue();
+      expect(container.read(obd2ReconnectProvider),
+          Obd2ReconnectState.reconnecting);
+
+      // The paired adapter reappears → the auto-record opener connects.
+      final listener = FakeBackgroundAdapterListener();
+      final coordinator = AutoTripCoordinator(
+        listener: listener,
+        startTrip: (_) async => null,
+        stopAndSaveAutomatic: () async {},
+        config: _config(),
+        sessionOpener: (mac) => _openFakeService(),
+        speedStreamFactory: _inertSpeedStream,
+      );
+      addTearDown(coordinator.stop);
+      await coordinator.start();
+      listener.emitConnected(_mac);
+      await pumpEventQueue();
+
+      expect(coordinator.hasOpenSession, isTrue,
+          reason: 'the auto-record authority owns the link now');
+      expect(container.read(obd2ReconnectProvider),
+          isNot(Obd2ReconnectState.reconnecting),
+          reason: 'one connect authority at a time: when the auto-record '
+              'opener takes the link, the idle #3019 loop must stand down — '
+              'on master both keep driving connect cycles at the one adapter '
+              '(the 06-28 breadcrumb pair, 15 ms apart)');
+    });
+
+    test(
+        'race 4 — a held recording link blocks a rival initiator entirely '
+        '(the instant connect/teardown war pattern is impossible)', () async {
+      // MASTER BUG: with a manual recording live, the auto-record
+      // foreground-arm path still opens a DIRECT connect to the same adapter
+      // (its `_tripActive` guard only knows about trips IT started).
+      // Establishing the second RFCOMM session tears down the recording's
+      // socket, whose reconnect then tears down the second — the field
+      // signature of ten successful ELM inits in 43 s, alternating
+      // firstConnect/liveReconnect (#3415 traces t16/t17). A held
+      // recording lease must block the rival initiator outright.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      final host = _FakeWalHost();
+      final pipeline = container.read(_pipelineProvider(host));
+      final service = Obd2Service(FakeObd2Transport(_elmOk()))
+        ..adapterMac = _mac;
+      await service.connect();
+      service.adapterMac = _mac;
+      await pipeline.start(service);
+      addTearDown(pipeline.stop);
+
+      var rivalConnects = 0;
+      final listener = FakeBackgroundAdapterListener();
+      final coordinator = AutoTripCoordinator(
+        listener: listener,
+        startTrip: (_) async => null,
+        stopAndSaveAutomatic: () async {},
+        config: _config(),
+        sessionOpener: (mac) {
+          rivalConnects++;
+          return _openFakeService();
+        },
+        foregroundSessionOpener: (mac) {
+          rivalConnects++;
+          return _openFakeService();
+        },
+        speedStreamFactory: _inertSpeedStream,
+      );
+      addTearDown(coordinator.stop);
+      await coordinator.start();
+
+      // Rival initiator 1: the foreground-active arm (app resumed mid-trip).
+      await coordinator.armForegroundActive();
+      // Rival initiator 2: a background AdapterConnected for the same MAC.
+      listener.emitConnected(_mac);
+      await pumpEventQueue();
+
+      expect(rivalConnects, 0,
+          reason: 'while a recording holds the link, NO rival initiator may '
+              'open a connect cycle at the adapter — on master the '
+              'auto-record openers connect anyway and destroy the '
+              'recording\'s single SPP session (the connect-success/teardown '
+              'alternation war)');
+      expect(coordinator.hasOpenSession, isFalse,
+          reason: 'the rival must not end up holding a session it stole '
+              'from the live recording');
+    });
+  });
+}
+
+const _mac = 'AA:BB:CC:00:11:22';
+
+/// Canned happy-path ELM init replies (mirrors the sibling
+/// `obd2_recording_pipeline_test.dart` harness).
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+AutoRecordConfig _config() => const AutoRecordConfig(
+      mac: _mac,
+      movementStartThresholdKmh: 5,
+      disconnectSaveDelay: Duration(seconds: 60),
+    );
+
+/// A connectable fake session for the coordinator's opener seam.
+Future<Obd2Service?> _openFakeService() async {
+  final svc = Obd2Service(FakeObd2Transport(_elmOk()))..adapterMac = _mac;
+  await svc.connect();
+  return svc;
+}
+
+/// Speed stream that never polls (day-long period) — these tests exercise
+/// the CONNECT authority, not the movement detection.
+Obd2SpeedStream _inertSpeedStream(Obd2Service service, {String? mac}) =>
+    Obd2SpeedStream(service, mac: mac, pollPeriod: const Duration(days: 1));
+
+/// #3382-style harness: a [TripBaselineRecorder] whose load is parked on an
+/// injected gate, keeping `start()` inside its trip-start window while the
+/// test fires a drop into that window.
+class _GatedBaselines extends TripBaselineRecorder {
+  _GatedBaselines(super.ref, this._gate);
+  final Future<void> _gate;
+  @override
+  Future<void> load() => _gate;
+}
+
+/// Transport whose [disconnect] can be parked on a gate, keeping `stop()`
+/// inside its teardown window while the test fires a drop into that window.
+class _GatedDisconnectTransport extends FakeObd2Transport {
+  _GatedDisconnectTransport(super.responses);
+  Future<void>? disconnectGate;
+  bool disconnectEntered = false;
+
+  @override
+  Future<void> disconnect() async {
+    disconnectEntered = true;
+    final gate = disconnectGate;
+    if (gate != null) await gate;
+    await super.disconnect();
+  }
+}
+
+final _pipelineProvider =
+    Provider.family<Obd2RecordingPipeline, Obd2RecordingPipelineHost>(
+  (ref, host) => Obd2RecordingPipeline(
+    ref: ref,
+    host: host,
+    haptics: TripHapticController(),
+    gps: TripGpsStreamController(
+      ref: ref,
+      lifecycleState: () => AppLifecycleState.resumed,
+    ),
+    baselines: TripBaselineRecorder(ref),
+    oemFuel: TripOemFuelLevelController(),
+    readActiveVehicle: () => null,
+    readOemPidsFlag: () => false,
+    readDiagnosticCaptureFlag: () => false,
+  ),
+);
+
+final _gatedBaselinesPipelineProvider = Provider.family<Obd2RecordingPipeline,
+    ({Obd2RecordingPipelineHost host, Future<void> gate})>(
+  (ref, args) => Obd2RecordingPipeline(
+    ref: ref,
+    host: args.host,
+    haptics: TripHapticController(),
+    gps: TripGpsStreamController(
+      ref: ref,
+      lifecycleState: () => AppLifecycleState.resumed,
+    ),
+    baselines: _GatedBaselines(ref, args.gate),
+    oemFuel: TripOemFuelLevelController(),
+    readActiveVehicle: () => null,
+    readOemPidsFlag: () => false,
+    readDiagnosticCaptureFlag: () => false,
+  ),
+);
+
+/// Minimal counting WAL host (mirrors the obd2_recording_pipeline_test
+/// harness — only what start/stop touch).
+class _FakeWalHost implements Obd2RecordingPipelineHost {
+  @override
+  TripRecordingState state = const TripRecordingState();
+  @override
+  String? lastTripVehicleId;
+  @override
+  DateTime? lastTripStartedAt;
+
+  @override
+  String? readActiveVehicleId() => null;
+  @override
+  void setSaveStage(TripSaveStage stage) {}
+  @override
+  void seedActiveSnapshot() {}
+  @override
+  void maybeFlushActiveSnapshot() {}
+  @override
+  Future<void> flushActiveSnapshot({bool force = false}) async {}
+  @override
+  Future<void> clearActiveSnapshot() async {}
+  @override
+  Future<TripPersistOutcome> saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+    List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
+    String? vehicleId,
+    String? adapterMac,
+    String? adapterName,
+    String? adapterFirmware,
+    int gpsFixCount = 0,
+  }) async =>
+      TripPersistOutcome.discardedNoMovement;
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -368,9 +368,14 @@ void main() {
       bumps: 0,
       decompositionIssue: null,
     ),
+    // #3420 — re-grandfathered 726 → 777: the coordinator now claims an
+    // auto-record lease on the Obd2LinkArbiter before opening a session
+    // (tryAcquire gate + preemption handler + lease releases at hand-off /
+    // teardown), closing the ungated auto-record ↔ #3019 front of the
+    // #3415 reconnect war.
     'lib/features/obd2/data/auto_trip_coordinator.dart': (
-      lines: 726,
-      bumps: 0,
+      lines: 777,
+      bumps: 1,
       decompositionIssue: null,
     ),
     // #3279 — elm327_parsers.dart decomposed below the cap (419 → 345): the


### PR DESCRIPTION
## Why

The 2026-07-02 field export (archived on #3415) proved the OBD2 reconnect war survived every shipped fix: ten successful ELM inits in 43 s alternating `firstConnect`/`liveReconnect`, the auto-record opener and the #3019 idle loop driving connect cycles 15 ms apart, 1,479 connect cycles in a single day, and a 177 km `gpsPlusObd2` trip with zero OBD2 features. Root cause is structural: N connect initiators × 1 adapter, coordinated only by flag discipline with race windows at both trip edges.

## What

**Commit 1 (#3419)** — four integration reproduction tests, all verified RED on master: drop inside the trip-start window; drop during stop teardown; auto-record vs idle interleaving; rival connects against a held recording link (the field war signature).

**Commit 2 (#3420)** — `Obd2LinkArbiter`, per the #3418 design:
- Every initiator (picker, pre-warm, auto-record, VIN reader, self-test, idle #3019, in-trip reconnect) holds a session lease before any connect. Priorities: recording > autoRecord > interactive > idle. Strictly-lower holders are preempted; equal-or-higher acquires are refused — except gesture-over-gesture, where the newest user tap wins over a hung earlier attempt (field trace t8: one native connect blocked 16.8 min).
- The arbiter is the sole `Obd2LinkDropSignal` consumer: drops reach the current holder only, else the registered idle policy. The #3019 provider's drop plumbing and ownership checks collapse into one `registerIdlePolicy` call.
- The recording lease is acquired at the very top of `Obd2RecordingPipeline.start()` (before any await) and released only after `svc.disconnect()` completes in `stop()` — both #3387 race windows are closed by construction. `Obd2RecordingLinkOwnership` stays as a thin shim so existing call sites and tests keep working (deletion is #3424, gated on these tests).
- In-trip reconnects now stamp `liveReconnect` (fixes the #3386 firstConnect masquerade in every future field trace).
- New never-throws `disconnectQuietly()` (+ fault-injection test) replaces six `unawaited(disconnect())` sites — the field's uncaught `PlatformException(io, bt socket closed, read return: -1)` can no longer escape to `PlatformDispatcher.onError`.

All four race tests green; `flutter analyze` clean; obd2 + consumption + vehicle + lint suites pass (5,697 tests). Deferred per the epic plan: whole-ladder budget/cooldown/probe (#3421), wedge escalation ladder (#3422), pin-store reconciliation (#3423), superseded-machinery deletion (#3424).

Part of Epic #3415.
Closes #3419
Closes #3420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
