### PR TITLE
docs(fdroid): TODO pointers at the location + barcode capability seams (#3473)

### DIFF
--- a/lib/core/location/geolocator_wrapper.dart
+++ b/lib/core/location/geolocator_wrapper.dart
@@ -15,6 +15,18 @@ part 'geolocator_wrapper.g.dart';
 /// All permission and location calls go through this provider instead of
 /// calling Geolocator.checkPermission() etc. directly, so tests can
 /// override the provider with a fake implementation.
+///
+/// TODO(#3476): location capability seam for the GMS-free F-Droid architecture
+/// (epic #3473). `forceLocationManager` already routes the LIBRE build through
+/// Android's LocationManager at runtime, but `geolocator_android`'s
+/// `FusedLocationClient` still leaves compile-time `com.google.android.gms.*`
+/// REFERENCES in the fdroid dex that `fdroid scanner` rejects. Plan (see
+/// `.local-docs/fdroid-gms-free-refactor-notes.md`): vendor + patch
+/// `geolocator_android` for the libre build (drop `FusedLocationClient` + the
+/// `GoogleApiAvailability` probe), swapped in via a libre-only
+/// `pubspec_overrides.yaml` — keeping this Dart API + all 11 call sites
+/// unchanged. Refactor TODO: extract `_SharedPositionSource` to its own file
+/// and split out a thin permissions seam.
 @Riverpod(keepAlive: true)
 GeolocatorWrapper geolocatorWrapper(Ref ref) {
   return GeolocatorWrapper();

--- a/lib/core/location/geolocator_wrapper.g.dart
+++ b/lib/core/location/geolocator_wrapper.g.dart
@@ -13,6 +13,18 @@ part of 'geolocator_wrapper.dart';
 /// All permission and location calls go through this provider instead of
 /// calling Geolocator.checkPermission() etc. directly, so tests can
 /// override the provider with a fake implementation.
+///
+/// TODO(#3476): location capability seam for the GMS-free F-Droid architecture
+/// (epic #3473). `forceLocationManager` already routes the LIBRE build through
+/// Android's LocationManager at runtime, but `geolocator_android`'s
+/// `FusedLocationClient` still leaves compile-time `com.google.android.gms.*`
+/// REFERENCES in the fdroid dex that `fdroid scanner` rejects. Plan (see
+/// `.local-docs/fdroid-gms-free-refactor-notes.md`): vendor + patch
+/// `geolocator_android` for the libre build (drop `FusedLocationClient` + the
+/// `GoogleApiAvailability` probe), swapped in via a libre-only
+/// `pubspec_overrides.yaml` — keeping this Dart API + all 11 call sites
+/// unchanged. Refactor TODO: extract `_SharedPositionSource` to its own file
+/// and split out a thin permissions seam.
 
 @ProviderFor(geolocatorWrapper)
 final geolocatorWrapperProvider = GeolocatorWrapperProvider._();
@@ -22,6 +34,18 @@ final geolocatorWrapperProvider = GeolocatorWrapperProvider._();
 /// All permission and location calls go through this provider instead of
 /// calling Geolocator.checkPermission() etc. directly, so tests can
 /// override the provider with a fake implementation.
+///
+/// TODO(#3476): location capability seam for the GMS-free F-Droid architecture
+/// (epic #3473). `forceLocationManager` already routes the LIBRE build through
+/// Android's LocationManager at runtime, but `geolocator_android`'s
+/// `FusedLocationClient` still leaves compile-time `com.google.android.gms.*`
+/// REFERENCES in the fdroid dex that `fdroid scanner` rejects. Plan (see
+/// `.local-docs/fdroid-gms-free-refactor-notes.md`): vendor + patch
+/// `geolocator_android` for the libre build (drop `FusedLocationClient` + the
+/// `GoogleApiAvailability` probe), swapped in via a libre-only
+/// `pubspec_overrides.yaml` — keeping this Dart API + all 11 call sites
+/// unchanged. Refactor TODO: extract `_SharedPositionSource` to its own file
+/// and split out a thin permissions seam.
 
 final class GeolocatorWrapperProvider
     extends
@@ -36,6 +60,18 @@ final class GeolocatorWrapperProvider
   /// All permission and location calls go through this provider instead of
   /// calling Geolocator.checkPermission() etc. directly, so tests can
   /// override the provider with a fake implementation.
+  ///
+  /// TODO(#3476): location capability seam for the GMS-free F-Droid architecture
+  /// (epic #3473). `forceLocationManager` already routes the LIBRE build through
+  /// Android's LocationManager at runtime, but `geolocator_android`'s
+  /// `FusedLocationClient` still leaves compile-time `com.google.android.gms.*`
+  /// REFERENCES in the fdroid dex that `fdroid scanner` rejects. Plan (see
+  /// `.local-docs/fdroid-gms-free-refactor-notes.md`): vendor + patch
+  /// `geolocator_android` for the libre build (drop `FusedLocationClient` + the
+  /// `GoogleApiAvailability` probe), swapped in via a libre-only
+  /// `pubspec_overrides.yaml` — keeping this Dart API + all 11 call sites
+  /// unchanged. Refactor TODO: extract `_SharedPositionSource` to its own file
+  /// and split out a thin permissions seam.
   GeolocatorWrapperProvider._()
     : super(
         from: null,

--- a/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
+++ b/lib/features/sync/presentation/widgets/qr_scanner_screen.dart
@@ -16,6 +16,15 @@ import 'qr_scanner_helpers.dart';
 /// Full-screen QR code scanner for scanning TankSync credentials and
 /// payment QR codes from the station-detail screen.
 ///
+/// TODO(#3477): barcode/QR capability seam for the GMS-free F-Droid
+/// architecture (epic #3473). `mobile_scanner` pulls ML Kit
+/// (`com.google.mlkit.vision.barcode`, rejected by `fdroid scanner`). Plan
+/// (see `.local-docs/fdroid-gms-free-refactor-notes.md`): a `BarcodeScanner`
+/// capability behind an `AppFlavor`-selected provider — `mobile_scanner` on
+/// Play/iOS, a FOSS ZXing scanner on libre — so TankSync QR device-linking
+/// keeps working on F-Droid. First extract the QR parse/validate logic
+/// (`qr_scanner_helpers.dart`) so both impls share it plugin-free.
+///
 /// #721 hardens the scanner against the failure modes the bare
 /// `MobileScanner` has no opinion on:
 /// * Camera permission denied → a settings CTA instead of a silent


### PR DESCRIPTION
Doc-only. Points the next implementer at the epic plan (`.local-docs/fdroid-gms-free-refactor-notes.md`) from the two GMS-tied surfaces — `geolocator_wrapper` (#3476 location) and `qr_scanner_screen` (#3477 barcode). Follows the merged foundation (#3482). Part of #3473.