### PR TITLE
refactor(fdroid): capability-abstraction foundation — AppFlavor + ReviewPrompter (#3473)

### DIFF
--- a/lib/core/feedback/in_app_review_service.dart
+++ b/lib/core/feedback/in_app_review_service.dart
@@ -3,12 +3,12 @@
 
 import 'dart:async';
 
-import 'package:in_app_review/in_app_review.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../logging/error_logger.dart';
 import '../storage/storage_keys.dart';
 import '../storage/storage_providers.dart';
+import 'review_prompter.dart';
 
 part 'in_app_review_service.g.dart';
 
@@ -33,32 +33,27 @@ const Duration kInAppReviewMinInterval = Duration(days: 30);
 /// on Android, `SKStoreReviewController` on iOS) — there are NO app-owned
 /// strings, hence zero ARB impact.
 ///
-/// LIBRE-BUILD SAFETY (never throws): the Android side of `in_app_review`
-/// depends on Play Core (`com.google.android.play:review`), which is a
-/// proprietary group STRIPPED from the F-Droid (`fdroid`) flavor (see
-/// `android/app/build.gradle.kts` `gmsExcludeGroups` and
-/// `scripts/audit_no_gms.sh`). On that build the review classes are absent,
-/// so touching the plugin would throw `NoClassDefFoundError` /
-/// `MissingPluginException`. Every interaction with the reviewer — including
-/// the `isAvailable()` probe — is therefore wrapped in a catch-all that
-/// swallows the error and no-ops, keeping the libre build crash-free. This
-/// guarantee is validated by the fault-injection test in
+/// LIBRE-BUILD SAFETY (never throws): the store-review interaction goes
+/// through the flavor-selected [reviewPrompterProvider] ([ReviewPrompter]) —
+/// the libre / F-Droid build gets [NoopReviewPrompter], which reports
+/// unavailable and never touches the Play-Core-backed `in_app_review` plugin
+/// (`com.google.android.play:review`, absent from the `fdroid` flavor).
+/// Belt-and-braces, every interaction is ALSO wrapped in a catch-all that
+/// swallows any `NoClassDefFoundError` / `MissingPluginException` and no-ops,
+/// keeping every build crash-free. Both guarantees are validated by
 /// `test/core/feedback/in_app_review_service_test.dart`.
 ///
 /// `keepAlive: true` because the counter must survive across route churn —
 /// each successful search anywhere in the app feeds the same tally.
 @Riverpod(keepAlive: true)
 class InAppReviewService extends _$InAppReviewService {
-  /// Probes whether the OS review flow is available. Defaults to the real
-  /// plugin; overridable in tests so we never hit the platform channel.
-  Future<bool> Function() isAvailable = InAppReview.instance.isAvailable;
-
-  /// Triggers the OS review dialog. Defaults to the real plugin;
-  /// overridable in tests.
-  Future<void> Function() requestReview = InAppReview.instance.requestReview;
-
   /// Clock seam — overridable so the 30-day cooldown is testable without
   /// real wall-clock waits. Defaults to [DateTime.now].
+  ///
+  /// The store-review interaction itself is the flavor-selected
+  /// [reviewPrompterProvider] ([ReviewPrompter]) — [StoreReviewPrompter] on
+  /// Play/iOS, [NoopReviewPrompter] on the libre build — so tests override
+  /// that provider rather than a plugin seam here.
   DateTime Function() now = DateTime.now;
 
   @override
@@ -98,8 +93,9 @@ class InAppReviewService extends _$InAppReviewService {
         now().toIso8601String(),
       );
 
-      if (await isAvailable()) {
-        await requestReview();
+      final prompter = ref.read(reviewPrompterProvider);
+      if (await prompter.isAvailable()) {
+        await prompter.requestReview();
       }
     } catch (e, st) {
       // Swallow everything — including NoClassDefFoundError /

--- a/lib/core/feedback/in_app_review_service.g.dart
+++ b/lib/core/feedback/in_app_review_service.g.dart
@@ -15,16 +15,14 @@ part of 'in_app_review_service.dart';
 /// on Android, `SKStoreReviewController` on iOS) — there are NO app-owned
 /// strings, hence zero ARB impact.
 ///
-/// LIBRE-BUILD SAFETY (never throws): the Android side of `in_app_review`
-/// depends on Play Core (`com.google.android.play:review`), which is a
-/// proprietary group STRIPPED from the F-Droid (`fdroid`) flavor (see
-/// `android/app/build.gradle.kts` `gmsExcludeGroups` and
-/// `scripts/audit_no_gms.sh`). On that build the review classes are absent,
-/// so touching the plugin would throw `NoClassDefFoundError` /
-/// `MissingPluginException`. Every interaction with the reviewer — including
-/// the `isAvailable()` probe — is therefore wrapped in a catch-all that
-/// swallows the error and no-ops, keeping the libre build crash-free. This
-/// guarantee is validated by the fault-injection test in
+/// LIBRE-BUILD SAFETY (never throws): the store-review interaction goes
+/// through the flavor-selected [reviewPrompterProvider] ([ReviewPrompter]) —
+/// the libre / F-Droid build gets [NoopReviewPrompter], which reports
+/// unavailable and never touches the Play-Core-backed `in_app_review` plugin
+/// (`com.google.android.play:review`, absent from the `fdroid` flavor).
+/// Belt-and-braces, every interaction is ALSO wrapped in a catch-all that
+/// swallows any `NoClassDefFoundError` / `MissingPluginException` and no-ops,
+/// keeping every build crash-free. Both guarantees are validated by
 /// `test/core/feedback/in_app_review_service_test.dart`.
 ///
 /// `keepAlive: true` because the counter must survive across route churn —
@@ -40,16 +38,14 @@ final inAppReviewServiceProvider = InAppReviewServiceProvider._();
 /// on Android, `SKStoreReviewController` on iOS) — there are NO app-owned
 /// strings, hence zero ARB impact.
 ///
-/// LIBRE-BUILD SAFETY (never throws): the Android side of `in_app_review`
-/// depends on Play Core (`com.google.android.play:review`), which is a
-/// proprietary group STRIPPED from the F-Droid (`fdroid`) flavor (see
-/// `android/app/build.gradle.kts` `gmsExcludeGroups` and
-/// `scripts/audit_no_gms.sh`). On that build the review classes are absent,
-/// so touching the plugin would throw `NoClassDefFoundError` /
-/// `MissingPluginException`. Every interaction with the reviewer — including
-/// the `isAvailable()` probe — is therefore wrapped in a catch-all that
-/// swallows the error and no-ops, keeping the libre build crash-free. This
-/// guarantee is validated by the fault-injection test in
+/// LIBRE-BUILD SAFETY (never throws): the store-review interaction goes
+/// through the flavor-selected [reviewPrompterProvider] ([ReviewPrompter]) —
+/// the libre / F-Droid build gets [NoopReviewPrompter], which reports
+/// unavailable and never touches the Play-Core-backed `in_app_review` plugin
+/// (`com.google.android.play:review`, absent from the `fdroid` flavor).
+/// Belt-and-braces, every interaction is ALSO wrapped in a catch-all that
+/// swallows any `NoClassDefFoundError` / `MissingPluginException` and no-ops,
+/// keeping every build crash-free. Both guarantees are validated by
 /// `test/core/feedback/in_app_review_service_test.dart`.
 ///
 /// `keepAlive: true` because the counter must survive across route churn —
@@ -63,16 +59,14 @@ final class InAppReviewServiceProvider
   /// on Android, `SKStoreReviewController` on iOS) — there are NO app-owned
   /// strings, hence zero ARB impact.
   ///
-  /// LIBRE-BUILD SAFETY (never throws): the Android side of `in_app_review`
-  /// depends on Play Core (`com.google.android.play:review`), which is a
-  /// proprietary group STRIPPED from the F-Droid (`fdroid`) flavor (see
-  /// `android/app/build.gradle.kts` `gmsExcludeGroups` and
-  /// `scripts/audit_no_gms.sh`). On that build the review classes are absent,
-  /// so touching the plugin would throw `NoClassDefFoundError` /
-  /// `MissingPluginException`. Every interaction with the reviewer — including
-  /// the `isAvailable()` probe — is therefore wrapped in a catch-all that
-  /// swallows the error and no-ops, keeping the libre build crash-free. This
-  /// guarantee is validated by the fault-injection test in
+  /// LIBRE-BUILD SAFETY (never throws): the store-review interaction goes
+  /// through the flavor-selected [reviewPrompterProvider] ([ReviewPrompter]) —
+  /// the libre / F-Droid build gets [NoopReviewPrompter], which reports
+  /// unavailable and never touches the Play-Core-backed `in_app_review` plugin
+  /// (`com.google.android.play:review`, absent from the `fdroid` flavor).
+  /// Belt-and-braces, every interaction is ALSO wrapped in a catch-all that
+  /// swallows any `NoClassDefFoundError` / `MissingPluginException` and no-ops,
+  /// keeping every build crash-free. Both guarantees are validated by
   /// `test/core/feedback/in_app_review_service_test.dart`.
   ///
   /// `keepAlive: true` because the counter must survive across route churn —
@@ -105,7 +99,7 @@ final class InAppReviewServiceProvider
 }
 
 String _$inAppReviewServiceHash() =>
-    r'550e05de2dcaa51191b8b64f80590d469a91c3e3';
+    r'dfe557c1b311ee4f0ad41fd1ba1ee742f6a1048e';
 
 /// Asks the OS to show its native store-review dialog at genuine positive
 /// moments, throttled by a count threshold and a 30-day cooldown (#3069).
@@ -114,16 +108,14 @@ String _$inAppReviewServiceHash() =>
 /// on Android, `SKStoreReviewController` on iOS) — there are NO app-owned
 /// strings, hence zero ARB impact.
 ///
-/// LIBRE-BUILD SAFETY (never throws): the Android side of `in_app_review`
-/// depends on Play Core (`com.google.android.play:review`), which is a
-/// proprietary group STRIPPED from the F-Droid (`fdroid`) flavor (see
-/// `android/app/build.gradle.kts` `gmsExcludeGroups` and
-/// `scripts/audit_no_gms.sh`). On that build the review classes are absent,
-/// so touching the plugin would throw `NoClassDefFoundError` /
-/// `MissingPluginException`. Every interaction with the reviewer — including
-/// the `isAvailable()` probe — is therefore wrapped in a catch-all that
-/// swallows the error and no-ops, keeping the libre build crash-free. This
-/// guarantee is validated by the fault-injection test in
+/// LIBRE-BUILD SAFETY (never throws): the store-review interaction goes
+/// through the flavor-selected [reviewPrompterProvider] ([ReviewPrompter]) —
+/// the libre / F-Droid build gets [NoopReviewPrompter], which reports
+/// unavailable and never touches the Play-Core-backed `in_app_review` plugin
+/// (`com.google.android.play:review`, absent from the `fdroid` flavor).
+/// Belt-and-braces, every interaction is ALSO wrapped in a catch-all that
+/// swallows any `NoClassDefFoundError` / `MissingPluginException` and no-ops,
+/// keeping every build crash-free. Both guarantees are validated by
 /// `test/core/feedback/in_app_review_service_test.dart`.
 ///
 /// `keepAlive: true` because the counter must survive across route churn —

--- a/lib/core/feedback/review_prompter.dart
+++ b/lib/core/feedback/review_prompter.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:in_app_review/in_app_review.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../platform/app_flavor.dart';
+
+part 'review_prompter.g.dart';
+
+/// A capability seam for asking the OS to show its native store-review dialog.
+///
+/// This is the [AppFlavor]-selected abstraction behind the store-review
+/// feature (#3473). The Play/iOS build uses [StoreReviewPrompter] (the real
+/// `in_app_review` plugin → Play In-App Review API / `SKStoreReviewController`);
+/// the F-Droid / libre build uses [NoopReviewPrompter] and never reaches the
+/// plugin's Play-Core-backed channel. Making the libre behaviour an EXPLICIT
+/// no-op implementation — rather than a `try/catch` swallowing a
+/// `NoClassDefFoundError` at runtime — is what lets the fdroid variant drop the
+/// proprietary `in_app_review` Android module entirely without any libre code
+/// path ever calling it.
+abstract interface class ReviewPrompter {
+  /// Whether the OS review flow is available right now.
+  Future<bool> isAvailable();
+
+  /// Ask the OS to present its native review dialog. The dialog is rendered
+  /// entirely by the platform (no app-owned strings), and the OS additionally
+  /// rate-limits it.
+  Future<void> requestReview();
+}
+
+/// Real implementation backed by the `in_app_review` plugin. Used on Play + iOS.
+class StoreReviewPrompter implements ReviewPrompter {
+  StoreReviewPrompter([InAppReview? reviewer])
+      : _reviewer = reviewer ?? InAppReview.instance;
+
+  final InAppReview _reviewer;
+
+  @override
+  Future<bool> isAvailable() => _reviewer.isAvailable();
+
+  @override
+  Future<void> requestReview() => _reviewer.requestReview();
+}
+
+/// Libre / F-Droid implementation: the store-review flow is unavailable, so it
+/// reports unavailable and does nothing. Never touches Play Core.
+class NoopReviewPrompter implements ReviewPrompter {
+  const NoopReviewPrompter();
+
+  @override
+  Future<bool> isAvailable() async => false;
+
+  @override
+  Future<void> requestReview() async {}
+}
+
+/// Flavor-selected [ReviewPrompter]: the libre build gets the no-op, every
+/// other build gets the real store prompter. Overridable in tests.
+@Riverpod(keepAlive: true)
+ReviewPrompter reviewPrompter(Ref ref) =>
+    AppFlavor.isLibre ? const NoopReviewPrompter() : StoreReviewPrompter();

--- a/lib/core/feedback/review_prompter.g.dart
+++ b/lib/core/feedback/review_prompter.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'review_prompter.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Flavor-selected [ReviewPrompter]: the libre build gets the no-op, every
+/// other build gets the real store prompter. Overridable in tests.
+
+@ProviderFor(reviewPrompter)
+final reviewPrompterProvider = ReviewPrompterProvider._();
+
+/// Flavor-selected [ReviewPrompter]: the libre build gets the no-op, every
+/// other build gets the real store prompter. Overridable in tests.
+
+final class ReviewPrompterProvider
+    extends $FunctionalProvider<ReviewPrompter, ReviewPrompter, ReviewPrompter>
+    with $Provider<ReviewPrompter> {
+  /// Flavor-selected [ReviewPrompter]: the libre build gets the no-op, every
+  /// other build gets the real store prompter. Overridable in tests.
+  ReviewPrompterProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'reviewPrompterProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$reviewPrompterHash();
+
+  @$internal
+  @override
+  $ProviderElement<ReviewPrompter> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ReviewPrompter create(Ref ref) {
+    return reviewPrompter(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ReviewPrompter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ReviewPrompter>(value),
+    );
+  }
+}
+
+String _$reviewPrompterHash() => r'6223e9edcd438f576d12ef681d9cb2a7c90b8ac6';

--- a/lib/core/platform/app_flavor.dart
+++ b/lib/core/platform/app_flavor.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Single source of truth for "which distribution flavor is this build?".
+///
+/// The app ships three ways — Google Play, Apple App Store, and F-Droid — from
+/// ONE code base, switched only by configuration (see the project's
+/// one-codebase-by-config rule). The only axis that changes app *behaviour* is
+/// whether Google's proprietary libraries (GMS, ML Kit, Play Core) are present:
+///
+///   * `play` flavor + iOS  → proprietary Google services available.
+///   * `fdroid` flavor      → GMS-free / libre: no proprietary Google code in
+///                            the dex (#2574 / #3473), so any capability that
+///                            would touch it must use a FOSS or no-op
+///                            implementation instead.
+///
+/// This is the seam every GMS-tied *capability* selects its implementation on
+/// (location, barcode scanning, store review …). Centralising it here — rather
+/// than each feature re-deriving `bool.fromEnvironment(...)` — means:
+///   * the fdroid build is decided in exactly ONE place, and
+///   * a new GMS-pulling plugin cannot silently re-enter the libre build,
+///     because libre code paths structurally never reach the Play-only impls.
+///
+/// The signal is the `FORCE_LOCATION_MANAGER` dart-define, which the F-Droid
+/// build command passes (`--dart-define=FORCE_LOCATION_MANAGER=true`, see
+/// `metadata/de.tankstellen.fuelprices.yml` and `.github/workflows/fdroid.yml`)
+/// and no other build does. It doubles as the libre marker so the recipe needs
+/// no extra define. [GeolocatorWrapper.forceLocationManager] reads the same
+/// define for its own routing.
+abstract final class AppFlavor {
+  const AppFlavor._();
+
+  /// True on the GMS-free / F-Droid (libre) build; false on Play + iOS.
+  ///
+  /// A compile-time constant so tree-shaking and R8 can fold libre-only
+  /// branches, and so tests can reason about it without a platform channel.
+  static const bool isLibre =
+      bool.fromEnvironment('FORCE_LOCATION_MANAGER');
+
+  /// True when proprietary Google services (GMS / ML Kit / Play Core) may be
+  /// present — i.e. the Play or iOS build. The inverse of [isLibre].
+  static const bool hasGoogleServices = !isLibre;
+}

--- a/test/core/feedback/in_app_review_service_test.dart
+++ b/test/core/feedback/in_app_review_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/feedback/in_app_review_service.dart';
+import 'package:tankstellen/core/feedback/review_prompter.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 
@@ -29,8 +30,9 @@ class _FakeSettings implements SettingsStorage {
 }
 
 /// Records how the reviewer seam was driven so each test can assert exactly
-/// how many times the OS dialog was requested.
-class _Reviewer {
+/// how many times the OS dialog was requested. Stands in for the
+/// flavor-selected [ReviewPrompter] via a provider override.
+class _Reviewer implements ReviewPrompter {
   int isAvailableCalls = 0;
   int requestReviewCalls = 0;
   bool available = true;
@@ -38,6 +40,7 @@ class _Reviewer {
   /// When set, both seam fns throw it — drives the never-throws fault test.
   Object? throwError;
 
+  @override
   Future<bool> isAvailable() async {
     isAvailableCalls++;
     final err = throwError;
@@ -45,6 +48,7 @@ class _Reviewer {
     return available;
   }
 
+  @override
   Future<void> requestReview() async {
     requestReviewCalls++;
     final err = throwError;
@@ -59,11 +63,10 @@ class _Reviewer {
 }) {
   final c = ProviderContainer(overrides: [
     settingsStorageProvider.overrideWithValue(settings),
+    reviewPrompterProvider.overrideWithValue(reviewer),
   ]);
   addTearDown(c.dispose);
-  final service = c.read(inAppReviewServiceProvider.notifier)
-    ..isAvailable = reviewer.isAvailable
-    ..requestReview = reviewer.requestReview;
+  final service = c.read(inAppReviewServiceProvider.notifier);
   if (now != null) service.now = now;
   return (container: c, service: service);
 }

--- a/test/core/feedback/review_prompter_test.dart
+++ b/test/core/feedback/review_prompter_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/feedback/review_prompter.dart';
+import 'package:tankstellen/core/platform/app_flavor.dart';
+
+void main() {
+  group('NoopReviewPrompter (libre build)', () {
+    test('reports unavailable and never performs a review request', () async {
+      const prompter = NoopReviewPrompter();
+      expect(await prompter.isAvailable(), isFalse);
+      // Must complete without throwing or touching any plugin.
+      await expectLater(prompter.requestReview(), completes);
+    });
+  });
+
+  group('reviewPrompterProvider selection', () {
+    test('resolves the store prompter when Google services are present', () {
+      // Tests run without the FORCE_LOCATION_MANAGER dart-define, so
+      // AppFlavor.isLibre is false — the provider must pick the real store
+      // prompter (the libre path is selected only in the fdroid build).
+      expect(AppFlavor.isLibre, isFalse);
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      expect(c.read(reviewPrompterProvider), isA<StoreReviewPrompter>());
+    });
+
+    test('is overridable for tests', () {
+      final c = ProviderContainer(overrides: [
+        reviewPrompterProvider.overrideWithValue(const NoopReviewPrompter()),
+      ]);
+      addTearDown(c.dispose);
+      expect(c.read(reviewPrompterProvider), isA<NoopReviewPrompter>());
+    });
+  });
+
+  group('AppFlavor', () {
+    test('isLibre and hasGoogleServices are inverses', () {
+      expect(AppFlavor.hasGoogleServices, !AppFlavor.isLibre);
+    });
+  });
+}


### PR DESCRIPTION
Foundation for the GMS-free F-Droid architecture (#3473). Instead of compiling GMS-tied plugins into the libre build and trying to strip them (fragile — a new plugin silently re-added GMS, which is how this regressed), select the implementation **per flavor behind a capability interface**, so libre code paths structurally never reach the proprietary impls.

## This PR (the pattern + first capability)
- **`AppFlavor`** (`lib/core/platform`) — single source of truth for `isLibre` / `hasGoogleServices`, from the `FORCE_LOCATION_MANAGER` dart-define the fdroid build already passes. Every GMS-tied capability selects on this.
- **`ReviewPrompter`** capability — interface + `StoreReviewPrompter` (in_app_review; Play/iOS) + `NoopReviewPrompter` (libre) + a flavor-selected provider.
- **`InAppReviewService`** now delegates to the flavor-selected `ReviewPrompter` instead of holding plugin seams. Libre degradation is an **explicit** `NoopReviewPrompter`, not a swallowed `NoClassDefFoundError` (catch-all stays belt-and-braces).

**No behaviour change** on any flavor today — Play/iOS keep the real store-review flow; libre was already effectively no-op. This is the exemplar the per-plugin children (#3476 location, #3477 barcode, #3478 passkeys, #3479 review/Play-Core native exclusion) follow.

`flutter analyze` clean; all `test/core/feedback` pass incl. the never-throws fault test + new `ReviewPrompter`/`AppFlavor` tests.

Part of #3473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)