### PR TITLE
fix(obd2): whole-ladder connect budget + post-close cooldown + real BLE in-range probe (#3421)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothSocket
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
@@ -73,6 +74,15 @@ object Obd2ClassicPlugin {
      *  is ~3 s). */
     private const val RFCOMM_CONNECT_TIMEOUT_MS = 7000L
 
+    /** #3421 — default WHOLE-LADDER budget. The #3348 watchdog bounds each
+     *  RUNG at 7 s but never the CALL: field traces (#3415 t5/t8) show one
+     *  native connect blocking 4.7–16.8 minutes across a wedged ladder.
+     *  Before each rung starts, the elapsed time is checked against the
+     *  budget and the remaining rungs are SKIPPED (strategy
+     *  `budget-exhausted`) once it is spent. The Dart side normally passes
+     *  its own `budgetMs`; this default keeps an old Dart caller bounded. */
+    private const val DEFAULT_CONNECT_BUDGET_MS = 20_000L
+
     private var socket: BluetoothSocket? = null
     private var readerThread: Thread? = null
     private val readerRunning = AtomicBoolean(false)
@@ -103,13 +113,17 @@ object Obd2ClassicPlugin {
                         ?: return result.error("arg", "address missing", null)
                     val uuid = call.argument<String>("uuid")
                         ?: return result.error("arg", "uuid missing", null)
+                    // #3421 — optional whole-ladder budget from Dart (absent
+                    // on an old Dart side → the bounded default applies).
+                    val budgetMs = call.argument<Number>("budgetMs")?.toLong()
+                        ?: DEFAULT_CONNECT_BUDGET_MS
                     thread(name = "obd2-classic-connect") {
                         // #2969 — return a Map{ok, strategy, error} so the Dart
                         // side surfaces WHICH RFCOMM strategy won (or that all
                         // were exhausted) + the last IOException, instead of a
                         // bare Boolean that threw away every diagnostic (only
                         // Logcat had it). The Dart binding accepts BOTH shapes.
-                        result.success(connect(context, address, uuid))
+                        result.success(connect(context, address, uuid, budgetMs))
                     }
                 }
                 "write" -> {
@@ -162,7 +176,17 @@ object Obd2ClassicPlugin {
         "error" to error,
     )
 
-    private fun connect(context: Context, address: String, uuid: String): Map<String, Any?> {
+    private fun connect(
+        context: Context,
+        address: String,
+        uuid: String,
+        budgetMs: Long,
+    ): Map<String, Any?> {
+        // #3421 — whole-ladder budget. Monotonic clock; started BEFORE the
+        // teardown of any prior socket so everything this call does counts.
+        val startedAt = SystemClock.elapsedRealtime()
+        fun budgetSpent(): Boolean =
+            SystemClock.elapsedRealtime() - startedAt >= budgetMs
         disconnect() // ensure any prior socket is closed
         val adapter = adapterOrNull(context)
             ?: return connectResult(false, "no-adapter", "Bluetooth adapter unavailable")
@@ -186,6 +210,12 @@ object Obd2ClassicPlugin {
         //    background "obd2-classic-connect" thread, so the Thread.sleep
         //    backoff between attempts never blocks the Flutter main thread.
         for (attempt in 1..MAX_RFCOMM_ATTEMPTS) {
+            // #3421 — skip the remaining rungs once the whole-ladder budget
+            // is spent. The per-rung #3348 watchdog is unchanged; this bounds
+            // the CALL, which the watchdog alone never did (#3415 t5/t8).
+            if (budgetSpent()) {
+                return budgetExhaustedResult(address, budgetMs, lastError)
+            }
             @Suppress("MissingPermission")
             val s = try {
                 device.createRfcommSocketToServiceRecord(serviceUuid)
@@ -211,6 +241,9 @@ object Obd2ClassicPlugin {
         // 2) Documented clone fallback: the INSECURE SPP socket. Many ELM327
         //    clones never complete the secure (authenticated/encrypted) RFCOMM
         //    handshake but connect fine over the insecure variant.
+        if (budgetSpent()) { // #3421
+            return budgetExhaustedResult(address, budgetMs, lastError)
+        }
         @Suppress("MissingPermission")
         val insecure = try {
             device.createInsecureRfcommSocketToServiceRecord(serviceUuid)
@@ -227,6 +260,9 @@ object Obd2ClassicPlugin {
         // 3) Last-resort reflection on the hidden channel-1 RFCOMM socket —
         //    the long-standing workaround for clones whose SDP record is
         //    missing/garbage so the UUID lookup resolves to no channel.
+        if (budgetSpent()) { // #3421
+            return budgetExhaustedResult(address, budgetMs, lastError)
+        }
         val reflected = reflectChannelOneSocket(device)
         if (reflected != null) {
             val r = tryConnectSocket(reflected, MAX_RFCOMM_ATTEMPTS + 2)
@@ -235,6 +271,23 @@ object Obd2ClassicPlugin {
         }
         Log.e(TAG, "connect: all RFCOMM strategies exhausted for $address")
         return connectResult(false, "exhausted", lastError)
+    }
+
+    /** #3421 — the whole-ladder budget ran out before this rung could start:
+     *  log + report the dedicated `budget-exhausted` strategy (with the last
+     *  rung's IOException, when any rung ran at all) so the Dart connect
+     *  trace tells a budget overrun apart from a fully-exhausted ladder. */
+    private fun budgetExhaustedResult(
+        address: String,
+        budgetMs: Long,
+        lastError: String?,
+    ): Map<String, Any?> {
+        Log.w(
+            TAG,
+            "connect: whole-ladder budget (${budgetMs}ms) exhausted for " +
+                "$address — skipping remaining rungs (#3421)",
+        )
+        return connectResult(false, "budget-exhausted", lastError)
     }
 
     /** Attempt to connect [s], adopt it as the live socket + start the reader

--- a/lib/features/consumption/providers/reconnect_scanner_factory.dart
+++ b/lib/features/consumption/providers/reconnect_scanner_factory.dart
@@ -56,20 +56,31 @@ AdapterReconnectScanner? Function(
     // #2524 — swap the pipeline's pointer (so stop() tears down the LIVE
     // svc) AND the controller's via `replaceService` (so the loop polls the
     // reconnected transport, not the closed one).
+    // #2565 — the transport kind ('ble'/'classic') of the link that just
+    // dropped, read ONCE off the dead service at handle-drop time. Null when
+    // unknown ⇒ the legacy BLE-direct-first path (behaviour unchanged for
+    // BLE adapters). Drives BOTH the connector's direct-path dispatch and
+    // the #3421 in-range probe below.
+    final transportHint = readLinkKind();
     final connector = ReconnectConnector(
       connection: connection,
       onConnected: onConnected,
-      // #2565 — the transport kind ('ble'/'classic') of the link that just
-      // dropped, read off the dead service. Null when unknown ⇒ the legacy
-      // BLE-direct-first path (behaviour unchanged for BLE adapters).
-      transportHint: readLinkKind(),
+      transportHint: transportHint,
       // #3014 — the live adapter NAME, so the in-trip reconnect trace headline
       // names the adapter instead of showing only the redacted MAC.
       adapterName: readAdapterName?.call(),
     );
     final scanner = AdapterReconnectScanner(
       pinnedMac: pinnedMac,
-      probe: (mac) async => true,
+      // #3421 — REAL in-range probe (was a stub `async => true`, which made
+      // every backoff cycle dial a full connect even with the adapter
+      // absent). BLE: a short bounded advert scan for the pinned MAC;
+      // Classic/unknown: `true` (no advert to sight — see the builder doc).
+      probe: buildObd2InRangeProbe(
+        bluetooth: connection.bluetooth,
+        scanGovernor: connection.scanGovernor,
+        transportHint: transportHint,
+      ),
       // #3420 — stamp every in-trip reconnect attempt as a liveReconnect:
       // the connector dials `connectByMacClassicDirect`/direct paths that
       // default to firstConnect, which made the field trace ring read as

--- a/lib/features/obd2/api.dart
+++ b/lib/features/obd2/api.dart
@@ -37,6 +37,7 @@ export 'data/obd2_connect_trace_persistence.dart';
 export 'data/obd2_connection_errors.dart';
 export 'data/obd2_connection_service.dart';
 export 'data/obd2_disconnect_quietly.dart';
+export 'data/obd2_in_range_probe.dart';
 export 'data/obd2_link_arbiter.dart';
 export 'data/obd2_permissions.dart';
 export 'data/obd2_read_telemetry.dart';

--- a/lib/features/obd2/data/classic_connect_cooldown.dart
+++ b/lib/features/obd2/data/classic_connect_cooldown.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+
+/// #3421 — post-close COOLDOWN for Classic RFCOMM re-opens (the #3404
+/// micro-lever).
+///
+/// An ELM327 adapter's single SPP channel is not released the instant the
+/// socket closes: a connect dialled back-to-back after a close/drop lands on
+/// the still-held channel and either blocks (the #3346 hang the per-rung
+/// watchdog now aborts) or burns a doomed ladder rung. Field evidence
+/// (#3415): `ble.connect.attempts` hit 1479 in one day with connect traces
+/// 0–1 ms apart. A 1.5 s minimum gap between a close/drop and the next
+/// connect to the SAME mac gives the adapter time to release its channel.
+///
+/// Ownership: `ClassicElmChannel` stamps [noteClosed] on every deliberate
+/// `close()` of a live link and on every unexpected drop edge, and awaits
+/// [awaitReadyToConnect] at the top of `open()` — reducing the native
+/// connect budget by the time waited, so the cooldown is counted INSIDE the
+/// #3421 whole-ladder budget. State is per-mac and lives in the process-wide
+/// [instance] because reconnect episodes create a fresh short-lived channel
+/// object per attempt; the cooldown must survive across them.
+class ClassicConnectCooldown {
+  ClassicConnectCooldown({
+    this.gap = const Duration(milliseconds: 1500),
+    DateTime Function()? now,
+    Future<void> Function(Duration)? wait,
+  })  : _now = now ?? DateTime.now,
+        _wait = wait ?? _realWait;
+
+  static Future<void> _realWait(Duration d) => Future<void>.delayed(d);
+
+  /// The single process-wide instance production wires (see the class doc:
+  /// per-mac state must outlive the short-lived channel objects). Tests
+  /// inject fresh instances with a fake clock + wait so nothing sleeps.
+  static final ClassicConnectCooldown instance = ClassicConnectCooldown();
+
+  /// Minimum gap between a close/drop and the next connect to the same mac.
+  /// 1.5 s sits inside the 1–2 s window #3421 specifies: long enough for a
+  /// clone to release its RFCOMM channel, short enough that a healthy
+  /// close→reopen (user retry, transport open-retry) is barely delayed.
+  final Duration gap;
+
+  final DateTime Function() _now;
+  final Future<void> Function(Duration) _wait;
+
+  final Map<String, DateTime> _lastClosedAt = {};
+
+  /// Stamp "the socket to [mac] just closed/dropped". Later stamps win.
+  void noteClosed(String mac) {
+    _lastClosedAt[_key(mac)] = _now();
+  }
+
+  /// Test-only: drop every per-mac stamp, so a suite exercising the REAL
+  /// channels against the shared [instance] doesn't inherit a prior test's
+  /// close stamp (and its up-to-1.5 s real-clock wait) across test cases.
+  @visibleForTesting
+  void debugClear() => _lastClosedAt.clear();
+
+  /// Wait out whatever remains of [gap] since the last [noteClosed] for
+  /// [mac]. Returns the duration actually waited (zero when no close is on
+  /// record, the gap already elapsed, or the clock went backwards) so the
+  /// caller can subtract it from the native connect budget. Never throws —
+  /// cooldown bookkeeping (the injected clock/wait seams) failing must never
+  /// abort a connect that would otherwise run; it fails open to
+  /// [Duration.zero].
+  Future<Duration> awaitReadyToConnect(String mac) async {
+    try {
+      final last = _lastClosedAt[_key(mac)];
+      if (last == null) return Duration.zero;
+      final since = _now().difference(last);
+      // A negative delta means the clock jumped backwards — treat it as
+      // "gap elapsed" rather than sleeping for a bogus long remainder.
+      if (since.isNegative || since >= gap) return Duration.zero;
+      final remaining = gap - since;
+      await _wait(remaining);
+      return remaining;
+    } catch (e, st) {
+      // Fail OPEN (see the never-throws contract above): the connect
+      // proceeds without the cooldown at worst — exactly the pre-#3421
+      // behaviour.
+      debugPrint('ClassicConnectCooldown: awaitReadyToConnect failed open '
+          '(connect proceeds): $e\n$st');
+      return Duration.zero;
+    }
+  }
+
+  static String _key(String mac) => mac.toUpperCase();
+}

--- a/lib/features/obd2/data/classic_elm_channel.dart
+++ b/lib/features/obd2/data/classic_elm_channel.dart
@@ -5,8 +5,10 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'classic_connect_cooldown.dart';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
+import 'obd2_platform_budgets.dart';
 import '../../../../core/utils/event_channel_cancel.dart';
 import 'obd2_comm_diagnostics.dart';
 import 'obd2_link_drop_signal.dart';
@@ -33,6 +35,24 @@ class ClassicElmChannel implements ElmByteChannel {
   final String address;
   final String sppUuid;
   final Obd2ClassicMethodChannel _plugin;
+
+  /// #3421 — whole-ladder budget (ms) threaded to the native `connect` so
+  /// the RFCOMM ladder as a WHOLE is bounded (the #3348 watchdog only bounds
+  /// each rung). Reduced by any post-close cooldown waited in [open], so the
+  /// cooldown is counted inside the budget.
+  final int connectBudgetMs;
+
+  /// #3421 — extra Dart-side slack on top of [connectBudgetMs] for the
+  /// defense-in-depth `.timeout` around `connectDetailed` (a wedged platform
+  /// thread never runs the native budget bookkeeping). Injectable so tests
+  /// don't wait the production 3 s.
+  final Duration deadlineGrace;
+
+  /// #3421 — per-mac post-close cooldown (the #3404 micro-lever). Injectable
+  /// for tests; production shares [ClassicConnectCooldown.instance] so the
+  /// gap survives across the short-lived channel objects a reconnect
+  /// episode creates.
+  final ClassicConnectCooldown _cooldown;
 
   StreamSubscription<List<int>>? _subscription;
 
@@ -61,7 +81,11 @@ class ClassicElmChannel implements ElmByteChannel {
     required this.address,
     Obd2ClassicMethodChannel? plugin,
     this.sppUuid = sppServiceUuid,
-  }) : _plugin = plugin ?? const Obd2ClassicMethodChannel();
+    this.connectBudgetMs = Obd2PlatformBudgets.classicConnectLadderBudgetMs,
+    this.deadlineGrace = Obd2PlatformBudgets.classicConnectDartGrace,
+    ClassicConnectCooldown? cooldown,
+  })  : _plugin = plugin ?? const Obd2ClassicMethodChannel(),
+        _cooldown = cooldown ?? ClassicConnectCooldown.instance;
 
   @override
   bool get isOpen => _open;
@@ -84,6 +108,18 @@ class ClassicElmChannel implements ElmByteChannel {
     if (_incoming.isClosed) {
       _incoming = StreamController<List<int>>.broadcast();
     }
+    // #3421 — post-close cooldown (the #3404 micro-lever): a connect dialled
+    // back-to-back after a close/drop lands on the adapter's still-held SPP
+    // channel and burns a doomed ladder rung (or hangs, #3346). Wait out the
+    // remainder of the 1.5 s gap since the last close/drop of THIS mac, and
+    // count the wait INSIDE the whole-ladder budget by reducing what the
+    // native side gets. Floor at 1 ms so a pathological budget/gap combo
+    // still dispatches one bounded native attempt.
+    final cooldownWaitedMs =
+        (await _cooldown.awaitReadyToConnect(address)).inMilliseconds;
+    final nativeBudgetMs = connectBudgetMs - cooldownWaitedMs < 1
+        ? 1
+        : connectBudgetMs - cooldownWaitedMs;
     // #2466 — gated comm-diagnostics connect-lifecycle tee. A no-op
     // unless Feature.debugMode armed the collector; each call
     // early-returns on `!enabled`, so production pays one cached-bool
@@ -97,10 +133,28 @@ class ClassicElmChannel implements ElmByteChannel {
       // #2969 — connectDetailed surfaces WHICH RFCOMM strategy won / the
       // terminal failure mode + the last native IOException, so the connect
       // trace carries the native cause (not just "rfcomm open returned false").
-      connectResult = await _plugin.connectDetailed(
-        address: address,
-        uuid: sppUuid,
-      );
+      // #3421 — the whole-ladder budget is threaded down natively AND
+      // enforced here as defense-in-depth: even a WEDGED platform thread
+      // (whose native budget bookkeeping never runs because the blocking
+      // `BluetoothSocket.connect()` refuses to return — field traces t5/t8,
+      // 4.7/16.8 min) can no longer hold this Dart caller past
+      // budget + [deadlineGrace]. The TimeoutException takes the existing
+      // thrown-failure classification below.
+      final deadline = Duration(milliseconds: nativeBudgetMs) + deadlineGrace;
+      connectResult = await _plugin
+          .connectDetailed(
+            address: address,
+            uuid: sppUuid,
+            budgetMs: nativeBudgetMs,
+          )
+          .timeout(
+            deadline,
+            onTimeout: () => throw TimeoutException(
+              'classic connect exceeded the whole-ladder budget '
+              '(${nativeBudgetMs}ms) + grace — platform thread wedged (#3421)',
+              deadline,
+            ),
+          );
       // ignore: catch_no_st — rethrow-only: the original stack is preserved by rethrow
     } catch (e) {
       // A thrown platform error during the RFCOMM open (bonding,
@@ -264,6 +318,10 @@ class ClassicElmChannel implements ElmByteChannel {
   /// `rfcomm-open-fail`; this covers the thrown-platform-error path
   /// (bonding / permission).
   static String _classifyClassicConnectFailure(Object e) {
+    // #3421 — the Dart-side whole-ladder deadline fired (wedged platform
+    // thread). Its own bin, so the field export tells a budget overrun
+    // apart from a clean rfcomm-open failure.
+    if (e is TimeoutException) return 'connect-budget-timeout';
     final msg = e.toString().toUpperCase();
     if (msg.contains('BOND') || msg.contains('PAIR')) return 'not-bonded';
     if (msg.contains('RFCOMM') || msg.contains('SOCKET')) {
@@ -280,12 +338,21 @@ class ClassicElmChannel implements ElmByteChannel {
   void _signalDrop({required String reason}) {
     if (_closing || _dropSignalled) return;
     _dropSignalled = true;
+    // #3421 — an unexpected drop counts as a socket close for the post-close
+    // cooldown: the adapter's SPP channel is exactly as busy after a drop as
+    // after a deliberate close, so the next connect must respect the gap.
+    _cooldown.noteClosed(address);
     Obd2LinkDropSignal.instance
         .notifyDrop(transportKind: 'classic', mac: address, reason: reason);
   }
 
   @override
   Future<void> close() async {
+    // #3421 — stamp the cooldown only when a LINK was actually torn down
+    // (live, or dropped and signalled): a close() after a FAILED open has
+    // nothing to cool down, and stamping it would needlessly delay the
+    // transport's #2906 open-retry rungs.
+    if (_open || _dropSignalled) _cooldown.noteClosed(address);
     _closing = true;
     _open = false;
     await _subscription?.safeCancel();

--- a/lib/features/obd2/data/classic_method_channel.dart
+++ b/lib/features/obd2/data/classic_method_channel.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import 'obd2_platform_budgets.dart';
+
 /// Thin Dart binding for the in-repo Kotlin plugin `Obd2ClassicPlugin`
 /// (#763). Separated from [PluginClassicBluetoothFacade] so tests can
 /// swap this out via a constructor-injected fake without touching the
@@ -46,19 +48,31 @@ class Obd2ClassicMethodChannel {
   /// the legacy bare `bool` (bidirectional back-compat: an old native side ↔ a
   /// new Dart side, and vice-versa, both work). Use [connectDetailed] when the
   /// strategy / native error are wanted for the connect trace.
-  Future<bool> connect({required String address, required String uuid}) async =>
-      (await connectDetailed(address: address, uuid: uuid)).ok;
+  ///
+  /// #3421 — [budgetMs] bounds the WHOLE native RFCOMM connect ladder
+  /// (secure×3 → insecure → reflection): the Kotlin side skips remaining
+  /// rungs once it is spent (strategy `budget-exhausted`). The per-rung 7 s
+  /// #3348 watchdog is unchanged.
+  Future<bool> connect({
+    required String address,
+    required String uuid,
+    int budgetMs = Obd2PlatformBudgets.classicConnectLadderBudgetMs,
+  }) async =>
+      (await connectDetailed(address: address, uuid: uuid, budgetMs: budgetMs))
+          .ok;
 
   /// As [connect] but returning the parsed native result so the connect-trace
   /// can surface WHICH RFCOMM strategy won / the terminal failure mode + the
-  /// last native IOException (#2969 correction 5).
+  /// last native IOException (#2969 correction 5). [budgetMs]: see [connect]
+  /// (#3421); an old native side simply ignores the extra argument.
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int budgetMs = Obd2PlatformBudgets.classicConnectLadderBudgetMs,
   }) async {
     final raw = await _methodChannel.invokeMethod<dynamic>(
       'connect',
-      {'address': address, 'uuid': uuid},
+      {'address': address, 'uuid': uuid, 'budgetMs': budgetMs},
     );
     return parseClassicConnectResult(raw);
   }

--- a/lib/features/obd2/data/obd2_in_range_probe.dart
+++ b/lib/features/obd2/data/obd2_in_range_probe.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import 'adapter_reconnect_scanner.dart' show AdapterInRangeProbe;
+import 'bluetooth_facade.dart';
+import 'obd2_comm_diagnostics.dart' show redactObd2Mac;
+import 'obd2_scan_governor.dart';
+
+/// #3421 — build a REAL in-range probe for the [AdapterReconnectScanner].
+///
+/// The in-trip reconnect scanner's probe was a stub (`(mac) async => true`,
+/// reconnect_scanner_factory.dart), so EVERY backoff cycle dialled a full
+/// connect even with the adapter absent — part of the #3415 field signature
+/// of 1479 connect attempts in one day. For a BLE adapter, a short passive
+/// sighting question ("is the pinned MAC advertising right now?") is far
+/// cheaper than a connect dance, so a miss now skips the connect entirely
+/// and just re-arms the backoff.
+///
+/// Reuses the existing facade scan primitive ([BluetoothFacade.scan] — the
+/// same flutter_blue_plus timed scan the picker and the #3014 scan-seed
+/// use), unfiltered per #3097 so name-only clones are sighted too, bounded
+/// by [scanWindow]. Every probe pays into the process-wide #3185 scan
+/// governor so a dense reconnect episode can't trip Android's silent
+/// 5-scans/30s throttle.
+///
+/// Transport dispatch ([transportHint] — the same live-link kind the
+/// [ReconnectConnector] receives, read off the dead-but-typed service at
+/// handle-drop time, #2565):
+///  * `'ble'` — the real advert probe below.
+///  * `'classic'` — always `true`: Classic SPP adapters do NOT advertise
+///    (they are enumerated from the bonded list), so there is no advert to
+///    sight; the bounded connect itself is the reachability check, and the
+///    classic connect storm is bounded separately (#3422).
+///  * `null` / unknown — conservatively `true`: probing an unknown-transport
+///    pin over BLE would starve a Classic adapter forever (it can never be
+///    sighted), so the pre-#3421 connect-always behaviour is kept.
+///
+/// A scan failure (BT off, plugin rejection) propagates to the scanner's
+/// `_probeSafely`, which already de-noises it as a connect transient
+/// (#2953) — no second classification layer here.
+AdapterInRangeProbe buildObd2InRangeProbe({
+  required BluetoothFacade bluetooth,
+  required Obd2ScanGovernor scanGovernor,
+  required String? transportHint,
+  Duration scanWindow = const Duration(seconds: 3),
+}) {
+  if (transportHint != 'ble') {
+    return (_) async => true;
+  }
+  return (mac) async {
+    await scanGovernor.admitScanStart(reason: 'in-range-probe');
+    final wanted = mac.toUpperCase();
+    var seen = false;
+    // The facade closes the stream at [scanWindow]; breaking out early on a
+    // sighting cancels the subscription, which stops the radio scan (the
+    // facade's onCancel path).
+    await for (final batch in bluetooth.scan(
+      serviceUuids: const {},
+      timeout: scanWindow,
+    )) {
+      if (batch.any((c) => c.deviceId.toUpperCase() == wanted)) {
+        seen = true;
+        break;
+      }
+    }
+    // #3421 acceptance — stamp every probe result so a field export shows
+    // whether the reconnect loop skipped connects because the adapter was
+    // genuinely out of range (miss) or dialled on a sighting.
+    BreadcrumbCollector.add(
+      'obd2-reconnect: ble-probe ${seen ? 'sighted' : 'miss'}',
+      detail: 'mac=${redactObd2Mac(mac)} '
+          'windowMs=${scanWindow.inMilliseconds}',
+    );
+    return seen;
+  };
+}

--- a/lib/features/obd2/data/obd2_platform_budgets.dart
+++ b/lib/features/obd2/data/obd2_platform_budgets.dart
@@ -74,4 +74,27 @@ class Obd2PlatformBudgets {
   /// non-iOS platform gets the Android budgets, exactly as before.
   static Obd2PlatformBudgets get resolved =>
       defaultTargetPlatform == TargetPlatform.iOS ? ios : android;
+
+  /// #3421 — WHOLE-LADDER budget (ms) for the native Classic RFCOMM connect
+  /// ladder (secure×3 → insecure → reflection channel-1 in
+  /// `Obd2ClassicPlugin.kt`). The #3348 watchdog bounds each RUNG at 7 s but
+  /// never the CALL: field trace t8 (#3415) shows ONE native connect blocking
+  /// 16.8 minutes (t5: 4.7 min) on a half-open wedged channel. Dart threads
+  /// this to the native `connect` as `budgetMs`; the Kotlin side skips the
+  /// remaining rungs once it is spent and reports strategy `budget-exhausted`.
+  /// Generous by design — a full healthy ladder (5 rungs × 7 s worst-case
+  /// watchdog would exceed it, but a HEALTHY connect lands on rung 1–2 in
+  /// ~1 s) — so it only bites when the ladder is genuinely wedged.
+  /// Platform-independent (Classic SPP is Android-only). A plain `int` so it
+  /// can serve as a const default parameter value on the channel binding.
+  static const int classicConnectLadderBudgetMs = 20000;
+
+  /// #3421 — Dart-side defense-in-depth grace on top of
+  /// [classicConnectLadderBudgetMs]: `ClassicElmChannel.open` wraps the
+  /// `connectDetailed` await in `.timeout(budget + grace)`, so even a WEDGED
+  /// platform thread — whose Kotlin-side budget bookkeeping never runs
+  /// because `BluetoothSocket.connect()` refuses to return — cannot hold a
+  /// Dart caller for minutes. 3 s comfortably clears normal MethodChannel
+  /// scheduling latency on top of the native budget.
+  static const Duration classicConnectDartGrace = Duration(seconds: 3);
 }

--- a/test/features/obd2/data/classic_connect_cooldown_test.dart
+++ b/test/features/obd2/data/classic_connect_cooldown_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_cooldown.dart';
+
+/// #3421 — post-close cooldown unit tests. The clock and the wait are
+/// injected (mirroring the Obd2ScanGovernor seams), so nothing here sleeps
+/// real time.
+void main() {
+  group('ClassicConnectCooldown (#3421)', () {
+    late int nowMs;
+    late List<Duration> waits;
+    late ClassicConnectCooldown cooldown;
+
+    setUp(() {
+      nowMs = 100000;
+      waits = [];
+      cooldown = ClassicConnectCooldown(
+        now: () => DateTime.fromMillisecondsSinceEpoch(nowMs),
+        wait: (d) async => waits.add(d),
+      );
+    });
+
+    test('waits out the REMAINDER of the gap after a recent close', () async {
+      cooldown.noteClosed('AA:BB');
+      nowMs += 400; // 400 ms of the 1500 ms gap already elapsed
+      final waited = await cooldown.awaitReadyToConnect('AA:BB');
+      expect(waited, const Duration(milliseconds: 1100));
+      expect(waits, [const Duration(milliseconds: 1100)]);
+    });
+
+    test('no wait once the gap has fully elapsed', () async {
+      cooldown.noteClosed('AA:BB');
+      nowMs += 1600;
+      expect(await cooldown.awaitReadyToConnect('AA:BB'), Duration.zero);
+      expect(waits, isEmpty);
+    });
+
+    test('no wait for a mac that never closed', () async {
+      expect(await cooldown.awaitReadyToConnect('AA:BB'), Duration.zero);
+      expect(waits, isEmpty);
+    });
+
+    test('the gap is per-mac — a close of X never delays Y', () async {
+      cooldown.noteClosed('AA:BB');
+      expect(await cooldown.awaitReadyToConnect('CC:DD'), Duration.zero);
+      expect(waits, isEmpty);
+    });
+
+    test('mac keys are case-insensitive (Android reports upper-case)',
+        () async {
+      cooldown.noteClosed('aa:bb:cc:dd:ee:01');
+      final waited = await cooldown.awaitReadyToConnect('AA:BB:CC:DD:EE:01');
+      expect(waited, const Duration(milliseconds: 1500));
+    });
+
+    test('a LATER close stamp wins (drop then deliberate close)', () async {
+      cooldown.noteClosed('AA:BB');
+      nowMs += 1000;
+      cooldown.noteClosed('AA:BB'); // re-stamped at +1000
+      nowMs += 400; // only 400 ms since the LAST stamp
+      final waited = await cooldown.awaitReadyToConnect('AA:BB');
+      expect(waited, const Duration(milliseconds: 1100));
+    });
+
+    test('clock going BACKWARDS fails open to zero (no bogus long sleep)',
+        () async {
+      cooldown.noteClosed('AA:BB');
+      nowMs -= 5000; // clock fault: now precedes the stamp
+      expect(await cooldown.awaitReadyToConnect('AA:BB'), Duration.zero);
+      expect(waits, isEmpty);
+    });
+
+    test('debugClear drops every stamp', () async {
+      cooldown.noteClosed('AA:BB');
+      cooldown.debugClear();
+      expect(await cooldown.awaitReadyToConnect('AA:BB'), Duration.zero);
+    });
+
+    // Fault-injection for the documented never-throws contract (#2349): a
+    // throwing wait seam must not abort the connect — the call completes
+    // normally with Duration.zero (fail-open).
+    test('never throws — a throwing wait seam fails open to zero', () async {
+      final faulty = ClassicConnectCooldown(
+        now: () => DateTime.fromMillisecondsSinceEpoch(nowMs),
+        wait: (_) => Future<void>.error(StateError('wait seam fault')),
+      );
+      faulty.noteClosed('AA:BB');
+      await expectLater(
+        faulty.awaitReadyToConnect('AA:BB'),
+        completion(Duration.zero),
+      );
+    });
+  });
+}

--- a/test/features/obd2/data/classic_elm_channel_budget_test.dart
+++ b/test/features/obd2/data/classic_elm_channel_budget_test.dart
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_cooldown.dart';
+import 'package:tankstellen/features/obd2/data/classic_elm_channel.dart';
+import 'package:tankstellen/features/obd2/data/classic_method_channel.dart';
+import 'package:tankstellen/features/obd2/data/obd2_connection_errors.dart';
+import 'package:tankstellen/features/obd2/data/obd2_platform_budgets.dart';
+import '../../../helpers/silence_error_logger.dart';
+
+/// Fake [Obd2ClassicMethodChannel] that records the budgetMs the channel
+/// threads through and can be armed to HANG (a wedged platform thread).
+class _BudgetFakePlugin extends Obd2ClassicMethodChannel {
+  _BudgetFakePlugin();
+
+  final List<int?> budgets = [];
+  bool hang = false;
+
+  final StreamController<List<int>> incomingController =
+      StreamController<List<int>>.broadcast();
+
+  @override
+  Future<ClassicConnectResult> connectDetailed({
+    required String address,
+    required String uuid,
+    int? budgetMs, // #3421
+  }) async {
+    budgets.add(budgetMs);
+    if (hang) {
+      // Never completes — models the #3415 t5/t8 wedged native connect.
+      return Completer<ClassicConnectResult>().future;
+    }
+    return (ok: true, strategy: 'secure', error: null);
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<List<int>> get incoming => incomingController.stream;
+
+  Future<void> dispose() async {
+    if (!incomingController.isClosed) await incomingController.close();
+  }
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+  late _BudgetFakePlugin fake;
+  late int nowMs;
+  late List<Duration> cooldownWaits;
+  late ClassicConnectCooldown cooldown;
+
+  setUp(() {
+    fake = _BudgetFakePlugin();
+    nowMs = 500000;
+    cooldownWaits = [];
+    // Frozen fake clock + recording no-op wait: the tests below advance
+    // [nowMs] explicitly, so nothing sleeps real time.
+    cooldown = ClassicConnectCooldown(
+      now: () => DateTime.fromMillisecondsSinceEpoch(nowMs),
+      wait: (d) async => cooldownWaits.add(d),
+    );
+  });
+
+  tearDown(() async {
+    await fake.dispose();
+  });
+
+  ClassicElmChannel channel({int? budgetMs, Duration? grace}) =>
+      ClassicElmChannel(
+        address: 'AA:BB',
+        plugin: fake,
+        cooldown: cooldown,
+        connectBudgetMs:
+            budgetMs ?? Obd2PlatformBudgets.classicConnectLadderBudgetMs,
+        deadlineGrace: grace ?? Obd2PlatformBudgets.classicConnectDartGrace,
+      );
+
+  group('#3421 — whole-ladder budget threading', () {
+    test('open() threads the default budget to the plugin', () async {
+      final ch = channel();
+      await ch.open();
+      expect(
+        fake.budgets,
+        [Obd2PlatformBudgets.classicConnectLadderBudgetMs],
+      );
+      await ch.close();
+    });
+
+    test('a custom connectBudgetMs is threaded verbatim', () async {
+      final ch = channel(budgetMs: 5000);
+      await ch.open();
+      expect(fake.budgets, [5000]);
+      await ch.close();
+    });
+  });
+
+  group('#3421 — post-close cooldown at the re-open seam', () {
+    test(
+        'close() of a LIVE link then a rapid re-open waits the 1.5 s gap '
+        'and counts it INSIDE the budget (native gets budget − waited)',
+        () async {
+      final ch = channel();
+      await ch.open(); // no stamp yet → no wait
+      expect(cooldownWaits, isEmpty);
+      await ch.close(); // stamps lastCloseAt for AA:BB at nowMs
+
+      // Re-open immediately (the fake clock has not advanced): the full
+      // 1500 ms gap must be waited and subtracted from the native budget.
+      await ch.open();
+      expect(cooldownWaits, [const Duration(milliseconds: 1500)]);
+      expect(
+        fake.budgets.last,
+        Obd2PlatformBudgets.classicConnectLadderBudgetMs - 1500,
+      );
+      await ch.close();
+    });
+
+    test('an unexpected DROP also stamps the cooldown', () async {
+      final ch = channel();
+      await ch.open();
+      // A benign Classic drop signature on the reader stream — the channel's
+      // onError flips `_open` and `_signalDrop` stamps the cooldown.
+      fake.incomingController.addError(
+        StateError('bt socket closed, read return: -1'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(ch.isOpen, isFalse);
+
+      await ch.open(); // reconnect attempt right after the drop
+      expect(cooldownWaits, [const Duration(milliseconds: 1500)]);
+      await ch.close();
+    });
+
+    test('a close() after a FAILED open does NOT stamp (open-retry rungs '
+        'stay unpaced)', () async {
+      final failing = _FailingOpenPlugin();
+      final ch = ClassicElmChannel(
+        address: 'AA:BB',
+        plugin: failing,
+        cooldown: cooldown,
+      );
+      await expectLater(ch.open(), throwsA(isA<Obd2AdapterUnresponsive>()));
+      await ch.close(); // the transport's #2906 inter-attempt teardown
+      await expectLater(ch.open(), throwsA(isA<Obd2AdapterUnresponsive>()));
+      expect(cooldownWaits, isEmpty,
+          reason: 'no link was ever live, so there is nothing to cool down');
+    });
+  });
+
+  group('#3421 — Dart-side deadline (defense-in-depth)', () {
+    test(
+        'a wedged platform thread cannot hold open() past budget + grace — '
+        'TimeoutException instead of the field 4.7–16.8 min hangs', () async {
+      fake.hang = true;
+      final ch = channel(
+        budgetMs: 60,
+        grace: const Duration(milliseconds: 40),
+      );
+      await expectLater(
+        ch.open(),
+        throwsA(isA<TimeoutException>()),
+      );
+      expect(ch.isOpen, isFalse);
+    });
+
+    test('a healthy connect is untouched by the deadline', () async {
+      final ch = channel(
+        budgetMs: 60,
+        grace: const Duration(milliseconds: 40),
+      );
+      await ch.open();
+      expect(ch.isOpen, isTrue);
+      await ch.close();
+    });
+  });
+}
+
+/// Plugin whose connect cleanly fails (ok:false) — the channel raises the
+/// typed Obd2AdapterUnresponsive BEFORE `_open` flips, so a close() that
+/// follows must not stamp the cooldown.
+class _FailingOpenPlugin extends Obd2ClassicMethodChannel {
+  _FailingOpenPlugin();
+
+  @override
+  Future<ClassicConnectResult> connectDetailed({
+    required String address,
+    required String uuid,
+    int? budgetMs, // #3421
+  }) async =>
+      (ok: false, strategy: 'exhausted', error: 'rfcomm open failed');
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<List<int>> get incoming => const Stream<List<int>>.empty();
+}

--- a/test/features/obd2/data/classic_elm_channel_diagnostics_test.dart
+++ b/test/features/obd2/data/classic_elm_channel_diagnostics_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_cooldown.dart';
 import 'package:tankstellen/features/obd2/data/classic_elm_channel.dart';
 import 'package:tankstellen/features/obd2/data/classic_method_channel.dart';
 import 'package:tankstellen/features/obd2/data/obd2_comm_diagnostics.dart';
@@ -47,6 +48,7 @@ class _FakeClassicPlugin extends Obd2ClassicMethodChannel {
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs, // #3421
   }) async {
     if (connectThrows != null) throw connectThrows!;
     return (
@@ -85,6 +87,8 @@ void main() {
 
   setUp(() {
     fake = _FakeClassicPlugin();
+    // #3421 — don't inherit a prior test's close stamp (≈1.5 s real wait).
+    ClassicConnectCooldown.instance.debugClear();
     Obd2CommDiagnostics.instance.reset();
     errorLogger.resetForTest();
     recorder = _CaptureRecorder();

--- a/test/features/obd2/data/classic_elm_channel_test.dart
+++ b/test/features/obd2/data/classic_elm_channel_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_cooldown.dart';
 import 'package:tankstellen/features/obd2/data/classic_elm_channel.dart';
 import 'package:tankstellen/features/obd2/data/classic_method_channel.dart';
 import 'package:tankstellen/features/obd2/data/obd2_connection_errors.dart';
@@ -30,10 +31,12 @@ class _FakeObd2ClassicMethodChannel extends Obd2ClassicMethodChannel {
 
   // #2969 — ClassicElmChannel.open now calls connectDetailed; override it so
   // the fake's connectResult still drives the SUT + records the call.
+  // #3421 — accepts the budgetMs the channel now threads through.
   @override
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs,
   }) async {
     connectCalls.add(_ConnectCall(address, uuid));
     return (
@@ -98,6 +101,7 @@ class _LateByteFakePlugin extends Obd2ClassicMethodChannel {
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs, // #3421
   }) async =>
       (ok: true, strategy: 'secure', error: null);
 
@@ -157,6 +161,10 @@ void main() {
 
   setUp(() {
     fake = _FakeObd2ClassicMethodChannel();
+    // #3421 — the shared post-close cooldown would otherwise carry a prior
+    // test's close stamp for 'AA:BB' into this one and sleep ~1.5 s of real
+    // clock on the first open().
+    ClassicConnectCooldown.instance.debugClear();
   });
 
   tearDown(() async {

--- a/test/features/obd2/data/classic_method_channel_test.dart
+++ b/test/features/obd2/data/classic_method_channel_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/obd2/data/classic_method_channel.dart';
+import 'package:tankstellen/features/obd2/data/obd2_platform_budgets.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -72,7 +73,47 @@ void main() {
       expect(captured!.arguments, {
         'address': 'AA:BB',
         'uuid': '00001101-0000-1000-8000-00805f9b34fb',
+        // #3421 — the whole-ladder budget rides along by default.
+        'budgetMs': Obd2PlatformBudgets.classicConnectLadderBudgetMs,
       });
+    });
+
+    // #3421 — the whole-ladder budget must reach the native side as
+    // `budgetMs` so the Kotlin ladder can skip remaining rungs when spent.
+    test('#3421 — connectDetailed forwards an explicit budgetMs', () async {
+      MethodCall? captured;
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        captured = call;
+        return {'ok': true, 'strategy': 'secure', 'error': null};
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      final r = await plugin.connectDetailed(
+        address: 'AA:BB',
+        uuid: 'UUID',
+        budgetMs: 12345,
+      );
+
+      expect(r.ok, isTrue);
+      expect((captured!.arguments as Map)['budgetMs'], 12345);
+    });
+
+    test(
+        '#3421 — connectDetailed defaults budgetMs to the audited '
+        'whole-ladder constant', () async {
+      MethodCall? captured;
+      messenger.setMockMethodCallHandler(methodChannel, (call) async {
+        captured = call;
+        return true;
+      });
+
+      const plugin = Obd2ClassicMethodChannel();
+      await plugin.connectDetailed(address: 'AA:BB', uuid: 'UUID');
+
+      expect(
+        (captured!.arguments as Map)['budgetMs'],
+        Obd2PlatformBudgets.classicConnectLadderBudgetMs,
+      );
     });
 
     test('connect defaults to false when native returns null', () async {

--- a/test/features/obd2/data/elm_channel_reopen_test.dart
+++ b/test/features/obd2/data/elm_channel_reopen_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/obd2/data/bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_cooldown.dart';
 import 'package:tankstellen/features/obd2/data/classic_elm_channel.dart';
 import 'package:tankstellen/features/obd2/data/classic_method_channel.dart';
 import 'package:tankstellen/features/obd2/data/flutter_blue_plus_elm_channel.dart';
@@ -44,6 +45,7 @@ class _ReopenFakePlugin extends Obd2ClassicMethodChannel {
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs, // #3421
   }) async {
     connectCalls++;
     if (connectCalls <= failuresBeforeSuccess) {
@@ -88,6 +90,12 @@ class _ReopenableFbpChannel extends FlutterBluePlusElmChannel {
   Future<void> tuneForRecording() async {}
 }
 
+/// #3421 — zero-wait cooldown: these tests deliberately drive rapid
+/// close() → open() cycles, which the post-close cooldown would otherwise
+/// pace with a real 1.5 s sleep per reopen.
+ClassicConnectCooldown noWaitCooldown() =>
+    ClassicConnectCooldown(wait: (_) async {});
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   silenceErrorLoggerSpool();
@@ -99,7 +107,8 @@ void main() {
         () async {
       final plugin = _ReopenFakePlugin(failuresBeforeSuccess: 1);
       addTearDown(plugin.dispose);
-      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+      final channel = ClassicElmChannel(
+          address: 'AA:BB', plugin: plugin, cooldown: noWaitCooldown());
       final transport = BluetoothObd2Transport(
         channel,
         readTimeout: const Duration(milliseconds: 400),
@@ -132,7 +141,8 @@ void main() {
     test('close() → open() → incoming bytes flow again', () async {
       final plugin = _ReopenFakePlugin();
       addTearDown(plugin.dispose);
-      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+      final channel = ClassicElmChannel(
+          address: 'AA:BB', plugin: plugin, cooldown: noWaitCooldown());
 
       await channel.open();
       await channel.close();
@@ -157,7 +167,8 @@ void main() {
         () async {
       final plugin = _ReopenFakePlugin();
       addTearDown(plugin.dispose);
-      final channel = ClassicElmChannel(address: 'AA:BB', plugin: plugin);
+      final channel = ClassicElmChannel(
+          address: 'AA:BB', plugin: plugin, cooldown: noWaitCooldown());
 
       await channel.open();
       await channel.close(); // deliberate close latches `_closing` on master

--- a/test/features/obd2/data/obd2_connect_trace_service_test.dart
+++ b/test/features/obd2/data/obd2_connect_trace_service_test.dart
@@ -283,6 +283,7 @@ class _FalseConnectPlugin extends Obd2ClassicMethodChannel {
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs, // #3421
   }) async =>
       (ok: false, strategy: 'exhausted', error: 'read failed, socket closed');
   @override
@@ -297,6 +298,7 @@ class _ThrowingConnectPlugin extends Obd2ClassicMethodChannel {
   Future<ClassicConnectResult> connectDetailed({
     required String address,
     required String uuid,
+    int? budgetMs, // #3421
   }) async =>
       throw Exception('RFCOMM socket open failed');
   @override

--- a/test/features/obd2/data/obd2_in_range_probe_test.dart
+++ b/test/features/obd2/data/obd2_in_range_probe_test.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/features/obd2/data/adapter_registry.dart';
+import 'package:tankstellen/features/obd2/data/bluetooth_facade.dart';
+import 'package:tankstellen/features/obd2/data/elm_byte_channel.dart';
+import 'package:tankstellen/features/obd2/data/obd2_in_range_probe.dart';
+import 'package:tankstellen/features/obd2/data/obd2_scan_governor.dart';
+
+/// Fake [BluetoothFacade] that replays PRE-SEEDED scan batches in the real
+/// event shape (accumulated candidate lists) — deliberately NOT an echo of
+/// the request, so a probe that "sees" the target can only do so because
+/// the fixture actually advertises it.
+class _FakeFacade implements BluetoothFacade {
+  _FakeFacade(this.batches);
+
+  final List<List<Obd2AdapterCandidate>> batches;
+  int scanCalls = 0;
+  Set<String>? lastServiceUuids;
+  Duration? lastTimeout;
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    scanCalls++;
+    lastServiceUuids = serviceUuids;
+    lastTimeout = timeout;
+    return Stream.fromIterable(batches);
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      throw UnimplementedError('probe never opens a channel');
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      throw UnimplementedError('probe never opens a channel');
+}
+
+Obd2AdapterCandidate _candidate(String id, {String name = 'vLinker FS'}) =>
+    Obd2AdapterCandidate(
+      deviceId: id,
+      deviceName: name,
+      advertisedServiceUuids: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      rssi: -62,
+    );
+
+void main() {
+  const mac = 'AA:BB:CC:DD:EE:01';
+
+  late Obd2ScanGovernor governor;
+
+  setUp(() {
+    // Fresh isolated token bucket with a no-op wait so a saturated bucket
+    // could never sleep the suite.
+    governor = Obd2ScanGovernor(wait: (_) async {});
+    BreadcrumbCollector.clear();
+  });
+
+  group('buildObd2InRangeProbe (#3421) — BLE transport', () {
+    test('advert sighted in a later batch → true (case-insensitive id)',
+        () async {
+      final facade = _FakeFacade([
+        [_candidate('11:22:33:44:55:66', name: 'someone else')],
+        [
+          _candidate('11:22:33:44:55:66', name: 'someone else'),
+          // Lower-cased id in the advert; the pinned mac is upper-case.
+          _candidate('aa:bb:cc:dd:ee:01'),
+        ],
+      ]);
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: 'ble',
+      );
+
+      expect(await probe(mac), isTrue);
+      expect(facade.scanCalls, 1);
+      // #3097 — unfiltered scan (a withServices filter starves name-only
+      // clones), bounded by the short probe window.
+      expect(facade.lastServiceUuids, isEmpty);
+      expect(facade.lastTimeout, const Duration(seconds: 3));
+      // #3185 — every probe pays into the process-wide scan budget.
+      expect(governor.debugStartCount, 1);
+      // #3421 acceptance — the result is stamped as a breadcrumb.
+      expect(
+        BreadcrumbCollector.snapshot()
+            .map((b) => b.action)
+            .where((a) => a.contains('ble-probe sighted')),
+        isNotEmpty,
+      );
+    });
+
+    test('silent scan window (no sighting of the pinned mac) → false',
+        () async {
+      final facade = _FakeFacade([
+        [_candidate('11:22:33:44:55:66', name: 'someone else')],
+      ]);
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: 'ble',
+      );
+
+      expect(await probe(mac), isFalse);
+      expect(governor.debugStartCount, 1);
+      expect(
+        BreadcrumbCollector.snapshot()
+            .map((b) => b.action)
+            .where((a) => a.contains('ble-probe miss')),
+        isNotEmpty,
+      );
+    });
+
+    test('an empty scan window → false', () async {
+      final facade = _FakeFacade(const []);
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: 'ble',
+      );
+      expect(await probe(mac), isFalse);
+    });
+
+    test(
+        'a scan failure propagates to the caller (the scanner already '
+        'de-noises probe throws, #2953)', () async {
+      final facade = _ThrowingScanFacade();
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: 'ble',
+      );
+      await expectLater(probe(mac), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('buildObd2InRangeProbe (#3421) — non-BLE transports', () {
+    test('classic pin → true WITHOUT touching the radio (no advert to sight)',
+        () async {
+      final facade = _FakeFacade(const []);
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: 'classic',
+      );
+      expect(await probe(mac), isTrue);
+      expect(facade.scanCalls, 0);
+      expect(governor.debugStartCount, 0);
+    });
+
+    test('unknown transport → conservatively true without scanning '
+        '(a wrongly-probed Classic pin would starve forever)', () async {
+      final facade = _FakeFacade(const []);
+      final probe = buildObd2InRangeProbe(
+        bluetooth: facade,
+        scanGovernor: governor,
+        transportHint: null,
+      );
+      expect(await probe(mac), isTrue);
+      expect(facade.scanCalls, 0);
+    });
+  });
+}
+
+/// Facade whose scan stream errors (BT off / plugin rejection).
+class _ThrowingScanFacade extends _FakeFacade {
+  _ThrowingScanFacade() : super(const []);
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) =>
+      Stream.error(StateError('startScan rejected'));
+}


### PR DESCRIPTION
## Why

Field traces on #3415 (t5/t8) showed a single native Classic connect call blocking **4.7–16.8 minutes** — the #3348 watchdog bounds each rung at 7 s but never the whole call — and the in-trip reconnect scanner's in-range probe was a stub (`always true`), so every backoff tick fired a blind connect at an absent adapter.

## What

- **Whole-ladder budget (20 s)**: Dart passes `budgetMs` through `classic_method_channel` → `Obd2ClassicPlugin.connect()` checks elapsed (monotonic clock) before each rung and skips the rest with a dedicated `budget-exhausted` strategy. Per-rung 7 s watchdog unchanged. Dart-side `.timeout(budget + 3 s)` as defense-in-depth against a wedged platform thread.
- **Post-close cooldown (1.5 s, per-mac)**: new `ClassicConnectCooldown` paces every re-open after a drop or live close (the #3404 micro-lever), waited time counted inside the budget. Never-throws with fault-injection test.
- **Real BLE in-range probe**: `buildObd2InRangeProbe` replaces the stub — 3 s facade advert scan for the pinned MAC under the scan-governor budget, breadcrumbed; Classic pins skip (SPP doesn't advertise; bounded storm is #3422).

`flutter analyze` clean; obd2 + consumption + lint suites pass (4,973 tests); Kotlin change reviewed (thread model untouched).

Part of Epic #3415.
Closes #3421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
