### PR TITLE
chore(fdroid): drop passkeys_android from the libre build (#3478)

### DIFF
--- a/pubspec_overrides.fdroid.yaml
+++ b/pubspec_overrides.fdroid.yaml
@@ -14,3 +14,7 @@ dependency_overrides:
   # #3479 — no-op store review (upstream pulls Play Core `…play:review`).
   in_app_review:
     path: tool/fdroid_stubs/in_app_review
+  # #3478 — Dart-only passkeys Android impl (upstream pulls GMS FIDO/auth via
+  # supabase_flutter). Unused on libre; keeps supabase compiling GMS-free.
+  passkeys_android:
+    path: tool/fdroid_stubs/passkeys_android

--- a/tool/fdroid_stubs/passkeys_android/lib/passkeys_android.dart
+++ b/tool/fdroid_stubs/passkeys_android/lib/passkeys_android.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
+import 'package:passkeys_platform_interface/types/types.dart';
+
+/// Libre / F-Droid no-op Android implementation of [PasskeysPlatform] (#3478).
+///
+/// Endorses `passkeys` for Android as a Dart-only impl (no native plugin), so
+/// the federated plugin resolves and Supabase compiles, but no GMS FIDO/auth
+/// code reaches the fdroid dex. Passkey auth is unavailable on the libre build;
+/// the app never invokes it (TankSync uses email/anon), so the operations
+/// throw [UnsupportedError] and [getAvailability] reports no support.
+class PasskeysAndroid extends PasskeysPlatform {
+  /// Registered by the generated plugin registrant on the libre build.
+  static void registerWith() => PasskeysPlatform.instance = PasskeysAndroid();
+
+  static Never _unsupported() => throw UnsupportedError(
+        'Passkeys are unavailable on the libre / F-Droid build (no GMS FIDO).',
+      );
+
+  @override
+  // ignore: deprecated_member_override
+  Future<bool> canAuthenticate() async => false;
+
+  @override
+  Future<RegisterResponseType> register(RegisterRequestType request) async =>
+      _unsupported();
+
+  @override
+  Future<AuthenticateResponseType> authenticate(
+    AuthenticateRequestType request,
+  ) async =>
+      _unsupported();
+
+  @override
+  Future<void> cancelCurrentAuthenticatorOperation() async {}
+
+  @override
+  Future<AvailabilityType> getAvailability() async => AvailabilityTypeAndroid(
+        hasPasskeySupport: false,
+        isNative: false,
+        isUserVerifyingPlatformAuthenticatorAvailable: false,
+      );
+}

--- a/tool/fdroid_stubs/passkeys_android/pubspec.yaml
+++ b/tool/fdroid_stubs/passkeys_android/pubspec.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+#
+# Libre / F-Droid drop-in for `passkeys_android` (#3478, epic #3473).
+#
+# The upstream `passkeys_android` is the federated Android implementation of the
+# `passkeys` plugin (pulled transitively by `supabase_flutter`). Its native
+# `FlutterPasskeysPlugin` references `com.google.android.gms.fido.*` /
+# `gms.auth.api.identity.*`, which `fdroid scanner` rejects. The app never uses
+# passkey auth (TankSync uses email/anon), so this replaces the Android impl
+# with a Dart-ONLY no-op: it still endorses `passkeys` for Android (so the
+# federated plugin resolves + Supabase compiles), but declares NO native
+# `package`/`pluginClass`, so ZERO GMS FIDO/auth code reaches the fdroid dex.
+#
+# Swapped in ONLY for the fdroid build via `pubspec_overrides.yaml`.
+name: passkeys_android
+description: Libre/F-Droid no-op Android impl of passkeys (no GMS FIDO). Epic #3473.
+version: 2.12.0
+publish_to: none
+
+environment:
+  sdk: ">=3.9.0 <4.0.0"
+  flutter: ">=3.0.0"
+
+flutter:
+  plugin:
+    implements: passkeys
+    platforms:
+      android:
+        # Dart-only endorsement: no `package`/`pluginClass` ⇒ no native code.
+        dartPluginClass: PasskeysAndroid
+
+dependencies:
+  flutter:
+    sdk: flutter
+  passkeys_platform_interface: ^2.4.0


### PR DESCRIPTION
Second application of the per-flavor swap mechanism (#3484, merged). `passkeys` is pulled transitively by `supabase_flutter`; its `passkeys_android` impl references `com.google.android.gms.fido.*` / `gms.auth.api.identity.*` (rejected by `fdroid scanner`). The app never uses passkey auth (TankSync uses email/anon).

Adds a **Dart-only** `passkeys_android` stub (`tool/fdroid_stubs/passkeys_android`): it endorses `passkeys` for Android so Supabase still compiles, but declares no native `package`/`pluginClass` → zero GMS FIDO/auth in the fdroid dex. Swapped in only for the fdroid build via the libre-only `pubspec_overrides`.

**Verified** (dex-scan of the fdroid release APK): all **29** `gms.fido`/`gms.auth.api.identity` references drop (69 → 39). No effect on Play/iOS.

Part of #3473 / #3478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)