### PR TITLE
fix(uk,ro): statutory Fuel Finder migration + bogus RO canary fix (#3190, #3457)

### DIFF
--- a/lib/core/services/country_raw_service_builder.dart
+++ b/lib/core/services/country_raw_service_builder.dart
@@ -20,8 +20,7 @@ import '../../features/station_services/romania/romania_station_service.dart';
 import '../../features/station_services/slovenia/slovenia_station_service.dart';
 import '../../features/station_services/south_korea/south_korea_station_service.dart';
 import '../../features/station_services/spain/miteco_station_service.dart';
-import '../../features/station_services/uk/uk_cma_bulk_station_service.dart';
-import '../../features/station_services/uk/uk_station_service.dart';
+import '../../features/station_services/uk/uk_service_builder.dart';
 import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
 import 'bulk_migration_flags.dart';
@@ -118,11 +117,17 @@ StationService buildRawCountryService(
     case 'PT':
       return PortugalStationService();
     case 'GB':
-      // #2277 staged rollout — consolidated CMA bulk file when flagged, else
-      // the legacy per-search retailer fan-out.
-      return BulkMigrationFlags.ukCmaBulk
-          ? UkCmaBulkStationService(cache: deps.cache)
-          : UkStationService();
+      // #3190 — statutory Fuel Finder API as PRIMARY once OAuth2 credentials
+      // are configured (Settings → API key, packed "client_id:client_secret"
+      // — the same single per-country key slot DE/KR/CL read), legacy
+      // retailer fan-out demoted to the in-service fallback; keyless
+      // installs keep the legacy / #2277 flag-gated behaviour unchanged.
+      // Composition lives feature-side in buildGbStationService (#3132
+      // boundary ratchet: one core→feature import instead of five).
+      return buildGbStationService(
+        apiKey: deps.storage.getApiKey(),
+        cache: deps.cache,
+      );
     case 'AU':
       return const AustraliaStationService();
     case 'MX':

--- a/lib/core/services/country_service_policies.dart
+++ b/lib/core/services/country_service_policies.dart
@@ -86,19 +86,24 @@ const _ukPolicyLegacy = FuelServicePolicy(
   sourceUrl: 'https://www.gov.uk/guidance/access-fuel-price-data',
 );
 
-/// UK CMA Fuel Finder — BULK consolidated twice-daily file (#2277): one
-/// whole-country download per ~12 h publication cadence, persisted and
-/// local-filtered. Soft TTL ≈ the publish cadence, hard TTL an offline-grace
-/// multiple. Selected only when `BulkMigrationFlags.ukCmaBulk` is `true`.
+/// UK Fuel Finder — BULK whole-country download (#2277, rebased on the
+/// statutory Fuel Finder API in #3190): the paged `/api/v1/pfs*` resources,
+/// persisted and local-filtered. Soft TTL ≈ the twice-daily consumer cadence,
+/// hard TTL an offline-grace multiple. Selected only when
+/// `BulkMigrationFlags.ukCmaBulk` is `true`. (The #3190 credentialed path
+/// keeps the legacy polled policy at chain level — the bulk primary governs
+/// its own dataset TTLs internally either way, so the per-search cache on
+/// top is merely conservative.)
 const _ukPolicyBulk = FuelServicePolicy(
   model: SourceModel.bulkFile,
   minInterval: Duration(hours: 1),
   datasetTtlSoft: Duration(hours: 12),
   datasetTtlHard: Duration(hours: 48),
   searchResultTtl: Duration.zero,
-  attribution: 'CMA Fuel Finder (consolidated)',
+  attribution: 'Fuel Finder (DESNZ / VE3 Global)',
   license: 'Open Government Licence v3.0',
-  sourceUrl: 'https://www.gov.uk/guidance/access-fuel-price-data',
+  sourceUrl:
+      'https://www.gov.uk/guidance/access-the-latest-fuel-prices-and-forecourt-data-via-api-or-email',
 );
 
 /// Staged-rollout selection (#2277): legacy by default, bulk when flagged.

--- a/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
+++ b/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
@@ -16,6 +16,7 @@ import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import 'uk_fuel_finder_auth.dart';
+import 'uk_fuel_finder_feed.dart';
 import 'uk_station_service.dart';
 
 /// UK CMA / Fuel Finder **bulk-file** fuel-price service (#2277).
@@ -33,27 +34,46 @@ import 'uk_station_service.dart';
 /// through the identical [UkStationService.parseCmaStations] used by the legacy
 /// path, so a given area returns the same stations.
 ///
-/// The consolidated download is JSON-shaped exactly like the retailer feeds
-/// (`{"stations": [ {site_id, brand, address, postcode, location:{latitude,
-/// longitude}, prices:{E5,E10,B7,...}} ]}`); the persisted dataset is the raw
-/// record list, re-filtered per search. The download URL is injectable so the
-/// subscription-issued consolidated endpoint is a one-line config change.
+/// The download has two modes (#3190):
 ///
-/// This service is only wired into the registry when
-/// `BulkMigrationFlags.ukCmaBulk` is `true` (staged rollout, defaults to the
-/// legacy fan-out).
+///  - **Statutory feed mode** — a [UkFuelFinderFeed] is wired (the registry
+///    does this once OAuth2 credentials are configured): the two paged
+///    `/api/v1/pfs*` resources of the live Fuel Finder API are downloaded and
+///    merged into CMA-shaped records. This is the production path.
+///  - **Single-URL mode** — no feed: one GET of [_consolidatedUrl] expecting
+///    the standardized CMA envelope (`{"stations": [ {site_id, brand,
+///    address, postcode, location:{latitude,longitude},
+///    prices:{E5,E10,B7,...}} ]}`), optionally Bearer-authenticated via
+///    [UkFuelFinderAuth]. Kept injectable for tests and any future
+///    consolidated-file publication.
+///
+/// Either way the persisted dataset is the raw CMA-shaped record list,
+/// re-filtered per search.
+///
+/// Registry wiring: with credentials the service runs feed-mode as the GB
+/// PRIMARY (legacy fan-out demoted to fallback); without credentials it is
+/// only selected when `BulkMigrationFlags.ukCmaBulk` is `true` (staged
+/// rollout, defaults to the legacy fan-out).
 class UkCmaBulkStationService
     with StationServiceHelpers, CachedDatasetMixin
     implements StationService {
   final Dio _dio;
   final String _consolidatedUrl;
 
+  /// #3190 — the statutory Fuel Finder feed client (token + the two batched
+  /// `/api/v1/pfs*` resources merged into CMA-shaped records). When set it
+  /// REPLACES the single consolidated download below: [_downloadConsolidated]
+  /// delegates to [UkFuelFinderFeed.downloadCmaShapedRecords] and everything
+  /// downstream (persist / local-filter / shared parse) is unchanged. This is
+  /// the path the registry wires once OAuth2 credentials are configured.
+  final UkFuelFinderFeed? _feed;
+
   /// #3190 — OAuth 2.0 client-credentials token source for the statutory Fuel
-  /// Finder API. Null on the pre-credentials path (no GOV.UK One Login client
+  /// Finder API. Null on the pre-credentials path (no registered client
   /// configured yet) → the consolidated request goes out unauthenticated, as
   /// before. When set, each download carries a `Bearer` token (fetched +
   /// cached by [UkFuelFinderAuth]); a 401 invalidates the token and retries
-  /// once.
+  /// once. Only read by the single-URL mode — [_feed] handles its own auth.
   final UkFuelFinderAuth? _auth;
 
   /// Disk persistence (read-through). When a [CacheStrategy] is supplied (the
@@ -62,22 +82,23 @@ class UkCmaBulkStationService
   /// offline. Null in the pure-in-memory parser tests.
   final PersistentDataset<List<Map<String, dynamic>>>? _persistent;
 
-  /// Default consolidated Fuel Finder download (#3190). The statutory Fuel
-  /// Finder Scheme (Motor Fuel Price (Open Data) Regulations 2025) replaced the
-  /// withdrawn voluntary CMA scheme on 2026-05-01; its public API lives on the
-  /// gov.uk developer portal. One consolidated file covers every forecourt.
-  /// Overridable so the exact `/public-api` price-list path — which must be
-  /// confirmed against the registered API docs — drops in without touching the
-  /// parse/persist/filter logic.
+  /// Default single-download URL for the legacy consolidated-file mode
+  /// (#3190). The confirmed statutory API publishes no one-file dump — it
+  /// pages two REST resources instead (see [UkFuelFinderFeed], the mode the
+  /// registry actually wires) — so this constant now points at the real
+  /// statutory prices resource (first batch) purely as the injectable
+  /// single-URL mode's least-wrong default; it replaces the earlier
+  /// `/public-api/v1/prices/latest` guess, which was never a live path.
   // i18n-ignore: gov.uk data endpoint URL, not user-facing text
   static const String defaultConsolidatedUrl =
-      'https://developer.fuel-finder.service.gov.uk/public-api/v1/prices/latest';
+      '${UkFuelFinderFeed.defaultBaseUrl}${UkFuelFinderFeed.pricesPath}';
 
   UkCmaBulkStationService({
     Dio? dio,
     String? consolidatedUrl,
     CacheStrategy? cache,
     UkFuelFinderAuth? auth,
+    UkFuelFinderFeed? feed,
   })  : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 15),
@@ -85,6 +106,7 @@ class UkCmaBulkStationService
               responseType: ResponseType.json,
             ),
         _auth = auth,
+        _feed = feed,
         _consolidatedUrl = consolidatedUrl ?? defaultConsolidatedUrl,
         _persistent = cache == null
             ? null
@@ -171,6 +193,13 @@ class UkCmaBulkStationService
   Future<List<Map<String, dynamic>>> _downloadConsolidated({
     CancelToken? cancelToken,
   }) async {
+    // #3190 — statutory feed mode: the two paged /api/v1/pfs* resources,
+    // merged into CMA-shaped records (auth + 401-retry live inside the feed).
+    final feed = _feed;
+    if (feed != null) {
+      return feed.downloadCmaShapedRecords(cancelToken: cancelToken);
+    }
+
     final auth = _auth;
     if (auth == null) {
       final response = await _dio.get<dynamic>(

--- a/lib/features/station_services/uk/uk_fuel_finder_auth.dart
+++ b/lib/features/station_services/uk/uk_fuel_finder_auth.dart
@@ -3,17 +3,53 @@
 
 import 'package:dio/dio.dart';
 
+import '../../../core/services/dio_factory.dart';
+
 /// OAuth 2.0 **client-credentials** token source for the UK statutory Fuel
 /// Finder API (#3190).
 ///
 /// The voluntary CMA scheme was withdrawn 2026-05-01 and replaced by the
 /// statutory Fuel Finder Scheme (*Motor Fuel Price (Open Data) Regulations
-/// 2025*), whose public API (developer.fuel-finder.service.gov.uk) is fronted
-/// by OAuth 2.0 client credentials — a `client_id` / `client_secret` pair
-/// generated via a GOV.UK One Login. This holds those credentials and the
-/// token endpoint, fetches a bearer token on demand (RFC 6749 §4.4), caches it
-/// until shortly before it expires, and re-fetches after [invalidate] (called
-/// on a 401).
+/// 2025*), operated by VE3 Global Ltd for DESNZ. Its REST API is fronted by
+/// OAuth 2.0 client credentials — a `client_id` / `client_secret` pair issued
+/// through the (free) developer portal. This holds those credentials and the
+/// token endpoint, fetches a bearer token on demand, caches it until shortly
+/// before it expires, and re-fetches after [invalidate] (called on a 401).
+///
+/// ## Live token contract (verified against the published API, 2026-07-03)
+///
+/// ```
+/// POST https://www.fuel-finder.service.gov.uk/api/v1/oauth/generate_access_token
+/// Content-Type: application/json
+/// {"client_id": "...", "client_secret": "..."}
+/// ```
+///
+/// answering (the envelope's `data` wrapper may be absent — both shapes are
+/// tolerated):
+///
+/// ```json
+/// {"data": {"access_token": "...", "expires_in": 3600}}
+/// ```
+///
+/// Note this is *not* the RFC 6749 §4.4 form-urlencoded `grant_type=`
+/// exchange — the Fuel Finder token endpoint takes a JSON body with the two
+/// credential fields only. Sources: the GOV.UK developer portal
+/// (`developer.fuel-finder.service.gov.uk/apis-ifr/access-token`,
+/// `/api-authentication`) and the contract cross-checked against a working
+/// third-party consumer of the live API.
+///
+/// ## Registering for credentials (free)
+///
+/// 1. Sign in at https://www.developer.fuel-finder.service.gov.uk/ with a
+///    GOV.UK One Login (free to create).
+/// 2. Create an **Information Recipient** application.
+/// 3. Copy the issued `client_id` / `client_secret`.
+/// 4. Paste them into Settings → API key while the United Kingdom is the
+///    active country, packed as `client_id:client_secret` (see
+///    [fromPackedCredentials]).
+///
+/// The data itself is published under the Open Government Licence v3.0 and is
+/// free for third-party use — no paid tier exists.
 ///
 /// It is deliberately a small, injectable collaborator — the bulk station
 /// service takes one (or null, the unauthenticated pre-credentials path) so the
@@ -21,19 +57,54 @@ import 'package:dio/dio.dart';
 class UkFuelFinderAuth {
   UkFuelFinderAuth({
     required Dio dio,
-    required this.tokenUrl,
+    String? tokenUrl,
     required this.clientId,
     required this.clientSecret,
     this.scope,
     DateTime Function() now = DateTime.now,
   })  : _dio = dio,
+        tokenUrl = tokenUrl ?? defaultTokenUrl,
         _now = now;
+
+  /// Live OAuth2 token endpoint of the statutory Fuel Finder API (#3190).
+  // i18n-ignore: gov.uk API endpoint URL, not user-facing text
+  static const String defaultTokenUrl =
+      'https://www.fuel-finder.service.gov.uk'
+      '/api/v1/oauth/generate_access_token';
+
+  /// Builds an auth from the Settings → API key slot, where the GB
+  /// credentials are packed as `client_id:client_secret` (the same
+  /// single-string per-country key slot DE/KR/CL already use). Returns null
+  /// when [packed] is null, blank, or not two non-empty `:`-separated halves —
+  /// the caller then stays on the keyless legacy path.
+  static UkFuelFinderAuth? fromPackedCredentials(
+    String? packed, {
+    Dio? dio,
+    String? tokenUrl,
+  }) {
+    if (packed == null) return null;
+    final separator = packed.indexOf(':');
+    if (separator <= 0 || separator >= packed.length - 1) return null;
+    final clientId = packed.substring(0, separator).trim();
+    final clientSecret = packed.substring(separator + 1).trim();
+    if (clientId.isEmpty || clientSecret.isEmpty) return null;
+    return UkFuelFinderAuth(
+      dio: dio ??
+          DioFactory.create(
+            connectTimeout: const Duration(seconds: 15),
+            receiveTimeout: const Duration(seconds: 20),
+          ),
+      tokenUrl: tokenUrl,
+      clientId: clientId,
+      clientSecret: clientSecret,
+    );
+  }
 
   final Dio _dio;
   final DateTime Function() _now;
 
-  /// The OAuth2 token endpoint (the `/token` URL from the Fuel Finder
-  /// developer portal). Injected — never guessed in code.
+  /// The OAuth2 token endpoint. Defaults to [defaultTokenUrl]; injectable for
+  /// tests or if the host ever moves.
   final String tokenUrl;
   final String clientId;
   final String clientSecret;
@@ -70,16 +141,18 @@ class UkFuelFinderAuth {
   }
 
   Future<String> _fetch({CancelToken? cancelToken}) async {
+    // #3190 — the live Fuel Finder token endpoint takes a JSON body carrying
+    // only the two credential fields (no `grant_type`); see the class docs
+    // for the verified contract.
     final response = await _dio.post<dynamic>(
       tokenUrl,
       data: {
-        'grant_type': 'client_credentials',
         'client_id': clientId,
         'client_secret': clientSecret,
         if (scope != null) 'scope': scope,
       },
       options: Options(
-        contentType: Headers.formUrlEncodedContentType,
+        contentType: Headers.jsonContentType,
         responseType: ResponseType.json,
       ),
       cancelToken: cancelToken,
@@ -92,7 +165,11 @@ class UkFuelFinderAuth {
         error: 'Malformed OAuth2 token response (not a JSON object)',
       );
     }
-    final token = body['access_token'];
+    // The live API wraps the token in a `data` envelope; tolerate a bare
+    // top-level shape too so a future envelope removal cannot break auth.
+    final data = body['data'];
+    final payload = data is Map ? data : body;
+    final token = payload['access_token'];
     if (token is! String || token.isEmpty) {
       throw DioException(
         requestOptions: response.requestOptions,
@@ -102,7 +179,7 @@ class UkFuelFinderAuth {
     // `expires_in` is seconds (RFC 6749 §5.1). Default to a conservative
     // 5 min when the server omits it so a missing field can't pin a stale
     // token forever.
-    final expiresIn = body['expires_in'];
+    final expiresIn = payload['expires_in'];
     final seconds = expiresIn is num ? expiresIn.toInt() : 300;
     _cachedToken = token;
     _expiresAt = _now().add(Duration(seconds: seconds));

--- a/lib/features/station_services/uk/uk_fuel_finder_feed.dart
+++ b/lib/features/station_services/uk/uk_fuel_finder_feed.dart
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../core/services/dio_factory.dart';
+import '../../../core/utils/json_extensions.dart';
+import 'uk_fuel_finder_auth.dart';
+
+/// Statutory **Fuel Finder** feed client (#3190).
+///
+/// Under the *Motor Fuel Price (Open Data) Regulations 2025* every UK motor
+/// fuel trader must report prices to the Fuel Finder aggregator (VE3 Global
+/// Ltd, for DESNZ) within 30 minutes of a change; the aggregated data is
+/// openly available to registered third parties (free registration, Open
+/// Government Licence v3.0). CMA enforcement started 2026-05-01, replacing
+/// the withdrawn voluntary retailer-feed scheme.
+///
+/// ## Live REST contract (research evidence, 2026-07-03)
+///
+/// ```
+/// base   https://www.fuel-finder.service.gov.uk
+/// token  POST /api/v1/oauth/generate_access_token   (see UkFuelFinderAuth)
+/// info   GET  /api/v1/pfs?batch-number=<n>          Bearer <token>
+/// prices GET  /api/v1/pfs/fuel-prices?batch-number=<n>
+/// ```
+///
+/// Both data resources are paginated with a 1-based `batch-number` query
+/// parameter; a 404 past the last batch (or an empty batch) ends the paging.
+/// An optional `effective-start-timestamp=<yyyy-MM-dd>` narrows either
+/// resource to records changed since that date (incremental refresh — not
+/// used here; the whole dataset persists via the bulk service's
+/// PersistentDataset and re-downloads only per its soft TTL). The published
+/// rate limit is roughly one request per 2 s with `429` + `Retry-After` on
+/// excess — the default Dio carries a 2.1 s rate-limit interceptor.
+///
+/// Sources: GOV.UK guidance "Access the latest fuel prices and forecourt
+/// data via API or email", the developer portal REST API pages
+/// (`developer.fuel-finder.service.gov.uk/public-api`, `/apicontent`,
+/// `/api-authentication`), cross-checked against a working third-party
+/// consumer of the live API. Field names below mirror that live contract.
+///
+/// ## Record shapes
+///
+/// Forecourt info (`/api/v1/pfs`) records:
+///
+/// ```json
+/// {
+///   "node_id": "...", "trading_name": "...", "brand_name": "...",
+///   "location": {"address_line_1": "...", "address_line_2": "...",
+///                "city": "...", "county": "...", "country": "...",
+///                "postcode": "...", "latitude": 51.5, "longitude": -0.12},
+///   "fuel_types": ["E10", "E5", "B7"], "amenities": [...],
+///   "opening_times": {...}
+/// }
+/// ```
+///
+/// Price (`/api/v1/pfs/fuel-prices`) records: `node_id` plus a `fuel_prices`
+/// list of `{fuel_type, price, price_last_updated,
+/// price_change_effective_timestamp}` entries. Grades are `E10`, `E5`,
+/// `B7`/`B7_STANDARD` (diesel) and `SDV`/`B7_PREMIUM` (super diesel); prices
+/// are pence per litre.
+///
+/// [mergeToCmaRecords] adapts the two resources into the standardized CMA
+/// record shape (`{site_id, brand, address, postcode, location:{latitude,
+/// longitude}, prices:{E5,E10,B7,SDV}}`) so the whole existing UK
+/// parse/persist/filter pipeline ([UkStationService.parseCmaStations] via
+/// [UkCmaBulkStationService]) is reused unchanged — one parser, one result
+/// set, regardless of source.
+///
+/// The feed's `opening_times` object is carried through on the merged record
+/// (key `opening_times`, shape passed verbatim) but is not yet mapped to the
+/// app's structured opening-hours model: its exact schema is not published
+/// and cannot be confirmed without a live registered sample. Tracked in the
+/// #3190 closing notes.
+class UkFuelFinderFeed {
+  /// Live statutory API host. Injectable for tests / host moves.
+  // i18n-ignore: gov.uk API endpoint URL, not user-facing text
+  static const String defaultBaseUrl = 'https://www.fuel-finder.service.gov.uk';
+
+  /// Forecourt (station) details resource.
+  static const String pfsPath = '/api/v1/pfs';
+
+  /// Fuel prices resource.
+  static const String pricesPath = '/api/v1/pfs/fuel-prices';
+
+  /// Hard paging cap so a server-side paging fault can never turn into an
+  /// unbounded request loop (~80 batches comfortably covers the ~8 500 UK
+  /// forecourts at the observed batch sizes).
+  static const int maxBatches = 80;
+
+  final Dio _dio;
+  final UkFuelFinderAuth _auth;
+  final String _baseUrl;
+
+  UkFuelFinderFeed({
+    required UkFuelFinderAuth auth,
+    Dio? dio,
+    String? baseUrl,
+  })  : _auth = auth,
+        _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 30),
+              // Published limit ≈ 1 request / 2 s — stay just above it.
+              rateLimit: const Duration(milliseconds: 2100),
+              rateLimitJitterRangeMs: 200,
+            ),
+        _baseUrl = baseUrl ?? defaultBaseUrl;
+
+  /// Downloads the whole-country dataset (forecourt info + prices, all
+  /// batches), merged into legacy-CMA-shaped records ready for
+  /// `UkStationService.parseCmaStations`.
+  ///
+  /// A 401/403 (token rotated / revoked server-side) invalidates the cached
+  /// token and retries the whole download ONCE with a fresh one.
+  Future<List<Map<String, dynamic>>> downloadCmaShapedRecords({
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      return await _download(cancelToken: cancelToken);
+    } on DioException catch (e) { // ignore: catch_no_st — rethrow preserves the stack; the 401/403 branch retries
+      final status = e.response?.statusCode;
+      if (status == 401 || status == 403) {
+        _auth.invalidate();
+        return _download(cancelToken: cancelToken);
+      }
+      rethrow;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _download({
+    CancelToken? cancelToken,
+  }) async {
+    final info = await _fetchBatched(pfsPath, cancelToken: cancelToken);
+    final prices = await _fetchBatched(pricesPath, cancelToken: cancelToken);
+    return mergeToCmaRecords(info, prices);
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchBatched(
+    String path, {
+    CancelToken? cancelToken,
+  }) async {
+    final records = <Map<String, dynamic>>[];
+    for (var batch = 1; batch <= maxBatches; batch++) {
+      final token = await _auth.accessToken(cancelToken: cancelToken);
+      Response<dynamic> response;
+      try {
+        response = await _dio.get<dynamic>(
+          '$_baseUrl$path',
+          queryParameters: {'batch-number': batch},
+          options: Options(
+            responseType: ResponseType.json,
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+          cancelToken: cancelToken,
+        );
+      } on DioException catch (e) { // ignore: catch_no_st — a 404 past the last batch is the documented end-of-pages signal
+        if (e.response?.statusCode == 404 && batch > 1) break;
+        rethrow;
+      }
+      final rows = extractRecords(response.data);
+      if (rows.isEmpty) break;
+      records.addAll(rows);
+      final total = extractTotalBatches(response.data);
+      if (total != null && batch >= total) break;
+    }
+    return records;
+  }
+
+  /// Extracts the record list from a batched response envelope. The exact
+  /// envelope key is not published, so this is deliberately tolerant (like
+  /// the token envelope in [UkFuelFinderAuth]): a bare top-level list, or the
+  /// first list-of-objects found at the top level or one `data` level down.
+  @visibleForTesting
+  static List<Map<String, dynamic>> extractRecords(dynamic data) {
+    List<Map<String, dynamic>> asRecordList(dynamic value) {
+      if (value is! List) return const [];
+      final out = <Map<String, dynamic>>[];
+      for (final row in value) {
+        if (row is Map) out.add(Map<String, dynamic>.from(row));
+      }
+      return out;
+    }
+
+    final direct = asRecordList(data);
+    if (direct.isNotEmpty) return direct;
+
+    Map<String, dynamic>? envelope;
+    if (data is Map<String, dynamic>) {
+      final inner = data['data'];
+      envelope =
+          inner is Map ? Map<String, dynamic>.from(inner) : data;
+    }
+    if (envelope == null) return const [];
+    for (final value in envelope.values) {
+      final rows = asRecordList(value);
+      if (rows.isNotEmpty) return rows;
+    }
+    return const [];
+  }
+
+  /// Reads a total-batch-count hint from a response envelope, when the server
+  /// sends one (checked at the top level and one `data`/`meta` level down).
+  @visibleForTesting
+  static int? extractTotalBatches(dynamic data) {
+    if (data is! Map) return null;
+    int? read(dynamic scope) {
+      if (scope is! Map) return null;
+      for (final key in const [
+        'total_batches', 'totalBatches', 'total-batches',
+      ]) {
+        final value = scope[key];
+        if (value is num) return value.toInt();
+        final parsed = int.tryParse(value?.toString() ?? '');
+        if (parsed != null) return parsed;
+      }
+      return null;
+    }
+
+    return read(data) ?? read(data['data']) ?? read(data['meta']);
+  }
+
+  /// Merges forecourt-info + price records (matched on the station
+  /// identifier) into legacy-CMA-shaped records so the shared
+  /// `parseCmaStations` pipeline consumes them unchanged. Pure — exposed for
+  /// fixture-driven tests.
+  @visibleForTesting
+  static List<Map<String, dynamic>> mergeToCmaRecords(
+    List<Map<String, dynamic>> info,
+    List<Map<String, dynamic>> prices,
+  ) {
+    final byId = <String, Map<String, dynamic>>{};
+
+    for (final row in info) {
+      final id = _stationId(row);
+      if (id.isEmpty) continue;
+      final location = row.getMap('location') ?? const <String, dynamic>{};
+      byId[id] = {
+        'site_id': id,
+        'site_name': row['trading_name']?.toString() ?? '',
+        'brand': row['brand_name']?.toString() ??
+            row['trading_name']?.toString() ??
+            '',
+        'address': _streetAddress(location),
+        'postcode': location['postcode']?.toString() ?? '',
+        'town': location['city']?.toString() ?? '',
+        'location': {
+          'latitude': location['latitude'],
+          'longitude': location['longitude'],
+        },
+        'prices': <String, dynamic>{},
+        // Carried verbatim for a future structured mapping (schema not yet
+        // confirmable without a live registered sample — see class docs).
+        if (row['opening_times'] is Map) 'opening_times': row['opening_times'],
+      };
+    }
+
+    for (final row in prices) {
+      final id = _stationId(row);
+      if (id.isEmpty) continue;
+      // A price row without a matching info row has no coordinates;
+      // parseCmaStations drops coordinate-less records, so skip it here.
+      final record = byId[id];
+      if (record == null) continue;
+      final target = record['prices'] as Map<String, dynamic>;
+      final entries = row['fuel_prices'];
+      if (entries is! List) continue;
+      for (final entry in entries) {
+        if (entry is! Map) continue;
+        final grade = cmaGradeFor(entry['fuel_type']?.toString());
+        final price = entry['price'];
+        if (grade == null || price is! num) continue;
+        target[grade] = price;
+      }
+    }
+
+    return byId.values.toList();
+  }
+
+  /// Maps a Fuel Finder grade to the standardized CMA price key the shared
+  /// parser reads (`E5`/`E10`/`B7`/`SDV`), or null for an unknown grade.
+  @visibleForTesting
+  static String? cmaGradeFor(String? fuelType) {
+    switch (fuelType?.trim().toUpperCase()) {
+      case 'E10':
+        return 'E10';
+      case 'E5':
+        return 'E5';
+      case 'B7':
+      case 'B7_STANDARD':
+        return 'B7';
+      case 'SDV':
+      case 'B7_PREMIUM':
+        return 'SDV';
+      default:
+        return null;
+    }
+  }
+
+  static String _stationId(Map<String, dynamic> row) {
+    for (final key in const ['node_id', 'site_id', 'id', 'station_id']) {
+      final value = row[key]?.toString().trim() ?? '';
+      if (value.isNotEmpty) return value;
+    }
+    return '';
+  }
+
+  static String _streetAddress(Map<String, dynamic> location) {
+    final parts = <String>[
+      for (final key in const ['address_line_1', 'address_line_2'])
+        location[key]?.toString().trim() ?? '',
+    ]..removeWhere((part) => part.isEmpty);
+    return parts.join(', ');
+  }
+}

--- a/lib/features/station_services/uk/uk_service_builder.dart
+++ b/lib/features/station_services/uk/uk_service_builder.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../core/cache/cache_manager.dart';
+import '../../../core/services/bulk_migration_flags.dart';
+import '../../../core/services/station_service.dart';
+import 'uk_cma_bulk_station_service.dart';
+import 'uk_fuel_finder_auth.dart';
+import 'uk_fuel_finder_feed.dart';
+import 'uk_station_service.dart';
+import 'uk_statutory_fallback_station_service.dart';
+
+/// Builds the GB raw [StationService] (#3190) — the single seam
+/// `buildRawCountryService` calls, so the feature owns its own composition
+/// (one core→feature import instead of five; the #3132 boundary ratchet).
+///
+/// Selection:
+///
+///  1. **Statutory Fuel Finder primary** — [apiKey] holds registered OAuth2
+///     credentials packed as `client_id:client_secret` (the shared
+///     per-country Settings key slot; see
+///     [UkFuelFinderAuth.fromPackedCredentials] for the free registration
+///     steps): the statutory bulk path ([UkCmaBulkStationService] with a
+///     [UkFuelFinderFeed]) answers searches, with the legacy retailer
+///     fan-out demoted to the in-service fallback
+///     ([UkStatutoryFallbackStationService]).
+///  2. **Keyless** — the pre-#3190 behaviour, unchanged: the legacy
+///     per-search retailer fan-out ([UkStationService]), or the
+///     unauthenticated bulk path when `BulkMigrationFlags.ukCmaBulk` is
+///     flagged on (#2277 staged rollout).
+StationService buildGbStationService({
+  required String? apiKey,
+  required CacheStrategy cache,
+}) {
+  final auth = UkFuelFinderAuth.fromPackedCredentials(apiKey);
+  if (auth != null) {
+    return UkStatutoryFallbackStationService(
+      primary: UkCmaBulkStationService(
+        cache: cache,
+        feed: UkFuelFinderFeed(auth: auth),
+      ),
+      fallback: UkStationService(),
+    );
+  }
+  return BulkMigrationFlags.ukCmaBulk
+      ? UkCmaBulkStationService(cache: cache)
+      : UkStationService();
+}

--- a/lib/features/station_services/uk/uk_statutory_fallback_station_service.dart
+++ b/lib/features/station_services/uk/uk_statutory_fallback_station_service.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import '../../../core/domain/search_params.dart';
+import '../../../core/domain/station.dart';
+import '../../../core/logging/error_logger.dart';
+import '../../../core/services/service_result.dart';
+import '../../../core/services/station_service.dart';
+
+/// GB primary/fallback composition for the statutory Fuel Finder migration
+/// (#3190).
+///
+/// Once OAuth2 credentials are configured the statutory Fuel Finder bulk
+/// path ([UkCmaBulkStationService] in feed mode) is the PRIMARY GB source,
+/// and the legacy per-search retailer fan-out ([UkStationService]) is
+/// demoted to an in-service fallback: it answers only when the statutory
+/// path throws (endpoint outage, auth rejection after the feed's own
+/// 401-retry, parse failure) **or** returns zero stations (an empty
+/// statutory dataset must not silently blank the country while retailer
+/// feeds still serve — the retailer feeds are themselves dying post-scheme,
+/// so an honest empty from both is still possible).
+///
+/// The fallback fires per-search and is cheap in aggregate: the surrounding
+/// [StationServiceChain] caches each search result, so a broken primary does
+/// not multiply the legacy fan-out beyond the legacy path's historical rate.
+///
+/// Detail/prices delegate to the primary — both wrapped services expose the
+/// same unsupported surface there (`throwDetailUnavailable` /
+/// `emptyPricesResult`), so no fallback is meaningful.
+class UkStatutoryFallbackStationService implements StationService {
+  UkStatutoryFallbackStationService({
+    required StationService primary,
+    required StationService fallback,
+  })  : _primary = primary,
+        _fallback = fallback;
+
+  final StationService _primary;
+  final StationService _fallback;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    ServiceResult<List<Station>> primaryResult;
+    try {
+      primaryResult =
+          await _primary.searchStations(params, cancelToken: cancelToken);
+    } on Exception catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'GB statutory Fuel Finder primary failed — legacy fallback',
+      }));
+      return _fallback.searchStations(params, cancelToken: cancelToken);
+    }
+    if (primaryResult.data.isEmpty) {
+      // Whole-radius empty from the statutory dataset: cross-check against
+      // the legacy fan-out so a broken/empty feed can't fake a fuel desert.
+      // If the fan-out itself fails, the primary's honest empty stands.
+      try {
+        return await _fallback.searchStations(params,
+            cancelToken: cancelToken);
+      } on Exception catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+          'where': 'GB legacy fallback failed after empty statutory result',
+        }));
+        return primaryResult;
+      }
+    }
+    return primaryResult;
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      _primary.getStationDetail(stationId);
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      _primary.getPrices(ids);
+}

--- a/test/docs/new_country_guide_test.dart
+++ b/test/docs/new_country_guide_test.dart
@@ -142,6 +142,17 @@ void main() {
             File('lib/core/services/country_raw_service_builder.dart');
         final builderContent =
             builderFile.existsSync() ? builderFile.readAsStringSync() : '';
+        // #3190 — countries whose composition moved feature-side behind a
+        // builder (the #3132 boundary pattern: the core raw builder imports
+        // ONE feature builder instead of N service files). A service imported
+        // by any features/station_services/**/*_service_builder.dart whose
+        // builder is itself wired in the core raw builder counts as wired.
+        final featureBuilderContent = featuresDir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.endsWith('_service_builder.dart'))
+            .map((f) => f.readAsStringSync())
+            .join('\n');
 
         final serviceFiles = featuresDir
             .listSync(recursive: true)
@@ -158,11 +169,13 @@ void main() {
           expect(
             serviceProviders.contains(fileName) ||
                 registryContent.contains(fileName) ||
-                builderContent.contains(fileName),
+                builderContent.contains(fileName) ||
+                featureBuilderContent.contains(fileName),
             isTrue,
             reason:
-                'service_providers.dart, country_service_registry.dart, or '
-                'country_raw_service_builder.dart must import $fileName',
+                'service_providers.dart, country_service_registry.dart, '
+                'country_raw_service_builder.dart, or a feature-side '
+                '*_service_builder.dart must import $fileName',
           );
         }
       });

--- a/test/features/route_search/data/cross_border_corridor_extent_test.dart
+++ b/test/features/route_search/data/cross_border_corridor_extent_test.dart
@@ -26,6 +26,11 @@ class _NoKeyStorage implements StorageRepository {
   @override
   bool hasApiKey() => false;
 
+  // #3190 — the GB registry case now reads the packed Fuel Finder
+  // credentials from the same slot; keyless here = legacy GB behaviour.
+  @override
+  String? getApiKey() => null;
+
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       super.noSuchMethod(invocation);

--- a/test/features/station_services/uk/uk_fuel_finder_auth_test.dart
+++ b/test/features/station_services/uk/uk_fuel_finder_auth_test.dart
@@ -10,9 +10,11 @@ import 'package:tankstellen/features/station_services/uk/uk_fuel_finder_auth.dar
 
 /// #3190 — the statutory Fuel Finder API is fronted by OAuth 2.0 client
 /// credentials. These pin the token flow against a mock transport (no live
-/// endpoint): the POST shape (RFC 6749 §4.4), caching until expiry, expiry
-/// re-fetch, [UkFuelFinderAuth.invalidate] re-fetch, and the malformed-response
-/// guards.
+/// endpoint): the POST shape (the live contract — a JSON body with
+/// `client_id` + `client_secret`, NOT the RFC 6749 form exchange), the
+/// `{data:{access_token,…}}` response envelope, caching until expiry, expiry
+/// re-fetch, [UkFuelFinderAuth.invalidate] re-fetch, the packed-credentials
+/// parser, and the malformed-response guards.
 
 /// Captures every request and serves a programmable queue of JSON bodies.
 class _CapturingAdapter implements HttpClientAdapter {
@@ -61,10 +63,11 @@ Dio _dio(_CapturingAdapter adapter) {
 }
 
 void main() {
-  const tokenUrl = 'https://developer.fuel-finder.service.gov.uk/oauth/token';
+  const tokenUrl = 'https://test.fuel-finder.example/oauth/token';
 
   group('UkFuelFinderAuth — client-credentials token flow (#3190)', () {
-    test('POSTs grant_type=client_credentials with the client id + secret', () async {
+    test('POSTs the JSON credential body of the live token contract',
+        () async {
       final adapter = _CapturingAdapter([
         (200, {'access_token': 'tok-1', 'token_type': 'Bearer', 'expires_in': 3600}),
       ]);
@@ -73,7 +76,6 @@ void main() {
         tokenUrl: tokenUrl,
         clientId: 'client-abc',
         clientSecret: 'secret-xyz',
-        scope: 'fuel-prices:read',
       );
 
       final token = await auth.accessToken();
@@ -81,11 +83,68 @@ void main() {
       expect(token, 'tok-1');
       expect(adapter.requests.single.path, tokenUrl);
       expect(adapter.requests.single.method, 'POST');
-      final body = adapter.requestBodies.single;
-      expect(body, contains('grant_type=client_credentials'));
-      expect(body, contains('client_id=client-abc'));
-      expect(body, contains('client_secret=secret-xyz'));
-      expect(body, contains('scope=fuel-prices'));
+      expect(adapter.requests.single.headers[Headers.contentTypeHeader],
+          contains('application/json'));
+      final body = jsonDecode(adapter.requestBodies.single);
+      expect(body, {
+        'client_id': 'client-abc',
+        'client_secret': 'secret-xyz',
+      });
+    });
+
+    test('defaults to the statutory generate_access_token endpoint', () {
+      expect(
+        UkFuelFinderAuth.defaultTokenUrl,
+        'https://www.fuel-finder.service.gov.uk'
+        '/api/v1/oauth/generate_access_token',
+      );
+      final auth = UkFuelFinderAuth(
+        dio: Dio(),
+        clientId: 'c',
+        clientSecret: 's',
+      );
+      expect(auth.tokenUrl, UkFuelFinderAuth.defaultTokenUrl);
+    });
+
+    test('unwraps the live {data:{access_token,expires_in}} envelope',
+        () async {
+      final adapter = _CapturingAdapter([
+        (200, {
+          'data': {'access_token': 'tok-enveloped', 'expires_in': 3600},
+        }),
+      ]);
+      final auth = UkFuelFinderAuth(
+        dio: _dio(adapter),
+        tokenUrl: tokenUrl,
+        clientId: 'c',
+        clientSecret: 's',
+      );
+
+      expect(await auth.accessToken(), 'tok-enveloped');
+    });
+
+    test('fromPackedCredentials parses the Settings key slot', () {
+      final auth = UkFuelFinderAuth.fromPackedCredentials(
+        'client-abc:secret-with:colon',
+        dio: Dio(),
+      );
+      expect(auth, isNotNull);
+      expect(auth!.clientId, 'client-abc');
+      // Everything past the FIRST separator is the secret.
+      expect(auth.clientSecret, 'secret-with:colon');
+      expect(auth.tokenUrl, UkFuelFinderAuth.defaultTokenUrl);
+
+      // Non-credential key shapes (e.g. a Tankerkönig key in the shared
+      // slot) must not produce a GB auth.
+      expect(UkFuelFinderAuth.fromPackedCredentials(null, dio: Dio()), isNull);
+      expect(UkFuelFinderAuth.fromPackedCredentials('', dio: Dio()), isNull);
+      expect(
+          UkFuelFinderAuth.fromPackedCredentials('no-separator', dio: Dio()),
+          isNull);
+      expect(UkFuelFinderAuth.fromPackedCredentials(':secret', dio: Dio()),
+          isNull);
+      expect(UkFuelFinderAuth.fromPackedCredentials('id:', dio: Dio()),
+          isNull);
     });
 
     test('caches the token — a second call within expiry does NOT re-POST',

--- a/test/features/station_services/uk/uk_fuel_finder_feed_test.dart
+++ b/test/features/station_services/uk/uk_fuel_finder_feed_test.dart
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/search_params.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/station_services/uk/uk_cma_bulk_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_fuel_finder_auth.dart';
+import 'package:tankstellen/features/station_services/uk/uk_fuel_finder_feed.dart';
+import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
+
+/// #3190 — the statutory Fuel Finder feed (token → paged `/api/v1/pfs` +
+/// `/api/v1/pfs/fuel-prices` → CMA-shaped merge → shared parseCmaStations).
+///
+/// Fixture provenance: `test/fixtures/uk_fuel_finder_pfs_slice.json` and
+/// `uk_fuel_finder_pfs_prices_slice.json` are **contract-derived**, NOT live
+/// recordings — the statutory API requires registered OAuth2 credentials that
+/// this repo does not (and must not) hold, so a live capture is impossible
+/// here. Field names, envelope shape, grade codes and pence-per-litre pricing
+/// were cross-checked against the GOV.UK developer-portal documentation and a
+/// working open-source consumer of the live API (2026-07-03). The first live
+/// credentialed run must replace these with trimmed real recordings — see the
+/// #3190 closing notes.
+dynamic _fixture(String name) => jsonDecode(
+      File('test/fixtures/$name').readAsStringSync(),
+    );
+
+/// Serves the token endpoint plus per-path batch queues, capturing every
+/// request (URL, headers, body) for shape assertions.
+class _FuelFinderAdapter implements HttpClientAdapter {
+  _FuelFinderAdapter({
+    required this.pfsBatches,
+    required this.priceBatches,
+    this.failFirstDataRequestWith = 0,
+  });
+
+  /// Batch bodies (JSON-encodable) served in order per resource path;
+  /// requests past the queue answer 404 (the documented end-of-pages).
+  final List<dynamic> pfsBatches;
+  final List<dynamic> priceBatches;
+
+  /// When non-zero, the first data GET fails with this HTTP status once.
+  final int failFirstDataRequestWith;
+  bool _dataFailed = false;
+
+  int tokenRequests = 0;
+  final List<String> tokenBodies = [];
+  final List<Uri> dataRequests = [];
+  final List<String?> dataAuthHeaders = [];
+
+  ResponseBody _json(dynamic body, [int status = 200]) =>
+      ResponseBody.fromString(jsonEncode(body), status, headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      });
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.path.contains('/oauth/')) {
+      tokenRequests++;
+      if (requestStream != null) {
+        final chunks = await requestStream.toList();
+        tokenBodies.add(utf8.decode(chunks.expand((c) => c).toList()));
+      } else {
+        tokenBodies.add(options.data == null ? '' : jsonEncode(options.data));
+      }
+      return _json({
+        'data': {'access_token': 'tok-$tokenRequests', 'expires_in': 3600},
+      });
+    }
+
+    dataRequests.add(options.uri);
+    dataAuthHeaders.add(options.headers['Authorization']?.toString());
+    if (failFirstDataRequestWith != 0 && !_dataFailed) {
+      _dataFailed = true;
+      return _json({'message': 'forced failure'}, failFirstDataRequestWith);
+    }
+
+    final isPrices = options.path.endsWith(UkFuelFinderFeed.pricesPath);
+    final queue = isPrices ? priceBatches : pfsBatches;
+    final batch =
+        int.tryParse(options.uri.queryParameters['batch-number'] ?? '') ?? 1;
+    if (batch > queue.length) return _json({'message': 'not found'}, 404);
+    return _json(queue[batch - 1]);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+UkFuelFinderFeed _feed(_FuelFinderAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return UkFuelFinderFeed(
+    auth: UkFuelFinderAuth(dio: dio, clientId: 'cid', clientSecret: 'csec'),
+    dio: dio,
+    baseUrl: 'https://test.fuel-finder.example',
+  );
+}
+
+const _london = SearchParams(lat: 51.5, lng: -0.13, radiusKm: 25);
+
+void main() {
+  final pfsSlice = _fixture('uk_fuel_finder_pfs_slice.json');
+  final pricesSlice = _fixture('uk_fuel_finder_pfs_prices_slice.json');
+
+  group('UkFuelFinderFeed — live-contract constants (#3190)', () {
+    test('base URL + resource paths match the statutory API', () {
+      expect(UkFuelFinderFeed.defaultBaseUrl,
+          'https://www.fuel-finder.service.gov.uk');
+      expect(UkFuelFinderFeed.pfsPath, '/api/v1/pfs');
+      expect(UkFuelFinderFeed.pricesPath, '/api/v1/pfs/fuel-prices');
+      expect(UkFuelFinderAuth.defaultTokenUrl,
+          'https://www.fuel-finder.service.gov.uk'
+          '/api/v1/oauth/generate_access_token');
+    });
+
+    test('bulk service default consolidated URL targets the statutory host',
+        () {
+      expect(UkCmaBulkStationService.defaultConsolidatedUrl,
+          startsWith('https://www.fuel-finder.service.gov.uk/'));
+    });
+  });
+
+  group('record extraction (envelope tolerance)', () {
+    test('reads the {data:{<list>}} envelope of both fixtures', () {
+      expect(UkFuelFinderFeed.extractRecords(pfsSlice), hasLength(3));
+      expect(UkFuelFinderFeed.extractRecords(pricesSlice), hasLength(3));
+    });
+
+    test('reads a bare top-level list and an un-enveloped map', () {
+      expect(
+        UkFuelFinderFeed.extractRecords([
+          {'node_id': 'x'},
+        ]),
+        hasLength(1),
+      );
+      expect(
+        UkFuelFinderFeed.extractRecords({
+          'stations': [
+            {'node_id': 'x'},
+          ],
+        }),
+        hasLength(1),
+      );
+      expect(UkFuelFinderFeed.extractRecords('nonsense'), isEmpty);
+    });
+
+    test('reads the total-batches hint from the envelope', () {
+      expect(UkFuelFinderFeed.extractTotalBatches(pfsSlice), 1);
+      expect(UkFuelFinderFeed.extractTotalBatches({'total_batches': 7}), 7);
+      expect(UkFuelFinderFeed.extractTotalBatches(const <Map<String, dynamic>>[]), isNull);
+    });
+  });
+
+  group('mergeToCmaRecords (fixture-driven adaptation)', () {
+    test('adapts info+prices into CMA-shaped records the shared parser reads',
+        () {
+      final records = UkFuelFinderFeed.mergeToCmaRecords(
+        UkFuelFinderFeed.extractRecords(pfsSlice),
+        UkFuelFinderFeed.extractRecords(pricesSlice),
+      );
+
+      expect(records, hasLength(3));
+      final victoria =
+          records.singleWhere((r) => r['site_id'] == 'PFS-100001');
+      expect(victoria['brand'], 'Applegreen');
+      expect(victoria['site_name'], 'APPLEGREEN LONDON VICTORIA');
+      expect(victoria['address'], '123 Victoria Street');
+      expect(victoria['postcode'], 'SW1E 6DE');
+      expect(victoria['town'], 'London');
+      expect((victoria['location'] as Map)['latitude'], 51.4966);
+      final prices = victoria['prices'] as Map<String, dynamic>;
+      // Grade mapping: E10→E10, E5→E5, B7_STANDARD→B7, B7_PREMIUM→SDV.
+      expect(prices, {
+        'E10': 141.9,
+        'E5': 154.9,
+        'B7': 148.9,
+        'SDV': 162.9,
+      });
+
+      // Two-line address joins street parts only (city/postcode have their
+      // own CMA fields).
+      final kensington =
+          records.singleWhere((r) => r['site_id'] == 'PFS-100002');
+      expect(kensington['address'], '22a Warwick Road, Kensington');
+    });
+
+    test('end-to-end: merged records flow through parseCmaStations with '
+        'pence→pounds conversion and radius filtering', () {
+      final records = UkFuelFinderFeed.mergeToCmaRecords(
+        UkFuelFinderFeed.extractRecords(pfsSlice),
+        UkFuelFinderFeed.extractRecords(pricesSlice),
+      );
+      final stations = UkStationService.parseCmaStations(
+        records,
+        lat: _london.lat,
+        lng: _london.lng,
+        radiusKm: _london.radiusKm,
+      );
+
+      // Edinburgh (PFS-200001) is outside the 25 km London radius.
+      expect(stations.map((s) => s.id),
+          unorderedEquals(['uk-PFS-100001', 'uk-PFS-100002']));
+      final victoria = stations.singleWhere((s) => s.id == 'uk-PFS-100001');
+      expect(victoria.e10, closeTo(1.419, 1e-9));
+      expect(victoria.e5, closeTo(1.549, 1e-9));
+      expect(victoria.diesel, closeTo(1.489, 1e-9));
+      expect(victoria.dieselPremium, closeTo(1.629, 1e-9));
+      expect(victoria.brand, 'Applegreen');
+    });
+
+    test('a price row without a matching info row is dropped (no coordinates)',
+        () {
+      final records = UkFuelFinderFeed.mergeToCmaRecords(
+        const [],
+        UkFuelFinderFeed.extractRecords(pricesSlice),
+      );
+      expect(records, isEmpty);
+    });
+
+    test('grade mapping covers both diesel aliases and rejects unknowns', () {
+      expect(UkFuelFinderFeed.cmaGradeFor('B7'), 'B7');
+      expect(UkFuelFinderFeed.cmaGradeFor('B7_STANDARD'), 'B7');
+      expect(UkFuelFinderFeed.cmaGradeFor('SDV'), 'SDV');
+      expect(UkFuelFinderFeed.cmaGradeFor('B7_PREMIUM'), 'SDV');
+      expect(UkFuelFinderFeed.cmaGradeFor('LPG'), isNull);
+      expect(UkFuelFinderFeed.cmaGradeFor(null), isNull);
+    });
+  });
+
+  group('download (auth + paging + retry)', () {
+    test('fetches ONE token, pages both resources with batch-number, and '
+        'sends the Bearer on every data GET', () async {
+      final adapter = _FuelFinderAdapter(
+        // Two pfs batches (no total hint on the second shape) + one prices
+        // batch; paging must stop on the 404 past the last pfs batch.
+        pfsBatches: [
+          {
+            'data': {
+              'pfs': UkFuelFinderFeed.extractRecords(pfsSlice).sublist(0, 2),
+            },
+          },
+          {
+            'data': {
+              'pfs': UkFuelFinderFeed.extractRecords(pfsSlice).sublist(2),
+            },
+          },
+        ],
+        priceBatches: [pricesSlice],
+      );
+
+      final records = await _feed(adapter).downloadCmaShapedRecords();
+
+      expect(records, hasLength(3));
+      expect(adapter.tokenRequests, 1);
+      // 2 pfs batches + the end-of-pages 404 probe + 1 prices batch
+      // (total_batches:1 hint stops the prices paging without a probe).
+      expect(adapter.dataRequests, hasLength(4));
+      expect(
+        adapter.dataRequests.map((u) => u.queryParameters['batch-number']),
+        ['1', '2', '3', '1'],
+      );
+      expect(adapter.dataAuthHeaders, everyElement('Bearer tok-1'));
+      // Token POST carries the JSON credential body of the live contract.
+      expect(adapter.tokenBodies.single, contains('"client_id":"cid"'));
+      expect(adapter.tokenBodies.single, contains('"client_secret":"csec"'));
+      expect(adapter.tokenBodies.single, isNot(contains('grant_type')));
+    });
+
+    test('honours the total_batches hint (no trailing 404 probe)', () async {
+      final adapter = _FuelFinderAdapter(
+        pfsBatches: [pfsSlice],
+        priceBatches: [pricesSlice],
+      );
+
+      await _feed(adapter).downloadCmaShapedRecords();
+
+      expect(
+        adapter.dataRequests.map((u) => u.queryParameters['batch-number']),
+        ['1', '1'],
+      );
+    });
+
+    test('a 401 invalidates the token and retries the download once',
+        () async {
+      final adapter = _FuelFinderAdapter(
+        pfsBatches: [pfsSlice],
+        priceBatches: [pricesSlice],
+        failFirstDataRequestWith: 401,
+      );
+
+      final records = await _feed(adapter).downloadCmaShapedRecords();
+
+      expect(records, hasLength(3));
+      expect(adapter.tokenRequests, 2, reason: 'fresh token after the 401');
+      expect(adapter.dataAuthHeaders.first, 'Bearer tok-1');
+      expect(adapter.dataAuthHeaders.last, 'Bearer tok-2');
+    });
+  });
+
+  group('UkCmaBulkStationService in feed mode', () {
+    test('searchStations answers from the statutory feed via the shared '
+        'parser', () async {
+      final adapter = _FuelFinderAdapter(
+        pfsBatches: [pfsSlice],
+        priceBatches: [pricesSlice],
+      );
+      final service = UkCmaBulkStationService(feed: _feed(adapter));
+
+      final result = await service.searchStations(_london);
+
+      expect(result.source, ServiceSource.ukApi);
+      expect(result.data.map((s) => s.id),
+          unorderedEquals(['uk-PFS-100001', 'uk-PFS-100002']));
+    });
+
+    test('downloads the dataset ONCE then serves later searches locally',
+        () async {
+      final adapter = _FuelFinderAdapter(
+        pfsBatches: [pfsSlice],
+        priceBatches: [pricesSlice],
+      );
+      final service = UkCmaBulkStationService(feed: _feed(adapter));
+
+      await service.searchStations(_london);
+      await service.searchStations(
+        const SearchParams(lat: 55.95, lng: -3.19, radiusKm: 25),
+      );
+
+      expect(adapter.dataRequests, hasLength(2),
+          reason: 'one pfs + one prices download serves every search');
+      expect(adapter.tokenRequests, 1);
+    });
+  });
+}

--- a/test/features/station_services/uk/uk_service_builder_test.dart
+++ b/test/features/station_services/uk/uk_service_builder_test.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/station_services/uk/uk_service_builder.dart';
+import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_statutory_fallback_station_service.dart';
+
+/// #3190 — GB service selection: registered Fuel Finder credentials route GB
+/// through the statutory bulk primary (legacy fan-out as fallback); anything
+/// else keeps the pre-#3190 keyless behaviour.
+
+/// Minimal in-memory [CacheStrategy] (no Hive).
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> entries = {};
+
+  @override
+  Future<void> put(
+    String key,
+    Map<String, dynamic> data, {
+    required Duration ttl,
+    required ServiceSource source,
+  }) async {
+    entries[key] = CacheEntry(
+      payload: data,
+      storedAt: DateTime.now(),
+      originalSource: source,
+      ttl: ttl,
+    );
+  }
+
+  @override
+  CacheEntry? get(String key) => entries[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final e = entries[key];
+    if (e == null || e.isExpired) return null;
+    return e;
+  }
+}
+
+void main() {
+  group('buildGbStationService (#3190)', () {
+    test('packed client_id:client_secret → statutory primary with legacy '
+        'fallback', () {
+      final service = buildGbStationService(
+        apiKey: 'client-abc:secret-xyz',
+        cache: _MemCache(),
+      );
+      expect(service, isA<UkStatutoryFallbackStationService>());
+    });
+
+    test('no key → legacy retailer fan-out (pre-#3190 behaviour)', () {
+      final service = buildGbStationService(
+        apiKey: null,
+        cache: _MemCache(),
+      );
+      expect(service, isA<UkStationService>());
+    });
+
+    test('a non-credential key (e.g. a Tankerkönig key in the shared slot) '
+        'stays on the legacy fan-out', () {
+      final service = buildGbStationService(
+        apiKey: '00000000-0000-0000-0000-000000000002',
+        cache: _MemCache(),
+      );
+      expect(service, isA<UkStationService>());
+    });
+  });
+}

--- a/test/features/station_services/uk/uk_statutory_fallback_station_service_test.dart
+++ b/test/features/station_services/uk/uk_statutory_fallback_station_service_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/search_params.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_statutory_fallback_station_service.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3190 — GB primary/fallback composition: statutory Fuel Finder PRIMARY,
+/// legacy retailer fan-out demoted to fallback (fires on primary failure or
+/// an empty primary result).
+
+Station _station(String id) => Station(
+      id: id,
+      name: 'S $id',
+      brand: 'BP',
+      street: '',
+      postCode: '',
+      place: '',
+      lat: 51.5,
+      lng: -0.12,
+      dist: 1.0,
+    );
+
+ServiceResult<List<Station>> _result(List<Station> stations) => ServiceResult(
+      data: stations,
+      source: ServiceSource.ukApi,
+      fetchedAt: DateTime.now(),
+    );
+
+class _StubService implements StationService {
+  _StubService({this.stations, this.error});
+
+  final List<Station>? stations;
+  final Exception? error;
+  int searchCalls = 0;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    searchCalls++;
+    final e = error;
+    if (e != null) throw e;
+    return _result(stations ?? const []);
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) =>
+      throw UnimplementedError();
+}
+
+const _params = SearchParams(lat: 51.5, lng: -0.12, radiusKm: 10);
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('UkStatutoryFallbackStationService (#3190)', () {
+    test('a healthy statutory primary answers — the legacy fan-out is NOT '
+        'touched', () async {
+      final primary = _StubService(stations: [_station('uk-p1')]);
+      final fallback = _StubService(stations: [_station('uk-legacy')]);
+      final service = UkStatutoryFallbackStationService(
+          primary: primary, fallback: fallback);
+
+      final result = await service.searchStations(_params);
+
+      expect(result.data.single.id, 'uk-p1');
+      expect(fallback.searchCalls, 0);
+    });
+
+    test('primary failure falls back to the legacy fan-out', () async {
+      final primary =
+          _StubService(error: const ApiException(message: 'feed down'));
+      final fallback = _StubService(stations: [_station('uk-legacy')]);
+      final service = UkStatutoryFallbackStationService(
+          primary: primary, fallback: fallback);
+
+      final result = await service.searchStations(_params);
+
+      expect(result.data.single.id, 'uk-legacy');
+      expect(primary.searchCalls, 1);
+    });
+
+    test('an EMPTY primary result cross-checks the legacy fan-out', () async {
+      final primary = _StubService(stations: const []);
+      final fallback = _StubService(stations: [_station('uk-legacy')]);
+      final service = UkStatutoryFallbackStationService(
+          primary: primary, fallback: fallback);
+
+      final result = await service.searchStations(_params);
+
+      expect(result.data.single.id, 'uk-legacy');
+      expect(fallback.searchCalls, 1);
+    });
+
+    test('empty primary + failing fallback → the honest empty stands',
+        () async {
+      final primary = _StubService(stations: const []);
+      final fallback =
+          _StubService(error: const ApiException(message: 'all feeds dead'));
+      final service = UkStatutoryFallbackStationService(
+          primary: primary, fallback: fallback);
+
+      final result = await service.searchStations(_params);
+
+      expect(result.data, isEmpty);
+    });
+
+    test('both paths failing rethrows the fallback error', () async {
+      final primary =
+          _StubService(error: const ApiException(message: 'feed down'));
+      final fallback =
+          _StubService(error: const ApiException(message: 'all feeds dead'));
+      final service = UkStatutoryFallbackStationService(
+          primary: primary, fallback: fallback);
+
+      expect(
+        () => service.searchStations(_params),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}

--- a/test/fixtures/uk_fuel_finder_pfs_prices_slice.json
+++ b/test/fixtures/uk_fuel_finder_pfs_prices_slice.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "total_batches": 1,
+    "fuel_prices": [
+      {
+        "node_id": "PFS-100001",
+        "fuel_prices": [
+          {
+            "fuel_type": "E10",
+            "price": 141.9,
+            "price_last_updated": "2026-07-01 08:30:00",
+            "price_change_effective_timestamp": "2026-07-01T08:00:00Z"
+          },
+          {
+            "fuel_type": "E5",
+            "price": 154.9,
+            "price_last_updated": "2026-07-01 08:30:00",
+            "price_change_effective_timestamp": "2026-07-01T08:00:00Z"
+          },
+          {
+            "fuel_type": "B7_STANDARD",
+            "price": 148.9,
+            "price_last_updated": "2026-07-01 08:30:00",
+            "price_change_effective_timestamp": "2026-07-01T08:00:00Z"
+          },
+          {
+            "fuel_type": "B7_PREMIUM",
+            "price": 162.9,
+            "price_last_updated": "2026-07-01 08:30:00",
+            "price_change_effective_timestamp": "2026-07-01T08:00:00Z"
+          }
+        ]
+      },
+      {
+        "node_id": "PFS-100002",
+        "fuel_prices": [
+          {
+            "fuel_type": "E10",
+            "price": 139.9,
+            "price_last_updated": "2026-07-01 06:05:00",
+            "price_change_effective_timestamp": "2026-07-01T06:00:00Z"
+          },
+          {
+            "fuel_type": "B7_STANDARD",
+            "price": 146.9,
+            "price_last_updated": "2026-07-01 06:05:00",
+            "price_change_effective_timestamp": "2026-07-01T06:00:00Z"
+          }
+        ]
+      },
+      {
+        "node_id": "PFS-200001",
+        "fuel_prices": [
+          {
+            "fuel_type": "E10",
+            "price": 143.9,
+            "price_last_updated": "2026-06-30 18:40:00",
+            "price_change_effective_timestamp": "2026-06-30T18:30:00Z"
+          },
+          {
+            "fuel_type": "E5",
+            "price": 156.9,
+            "price_last_updated": "2026-06-30 18:40:00",
+            "price_change_effective_timestamp": "2026-06-30T18:30:00Z"
+          },
+          {
+            "fuel_type": "B7_STANDARD",
+            "price": 150.9,
+            "price_last_updated": "2026-06-30 18:40:00",
+            "price_change_effective_timestamp": "2026-06-30T18:30:00Z"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/uk_fuel_finder_pfs_slice.json
+++ b/test/fixtures/uk_fuel_finder_pfs_slice.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "total_batches": 1,
+    "pfs": [
+      {
+        "node_id": "PFS-100001",
+        "trading_name": "APPLEGREEN LONDON VICTORIA",
+        "brand_name": "Applegreen",
+        "location": {
+          "address_line_1": "123 Victoria Street",
+          "address_line_2": "",
+          "city": "London",
+          "county": "Greater London",
+          "country": "England",
+          "postcode": "SW1E 6DE",
+          "latitude": 51.4966,
+          "longitude": -0.1348
+        },
+        "fuel_types": ["E10", "E5", "B7_STANDARD", "B7_PREMIUM"],
+        "amenities": ["CAR_WASH", "SHOP"],
+        "opening_times": {}
+      },
+      {
+        "node_id": "PFS-100002",
+        "trading_name": "TESCO KENSINGTON EXPRESS",
+        "brand_name": "Tesco",
+        "location": {
+          "address_line_1": "22a Warwick Road",
+          "address_line_2": "Kensington",
+          "city": "London",
+          "county": "Greater London",
+          "country": "England",
+          "postcode": "W14 8LP",
+          "latitude": 51.4901,
+          "longitude": -0.1963
+        },
+        "fuel_types": ["E10", "B7_STANDARD"],
+        "amenities": ["SHOP"],
+        "opening_times": {}
+      },
+      {
+        "node_id": "PFS-200001",
+        "trading_name": "BP EDINBURGH WESTFIELD",
+        "brand_name": "BP",
+        "location": {
+          "address_line_1": "1 Westfield Road",
+          "address_line_2": "",
+          "city": "Edinburgh",
+          "county": "City of Edinburgh",
+          "country": "Scotland",
+          "postcode": "EH11 2QW",
+          "latitude": 55.9366,
+          "longitude": -3.2415
+        },
+        "fuel_types": ["E10", "E5", "B7_STANDARD"],
+        "amenities": [],
+        "opening_times": {}
+      }
+    ]
+  }
+}

--- a/test/lint/feature_boundary_test.dart
+++ b/test/lint/feature_boundary_test.dart
@@ -394,6 +394,9 @@ const _featurePairBaseline = <String, int>{
 // (the journal/trigger/telemetry seams remain), price_history and widget
 // hit ZERO. #3137 — the obd2 extraction added no core→obd2 edge (the
 // event-channel guard lives in core/utils since #3134).
+// #3190 — station_services 19→18: the GB composition moved feature-side
+// (uk_service_builder.dart), collapsing the builder's two UK imports into
+// one seam.
 const _coreImportBaseline = <String, int>{
   'alerts': 3,
   'consumption': 6,
@@ -402,7 +405,7 @@ const _coreImportBaseline = <String, int>{
   'map': 1,
   'profile': 4,
   'search': 2,
-  'station_services': 19,
+  'station_services': 18,
 };
 
 /// Post-#3133 measurement (2026-06-11): `lib/features/` files importing

--- a/test/tool/endpoint_canary_targets_test.dart
+++ b/test/tool/endpoint_canary_targets_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_services/romania/romania_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
+
+import '../../tool/endpoint_canary.dart';
+
+/// #3457 — canary-vs-service endpoint drift guards.
+///
+/// The canary tool declares its probe URLs by hand (it cannot import the
+/// Flutter-importing service classes), so nothing structural stopped the RO
+/// probe from still pointing at the dead third-party `pretcarburant.ro` long
+/// after #3193 rebased the service onto the official
+/// `monitorulpreturilor.info` observatory — the weekly canary then reported a
+/// bogus RO outage (#3409 run of 2026-06-29). These tests import BOTH sides
+/// and fail on drift, so a service endpoint change without the matching
+/// canary update can no longer ship.
+void main() {
+  CanaryTarget targetFor(String country) =>
+      targets.singleWhere((t) => t.country == country);
+
+  group('endpoint canary ↔ service endpoint drift (#3457)', () {
+    test('RO probe mirrors RomaniaStationService.defaultBaseUrl + searchPath',
+        () {
+      final ro = targetFor('RO');
+      expect(ro.skip, isNull, reason: 'RO has a live keyless endpoint');
+      expect(
+        ro.url,
+        startsWith(
+          '${RomaniaStationService.defaultBaseUrl}'
+          '${RomaniaStationService.searchPath}',
+        ),
+      );
+      // The observatory quirks (see the service docs): exactly ONE catalog
+      // product id per request, and JSON only via content negotiation.
+      expect(ro.url, contains('CSVGasCatalogProductIds=11'));
+      expect(ro.headers['Accept'], 'application/json');
+      expect(ro.bodyMarker, '"Stations"');
+    });
+
+    test('no probe references the dead third-party pretcarburant.ro', () {
+      for (final t in targets) {
+        expect(t.url ?? '', isNot(contains('pretcarburant')),
+            reason: '${t.country} probe must not target the retired '
+                'third-party mirror (#3193/#3457)');
+      }
+    });
+
+    test('GB probe is one of the shipped legacy retailer feeds', () {
+      final gb = targetFor('GB');
+      expect(
+        UkStationService.defaultCmaFeedUrls,
+        contains(gb.url),
+        reason: 'the GB sentinel must probe a feed the fallback fan-out '
+            'actually calls (#3190)',
+      );
+    });
+  });
+}

--- a/tool/endpoint_canary.dart
+++ b/tool/endpoint_canary.dart
@@ -54,6 +54,7 @@ class CanaryTarget {
     this.url,
     this.method = 'GET',
     this.bodyMarker,
+    this.headers = const {},
     this.skip,
     this.note = '',
   });
@@ -73,6 +74,10 @@ class CanaryTarget {
   /// Substring expected in the first 64 KiB of a GET body — the minimal
   /// shape check that catches a "200 but the API moved" soft-404.
   final String? bodyMarker;
+
+  /// Extra request headers, for endpoints that content-negotiate (#3457 —
+  /// the RO WCF backend serves XML unless `Accept: application/json`).
+  final Map<String, String> headers;
 
   /// Non-null → target is skipped (reported, never failed).
   final SkipReason? skip;
@@ -159,10 +164,12 @@ const List<CanaryTarget> targets = [
     url: 'https://applegreenstores.com/fuel-prices/data.json',
     bodyMarker: '"stations"',
     note: 'uk/uk_station_service.dart — probes one keyless retailer feed of '
-        'the shipped fan-out. NOTE: reachability only; the CMA scheme was '
-        'withdrawn and feeds may serve stale data. The Fuel Finder bulk '
-        'replacement (uk_cma_bulk_station_service.dart) answers 403 '
-        'without registered access, so it cannot be probed keylessly.',
+        'the legacy fan-out (now the GB fallback path, #3190). NOTE: '
+        'reachability only; the voluntary CMA scheme was withdrawn and feeds '
+        'may serve stale data. The statutory Fuel Finder primary '
+        '(www.fuel-finder.service.gov.uk/api/v1/pfs, '
+        'uk_fuel_finder_feed.dart) requires OAuth2 client credentials, so it '
+        'cannot be probed keylessly.',
   ),
   CanaryTarget(
     country: 'AU',
@@ -223,11 +230,18 @@ const List<CanaryTarget> targets = [
   ),
   CanaryTarget(
     country: 'RO',
-    name: 'Monitorul Prețurilor (pretcarburant.ro)',
-    url: 'https://pretcarburant.ro/api/stations',
-    bodyMarker: '"stations"',
-    note: 'romania/romania_station_service.dart — 404 as of 2026-06-10; '
-        'kept ACTIVE on purpose so the canary keeps tracking the outage.',
+    name: 'Monitorul Prețurilor (monitorulpreturilor.info)',
+    url: 'https://monitorulpreturilor.info/pmonsvc/Gas/GetGasItemsByLatLon'
+        '?lon=26.10&lat=44.43&buffer=5000&CSVGasCatalogProductIds=11'
+        '&OrderBy=dist',
+    headers: {'Accept': 'application/json'},
+    bodyMarker: '"Stations"',
+    note: 'romania/romania_station_service.dart — #3457: the service was '
+        'rebased onto the official Competition Council observatory in #3193, '
+        'but this probe still pointed at the dead third-party '
+        'pretcarburant.ro. Mirrors defaultBaseUrl + searchPath (Bucharest '
+        'centre, Benzină standard). The Accept header forces JSON — the WCF '
+        'backend otherwise serves XML.',
   ),
 ];
 
@@ -252,6 +266,7 @@ Future<ProbeResult> probe(CanaryTarget t, Duration timeout) async {
     final uri = Uri.parse(t.url!);
     final request = await client.openUrl(t.method, uri).timeout(timeout);
     request.followRedirects = true;
+    t.headers.forEach(request.headers.set);
     final response = await request.close().timeout(timeout);
     final status = response.statusCode;
 


### PR DESCRIPTION
## Why

#3190 was blocked on "the statutory API is unpublished" — no longer true: the Fuel Finder scheme is live (statutory data since 2026-02-02, VE3 Global aggregator, OGL v3, CMA-enforced since 2026-05-01), free after GOV.UK One Login registration. #3457: the weekly canary reported RO dead, but the service was already migrated to the official source in #3193 — only the canary still probed the dead third-party mirror.

## What

- **GB**: `UkFuelFinderFeed` — paginated `/api/v1/pfs` + `/pfs/fuel-prices` download against the live JSON-body OAuth2 token contract (verified against the GOV.UK developer portal + a working open-source consumer), rate-limited (2.1 s), 401-retried, merged into the legacy CMA record shape so `parseCmaStations` is reused unchanged. With packed `client_id:client_secret` in the per-country key slot the statutory feed is PRIMARY, the 14-retailer legacy fan-out demotes to in-service fallback; keyless installs unchanged. Registration steps documented in the auth dartdoc. Fixtures are contract-derived (labeled — live capture needs registered credentials; first credentialed run should replace them with trimmed real recordings).
- **RO**: canary probe now mirrors `RomaniaStationService.defaultBaseUrl` (with the `Accept: application/json` header the WCF backend needs) + drift-guard tests pinning canary↔service URL lockstep and banning the dead mirror.

Verification: analyze clean; station-services/tool/route-search/core-services/lint suites green (only the documented geo-blocked Argentina live-endpoint test fails from EU networks).

Closes #3190
Closes #3457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
