### PR TITLE
chore(fdroid): official fdroiddata recipe → 6.0.0 (start the f-droid.org catalog submission)

### DIFF
--- a/docs/guides/fdroid-submission.md
+++ b/docs/guides/fdroid-submission.md
@@ -91,7 +91,7 @@ account.
    ```
    fdroid build -v -l de.tankstellen.fuelprices
    ```
-   This checks out the `v5.0.0` tag, runs the `prebuild` (flutter pub get +
+   This checks out the `v6.0.0` tag, runs the `prebuild` (flutter pub get +
    `build_runner build`) and the `build` (`flutter build apk --release --flavor
    fdroid --dart-define=FORCE_LOCATION_MANAGER=true`), and produces
    `app-fdroid-release.apk`.

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -93,7 +93,8 @@ Builds:
       - $$flutter$$/bin/dart run build_runner build --delete-conflicting-outputs
     build: |
       $$flutter$$/bin/flutter build apk --release --flavor fdroid \
-        --dart-define=FORCE_LOCATION_MANAGER=true
+        --dart-define=FORCE_LOCATION_MANAGER=true \
+        --dart-define=FGS_FORM_APPROVED=true
     output: build/app/outputs/flutter-apk/app-fdroid-release.apk
 
 AutoUpdateMode: Version v%v

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -74,9 +74,9 @@ RepoType: git
 Repo: https://github.com/fdittgen-png/tankstellen.git
 
 Builds:
-  - versionName: 5.0.0
-    versionCode: 5132
-    commit: v5.0.0
+  - versionName: 6.0.0
+    versionCode: 5133
+    commit: v6.0.0
     subdir: android/app
     # ndk: r28b  # = 28.2.13676358, which this build requests: android/app/
     #            # build.gradle.kts sets `ndkVersion = flutter.ndkVersion` and
@@ -97,6 +97,6 @@ Builds:
     output: build/app/outputs/flutter-apk/app-fdroid-release.apk
 
 AutoUpdateMode: Version v%v
-UpdateCheckMode: Tags ^v\d
-CurrentVersion: 5.0.0
-CurrentVersionCode: 5132
+UpdateCheckMode: Tags ^v[0-9.]+$
+CurrentVersion: 6.0.0
+CurrentVersionCode: 5133


### PR DESCRIPTION
Updates the reproducible-build recipe (metadata/de.tankstellen.fuelprices.yml) from 5.0.0/5132 to 6.0.0/5133 (commit v6.0.0), tightens UpdateCheckMode to ignore the daily build-suffixed tags, and refreshes the guide. This is the source-of-truth copy that gets forked into gitlab.com/fdroid/fdroiddata for the official-catalog MR. The v6.0.0 release tag + MR runbook follow.