### PR TITLE
fix(fdroid): build an unsigned release APK for the fdroid flavor (#3471)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -189,10 +189,25 @@ android {
             } else {
                 val taskNames = gradle.startParameter.taskNames
                     .map { it.lowercase() }
-                val isReleaseRequested = taskNames.any { name ->
+                val releaseTasks = taskNames.filter { name ->
                     name.contains("release") && !name.contains("debug")
                 }
-                if (isReleaseRequested) {
+                val isReleaseRequested = releaseTasks.isNotEmpty()
+                // #3471 — the F-Droid buildserver builds the GMS-free `fdroid`
+                // flavor from source with NO keystore and re-signs the
+                // resulting APK with its OWN key. So for an fdroid-ONLY release
+                // an UNSIGNED release APK (signingConfig = null) is the correct,
+                // expected output — F-Droid supplies the signature downstream.
+                // This is deliberately NOT the debug-key fallback that #48
+                // outlawed: the debug config is never referenced, and the throw
+                // below still fires for every non-fdroid release (Play/upload
+                // builds, whose in-place upgrades REQUIRE the real upload
+                // key). Guard on `all` so a mixed `assembleFdroidRelease
+                // assemblePlayRelease` invocation without a keystore still
+                // throws rather than shipping an unsigned Play artefact.
+                val isFdroidOnlyRelease =
+                    isReleaseRequested && releaseTasks.all { it.contains("fdroid") }
+                if (isReleaseRequested && !isFdroidOnlyRelease) {
                     throw GradleException(
                         "No release signing configuration available. " +
                             "Set ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD / " +
@@ -201,13 +216,12 @@ android {
                             "Release builds never fall back to the debug key — see #48."
                     )
                 }
-                // Debug-only builds (e.g. `assemblePlayDebug`) don't need
-                // a release signing config. Leaving this null lets the
-                // configuration phase complete; any subsequent attempt to
-                // actually assemble a release variant would fail at the
-                // signing task, which is still strictly safer than
-                // silently signing with the debug key (the original #48
-                // failure mode).
+                // Two paths land here with a null signing config:
+                //   1. Debug-only builds (e.g. `assemblePlayDebug`) — Dependabot
+                //      CI runs these and legitimately can't read the keystore
+                //      secrets; leaving null lets configuration complete.
+                //   2. The fdroid-only release above — an intentionally unsigned
+                //      release APK for F-Droid to sign.
                 null
             }
         }

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -74,15 +74,10 @@ RepoType: git
 Repo: https://github.com/fdittgen-png/tankstellen.git
 
 Builds:
-  - versionName: 6.0.0
-    versionCode: 5133
-    commit: v6.0.0
+  - versionName: 6.0.1
+    versionCode: 5134
+    commit: v6.0.1
     subdir: android/app
-    # ndk: r28b  # = 28.2.13676358, which this build requests: android/app/
-    #            # build.gradle.kts sets `ndkVersion = flutter.ndkVersion` and
-    #            # Flutter 3.41.9 pins 28.2.13676358 (r28b). Uncomment + confirm
-    #            # against F-Droid's buildserver NDK list on the first MR
-    #            # `fdroid build` (it logs the version it actually provisions).
     gradle:
       - fdroid
     srclibs:
@@ -91,13 +86,16 @@ Builds:
       - $$flutter$$/bin/flutter config --no-analytics
       - $$flutter$$/bin/flutter pub get
       - $$flutter$$/bin/dart run build_runner build --delete-conflicting-outputs
+    scanignore:
+      - third_party/google_mlkit_commons
+      - third_party/google_mlkit_text_recognition
     build: |
       $$flutter$$/bin/flutter build apk --release --flavor fdroid \
         --dart-define=FORCE_LOCATION_MANAGER=true \
         --dart-define=FGS_FORM_APPROVED=true
     output: build/app/outputs/flutter-apk/app-fdroid-release.apk
 
-AutoUpdateMode: Version v%v
+AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9.]+$
-CurrentVersion: 6.0.0
-CurrentVersionCode: 5133
+CurrentVersion: 6.0.1
+CurrentVersionCode: 5134

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 17 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 6.0.0+5133
+version: 6.0.1+5134
 
 environment:
   sdk: ^3.11.3

--- a/test/app/signing_config_test.dart
+++ b/test/app/signing_config_test.dart
@@ -90,6 +90,56 @@ void main() {
     );
   });
 
+  group('F-Droid flavor builds unsigned without a keystore (#3471)', () {
+    test(
+      'an fdroid-only release is detected and NOT thrown on — F-Droid '
+      'supplies the signature, so the build must proceed unsigned',
+      () {
+        // The guard scopes the #48 throw to non-fdroid releases. The tell is
+        // the fdroid-only detection feeding an `all { it.contains("fdroid") }`
+        // check that suppresses the throw for that one path.
+        expect(
+          gradleSource,
+          contains('isFdroidOnlyRelease'),
+          reason:
+              'the fdroid flavor must be allowed to build an unsigned release '
+              'APK for F-Droid to sign — see #3471',
+        );
+        expect(
+          gradleSource,
+          contains('releaseTasks.all { it.contains("fdroid") }'),
+          reason:
+              'the unsigned path must require EVERY requested release task to '
+              'be an fdroid task, so a mixed fdroid+play invocation without a '
+              'keystore still throws rather than shipping an unsigned Play APK',
+        );
+        // Belt-and-braces: the throw must still be conditional on a
+        // non-fdroid release, never unconditional.
+        expect(
+          gradleSource,
+          contains('if (isReleaseRequested && !isFdroidOnlyRelease)'),
+          reason: 'the #48 throw must still fire for every non-fdroid release',
+        );
+      },
+    );
+
+    test(
+      'the unsigned fdroid path is NOT a debug-key fallback — the debug '
+      'signing config must never be referenced for a release build',
+      () {
+        // Re-assert the #48 invariant explicitly in the #3471 context: the fix
+        // routes fdroid releases through `null` (unsigned), never the debug key.
+        expect(
+          gradleSource,
+          isNot(contains('signingConfigs.getByName("debug")')),
+          reason:
+              'the fdroid-unsigned path must use a null signing config, not '
+              'the debug key — that was the original #48 bug',
+        );
+      },
+    );
+  });
+
   group('CI workflow writes the decoded keystore + env vars (#48)', () {
     test(
       'ci.yml has a "Decode signing keystore" step that reads three '


### PR DESCRIPTION
## Why

The official fdroiddata reproducible-build MR (!42093) now reaches gradle — source clones at the tag, the Flutter srclib resolves, `flutter pub get` + `build_runner` succeed, and the ML Kit references are correctly `scanignore`d. It then fails at `android/app/build.gradle.kts` because `assembleFdroidRelease` requests a **release** build with **no keystore** and the #48 guard throws.

F-Droid **deliberately** builds with no keystore and **re-signs the APK with its own key**. So for the `fdroid` flavor an **unsigned** release APK is the correct, expected output.

## What

- Scope the #48 signing guard: an **fdroid-only** release now emits an unsigned APK (`signingConfig = null`); every **non-fdroid** release still throws the #48 `GradleException` (Play in-place upgrades require the real upload key).
- This is **not** the debug-key fallback #48 outlawed — the debug config is never referenced. The `releaseTasks.all { fdroid }` guard keeps a mixed `assembleFdroidRelease assemblePlayRelease` invocation throwing rather than shipping an unsigned Play artefact.
- Bump to `6.0.1+5134` for a clean F-Droid release tag; sync the in-repo fdroiddata recipe reference (scanignore + `AutoUpdateMode: Version` + 6.0.1).

## Verification

Built locally with **no keystore** (F-Droid's exact path):

```
flutter build apk --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
✓ Built build/app/outputs/flutter-apk/app-fdroid-release.apk (131.4MB)
```

Output name matches the recipe's `output:` exactly (Flutter renames the raw `-unsigned.apk` on copy). All 8 `test/app/signing_config_test.dart` guards pass, including two new #3471 guards.

Closes #3471. Follow-up to #48. Unblocks the f-droid.org catalog submission.