### PR TITLE
fix(ios-ci): sync_certs repair mode + pin macos-15 — unblock TestFlight (missing widget profile)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      sync_certs:
+        description: 'Repair mode: run write-mode match (appstore) to generate MISSING provisioning profiles into the certs repo instead of building. Use when match fails with "No matching provisioning profiles found" (e.g. a new signed target like the widget extension was added).'
+        required: false
+        type: boolean
+        default: false
   schedule:
     # 04:30 Europe/Paris is intentionally distinct from the other daily crons:
     # daily-beta.yml runs at 16:00 and daily-github-release.yml at 21:00, so the
@@ -38,7 +43,10 @@ concurrency:
 
 jobs:
   build-and-upload:
-    runs-on: macos-latest
+    # Pinned (was macos-latest): the macos-latest label migrates to macOS 26
+    # beginning 2026-06-15 (actions/runner-images#14167); pin so the Xcode /
+    # SDK selection below stays deterministic until macOS 26 is validated.
+    runs-on: macos-15
     timeout-minutes: 60
     permissions:
       # contents: write — required by the post-upload tag push (#3177) so
@@ -152,7 +160,15 @@ jobs:
           BETA_FEEDBACK_EMAIL: ${{ secrets.BETA_FEEDBACK_EMAIL || '' }}
           FASTLANE_DISABLE_COLORS: '1'
           FASTLANE_HIDE_CHANGELOG: '1'
-        run: bundle exec fastlane release_testflight build_number:"${IOS_BUILD_NUMBER}" changelog:"${TESTFLIGHT_CHANGELOG}" distribute_external:"${DISTRIBUTE}"
+        # sync_certs repair mode (#3467): generate missing appstore profiles
+        # into the match repo (needs MATCH_DEPLOY_KEY with WRITE access),
+        # then exit without building.
+        run: |
+          if [ "${{ inputs.sync_certs }}" = "true" ]; then
+            bundle exec fastlane match_sync_appstore
+          else
+            bundle exec fastlane release_testflight build_number:"${IOS_BUILD_NUMBER}" changelog:"${TESTFLIGHT_CHANGELOG}" distribute_external:"${DISTRIBUTE}"
+          fi
 
       - name: Clean up decoded API key
         if: always()

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -119,6 +119,14 @@ platform :ios do
     match(type: "appstore", api_key: key, readonly: false)
   end
 
+  desc "Repair: generate MISSING appstore provisioning profiles into the match repo."
+  desc "CI-safe (unlike match_bootstrap): appstore type only, existing certs reused,"
+  desc "no certificate generation forced. Run via the workflow's sync_certs input"
+  desc "when a new signed target (e.g. the widget extension) lacks its profile."
+  lane :match_sync_appstore do
+    match(type: "appstore", api_key: asc_api_key, readonly: false)
+  end
+
   desc "Build a signed appstore-distribution IPA. Expects match_appstore to have populated the keychain first."
   lane :build_appstore do |options|
     build_number = options[:build_number] || ENV["IOS_BUILD_NUMBER"] || Time.now.strftime("%Y%m%d")


### PR DESCRIPTION
## Why

The daily iOS TestFlight build has failed since 2026-07-02: `match` (readonly) finds **no AppStore provisioning profile for `de.tankstellen.tankstellen.TankstellenWidget`** — the widget id is in the Matchfile but write-mode match never ran after the extension target was added. The distribution certificate itself is valid (to 2027-05). The local bootstrap path is blocked on the 1Password-held `MATCH_PASSWORD`; CI is the only place the secret exists.

## What

- New `workflow_dispatch` input **`sync_certs`**: runs the new CI-safe `match_sync_appstore` lane (appstore type only, `readonly: false`, reuses existing certs, no forced cert generation) to write missing profiles into the certs repo, then exits without building. Unlike `match_bootstrap`, deliberately CI-allowed and side-effect-minimal.
- **Runner pinned `macos-latest` → `macos-15`** — the label migrates to macOS 26 from 2026-06-15 (actions/runner-images#14167); pinning keeps the documented Xcode/SDK selection deterministic until macOS 26 is validated.

Sequence after merge: dispatch once with `sync_certs=true` (writes the widget profile; requires `MATCH_DEPLOY_KEY` to have write access — if it turns out read-only, the run's error will say so and the deploy key needs a write grant), then a normal dispatch to confirm the build goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
