### PR TITLE
feat(fdroid): GMS-free vendored geolocator_android for the libre build (#3476)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -64,6 +64,12 @@ plugins:
       scoped_providers_should_specify_dependencies: false
 
 analyzer:
+  # Vendored upstream plugins (patched for the GMS-free F-Droid build, #3473 —
+  # e.g. third_party/geolocator_android) keep their own upstream conventions;
+  # don't hold third-party code to the app's strict lints. They compile as
+  # normal packages; only the app's own sources are linted.
+  exclude:
+    - third_party/**
   # Strict language modes (#3160) — the project paid for implicit-dynamic
   # casts twice (#2296, #2311 in the Hive/JSON codec layer); these make
   # implicit downcasts, raw generic types and uninferable invocations

--- a/pubspec_overrides.fdroid.yaml
+++ b/pubspec_overrides.fdroid.yaml
@@ -18,3 +18,8 @@ dependency_overrides:
   # supabase_flutter). Unused on libre; keeps supabase compiling GMS-free.
   passkeys_android:
     path: tool/fdroid_stubs/passkeys_android
+  # #3476 — vendored GMS-free geolocator_android: FusedLocationClient +
+  # GoogleApiAvailability removed, always uses Android's LocationManager (the
+  # app already forces this). Drops all com.google.android.gms.location refs.
+  geolocator_android:
+    path: third_party/geolocator_android

--- a/third_party/geolocator_android/LICENSE
+++ b/third_party/geolocator_android/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Baseflow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/geolocator_android/android/build.gradle
+++ b/third_party/geolocator_android/android/build.gradle
@@ -1,0 +1,48 @@
+group 'com.baseflow.geolocator'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:9.0.1'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    if (project.android.hasProperty("namespace")) {
+        namespace("com.baseflow.geolocator")
+    }
+
+    compileSdk flutter.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion flutter.minSdkVersion
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core:1.16.0'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.1.1'
+}

--- a/third_party/geolocator_android/android/settings.gradle
+++ b/third_party/geolocator_android/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'geolocator'

--- a/third_party/geolocator_android/android/src/main/AndroidManifest.xml
+++ b/third_party/geolocator_android/android/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.baseflow.geolocator">
+
+    <application>
+        <service
+                android:enabled="true"
+                android:exported="false"
+                android:foregroundServiceType="location"
+                android:name=".GeolocatorLocationService"/>
+    </application>
+</manifest>

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -1,0 +1,236 @@
+package com.baseflow.geolocator;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Notification;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.net.wifi.WifiManager;
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.location.BackgroundNotification;
+import com.baseflow.geolocator.location.ForegroundNotificationOptions;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.LocationOptions;
+
+import io.flutter.plugin.common.EventChannel;
+
+public class GeolocatorLocationService extends Service {
+  private static final String TAG = "FlutterGeolocator";
+  private static final int ONGOING_NOTIFICATION_ID = 75415;
+  private static final String CHANNEL_ID = "geolocator_channel_01";
+  private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
+  private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
+  private final LocalBinder binder = new LocalBinder(this);
+  // Service is foreground
+  private boolean isForeground = false;
+  private int connectedEngines = 0;
+  private int listenerCount = 0;
+  @Nullable private Activity activity = null;
+  @Nullable private GeolocationManager geolocationManager = null;
+  @Nullable private LocationClient locationClient;
+
+  @Nullable private PowerManager.WakeLock wakeLock = null;
+  @Nullable private WifiManager.WifiLock wifiLock = null;
+
+  @Nullable private BackgroundNotification backgroundNotification = null;
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Log.d(TAG, "Creating service.");
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    return START_STICKY;
+  }
+
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+    Log.d(TAG, "Binding to location service.");
+    return binder;
+  }
+
+  @Override
+  public boolean onUnbind(Intent intent) {
+    Log.d(TAG, "Unbinding from location service.");
+    return super.onUnbind(intent);
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.d(TAG, "Destroying location service.");
+
+    stopLocationService();
+    disableBackgroundMode();
+    geolocationManager = null;
+    backgroundNotification = null;
+
+    Log.d(TAG, "Destroyed location service.");
+    super.onDestroy();
+  }
+
+  public boolean canStopLocationService(boolean cancellationRequested) {
+    if (cancellationRequested) {
+      return listenerCount == 1;
+    }
+    return connectedEngines == 0;
+  }
+
+  public void flutterEngineConnected() {
+
+    connectedEngines++;
+    Log.d(TAG, "Flutter engine connected. Connected engine count " + connectedEngines);
+  }
+
+  public void flutterEngineDisconnected() {
+
+    connectedEngines--;
+    Log.d(TAG, "Flutter engine disconnected. Connected engine count " + connectedEngines);
+  }
+
+  public void startLocationService(
+      boolean forceLocationManager,
+      LocationOptions locationOptions,
+      EventChannel.EventSink events) {
+
+    listenerCount++;
+    if (geolocationManager != null) {
+      locationClient =
+          geolocationManager.createLocationClient(
+              this.getApplicationContext(),
+              Boolean.TRUE.equals(forceLocationManager),
+              locationOptions);
+
+      geolocationManager.startPositionUpdates(
+          locationClient,
+          activity,
+          (Location location) -> events.success(LocationMapper.toHashMap(location)),
+          (ErrorCodes errorCodes) ->
+              events.error(errorCodes.toString(), errorCodes.toDescription(), null));
+    }
+  }
+
+  public void stopLocationService() {
+    listenerCount--;
+    Log.d(TAG, "Stopping location service.");
+    if (locationClient != null && geolocationManager != null) {
+      geolocationManager.stopPositionUpdates(locationClient);
+    }
+  }
+
+  public void enableBackgroundMode(ForegroundNotificationOptions options) {
+    if (backgroundNotification != null) {
+      Log.d(TAG, "Service already in foreground mode.");
+      changeNotificationOptions(options);
+    } else {
+      Log.d(TAG, "Start service in foreground mode.");
+
+      backgroundNotification =
+          new BackgroundNotification(
+              this.getApplicationContext(), CHANNEL_ID, ONGOING_NOTIFICATION_ID, options);
+      backgroundNotification.updateChannel(options.getNotificationChannelName());
+      Notification notification = backgroundNotification.build();
+      startForeground(ONGOING_NOTIFICATION_ID, notification);
+      isForeground = true;
+    }
+    obtainWakeLocks(options);
+  }
+
+  @SuppressWarnings("deprecation")
+  public void disableBackgroundMode() {
+    if (isForeground) {
+      Log.d(TAG, "Stop service in foreground.");
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        stopForeground(Service.STOP_FOREGROUND_REMOVE);
+      } else {
+        stopForeground(true);
+      }
+      releaseWakeLocks();
+      isForeground = false;
+      backgroundNotification = null;
+    }
+  }
+
+  public void changeNotificationOptions(ForegroundNotificationOptions options) {
+    if (backgroundNotification != null) {
+      backgroundNotification.updateOptions(options, isForeground);
+      obtainWakeLocks(options);
+    }
+  }
+
+  public void setActivity(@Nullable Activity activity) {
+    this.activity = activity;
+  }
+
+  public void setGeolocationManager(@Nullable GeolocationManager geolocationManager) {
+      this.geolocationManager = geolocationManager;
+  }
+
+  private void releaseWakeLocks() {
+    if (wakeLock != null && wakeLock.isHeld()) {
+      wakeLock.release();
+      wakeLock = null;
+    }
+    if (wifiLock != null && wifiLock.isHeld()) {
+      wifiLock.release();
+      wifiLock = null;
+    }
+  }
+
+  @SuppressLint("WakelockTimeout")
+  private void obtainWakeLocks(ForegroundNotificationOptions options) {
+    releaseWakeLocks();
+    if (options.isEnableWakeLock()) {
+      PowerManager powerManager =
+          (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
+      if (powerManager != null) {
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
+        wakeLock.setReferenceCounted(false);
+        wakeLock.acquire();
+      }
+    }
+    if (options.isEnableWifiLock()) {
+      WifiManager wifiManager =
+          (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+      if (wifiManager != null) {
+        wifiLock = wifiManager.createWifiLock(getWifiLockType(), WIFILOCK_TAG);
+        wifiLock.setReferenceCounted(false);
+        wifiLock.acquire();
+      }
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private int getWifiLockType() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return WifiManager.WIFI_MODE_FULL_HIGH_PERF;
+    }
+    return WifiManager.WIFI_MODE_FULL_LOW_LATENCY;
+  }
+
+  class LocalBinder extends Binder {
+    private final GeolocatorLocationService locationService;
+
+    LocalBinder(GeolocatorLocationService locationService) {
+      this.locationService = locationService;
+    }
+
+    public GeolocatorLocationService getLocationService() {
+      return locationService;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -1,0 +1,193 @@
+package com.baseflow.geolocator;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationAccuracyManager;
+import com.baseflow.geolocator.permission.PermissionManager;
+
+import io.flutter.Log;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+
+/** GeolocatorPlugin */
+public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
+
+  private static final String TAG = "FlutterGeolocator";
+  private final PermissionManager permissionManager;
+  private final GeolocationManager geolocationManager;
+  private final LocationAccuracyManager locationAccuracyManager;
+
+  @Nullable private GeolocatorLocationService foregroundLocationService;
+
+  @Nullable private MethodCallHandlerImpl methodCallHandler;
+
+  @Nullable private StreamHandlerImpl streamHandler;
+  private final ServiceConnection serviceConnection =
+      new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+          Log.d(TAG, "Geolocator foreground service connected");
+          if (service instanceof GeolocatorLocationService.LocalBinder) {
+            initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
+          }
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+          Log.d(TAG, "Geolocator foreground service disconnected");
+          if (foregroundLocationService != null) {
+            foregroundLocationService.setActivity(null);
+            foregroundLocationService = null;
+          }
+        }
+      };
+  @Nullable private LocationServiceHandlerImpl locationServiceHandler;
+
+  @Nullable private ActivityPluginBinding pluginBinding;
+
+  public GeolocatorPlugin() {
+    permissionManager = PermissionManager.getInstance();
+    geolocationManager = GeolocationManager.getInstance();
+    locationAccuracyManager = LocationAccuracyManager.getInstance();
+  }
+
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+    methodCallHandler =
+        new MethodCallHandlerImpl(
+            this.permissionManager, this.geolocationManager, this.locationAccuracyManager);
+    methodCallHandler.startListening(
+        flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
+    streamHandler = new StreamHandlerImpl(this.permissionManager, this.geolocationManager);
+    streamHandler.startListening(
+        flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
+
+    locationServiceHandler = new LocationServiceHandlerImpl();
+    locationServiceHandler.setContext(flutterPluginBinding.getApplicationContext());
+    locationServiceHandler.startListening(
+        flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
+
+    bindForegroundService(flutterPluginBinding.getApplicationContext());
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    unbindForegroundService(binding.getApplicationContext());
+    dispose();
+  }
+
+  @Override
+  public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    Log.d(TAG, "Attaching Geolocator to activity");
+    this.pluginBinding = binding;
+    registerListeners();
+    if (methodCallHandler != null) {
+      methodCallHandler.setActivity(binding.getActivity());
+    }
+    if (streamHandler != null) {
+      streamHandler.setActivity(binding.getActivity());
+    }
+    if (foregroundLocationService != null) {
+      foregroundLocationService.setActivity(pluginBinding.getActivity());
+    }
+  }
+
+  @Override
+  public void onDetachedFromActivityForConfigChanges() {
+    onDetachedFromActivity();
+  }
+
+  @Override
+  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+    onAttachedToActivity(binding);
+  }
+
+  @Override
+  public void onDetachedFromActivity() {
+    Log.d(TAG, "Detaching Geolocator from activity");
+    deregisterListeners();
+    if (methodCallHandler != null) {
+      methodCallHandler.setActivity(null);
+    }
+    if (streamHandler != null) {
+      streamHandler.setActivity(null);
+    }
+    if (foregroundLocationService != null) {
+      foregroundLocationService.setActivity(null);
+    }
+    if (pluginBinding != null) {
+      pluginBinding = null;
+    }
+  }
+
+  private void registerListeners() {
+    if (pluginBinding != null) {
+      pluginBinding.addActivityResultListener(this.geolocationManager);
+      pluginBinding.addRequestPermissionsResultListener(this.permissionManager);
+    }
+  }
+
+  private void deregisterListeners() {
+    if (pluginBinding != null) {
+      pluginBinding.removeActivityResultListener(this.geolocationManager);
+      pluginBinding.removeRequestPermissionsResultListener(this.permissionManager);
+    }
+  }
+
+  private void bindForegroundService(Context context) {
+    context.bindService(
+        new Intent(context, GeolocatorLocationService.class),
+        serviceConnection,
+        Context.BIND_AUTO_CREATE);
+  }
+
+  private void unbindForegroundService(Context context) {
+    if (foregroundLocationService != null) {
+      foregroundLocationService.flutterEngineDisconnected();
+    }
+    context.unbindService(serviceConnection);
+  }
+
+  private void initialize(GeolocatorLocationService service) {
+    Log.d(TAG, "Initializing Geolocator services");
+    foregroundLocationService = service;
+    foregroundLocationService.setGeolocationManager(geolocationManager);
+    foregroundLocationService.flutterEngineConnected();
+
+    if (streamHandler != null) {
+      streamHandler.setForegroundLocationService(service);
+    }
+  }
+
+  private void dispose() {
+    Log.d(TAG, "Disposing Geolocator services");
+    if (methodCallHandler != null) {
+      methodCallHandler.stopListening();
+      methodCallHandler.setActivity(null);
+      methodCallHandler = null;
+    }
+    if (streamHandler != null) {
+      streamHandler.stopListening();
+      streamHandler.setForegroundLocationService(null);
+      streamHandler = null;
+    }
+    if (locationServiceHandler != null) {
+      locationServiceHandler.setContext(null);
+      locationServiceHandler.stopListening();
+      locationServiceHandler = null;
+    }
+    if (foregroundLocationService != null) {
+      foregroundLocationService.setActivity(null);
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -1,0 +1,72 @@
+package com.baseflow.geolocator;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.location.LocationManager;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
+import com.baseflow.geolocator.location.LocationServiceStatusReceiver;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.EventChannel;
+
+public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
+
+  private static final String TAG = "LocationServiceHandler";
+
+  @Nullable private EventChannel channel;
+  @Nullable private Context context;
+  @Nullable private LocationServiceStatusReceiver receiver;
+
+  void startListening(Context context, BinaryMessenger messenger) {
+    if (channel != null) {
+      Log.w(TAG, "Setting a event call handler before the last was disposed.");
+      stopListening();
+    }
+    channel = new EventChannel(messenger, "flutter.baseflow.com/geolocator_service_updates_android");
+    channel.setStreamHandler(this);
+    this.context = context;
+  }
+
+  void stopListening() {
+    if (channel == null) {
+      return;
+    }
+
+    disposeListeners();
+    channel.setStreamHandler(null);
+    channel = null;
+  }
+
+  void setContext(@Nullable Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public void onListen(Object arguments, EventChannel.EventSink events) {
+    if (context == null) {
+      return;
+    }
+
+    IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
+    filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
+    receiver = new LocationServiceStatusReceiver(events);
+    ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_EXPORTED);
+  }
+
+  @Override
+  public void onCancel(Object arguments) {
+
+    disposeListeners();
+  }
+
+  private void disposeListeners() {
+    if (context != null && receiver != null) {
+      context.unregisterReceiver(receiver);
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -1,0 +1,282 @@
+package com.baseflow.geolocator;
+
+import android.app.Activity;
+import android.content.Context;
+import android.location.Location;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+import com.baseflow.geolocator.location.FlutterLocationServiceListener;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationAccuracyStatus;
+import com.baseflow.geolocator.location.LocationAccuracyManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.LocationOptions;
+import com.baseflow.geolocator.permission.LocationPermission;
+import com.baseflow.geolocator.permission.PermissionManager;
+import com.baseflow.geolocator.utils.Utils;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Translates incoming Geolocator MethodCalls into well formed Java function calls for {@link
+ * GeolocationManager}.
+ */
+class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
+
+  private static final String TAG = "MethodCallHandlerImpl";
+  private final PermissionManager permissionManager;
+  private final GeolocationManager geolocationManager;
+  private final LocationAccuracyManager locationAccuracyManager;
+
+  @VisibleForTesting final Map<String, LocationClient> pendingCurrentPositionLocationClients;
+
+  @Nullable private Context context;
+
+  @Nullable private Activity activity;
+
+  MethodCallHandlerImpl(
+      PermissionManager permissionManager,
+      GeolocationManager geolocationManager,
+      LocationAccuracyManager locationAccuracyManager) {
+    this.permissionManager = permissionManager;
+    this.geolocationManager = geolocationManager;
+    this.locationAccuracyManager = locationAccuracyManager;
+    this.pendingCurrentPositionLocationClients = new HashMap<>();
+  }
+
+  @Nullable private MethodChannel channel;
+
+  @Override
+  public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+    switch (call.method) {
+      case "checkPermission":
+        onCheckPermission(result);
+        break;
+      case "isLocationServiceEnabled":
+        onIsLocationServiceEnabled(result);
+        break;
+      case "requestPermission":
+        onRequestPermission(result);
+        break;
+      case "getLastKnownPosition":
+        onGetLastKnownPosition(call, result);
+        break;
+      case "getLocationAccuracy":
+        getLocationAccuracy(result, this.context);
+        break;
+      case "getCurrentPosition":
+        onGetCurrentPosition(call, result);
+        break;
+      case "cancelGetCurrentPosition":
+        onCancelGetCurrentPosition(call, result);
+        break;
+      case "openAppSettings":
+        boolean hasOpenedAppSettings = Utils.openAppSettings(this.context);
+        result.success(hasOpenedAppSettings);
+        break;
+      case "openLocationSettings":
+        boolean hasOpenedLocationSettings = Utils.openLocationSettings(this.context);
+        result.success(hasOpenedLocationSettings);
+        break;
+      default:
+        result.notImplemented();
+        break;
+    }
+  }
+
+  /**
+   * Registers this instance as a method call handler on the given {@code messenger}.
+   *
+   * <p>Stops any previously started and unstopped calls.
+   *
+   * <p>This should be cleaned with {@link #stopListening} once the messenger is disposed of.
+   */
+  void startListening(Context context, BinaryMessenger messenger) {
+    if (channel != null) {
+      Log.w(TAG, "Setting a method call handler before the last was disposed.");
+      stopListening();
+    }
+
+    channel = new MethodChannel(messenger, "flutter.baseflow.com/geolocator_android");
+    channel.setMethodCallHandler(this);
+    this.context = context;
+  }
+
+  /**
+   * Clears this instance from listening to method calls.
+   *
+   * <p>Does nothing if {@link #startListening} hasn't been called, or if we're already stopped.
+   */
+  void stopListening() {
+    if (channel == null) {
+      Log.d(TAG, "Tried to stop listening when no MethodChannel had been initialized.");
+      return;
+    }
+
+    channel.setMethodCallHandler(null);
+    channel = null;
+  }
+
+  void setActivity(@Nullable Activity activity) {
+    this.activity = activity;
+  }
+
+  private void onCheckPermission(MethodChannel.Result result) {
+    try {
+      LocationPermission permission = permissionManager.checkPermissionStatus(context);
+      result.success(permission.toInt());
+    } catch (PermissionUndefinedException e) {
+      ErrorCodes errorCode = ErrorCodes.permissionDefinitionsNotFound;
+      result.error(errorCode.toString(), errorCode.toDescription(), null);
+    }
+  }
+
+  private void onIsLocationServiceEnabled(MethodChannel.Result result) {
+    geolocationManager.isLocationServiceEnabled(
+        context, new FlutterLocationServiceListener(result));
+  }
+
+  private void onRequestPermission(MethodChannel.Result result) {
+    try {
+      permissionManager.requestPermission(
+          activity,
+          (LocationPermission permission) -> result.success(permission.toInt()),
+          (ErrorCodes errorCode) ->
+              result.error(errorCode.toString(), errorCode.toDescription(), null));
+    } catch (PermissionUndefinedException e) {
+      ErrorCodes errorCode = ErrorCodes.permissionDefinitionsNotFound;
+      result.error(errorCode.toString(), errorCode.toDescription(), null);
+    }
+  }
+
+  private void getLocationAccuracy(MethodChannel.Result result, Context context) {
+    final LocationAccuracyStatus status =
+        locationAccuracyManager.getLocationAccuracy(
+            context,
+            (ErrorCodes errorCode) ->
+                result.error(errorCode.toString(), errorCode.toDescription(), null));
+    if (status != null) {
+      result.success(status.ordinal());
+    }
+  }
+
+  private void onGetLastKnownPosition(MethodCall call, MethodChannel.Result result) {
+    try {
+      if (!permissionManager.hasPermission(context)) {
+        result.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
+        return;
+      }
+    } catch (PermissionUndefinedException e) {
+      result.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
+    }
+
+    Boolean forceLocationManager = call.argument("forceLocationManager");
+
+    geolocationManager.getLastKnownPosition(
+        context,
+        forceLocationManager != null && forceLocationManager,
+        (Location location) -> result.success(LocationMapper.toHashMap(location)),
+        (ErrorCodes errorCode) ->
+            result.error(errorCode.toString(), errorCode.toDescription(), null));
+  }
+
+  /**
+   * Retrieves the current position.
+   *
+   * <p>Listens to location updates until it receives a location or encounters an error.
+   *
+   * <p>To manually cancel this request, call {@link #onCancelGetCurrentPosition}.
+   */
+  private void onGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
+    try {
+      if (!permissionManager.hasPermission(context)) {
+        result.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
+        return;
+      }
+    } catch (PermissionUndefinedException e) {
+      result.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) call.arguments;
+    boolean forceLocationManager = false;
+    if (map.get("forceLocationManager") != null) {
+      forceLocationManager = (boolean) map.get("forceLocationManager");
+    }
+    LocationOptions locationOptions = LocationOptions.parseArguments(map);
+    String requestId = (String) map.get("requestId");
+
+    final boolean[] replySubmitted = {false};
+
+    LocationClient locationClient =
+        geolocationManager.createLocationClient(context, forceLocationManager, locationOptions);
+    pendingCurrentPositionLocationClients.put(requestId, locationClient);
+
+    geolocationManager.startPositionUpdates(
+        locationClient,
+        activity,
+        (Location location) -> {
+          if (replySubmitted[0]) {
+            return;
+          }
+
+          replySubmitted[0] = true;
+          geolocationManager.stopPositionUpdates(locationClient);
+          pendingCurrentPositionLocationClients.remove(requestId);
+          result.success(LocationMapper.toHashMap(location));
+        },
+        (ErrorCodes errorCode) -> {
+          if (replySubmitted[0]) {
+            return;
+          }
+
+          replySubmitted[0] = true;
+          geolocationManager.stopPositionUpdates(locationClient);
+          pendingCurrentPositionLocationClients.remove(requestId);
+          result.error(errorCode.toString(), errorCode.toDescription(), null);
+        });
+  }
+
+  /**
+   * Cancels a request for the current position that was initiated with {@link #onGetCurrentPosition}.
+   */
+  private void onCancelGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> arguments = (Map<String, Object>) call.arguments;
+    String requestId = (String) arguments.get("requestId");
+
+    LocationClient locationClient = this.pendingCurrentPositionLocationClients.get(requestId);
+    if (locationClient != null) {
+      locationClient.stopPositionUpdates();
+    }
+    this.pendingCurrentPositionLocationClients.remove(requestId);
+
+    result.success(null);
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -1,0 +1,164 @@
+package com.baseflow.geolocator;
+
+import android.app.Activity;
+import android.content.Context;
+import android.location.Location;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+import com.baseflow.geolocator.location.ForegroundNotificationOptions;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.LocationOptions;
+import com.baseflow.geolocator.permission.PermissionManager;
+
+import java.util.Map;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.EventChannel;
+
+class StreamHandlerImpl implements EventChannel.StreamHandler {
+  private static final String TAG = "FlutterGeolocator";
+
+  private final PermissionManager permissionManager;
+
+  @Nullable private EventChannel channel;
+  @Nullable private Context context;
+  @Nullable private Activity activity;
+  @Nullable private GeolocatorLocationService foregroundLocationService;
+  @Nullable private GeolocationManager geolocationManager;
+  @Nullable private LocationClient locationClient;
+
+  public StreamHandlerImpl(PermissionManager permissionManager, GeolocationManager geolocationManager) {
+    this.permissionManager = permissionManager;
+    this.geolocationManager = geolocationManager;
+  }
+
+  public void setForegroundLocationService(
+      @Nullable GeolocatorLocationService foregroundLocationService) {
+    this.foregroundLocationService = foregroundLocationService;
+  }
+
+  public void setActivity(@Nullable Activity activity) {
+
+    if (activity == null && locationClient != null && channel != null) {
+      stopListening();
+    }
+
+    this.activity = activity;
+  }
+
+  /**
+   * Registers this instance as event stream handler on the given {@code messenger}.
+   *
+   * <p>Stops any previously started and unstopped calls.
+   *
+   * <p>This should be cleaned with {@link #stopListening} once the messenger is disposed of.
+   */
+  void startListening(Context context, BinaryMessenger messenger) {
+    if (channel != null) {
+      Log.w(TAG, "Setting a event call handler before the last was disposed.");
+      stopListening();
+    }
+
+    channel = new EventChannel(messenger, "flutter.baseflow.com/geolocator_updates_android");
+    channel.setStreamHandler(this);
+    this.context = context;
+  }
+
+  /**
+   * Clears this instance from listening to method calls.
+   *
+   * <p>Does nothing if {@link #startListening} hasn't been called, or if we're already stopped.
+   */
+  void stopListening() {
+    if (channel == null) {
+      Log.d(TAG, "Tried to stop listening when no MethodChannel had been initialized.");
+      return;
+    }
+
+    disposeListeners(false);
+    channel.setStreamHandler(null);
+    channel = null;
+  }
+
+  @SuppressWarnings({"ConstantConditions", "unchecked"})
+  @Override
+  public void onListen(Object arguments, EventChannel.EventSink events) {
+    try {
+      if (!permissionManager.hasPermission(this.context)) {
+        events.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
+        return;
+      }
+    } catch (PermissionUndefinedException e) {
+      events.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
+    }
+
+    if (foregroundLocationService == null) {
+      Log.e(TAG, "Location background service has not started correctly");
+      return;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) arguments;
+    boolean forceLocationManager = false;
+    if (map != null && map.get("forceLocationManager") != null) {
+      forceLocationManager = (boolean) map.get("forceLocationManager");
+    }
+    LocationOptions locationOptions = LocationOptions.parseArguments(map);
+    ForegroundNotificationOptions foregroundNotificationOptions = null;
+
+    if (map != null) {
+      foregroundNotificationOptions =
+          ForegroundNotificationOptions.parseArguments(
+              (Map<String, Object>) map.get("foregroundNotificationConfig"));
+    }
+    if (foregroundNotificationOptions != null) {
+      Log.e(TAG, "Geolocator position updates started using Android foreground service");
+      foregroundLocationService.startLocationService(forceLocationManager, locationOptions, events);
+      foregroundLocationService.enableBackgroundMode(foregroundNotificationOptions);
+    } else {
+      Log.e(TAG, "Geolocator position updates started");
+      locationClient =
+          geolocationManager.createLocationClient(
+              context, Boolean.TRUE.equals(forceLocationManager), locationOptions);
+
+      geolocationManager.startPositionUpdates(
+          locationClient,
+          activity,
+          (Location location) -> events.success(LocationMapper.toHashMap(location)),
+          (ErrorCodes errorCodes) ->
+              events.error(errorCodes.toString(), errorCodes.toDescription(), null));
+    }
+  }
+
+  @Override
+  public void onCancel(Object arguments) {
+    disposeListeners(true);
+  }
+
+  private void disposeListeners(boolean cancelled) {
+    Log.e(TAG, "Geolocator position updates stopped");
+    if (foregroundLocationService != null && foregroundLocationService.canStopLocationService(cancelled)) {
+      foregroundLocationService.stopLocationService();
+      foregroundLocationService.disableBackgroundMode();
+    } else {
+      Log.e(TAG, "There is still another flutter engine connected, not stopping location service");
+    }
+    if (locationClient != null && geolocationManager != null) {
+      geolocationManager.stopPositionUpdates(locationClient);
+      locationClient = null;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCallback.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCallback.java
@@ -1,0 +1,6 @@
+package com.baseflow.geolocator.errors;
+
+@FunctionalInterface
+public interface ErrorCallback {
+  void onError(ErrorCodes errorCode);
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
@@ -1,0 +1,48 @@
+package com.baseflow.geolocator.errors;
+
+public enum ErrorCodes {
+  activityMissing,
+  errorWhileAcquiringPosition,
+  locationServicesDisabled,
+  permissionDefinitionsNotFound,
+  permissionDenied,
+  permissionRequestInProgress;
+
+  public String toString() {
+    switch (this) {
+      case activityMissing:
+        return "ACTIVITY_MISSING";
+      case errorWhileAcquiringPosition:
+        return "ERROR_WHILE_ACQUIRING_POSITION";
+      case locationServicesDisabled:
+        return "LOCATION_SERVICES_DISABLED";
+      case permissionDefinitionsNotFound:
+        return "PERMISSION_DEFINITIONS_NOT_FOUND";
+      case permissionDenied:
+        return "PERMISSION_DENIED";
+      case permissionRequestInProgress:
+        return "PERMISSION_REQUEST_IN_PROGRESS";
+      default:
+        throw new IndexOutOfBoundsException();
+    }
+  }
+
+  public String toDescription() {
+    switch (this) {
+      case activityMissing:
+        return "Activity is missing. This might happen when running a certain function from the background that requires a UI element (e.g. requesting permissions or enabling the location services).";
+      case errorWhileAcquiringPosition:
+        return "An unexpected error occurred while trying to acquire the device's position.";
+      case locationServicesDisabled:
+        return "Location services are disabled. To receive location updates the location services should be enabled.";
+      case permissionDefinitionsNotFound:
+        return "No location permissions are defined in the manifest. Make sure at least ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION are defined in the manifest.";
+      case permissionDenied:
+        return "User denied permissions to access the device's location.";
+      case permissionRequestInProgress:
+        return "Already listening for location updates. If you want to restart listening please cancel other subscriptions first";
+      default:
+        throw new IndexOutOfBoundsException();
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
@@ -1,0 +1,6 @@
+package com.baseflow.geolocator.errors;
+
+import android.annotation.SuppressLint;
+
+@SuppressWarnings("serial")
+public class PermissionUndefinedException extends Exception {}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/AndroidIconResource.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/AndroidIconResource.java
@@ -1,0 +1,34 @@
+package com.baseflow.geolocator.location;
+
+import java.util.Map;
+
+public class AndroidIconResource {
+    private final String name;
+    private final String defType;
+
+    public static AndroidIconResource parseArguments(Map<String, Object> arguments) {
+        if (arguments == null) {
+            return null;
+        }
+
+        final String name = (String) arguments.get("name");
+        final String defType = (String) arguments.get("defType");
+
+        return new AndroidIconResource(
+                name,
+                defType);
+    }
+
+    private AndroidIconResource(String name, String defType) {
+        this.name = name;
+        this.defType = defType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDefType() {
+        return defType;
+    }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
@@ -1,0 +1,111 @@
+package com.baseflow.geolocator.location;
+
+import android.annotation.SuppressLint;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+public class BackgroundNotification {
+    @NonNull
+    private final Context context;
+    @NonNull
+    private final Integer notificationId;
+    @NonNull
+    private final String channelId;
+    @NonNull
+    private NotificationCompat.Builder builder;
+
+    public BackgroundNotification(
+        @NonNull Context context,
+        @NonNull String channelId ,
+        @NonNull Integer notificationId,
+        ForegroundNotificationOptions options
+    ) {
+        this.context = context;
+        this.notificationId = notificationId;
+        this.channelId = channelId;
+        builder = new NotificationCompat.Builder(context, channelId)
+                .setPriority(NotificationCompat.PRIORITY_HIGH);
+        updateNotification(options, false);
+    }
+
+    private int getDrawableId(String iconName, String defType) {
+        return context.getResources().getIdentifier(iconName, defType, context.getPackageName());
+    }
+
+    @SuppressLint("UnspecifiedImmutableFlag")
+    private PendingIntent buildBringToFrontIntent() {
+        Intent intent = context.getPackageManager()
+                .getLaunchIntentForPackage(context.getPackageName());
+
+        if (intent != null) {
+            intent.setPackage(null);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+            int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+                flags = flags | PendingIntent.FLAG_IMMUTABLE;
+            }
+            return PendingIntent.getActivity(context, 0, intent, flags);
+        }
+
+        return null;
+    }
+
+    public void updateChannel(String channelName) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            NotificationChannel channel = new NotificationChannel(
+                    channelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_NONE
+            );
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private void updateNotification(
+            ForegroundNotificationOptions options,
+            boolean notify
+    ) {
+        int iconId = getDrawableId(options.getNotificationIcon().getName(), options.getNotificationIcon().getDefType());
+        if(iconId == 0) {
+            getDrawableId("ic_launcher.png", "mipmap");
+        }
+
+        builder = builder
+                .setContentTitle(options.getNotificationTitle())
+                .setSmallIcon(iconId)
+                .setContentText(options.getNotificationText())
+                .setContentIntent(buildBringToFrontIntent())
+                .setOngoing(options.isSetOngoing());
+
+        @Nullable final Integer notificationColor = options.getColor();
+        if (notificationColor != null) {
+            builder = builder
+                .setColor(notificationColor);
+        }
+
+        if (notify) {
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            notificationManager.notify(notificationId, builder.build());
+        }
+    }
+
+    public void updateOptions(ForegroundNotificationOptions options, boolean isVisible) {
+        updateNotification(options, isVisible);
+    }
+
+    public Notification build() {
+        return builder.build();
+    }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FlutterLocationServiceListener.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FlutterLocationServiceListener.java
@@ -1,0 +1,23 @@
+package com.baseflow.geolocator.location;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+
+import io.flutter.plugin.common.MethodChannel;
+
+public class FlutterLocationServiceListener implements LocationServiceListener {
+  private MethodChannel.Result result;
+
+  public FlutterLocationServiceListener(MethodChannel.Result result) {
+    this.result = result;
+  }
+
+  @Override
+  public void onLocationServiceResult(boolean isEnabled) {
+    result.success(isEnabled);
+  }
+
+  @Override
+  public void onLocationServiceError(ErrorCodes errorCode) {
+    result.error(errorCode.toString(), errorCode.toDescription(), null);
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
@@ -1,0 +1,110 @@
+package com.baseflow.geolocator.location;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Map;
+
+@SuppressWarnings({"ConstantConditions", "unchecked"})
+public class ForegroundNotificationOptions {
+
+    @NonNull
+    private final String notificationTitle;
+    @NonNull
+    private final String notificationText;
+    @NonNull
+    private final String notificationChannelName;
+    @NonNull
+    private final AndroidIconResource notificationIcon;
+    private final boolean enableWifiLock;
+    private final boolean enableWakeLock;
+    private final boolean setOngoing;
+    @Nullable
+    private final Integer color;
+
+
+    public static ForegroundNotificationOptions parseArguments(@Nullable  Map<String, Object> arguments) {
+    if (arguments == null) {
+      return null;
+    }
+
+    final AndroidIconResource notificationIcon = AndroidIconResource.parseArguments((Map<String, Object>)arguments.get("notificationIcon"));
+    final String notificationTitle = (String) arguments.get("notificationTitle");
+    final String notificationChannelName = (String) arguments.get("notificationChannelName");
+    final String notificationText = (String) arguments.get("notificationText");
+    final Boolean enableWifiLock = (Boolean) arguments.get("enableWifiLock");
+    final Boolean enableWakeLock = (Boolean) arguments.get("enableWakeLock");
+    final Boolean setOngoing = (Boolean) arguments.get("setOngoing");
+
+    @Nullable Integer color = null;
+    final Object colorObject = arguments.get("color");
+    if (colorObject != null) {
+        color = ((Number) colorObject).intValue();
+    }
+
+    return new ForegroundNotificationOptions(
+            notificationTitle,
+            notificationText,
+            notificationChannelName,
+            notificationIcon,
+            enableWifiLock,
+            enableWakeLock,
+            setOngoing,
+            color);
+  }
+
+    private ForegroundNotificationOptions(
+        @NonNull String notificationTitle,
+        @NonNull String notificationText,
+        @NonNull String notificationChannelName,
+        @NonNull AndroidIconResource notificationIcon,
+        boolean enableWifiLock,
+        boolean enableWakeLock,
+        boolean setOngoing,
+        @Nullable Integer color) {
+        this.notificationTitle = notificationTitle;
+        this.notificationText = notificationText;
+        this.notificationChannelName = notificationChannelName;
+        this.notificationIcon = notificationIcon;
+        this.enableWifiLock = enableWifiLock;
+        this.enableWakeLock = enableWakeLock;
+        this.setOngoing = setOngoing;
+        this.color = color;
+    }
+
+    @NonNull
+    public String getNotificationTitle() {
+        return notificationTitle;
+    }
+
+    @NonNull
+    public String getNotificationText() {
+        return notificationText;
+    }
+
+    @NonNull
+    public String getNotificationChannelName() {
+        return notificationChannelName;
+    }
+
+    @NonNull
+    public AndroidIconResource getNotificationIcon() {
+        return notificationIcon;
+    }
+
+    public boolean isEnableWifiLock() {
+        return enableWifiLock;
+    }
+
+    public boolean isEnableWakeLock() {
+        return enableWakeLock;
+    }
+
+    public boolean isSetOngoing() {
+        return setOngoing;
+    }
+
+    @Nullable public Integer getColor() {
+        return color;
+    }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -1,0 +1,93 @@
+package com.baseflow.geolocator.location;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.errors.ErrorCallback;
+import com.baseflow.geolocator.errors.ErrorCodes;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class GeolocationManager
+    implements io.flutter.plugin.common.PluginRegistry.ActivityResultListener {
+
+    private static GeolocationManager geolocationManagerInstance = null;
+
+  private final List<LocationClient> locationClients;
+
+  private GeolocationManager() {
+    this.locationClients = new CopyOnWriteArrayList<>();
+  }
+
+  public static synchronized GeolocationManager getInstance() {
+      if (geolocationManagerInstance == null) {
+          geolocationManagerInstance = new GeolocationManager();
+      }
+
+      return geolocationManagerInstance;
+  }
+
+  public void getLastKnownPosition(
+      Context context,
+      boolean forceLocationManager,
+      PositionChangedCallback positionChangedCallback,
+      ErrorCallback errorCallback) {
+
+    LocationClient locationClient = createLocationClient(context, forceLocationManager, null);
+    locationClient.getLastKnownPosition(positionChangedCallback, errorCallback);
+  }
+
+  public void isLocationServiceEnabled(
+      @Nullable Context context, LocationServiceListener listener) {
+    if (context == null) {
+      listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
+    }
+
+    LocationClient locationClient = createLocationClient(context, false, null);
+    locationClient.isLocationServiceEnabled(listener);
+  }
+
+  public void startPositionUpdates(
+      @NonNull LocationClient locationClient,
+      @Nullable Activity activity,
+      @NonNull PositionChangedCallback positionChangedCallback,
+      @NonNull ErrorCallback errorCallback) {
+
+    this.locationClients.add(locationClient);
+    locationClient.startPositionUpdates(activity, positionChangedCallback, errorCallback);
+  }
+
+  public void stopPositionUpdates(@NonNull LocationClient locationClient) {
+    locationClients.remove(locationClient);
+    locationClient.stopPositionUpdates();
+  }
+
+  public LocationClient createLocationClient(
+      Context context,
+      boolean forceAndroidLocationManager,
+      @Nullable LocationOptions locationOptions) {
+    // #3473 — libre / F-Droid vendored geolocator_android: the GMS
+    // `FusedLocationClient` is removed from this copy, so we ALWAYS use
+    // Android's `LocationManager` (the app already forces this via
+    // `forceLocationManager=true`). No `com.google.android.gms.*` reference
+    // survives into the fdroid dex. The `forceAndroidLocationManager` param is
+    // honoured trivially — every path returns the LocationManager client.
+    return new LocationManagerClient(context, locationOptions);
+  }
+
+  @Override
+  public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+    for (LocationClient client : this.locationClients) {
+      if (client.onActivityResult(requestCode, resultCode)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracy.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracy.java
@@ -1,0 +1,10 @@
+package com.baseflow.geolocator.location;
+
+public enum LocationAccuracy {
+  lowest,
+  low,
+  medium,
+  high,
+  best,
+  bestForNavigation
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyManager.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyManager.java
@@ -1,0 +1,39 @@
+package com.baseflow.geolocator.location;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import androidx.core.content.ContextCompat;
+
+import com.baseflow.geolocator.errors.ErrorCallback;
+import com.baseflow.geolocator.errors.ErrorCodes;
+
+public class LocationAccuracyManager {
+
+    private LocationAccuracyManager() {}
+
+  private static LocationAccuracyManager locationAccuracyManagerInstance = null;
+
+  public static synchronized LocationAccuracyManager getInstance() {
+    if (locationAccuracyManagerInstance == null) {
+      locationAccuracyManagerInstance = new LocationAccuracyManager();
+    }
+
+    return locationAccuracyManagerInstance;
+  }
+
+  public LocationAccuracyStatus getLocationAccuracy(Context context, ErrorCallback errorCallback) {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        == PackageManager.PERMISSION_GRANTED) {
+      return LocationAccuracyStatus.precise;
+    } else if (ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_COARSE_LOCATION)
+        == PackageManager.PERMISSION_GRANTED) {
+      return LocationAccuracyStatus.reduced;
+    } else {
+      errorCallback.onError(ErrorCodes.permissionDenied);
+      return null;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyStatus.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyStatus.java
@@ -1,0 +1,9 @@
+package com.baseflow.geolocator.location;
+
+public enum LocationAccuracyStatus {
+  /// A approximate location will be returned (Approximate location).
+  reduced,
+
+  /// The precise location of the device will be returned.
+  precise,
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
@@ -1,0 +1,30 @@
+package com.baseflow.geolocator.location;
+
+import android.app.Activity;
+
+import android.content.Context;
+import android.location.LocationManager;
+import com.baseflow.geolocator.errors.ErrorCallback;
+
+public interface LocationClient {
+  void isLocationServiceEnabled(LocationServiceListener listener);
+
+  void getLastKnownPosition(
+      PositionChangedCallback positionChangedCallback, ErrorCallback errorCallback);
+
+  boolean onActivityResult(int requestCode, int resultCode);
+
+  void startPositionUpdates(
+      Activity activity,
+      PositionChangedCallback positionChangedCallback,
+      ErrorCallback errorCallback);
+
+  void stopPositionUpdates();
+  
+  default boolean checkLocationService(Context context){
+    LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+    boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    return gps_enabled || network_enabled;
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -1,0 +1,254 @@
+package com.baseflow.geolocator.location;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.location.LocationListenerCompat;
+import androidx.core.location.LocationManagerCompat;
+import androidx.core.location.LocationRequestCompat;
+
+import com.baseflow.geolocator.errors.ErrorCallback;
+import com.baseflow.geolocator.errors.ErrorCodes;
+
+import java.util.List;
+
+class LocationManagerClient implements LocationClient, LocationListenerCompat {
+
+  private static final long TWO_MINUTES = 120000;
+  private final LocationManager locationManager;
+  private final NmeaClient nmeaClient;
+  @Nullable private final LocationOptions locationOptions;
+  public Context context;
+  private boolean isListening = false;
+
+  @Nullable private Location currentBestLocation;
+  @Nullable private String currentLocationProvider;
+  @Nullable private PositionChangedCallback positionChangedCallback;
+  @Nullable private ErrorCallback errorCallback;
+
+  public LocationManagerClient(
+      @NonNull Context context, @Nullable LocationOptions locationOptions) {
+    this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    this.locationOptions = locationOptions;
+    this.context = context;
+    this.nmeaClient = new NmeaClient(context, locationOptions);
+  }
+
+  static boolean isBetterLocation(Location location, Location bestLocation) {
+    if (bestLocation == null) return true;
+
+    long timeDelta = location.getTime() - bestLocation.getTime();
+    boolean isSignificantlyNewer = timeDelta > TWO_MINUTES;
+    boolean isSignificantlyOlder = timeDelta < -TWO_MINUTES;
+    boolean isNewer = timeDelta > 0;
+
+    if (isSignificantlyNewer) return true;
+
+    if (isSignificantlyOlder) return false;
+
+    float accuracyDelta = (int) (location.getAccuracy() - bestLocation.getAccuracy());
+    boolean isLessAccurate = accuracyDelta > 0;
+    boolean isMoreAccurate = accuracyDelta < 0;
+    boolean isSignificantlyLessAccurate = accuracyDelta > 200;
+
+    boolean isFromSameProvider = false;
+    if (location.getProvider() != null) {
+      isFromSameProvider = location.getProvider().equals(bestLocation.getProvider());
+    }
+
+    if (isMoreAccurate) return true;
+
+    if (isNewer && !isLessAccurate) return true;
+
+    //noinspection RedundantIfStatement
+    if (isNewer && !isSignificantlyLessAccurate && isFromSameProvider) return true;
+
+    return false;
+  }
+
+  private static @Nullable String determineProvider(
+      @NonNull LocationManager locationManager,
+      @NonNull LocationAccuracy accuracy) {
+
+      final List<String> enabledProviders = locationManager.getProviders(true);
+
+      if (accuracy == LocationAccuracy.lowest) {
+          return LocationManager.PASSIVE_PROVIDER;
+      } else if (enabledProviders.contains(LocationManager.FUSED_PROVIDER) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          return LocationManager.FUSED_PROVIDER;
+      } else if (enabledProviders.contains(LocationManager.GPS_PROVIDER)) {
+          return LocationManager.GPS_PROVIDER;
+      } else if (enabledProviders.contains(LocationManager.NETWORK_PROVIDER)) {
+          return LocationManager.NETWORK_PROVIDER;
+      } else if (!enabledProviders.isEmpty()){
+          return enabledProviders.get(0);
+      } else {
+          return null;
+      }
+  }
+
+  private static @LocationRequestCompat.Quality int accuracyToQuality(@NonNull LocationAccuracy accuracy) {
+      switch (accuracy) {
+          case lowest:
+          case low:
+              return LocationRequestCompat.QUALITY_LOW_POWER;
+          case high:
+          case best:
+          case bestForNavigation:
+              return LocationRequestCompat.QUALITY_HIGH_ACCURACY;
+          case medium:
+          default:
+              return LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY;
+      }
+  }
+
+  @Override
+  public void isLocationServiceEnabled(LocationServiceListener listener) {
+    if (locationManager == null) {
+      listener.onLocationServiceResult(false);
+      return;
+    }
+
+    listener.onLocationServiceResult(checkLocationService(context));
+  }
+
+  @Override
+  public void getLastKnownPosition(
+      PositionChangedCallback positionChangedCallback, ErrorCallback errorCallback) {
+    Location bestLocation = null;
+
+    for (String provider : locationManager.getProviders(true)) {
+      @SuppressLint("MissingPermission")
+      Location location = locationManager.getLastKnownLocation(provider);
+
+      if (location != null && isBetterLocation(location, bestLocation)) {
+        bestLocation = location;
+      }
+    }
+
+    positionChangedCallback.onPositionChanged(bestLocation);
+  }
+
+  @Override
+  public boolean onActivityResult(int requestCode, int resultCode) {
+    return false;
+  }
+
+  @SuppressLint("MissingPermission")
+  @Override
+  public void startPositionUpdates(
+      Activity activity,
+      PositionChangedCallback positionChangedCallback,
+      ErrorCallback errorCallback) {
+
+    if (!checkLocationService(context)) {
+      errorCallback.onError(ErrorCodes.locationServicesDisabled);
+      return;
+    }
+
+    this.positionChangedCallback = positionChangedCallback;
+    this.errorCallback = errorCallback;
+
+    LocationAccuracy accuracy = LocationAccuracy.best;
+    long timeInterval = 0;
+    float distanceFilter = 0;
+    @LocationRequestCompat.Quality int quality = LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY;
+
+    if (this.locationOptions != null) {
+      distanceFilter = locationOptions.getDistanceFilter();
+      accuracy = locationOptions.getAccuracy();
+      timeInterval = accuracy == LocationAccuracy.lowest
+          ? LocationRequestCompat.PASSIVE_INTERVAL
+          : locationOptions.getTimeInterval();
+      quality = accuracyToQuality(accuracy);
+    }
+
+    this.currentLocationProvider = determineProvider(this.locationManager, accuracy);
+
+    if (this.currentLocationProvider == null) {
+      errorCallback.onError(ErrorCodes.locationServicesDisabled);
+      return;
+    }
+
+    final LocationRequestCompat locationRequest = new LocationRequestCompat.Builder(timeInterval)
+        .setMinUpdateDistanceMeters(distanceFilter)
+        .setMinUpdateIntervalMillis(timeInterval)
+        .setQuality(quality)
+        .build();
+
+    this.isListening = true;
+    this.nmeaClient.start();
+
+    LocationManagerCompat.requestLocationUpdates(
+        this.locationManager,
+        this.currentLocationProvider,
+        locationRequest,
+        this,
+        Looper.getMainLooper());
+  }
+
+  @SuppressLint("MissingPermission")
+  @Override
+  public void stopPositionUpdates() {
+    this.isListening = false;
+    this.nmeaClient.stop();
+    this.locationManager.removeUpdates(this);
+  }
+
+  @Override
+  public synchronized void onLocationChanged(Location location) {
+    if (isBetterLocation(location, currentBestLocation)) {
+      this.currentBestLocation = location;
+
+      if (this.positionChangedCallback != null) {
+        nmeaClient.enrichExtrasWithNmea(location);
+        this.positionChangedCallback.onPositionChanged(currentBestLocation);
+      }
+    }
+  }
+
+  /**
+   * This callback will never be invoked on Android Q and above, and providers can be considered as
+   * always in the {@link android.location.LocationProvider#AVAILABLE} state.
+   * See the <a href=https://developer.android.com/reference/android/location/LocationListener#onStatusChanged(java.lang.String,%20int,%20android.os.Bundle)>Android documentation</a>
+   * for more information.
+   */
+  @SuppressWarnings({"deprecation", "RedundantSuppression"})
+  @TargetApi(28)
+  @Override
+  public void onStatusChanged(@NonNull String provider, int status, Bundle extras) {
+    if (status == android.location.LocationProvider.AVAILABLE) {
+      onProviderEnabled(provider);
+    } else if (status == android.location.LocationProvider.OUT_OF_SERVICE) {
+      onProviderDisabled(provider);
+    }
+  }
+
+  @Override
+  public void onProviderEnabled(@NonNull String provider) {}
+
+  @SuppressLint("MissingPermission")
+  @Override
+  public void onProviderDisabled(String provider) {
+    if (provider.equals(this.currentLocationProvider)) {
+      if (isListening) {
+        this.locationManager.removeUpdates(this);
+      }
+
+      if (this.errorCallback != null) {
+        errorCallback.onError(ErrorCodes.locationServicesDisabled);
+      }
+
+      this.currentLocationProvider = null;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -1,0 +1,71 @@
+package com.baseflow.geolocator.location;
+
+import android.location.Location;
+import android.os.Build;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LocationMapper {
+  public static Map<String, Object> toHashMap(Location location) {
+    if (location == null) {
+      return null;
+    }
+
+    Map<String, Object> position = new HashMap<>();
+
+    position.put("latitude", location.getLatitude());
+    position.put("longitude", location.getLongitude());
+    position.put("timestamp", location.getTime());
+    position.put("is_mocked", isMocked(location));
+
+    if (location.hasAltitude()) position.put("altitude", location.getAltitude());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasVerticalAccuracy())
+      position.put("altitude_accuracy", location.getVerticalAccuracyMeters());
+    if (location.hasAccuracy()) position.put("accuracy", (double) location.getAccuracy());
+    if (location.hasBearing()) position.put("heading", (double) location.getBearing());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasBearingAccuracy())
+      position.put("heading_accuracy", location.getBearingAccuracyDegrees());
+    if (location.hasSpeed()) position.put("speed", (double) location.getSpeed());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
+      position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
+
+    if (location.getExtras() != null) {
+      if (location.getExtras().containsKey(NmeaClient.NMEA_ALTITUDE_EXTRA)) {
+        Double mslAltitude = location.getExtras().getDouble(NmeaClient.NMEA_ALTITUDE_EXTRA);
+        position.put("altitude", mslAltitude);
+      }
+      if (location.getExtras().containsKey(NmeaClient.GNSS_SATELLITE_COUNT_EXTRA)) {
+        Double mslSatelliteCount =
+            location.getExtras().getDouble(NmeaClient.GNSS_SATELLITE_COUNT_EXTRA);
+        position.put("gnss_satellite_count", mslSatelliteCount);
+      }
+      if (location.getExtras().containsKey(NmeaClient.GNSS_SATELLITES_USED_IN_FIX_EXTRA)) {
+        Double mslSatellitesUsedInFix =
+            location.getExtras().getDouble(NmeaClient.GNSS_SATELLITES_USED_IN_FIX_EXTRA);
+        position.put("gnss_satellites_used_in_fix", mslSatellitesUsedInFix);
+      }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && location.hasMslAltitude())
+      {
+        double mslAltitude = location.getMslAltitudeMeters();
+        position.put("altitude", mslAltitude);
+        if (location.hasMslAltitudeAccuracy()) {
+          float mslAccuracy = location.getMslAltitudeAccuracyMeters();
+          position.put("altitude_accuracy", mslAccuracy);
+        }
+      }
+    }
+    return position;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static boolean isMocked(Location location) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      return location.isMock();
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      return location.isFromMockProvider();
+    } else {
+      return false;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -1,0 +1,78 @@
+package com.baseflow.geolocator.location;
+
+import java.util.Map;
+
+public class LocationOptions {
+  public static final String USE_MSL_ALTITUDE_EXTRA = "geolocator_use_mslAltitude";
+
+  private final LocationAccuracy accuracy;
+  private final long distanceFilter;
+  private final long timeInterval;
+  private final boolean useMSLAltitude;
+
+  private LocationOptions(
+      LocationAccuracy accuracy, long distanceFilter, long timeInterval, boolean useMSLAltitude) {
+    this.accuracy = accuracy;
+    this.distanceFilter = distanceFilter;
+    this.timeInterval = timeInterval;
+    this.useMSLAltitude = useMSLAltitude;
+  }
+
+  public static LocationOptions parseArguments(Map<String, Object> arguments) {
+    if (arguments == null) {
+      return new LocationOptions(LocationAccuracy.best, 0, 5000, false);
+    }
+
+    final Integer accuracy = (Integer) arguments.get("accuracy");
+    final Integer distanceFilter = (Integer) arguments.get("distanceFilter");
+    final Integer timeInterval = (Integer) arguments.get("timeInterval");
+    final Boolean useMSLAltitude = (Boolean) arguments.get("useMSLAltitude");
+
+    LocationAccuracy locationAccuracy = LocationAccuracy.best;
+
+    if (accuracy != null) {
+      switch (accuracy) {
+        case 0:
+          locationAccuracy = LocationAccuracy.lowest;
+          break;
+        case 1:
+          locationAccuracy = LocationAccuracy.low;
+          break;
+        case 2:
+          locationAccuracy = LocationAccuracy.medium;
+          break;
+        case 3:
+          locationAccuracy = LocationAccuracy.high;
+          break;
+        case 5:
+          locationAccuracy = LocationAccuracy.bestForNavigation;
+          break;
+        case 4:
+        default:
+          break;
+      }
+    }
+
+    return new LocationOptions(
+        locationAccuracy,
+        distanceFilter != null ? distanceFilter : 0,
+        timeInterval != null ? timeInterval : 5000,
+        useMSLAltitude != null && useMSLAltitude);
+  }
+
+  public LocationAccuracy getAccuracy() {
+    return accuracy;
+  }
+
+  public long getDistanceFilter() {
+    return distanceFilter;
+  }
+
+  public long getTimeInterval() {
+    return timeInterval;
+  }
+
+  public boolean isUseMSLAltitude() {
+    return useMSLAltitude;
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationServiceListener.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationServiceListener.java
@@ -1,0 +1,11 @@
+package com.baseflow.geolocator.location;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+
+import io.flutter.plugin.common.MethodChannel;
+
+public interface LocationServiceListener {
+  void onLocationServiceResult(boolean isEnabled);
+
+  void onLocationServiceError(ErrorCodes errorCode);
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationServiceStatusReceiver.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationServiceStatusReceiver.java
@@ -1,0 +1,49 @@
+package com.baseflow.geolocator.location;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.location.LocationManager;
+
+import androidx.annotation.NonNull;
+
+import io.flutter.plugin.common.EventChannel;
+
+public class LocationServiceStatusReceiver extends BroadcastReceiver {
+  @NonNull private final EventChannel.EventSink events;
+
+  private ServiceStatus lastKnownServiceStatus;
+
+  public LocationServiceStatusReceiver(@NonNull EventChannel.EventSink events) {
+    this.events = events;
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (LocationManager.PROVIDERS_CHANGED_ACTION.equals(intent.getAction())) {
+
+      LocationManager locationManager =
+          (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+      boolean isGpsEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+      boolean isNetworkEnabled =
+          locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+
+      if (isGpsEnabled || isNetworkEnabled) {
+        /*
+        It may occur that the [BroadcastReceiver] receives several events of the same type,
+        that's why you should check whether or not the event is fired more than one time.
+        This is realised by saving the [lastKnownServiceStatus].
+         */
+        if (lastKnownServiceStatus == null || lastKnownServiceStatus == ServiceStatus.disabled) {
+          lastKnownServiceStatus = ServiceStatus.enabled;
+          events.success(ServiceStatus.enabled.ordinal());
+        }
+      } else {
+        if (lastKnownServiceStatus == null || lastKnownServiceStatus == ServiceStatus.enabled) {
+          lastKnownServiceStatus = ServiceStatus.disabled;
+          events.success(ServiceStatus.disabled.ordinal());
+        }
+      }
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -1,0 +1,137 @@
+package com.baseflow.geolocator.location;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.GnssStatus;
+import android.location.Location;
+import android.location.LocationManager;
+import android.location.OnNmeaMessageListener;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Calendar;
+
+public class NmeaClient {
+
+  public static final String NMEA_ALTITUDE_EXTRA = "geolocator_mslAltitude";
+  public static final String GNSS_SATELLITE_COUNT_EXTRA = "geolocator_mslSatelliteCount";
+  public static final String GNSS_SATELLITES_USED_IN_FIX_EXTRA = "geolocator_mslSatellitesUsedInFix";
+
+  private final Context context;
+  private final LocationManager locationManager;
+  @Nullable private final LocationOptions locationOptions;
+
+  @TargetApi(Build.VERSION_CODES.N)
+  private OnNmeaMessageListener nmeaMessageListener;
+  @TargetApi(Build.VERSION_CODES.N)
+  private GnssStatus.Callback gnssCallback;
+
+  private String lastNmeaMessage;
+  private double gnss_satellite_count;
+  private double gnss_satellites_used_in_fix;
+  @Nullable private Calendar lastNmeaMessageTime;
+  private boolean listenerAdded = false;
+
+  public NmeaClient(@NonNull Context context, @Nullable LocationOptions locationOptions) {
+    this.context = context;
+    this.locationOptions = locationOptions;
+    this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      nmeaMessageListener =
+          (message, timestamp) -> {
+            if (message.trim().matches("^\\$..GGA.*$")) {
+              lastNmeaMessage = message;
+              lastNmeaMessageTime = Calendar.getInstance();
+            }
+          };
+
+        gnssCallback = new GnssStatus.Callback() {
+            @Override
+            public void onSatelliteStatusChanged(@NonNull GnssStatus status) {
+                gnss_satellite_count = status.getSatelliteCount();
+                gnss_satellites_used_in_fix = 0;
+                for (int i = 0; i < gnss_satellite_count; ++i) {
+                    if (status.usedInFix(i)) {
+                        ++gnss_satellites_used_in_fix;
+                    }
+                }
+            }
+        };
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  public void start() {
+    if (listenerAdded) {
+      return;
+    }
+
+    if (locationOptions != null) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+        if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            == PackageManager.PERMISSION_GRANTED) {
+          locationManager.addNmeaListener(nmeaMessageListener, null);
+          locationManager.registerGnssStatusCallback(gnssCallback, null);
+          listenerAdded = true;
+        }
+      }
+    }
+  }
+
+  public void stop() {
+    if (locationOptions != null) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+        locationManager.removeNmeaListener(nmeaMessageListener);
+        locationManager.unregisterGnssStatusCallback(gnssCallback);
+        listenerAdded = false;
+      }
+    }
+  }
+
+  public void enrichExtrasWithNmea(@Nullable Location location) {
+
+    if (location == null) {
+      return;
+    }
+
+    if (location.getExtras() == null) {
+      location.setExtras(Bundle.EMPTY);
+    }
+    location.getExtras().putDouble(GNSS_SATELLITE_COUNT_EXTRA, gnss_satellite_count);
+    location.getExtras().putDouble(GNSS_SATELLITES_USED_IN_FIX_EXTRA, gnss_satellites_used_in_fix);
+
+    if (lastNmeaMessage != null && locationOptions != null && listenerAdded) {
+
+      Calendar expiryDate = Calendar.getInstance();
+      expiryDate.add(Calendar.SECOND, -5);
+      if (lastNmeaMessageTime != null && lastNmeaMessageTime.before(expiryDate)) {
+        // do not use MSL for old altitude values
+        return;
+      }
+
+      if (locationOptions.isUseMSLAltitude()) {
+        String[] tokens = lastNmeaMessage.split(",");
+        String type = tokens[0];
+
+        // Parse altitude above sea level, Detailed description of NMEA string here
+        // http://aprs.gids.nl/nmea/#gga
+        if (lastNmeaMessage.trim().matches("^\\$..GGA.*$") && tokens.length > 9) {
+          if (!tokens[9].isEmpty()) {
+            double mslAltitude = Double.parseDouble(tokens[9]);
+            if (location.getExtras() == null) {
+              location.setExtras(Bundle.EMPTY);
+            }
+            location.getExtras().putDouble(NMEA_ALTITUDE_EXTRA, mslAltitude);
+          }
+        }
+      }
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/PositionChangedCallback.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/PositionChangedCallback.java
@@ -1,0 +1,8 @@
+package com.baseflow.geolocator.location;
+
+import android.location.Location;
+
+@FunctionalInterface
+public interface PositionChangedCallback {
+  void onPositionChanged(Location location);
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ServiceStatus.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ServiceStatus.java
@@ -1,0 +1,6 @@
+package com.baseflow.geolocator.location;
+
+public enum ServiceStatus {
+    disabled,
+    enabled
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/LocationPermission.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/LocationPermission.java
@@ -1,0 +1,31 @@
+package com.baseflow.geolocator.permission;
+
+public enum LocationPermission {
+  /// Permission to access the device's location is denied by the user.
+  denied,
+  /// Permission to access the device's location is denied for ever. The
+  /// permission dialog will not been shown again until the user updates
+  /// the permission in the App settings.
+  deniedForever,
+  /// Permission to access the device's location is allowed only while
+  /// the App is in use.
+  whileInUse,
+  /// Permission to access the device's location is allowed even when the
+  /// App is running in the background.
+  always;
+
+  public int toInt() {
+    switch (this) {
+      case denied:
+        return 0;
+      case deniedForever:
+        return 1;
+      case whileInUse:
+        return 2;
+      case always:
+        return 3;
+      default:
+        throw new IndexOutOfBoundsException();
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -1,0 +1,239 @@
+package com.baseflow.geolocator.permission;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import com.baseflow.geolocator.errors.ErrorCallback;
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+
+import java.security.Permission;
+import java.util.*;
+
+@SuppressWarnings("deprecation")
+public class PermissionManager
+    implements io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener {
+
+    private PermissionManager() {}
+
+  private static final int PERMISSION_REQUEST_CODE = 109;
+
+  private static PermissionManager permissionManagerInstance = null;
+
+  @Nullable private Activity activity;
+  @Nullable private ErrorCallback errorCallback;
+  @Nullable private PermissionResultCallback resultCallback;
+
+  public static synchronized PermissionManager getInstance() {
+      if (permissionManagerInstance == null) {
+          permissionManagerInstance = new PermissionManager();
+      }
+
+      return permissionManagerInstance;
+  }
+
+  public LocationPermission checkPermissionStatus(Context context)
+      throws PermissionUndefinedException {
+    List<String> permissions = getLocationPermissionsFromManifest(context);
+
+    // If target is before Android M, permission is always granted
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return LocationPermission.always;
+    }
+
+    int permissionStatus = PackageManager.PERMISSION_DENIED;
+
+    for (String permission : permissions) {
+      if (ContextCompat.checkSelfPermission(context, permission)
+          == PackageManager.PERMISSION_GRANTED) {
+        permissionStatus = PackageManager.PERMISSION_GRANTED;
+        break;
+      }
+    }
+
+    if (permissionStatus == PackageManager.PERMISSION_DENIED) {
+      return LocationPermission.denied;
+    }
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return LocationPermission.always;
+    }
+
+    boolean wantsBackgroundLocation =
+        PermissionUtils.hasPermissionInManifest(
+            context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    if (!wantsBackgroundLocation) {
+      return LocationPermission.whileInUse;
+    }
+
+    final int permissionStatusBackground =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    if (permissionStatusBackground == PackageManager.PERMISSION_GRANTED) {
+      return LocationPermission.always;
+    }
+
+    return LocationPermission.whileInUse;
+  }
+
+  public void requestPermission(
+      Activity activity, PermissionResultCallback resultCallback, ErrorCallback errorCallback)
+      throws PermissionUndefinedException {
+
+    if (activity == null) {
+      errorCallback.onError(ErrorCodes.activityMissing);
+      return;
+    }
+
+    // Before Android M, requesting permissions was not needed.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      resultCallback.onResult(LocationPermission.always);
+      return;
+    }
+
+    final List<String> permissionsToRequest = getLocationPermissionsFromManifest(activity);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && PermissionUtils.hasPermissionInManifest(
+            activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
+      final LocationPermission permissionStatus = checkPermissionStatus(activity);
+      if (permissionStatus == LocationPermission.whileInUse) {
+        permissionsToRequest.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+      }
+    }
+
+    this.errorCallback = errorCallback;
+    this.resultCallback = resultCallback;
+    this.activity = activity;
+
+    ActivityCompat.requestPermissions(
+        activity, permissionsToRequest.toArray(new String[0]), PERMISSION_REQUEST_CODE);
+  }
+
+  @Override
+  public boolean onRequestPermissionsResult(
+      int requestCode, String[] permissions, int[] grantResults) {
+    if (requestCode != PERMISSION_REQUEST_CODE) {
+      return false;
+    }
+
+    if (this.activity == null) {
+      Log.e("Geolocator", "Trying to process permission result without an valid Activity instance");
+      if (this.errorCallback != null) {
+        this.errorCallback.onError(ErrorCodes.activityMissing);
+      }
+      return false;
+    }
+
+    List<String> requestedPermissions;
+
+    try {
+      requestedPermissions = getLocationPermissionsFromManifest(this.activity);
+    } catch (PermissionUndefinedException ex) {
+      if (this.errorCallback != null) {
+        this.errorCallback.onError(ErrorCodes.permissionDefinitionsNotFound);
+      }
+
+      return false;
+    }
+
+    if (grantResults.length == 0) {
+      Log.i(
+          "Geolocator",
+          "The grantResults array is empty. This can happen when the user cancels the permission request");
+      return false;
+    }
+
+    LocationPermission locationPermission = LocationPermission.denied;
+    int grantedResult = PackageManager.PERMISSION_DENIED;
+    boolean shouldShowRationale = false;
+    boolean permissionsPartOfPermissionsResult = false;
+
+    for (String permission : requestedPermissions) {
+      int requestedPermissionIndex = indexOf(permissions, permission);
+      if (requestedPermissionIndex >= 0) {
+          permissionsPartOfPermissionsResult = true;
+      }
+      if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
+        grantedResult = PackageManager.PERMISSION_GRANTED;
+      }
+      if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+        shouldShowRationale = true;
+      }
+    }
+
+    if(!permissionsPartOfPermissionsResult) {
+        Log.w(
+                "Geolocator",
+                "Location permissions not part of permissions send to onRequestPermissionsResult method.");
+        return false;
+    }
+
+    if (grantedResult == PackageManager.PERMISSION_GRANTED) {
+        locationPermission = (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q || hasBackgroundAccess(permissions, grantResults))
+                ? LocationPermission.always
+                : LocationPermission.whileInUse;
+    } else {
+      if (!shouldShowRationale) {
+        locationPermission = LocationPermission.deniedForever;
+      }
+    }
+
+    if (this.resultCallback != null) {
+      this.resultCallback.onResult(locationPermission);
+    }
+
+    return true;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  private boolean hasBackgroundAccess(String[] permissions, int[] grantResults) {
+    int backgroundPermissionIndex =
+        indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    return backgroundPermissionIndex >= 0
+        && grantResults[backgroundPermissionIndex] == PackageManager.PERMISSION_GRANTED;
+  }
+
+  private static <T> int indexOf(T[] arr, T val) {
+    return Arrays.asList(arr).indexOf(val);
+  }
+
+  private static List<String> getLocationPermissionsFromManifest(Context context)
+      throws PermissionUndefinedException {
+    boolean fineLocationPermissionExists =
+        PermissionUtils.hasPermissionInManifest(context, Manifest.permission.ACCESS_FINE_LOCATION);
+    boolean coarseLocationPermissionExists =
+        PermissionUtils.hasPermissionInManifest(
+            context, Manifest.permission.ACCESS_COARSE_LOCATION);
+
+    if (!fineLocationPermissionExists && !coarseLocationPermissionExists) {
+      throw new PermissionUndefinedException();
+    }
+
+    List<String> permissions = new ArrayList<>();
+
+    if (fineLocationPermissionExists) {
+      permissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+
+    if (coarseLocationPermissionExists) {
+      permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+    }
+
+    return permissions;
+  }
+
+    public boolean hasPermission(Context context) throws PermissionUndefinedException {
+        LocationPermission locationPermission = this.checkPermissionStatus(context);
+
+        return locationPermission == LocationPermission.whileInUse || locationPermission == LocationPermission.always;
+    }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionResultCallback.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionResultCallback.java
@@ -1,0 +1,6 @@
+package com.baseflow.geolocator.permission;
+
+@FunctionalInterface
+public interface PermissionResultCallback {
+  void onResult(LocationPermission permission);
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
@@ -1,0 +1,38 @@
+package com.baseflow.geolocator.permission;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+public class PermissionUtils {
+  public static boolean hasPermissionInManifest(Context context, String permission) {
+    try {
+      PackageInfo info = getPackageInfo(context);
+      if (info.requestedPermissions != null) {
+        for (String p : info.requestedPermissions) {
+          if (p.equals(permission)) {
+            return true;
+          }
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static PackageInfo getPackageInfo(Context context) throws PackageManager.NameNotFoundException {
+    final PackageManager packageManager = context.getPackageManager();
+    final String packageName = context.getPackageName();
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      return packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS);
+    }
+    
+    return packageManager.getPackageInfo(packageName,
+        PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS));
+  }
+}

--- a/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/utils/Utils.java
+++ b/third_party/geolocator_android/android/src/main/java/com/baseflow/geolocator/utils/Utils.java
@@ -1,0 +1,41 @@
+package com.baseflow.geolocator.utils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.provider.Settings;
+
+public class Utils {
+  public static boolean openAppSettings(Context context) {
+    try {
+      Intent settingsIntent = new Intent();
+      settingsIntent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+      settingsIntent.addCategory(Intent.CATEGORY_DEFAULT);
+      settingsIntent.setData(android.net.Uri.parse("package:" + context.getPackageName()));
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+
+      context.startActivity(settingsIntent);
+
+      return true;
+    } catch (Exception ex) {
+      return false;
+    }
+  }
+
+  public static boolean openLocationSettings(Context context) {
+    try {
+      Intent settingsIntent = new Intent();
+      settingsIntent.setAction(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+      settingsIntent.addCategory(Intent.CATEGORY_DEFAULT);
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+      settingsIntent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+
+      context.startActivity(settingsIntent);
+      return true;
+    } catch (Exception ex) {
+      return false;
+    }
+  }
+}

--- a/third_party/geolocator_android/android/src/test/java/com/baseflow/geolocator/MethodCallHandlerImplTest.java
+++ b/third_party/geolocator_android/android/src/test/java/com/baseflow/geolocator/MethodCallHandlerImplTest.java
@@ -1,0 +1,132 @@
+package com.baseflow.geolocator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.location.Location;
+
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationAccuracyManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.PositionChangedCallback;
+import com.baseflow.geolocator.permission.PermissionManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+public class MethodCallHandlerImplTest {
+  @Mock PermissionManager mockPermissionManager;
+  @Mock GeolocationManager mockGeolocationManager;
+  @Mock LocationAccuracyManager mockLocationAccuracyManager;
+  @Mock Location mockLocation;
+  @Mock LocationClient mockLocationClient;
+  @Mock AutoCloseable mockCloseable;
+
+  @Before
+  public void setUp() throws PermissionUndefinedException {
+    mockCloseable = MockitoAnnotations.openMocks(this);
+
+    when(mockLocation.getLatitude()).thenReturn(10.0);
+    when(mockLocation.getLongitude()).thenReturn(20.0);
+    when(mockLocation.getTime()).thenReturn(30L);
+    when(mockLocation.isMock()).thenReturn(false);
+    when(mockPermissionManager.hasPermission(any())).thenReturn(true);
+    when(mockGeolocationManager.createLocationClient(any(), anyBoolean(), any()))
+        .thenReturn(mockLocationClient);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mockCloseable.close();
+  }
+
+  @Test
+  public void onGetCurrentPosition_getsPosition() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    final ArgumentCaptor<PositionChangedCallback> callbackCaptor =
+        ArgumentCaptor.forClass(PositionChangedCallback.class);
+    Answer<Void> answer = invocation -> {
+      callbackCaptor.getValue().onPositionChanged(mockLocation);
+      return null;
+    };
+    doAnswer(answer)
+        .when(mockGeolocationManager)
+        .startPositionUpdates(any(), any(), callbackCaptor.capture(), any());
+
+    Map<String, Object> arguments = new HashMap<>();
+    ArgumentCaptor<Object> resultCaptor = ArgumentCaptor.forClass(Object.class);
+    Map<String, Object> expectedJson = LocationMapper.toHashMap(mockLocation);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("getCurrentPosition", arguments), mockResult);
+
+    // Assert
+    verify(mockResult).success(resultCaptor.capture());
+    assertEquals(expectedJson, resultCaptor.getValue());
+  }
+
+  @Test
+  public void onGetCurrentPosition_setsPendingLocationClient() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String requestId = "example_request_id";
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("requestId", requestId);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("getCurrentPosition", arguments), mockResult);
+
+    // Assert
+    assertTrue(methodCallHandler.pendingCurrentPositionLocationClients.containsKey(requestId));
+  }
+
+  @Test
+  public void onCancelGetCurrentPosition_clearsPendingLocationClient() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String requestId = "example_request_id";
+    methodCallHandler.pendingCurrentPositionLocationClients.put(requestId, null);
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("requestId", requestId);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("cancelGetCurrentPosition", arguments), mockResult);
+
+    // Assert
+    assertTrue(methodCallHandler.pendingCurrentPositionLocationClients.isEmpty());
+  }
+
+  private MethodCallHandlerImpl createMethodCallHandler() {
+    return new MethodCallHandlerImpl(
+        mockPermissionManager,
+        mockGeolocationManager,
+        mockLocationAccuracyManager
+    );
+  }
+}

--- a/third_party/geolocator_android/lib/geolocator_android.dart
+++ b/third_party/geolocator_android/lib/geolocator_android.dart
@@ -1,0 +1,22 @@
+export 'package:geolocator_platform_interface/geolocator_platform_interface.dart'
+    show
+        ActivityMissingException,
+        AlreadySubscribedException,
+        InvalidPermissionException,
+        LocationAccuracy,
+        LocationAccuracyStatus,
+        LocationPermission,
+        LocationServiceDisabledException,
+        LocationSettings,
+        PermissionDefinitionsNotFoundException,
+        PermissionDeniedException,
+        PermissionRequestInProgressException,
+        Position,
+        PositionUpdateException,
+        ServiceStatus;
+
+export 'src/geolocator_android.dart';
+export 'src/types/android_settings.dart' show AndroidSettings;
+export 'src/types/android_position.dart' show AndroidPosition;
+export 'src/types/foreground_settings.dart'
+    show AndroidResource, ForegroundNotificationConfig;

--- a/third_party/geolocator_android/lib/src/geolocator_android.dart
+++ b/third_party/geolocator_android/lib/src/geolocator_android.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:geolocator_android/geolocator_android.dart';
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+import 'package:uuid/uuid.dart';
+
+/// An implementation of [GeolocatorPlatform] that uses method channels.
+class GeolocatorAndroid extends GeolocatorPlatform {
+  /// The method channel used to interact with the native platform.
+  static const _methodChannel =
+      MethodChannel('flutter.baseflow.com/geolocator_android');
+
+  /// The event channel used to receive [Position] updates from the native
+  /// platform.
+  static const _eventChannel =
+      EventChannel('flutter.baseflow.com/geolocator_updates_android');
+
+  /// The event channel used to receive [LocationServiceStatus] updates from the
+  /// native platform.
+  static const _serviceStatusEventChannel =
+      EventChannel('flutter.baseflow.com/geolocator_service_updates_android');
+
+  /// Registers this class as the default instance of [GeolocatorPlatform].
+  static void registerWith() {
+    GeolocatorPlatform.instance = GeolocatorAndroid();
+  }
+
+  /// On Android devices you can set [forcedLocationManager]
+  /// to true to force the plugin to use the [LocationManager] to determine the
+  /// position instead of the [FusedLocationProviderClient]. On iOS this is
+  /// ignored.
+  bool forcedLocationManager = false;
+
+  Stream<Position>? _positionStream;
+  Stream<ServiceStatus>? _serviceStatusStream;
+
+  final Uuid _uuid = const Uuid();
+
+  @override
+  Future<LocationPermission> checkPermission() async {
+    try {
+      // ignore: omit_local_variable_types
+      final int permission =
+          await _methodChannel.invokeMethod('checkPermission');
+
+      return permission.toLocationPermission();
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<LocationPermission> requestPermission() async {
+    try {
+      // ignore: omit_local_variable_types
+      final int permission =
+          await _methodChannel.invokeMethod('requestPermission');
+
+      return permission.toLocationPermission();
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<bool> isLocationServiceEnabled() async => _methodChannel
+      .invokeMethod<bool>('isLocationServiceEnabled')
+      .then((value) => value ?? false);
+
+  @override
+  Future<Position?> getLastKnownPosition({
+    bool forceLocationManager = false,
+  }) async {
+    try {
+      final parameters = <String, dynamic>{
+        'forceLocationManager': forceLocationManager,
+      };
+
+      final positionMap =
+          await _methodChannel.invokeMethod('getLastKnownPosition', parameters);
+
+      return positionMap != null ? AndroidPosition.fromMap(positionMap) : null;
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<LocationAccuracyStatus> getLocationAccuracy() async {
+    final int accuracy =
+        await _methodChannel.invokeMethod('getLocationAccuracy');
+    return LocationAccuracyStatus.values[accuracy];
+  }
+
+  @override
+  Future<Position> getCurrentPosition({
+    LocationSettings? locationSettings,
+    String? requestId,
+  }) async {
+    requestId = requestId ?? _uuid.v4();
+
+    try {
+      Future<dynamic> positionFuture;
+
+      final Duration? timeLimit = locationSettings?.timeLimit;
+
+      positionFuture = _methodChannel.invokeMethod(
+        'getCurrentPosition',
+        {
+          ...?locationSettings?.toJson(),
+          'requestId': requestId,
+        },
+      );
+
+      if (timeLimit != null) {
+        positionFuture = positionFuture.timeout(timeLimit);
+      }
+
+      final positionMap = await positionFuture;
+      return AndroidPosition.fromMap(positionMap);
+    } on TimeoutException {
+      final parameters = <String, dynamic>{
+        'requestId': requestId,
+      };
+      _methodChannel.invokeMethod(
+        'cancelGetCurrentPosition',
+        parameters,
+      );
+      rethrow;
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Stream<ServiceStatus> getServiceStatusStream() {
+    if (_serviceStatusStream != null) {
+      return _serviceStatusStream!;
+    }
+    var serviceStatusStream =
+        _serviceStatusEventChannel.receiveBroadcastStream();
+
+    _serviceStatusStream = serviceStatusStream
+        .map((dynamic element) => ServiceStatus.values[element as int])
+        .handleError((error) {
+      _serviceStatusStream = null;
+      if (error is PlatformException) {
+        error = _handlePlatformException(error);
+      }
+      throw error;
+    });
+
+    return _serviceStatusStream!;
+  }
+
+  @override
+  Stream<Position> getPositionStream({
+    LocationSettings? locationSettings,
+  }) {
+    if (_positionStream != null) {
+      return _positionStream!;
+    }
+    var originalStream = _eventChannel.receiveBroadcastStream(
+      locationSettings?.toJson(),
+    );
+    var positionStream = _wrapStream(originalStream);
+
+    var timeLimit = locationSettings?.timeLimit;
+
+    if (timeLimit != null) {
+      positionStream = positionStream.timeout(
+        timeLimit,
+        onTimeout: (s) {
+          _positionStream = null;
+          s.addError(TimeoutException(
+            'Time limit reached while waiting for position update.',
+            timeLimit,
+          ));
+          s.close();
+        },
+      );
+    }
+
+    _positionStream = positionStream
+        .map<Position>((dynamic element) =>
+            AndroidPosition.fromMap(element.cast<String, dynamic>()))
+        .handleError(
+      (error) {
+        if (error is PlatformException) {
+          error = _handlePlatformException(error);
+        }
+        throw error;
+      },
+    );
+    return _positionStream!;
+  }
+
+  Stream<dynamic> _wrapStream(Stream<dynamic> incoming) {
+    return incoming.asBroadcastStream(onCancel: (subscription) {
+      subscription.cancel();
+      _positionStream = null;
+    });
+  }
+
+  @override
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
+    required String purposeKey,
+  }) async {
+    try {
+      final int status = await _methodChannel.invokeMethod(
+        'requestTemporaryFullAccuracy',
+        <String, dynamic>{
+          'purposeKey': purposeKey,
+        },
+      );
+      return LocationAccuracyStatus.values[status];
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+      throw error;
+    }
+  }
+
+  @override
+  Future<bool> openAppSettings() async => _methodChannel
+      .invokeMethod<bool>('openAppSettings')
+      .then((value) => value ?? false);
+
+  @override
+  Future<bool> openLocationSettings() async => _methodChannel
+      .invokeMethod<bool>('openLocationSettings')
+      .then((value) => value ?? false);
+
+  Exception _handlePlatformException(PlatformException exception) {
+    switch (exception.code) {
+      case 'ACTIVITY_MISSING':
+        return ActivityMissingException(exception.message);
+      case 'LOCATION_SERVICES_DISABLED':
+        return const LocationServiceDisabledException();
+      case 'LOCATION_SUBSCRIPTION_ACTIVE':
+        return const AlreadySubscribedException();
+      case 'PERMISSION_DEFINITIONS_NOT_FOUND':
+        return PermissionDefinitionsNotFoundException(exception.message);
+      case 'PERMISSION_DENIED':
+        return PermissionDeniedException(exception.message);
+      case 'PERMISSION_REQUEST_IN_PROGRESS':
+        return PermissionRequestInProgressException(exception.message);
+      case 'LOCATION_UPDATE_FAILURE':
+        return PositionUpdateException(exception.message);
+      default:
+        return exception;
+    }
+  }
+}

--- a/third_party/geolocator_android/lib/src/types/android_position.dart
+++ b/third_party/geolocator_android/lib/src/types/android_position.dart
@@ -1,0 +1,99 @@
+// ignore_for_file: use_super_parameters
+
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:meta/meta.dart';
+
+/// Contains additional location information only available on Android platforms.
+@immutable
+class AndroidPosition extends Position {
+  /// Constructs an instance with the given values for testing. [AndroidPosition]
+  /// instances constructed this way won't actually reflect any real information
+  /// from the platform, just whatever was passed in at construction time.
+  const AndroidPosition({
+    required this.satelliteCount,
+    required this.satellitesUsedInFix,
+    required longitude,
+    required latitude,
+    required timestamp,
+    required accuracy,
+    required altitude,
+    required altitudeAccuracy,
+    required heading,
+    required headingAccuracy,
+    required speed,
+    required speedAccuracy,
+    super.floor,
+    isMocked = false,
+  }) : super(
+          longitude: longitude,
+          latitude: latitude,
+          timestamp: timestamp,
+          accuracy: accuracy,
+          altitude: altitude,
+          altitudeAccuracy: altitudeAccuracy,
+          heading: heading,
+          headingAccuracy: headingAccuracy,
+          speed: speed,
+          speedAccuracy: speedAccuracy,
+          isMocked: isMocked,
+        );
+
+  /// If available it returns the number of GNSS satellites.
+  ///
+  /// If the number of satellites is not available it returns the default value: 0.0.
+  final double satelliteCount;
+
+  /// If available it returns the number of GNSS satellites used in fix.
+  ///
+  /// If the number of satellites used in fix is not available it returns the default value: 0.0.
+  final double satellitesUsedInFix;
+
+  @override
+  bool operator ==(Object other) {
+    var areEqual = other is AndroidPosition &&
+        super == other &&
+        other.satelliteCount == satelliteCount &&
+        other.satellitesUsedInFix == satellitesUsedInFix;
+    return areEqual;
+  }
+
+  @override
+  int get hashCode =>
+      satelliteCount.hashCode ^ satellitesUsedInFix.hashCode ^ super.hashCode;
+
+  /// Converts the supplied [Map] to an instance of the [AndroidPosition] class.
+  static AndroidPosition fromMap(dynamic message) {
+    final Map<dynamic, dynamic> positionMap = message;
+    // Call the Position fromMap method so future changes to the Position class are automatically picked up.
+    final position = Position.fromMap(positionMap);
+
+    return AndroidPosition(
+      satelliteCount: positionMap['gnss_satellite_count'] ?? 0.0,
+      satellitesUsedInFix: positionMap['gnss_satellites_used_in_fix'] ?? 0.0,
+      latitude: position.latitude,
+      longitude: position.longitude,
+      timestamp: position.timestamp,
+      accuracy: position.accuracy,
+      altitude: position.altitude,
+      altitudeAccuracy: position.altitudeAccuracy,
+      heading: position.heading,
+      headingAccuracy: position.headingAccuracy,
+      speed: position.speed,
+      speedAccuracy: position.speedAccuracy,
+      floor: position.floor,
+      isMocked: position.isMocked,
+    );
+  }
+
+  /// Converts the [AndroidPosition] instance into a [Map] instance that can be
+  /// serialized to JSON.
+  @override
+  Map<String, dynamic> toJson() {
+    return super.toJson()
+      ..addAll({
+        'gnss_satellite_count': satelliteCount,
+        'gnss_satellites_used_in_fix': satellitesUsedInFix,
+      });
+  }
+}

--- a/third_party/geolocator_android/lib/src/types/android_settings.dart
+++ b/third_party/geolocator_android/lib/src/types/android_settings.dart
@@ -1,0 +1,84 @@
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+
+import 'foreground_settings.dart';
+
+/// Represents different Android specific settings with which you can set a value
+/// other then the default value of the setting.
+class AndroidSettings extends LocationSettings {
+  /// Initializes a new [AndroidSpecificSettings] instance with default values.
+  ///
+  /// The following default values are used:
+  /// - forceLocationManager: false
+  AndroidSettings({
+    this.forceLocationManager = false,
+    super.accuracy,
+    super.distanceFilter,
+    this.intervalDuration,
+    super.timeLimit,
+    this.foregroundNotificationConfig,
+    this.useMSLAltitude = false,
+  });
+
+  /// Forces the Geolocator plugin to use the legacy LocationManager instead of
+  /// the FusedLocationProviderClient (Android only).
+  ///
+  /// Internally the Geolocator will check if Google Play Services are installed
+  /// on the device and not excluded as a dependency. If they are not installed
+  /// or excluded as a dependency the Geolocator plugin will automatically
+  /// switch to the LocationManager implementation. However if you want to force
+  /// the Geolocator plugin to use the LocationManager implementation even when
+  /// the Google Play Services are installed you could set this property to
+  /// true.
+  ///
+  /// To exclude Google mobile services from your app (for example because you
+  /// want to publish your app to the F-Droid app store) you can add the
+  /// following code to your `android/app/build.gradle` file:
+  /// ```gradle
+  /// configurations.implementation {
+  ///   exclude group: 'com.google.android.gms'
+  /// }
+  /// ```
+  final bool forceLocationManager;
+
+  /// The desired interval for active location updates.
+  ///
+  /// If this value is `null` an interval duration of 5000ms is applied.
+  final Duration? intervalDuration;
+
+  /// If this is set then the services is started as a Foreground service with a persistent notification
+  /// showing the user that the service will continue running in the background.
+  ///
+  /// Note: Using this foreground notification does not run your service in the background, it just
+  /// increases the priority of your activity making it less likely for Android to kill the activity
+  /// when switching between apps. It does not prevent Android from killing the activity. If you want to
+  /// receive background location updates even if the activity is destroyed you need to use a third party
+  /// background service package that will start a new Flutter Engine that is not tied to your main activity.
+  final ForegroundNotificationConfig? foregroundNotificationConfig;
+
+  /// Set to true if altitude should be calculated as MSL (EGM2008) from NMEA messages
+  /// and reported as the altitude instead of using the geoidal height (WSG84). Setting
+  /// this property true will help to align Android altitude to that of iOS which uses MSL.
+  ///
+  /// If the NMEA message is empty then the altitude reported will still be the standard WSG84
+  /// altitude from the GPS receiver.
+  ///
+  /// MSL Altitude is only available starting from Android N and not all devices support
+  /// NMEA message returning $GPGGA sequences.
+  ///
+  /// This property only works with position stream updates and has no effect when getting the
+  /// current position or last known position.
+  ///
+  /// Defaults to false
+  final bool useMSLAltitude;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return super.toJson()
+      ..addAll({
+        'forceLocationManager': forceLocationManager,
+        'timeInterval': intervalDuration?.inMilliseconds,
+        'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
+        'useMSLAltitude': useMSLAltitude,
+      });
+  }
+}

--- a/third_party/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/third_party/geolocator_android/lib/src/types/foreground_settings.dart
@@ -1,0 +1,125 @@
+import 'dart:ui';
+
+/// Uniquely identifies an Android resource.
+class AndroidResource {
+  /// The name of the desired resource.
+  final String name;
+
+  /// Optional default resource type to find, if "type/" is not included in the name.
+  ///
+  /// Can be null to require an explicit type.
+  final String defType;
+
+  /// Uniquely identifies an Android resource.
+  const AndroidResource({
+    required this.name,
+    this.defType = 'drawable',
+  });
+
+  /// Returns a JSON representation of this class.
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'defType': defType,
+    };
+  }
+}
+
+/// Configuration for the foreground notification. When this is provided the location service will run as a foreground service.
+class ForegroundNotificationConfig {
+  /// Creates an Android specific configuration for the [FlutterBackground] plugin.
+  ///
+  /// [notificationTitle] is the title used for the foreground service
+  /// notification.
+  /// [notificationText] is the body used for the foreground service
+  /// notification.
+  /// [notificationChannelName] is the name of the notification channel as it is
+  /// displayed in the system settings.
+  /// [notificationIcon] must be a drawable resource.
+  /// E. g. if the icon with name "background_icon" is in the "drawable"
+  /// resource folder, it should be of value
+  /// `AndroidResource(name: 'background_icon', defType: 'drawable').
+  /// [enableWifiLock] indicates wether or not a WifiLock is acquired, when the
+  /// background execution is started. This allows the application to keep the
+  /// Wi-Fi radio awake, even when the user has not used the device in a while.
+  /// [enableWakeLock] indicates wether or not a Wakelock is acquired, when the
+  /// background execution is started. If this is false then the system can
+  /// still sleep and all location events will be received at once when the
+  /// system wakes up again.
+  /// [setOngoing] indicates wether or not the displayed notification is
+  /// persistent and the user cannot dismiss it.
+  /// [color] is the accent color that is applied to the [notificationIcon].
+  const ForegroundNotificationConfig({
+    required this.notificationTitle,
+    required this.notificationText,
+    this.notificationChannelName = 'Background Location',
+    this.notificationIcon =
+        const AndroidResource(name: 'ic_launcher', defType: 'mipmap'),
+    this.enableWifiLock = false,
+    this.enableWakeLock = false,
+    this.setOngoing = false,
+    this.color,
+  });
+
+  /// The title used for the foreground service notification.
+  final String notificationTitle;
+
+  /// The body used for the foreground service notification.
+  final String notificationText;
+
+  /// The user visible name of the notification channel.
+  ///
+  /// The notification channel name will be displayed in the system settings.
+  /// The maximum recommended length is 40 characters, the name might be
+  /// truncated if it is to long. Default value: "Background Location".
+  final String notificationChannelName;
+
+  /// The resource name of the icon to be used for the foreground notification.
+  final AndroidResource notificationIcon;
+
+  /// When enabled, a WifiLock is acquired when background execution is started.
+  /// This allows the application to keep the Wi-Fi radio awake, even when the
+  /// user has not used the device in a while (e.g. for background network
+  /// communications).
+  ///
+  /// Wifi lock permissions should be obtained first by using a permissions library.
+  final bool enableWifiLock;
+
+  /// When enabled, a Wakelock is acquired when background execution is
+  /// started.
+  ///
+  /// If this is false then the system can still sleep and all location
+  /// events will be received at once when the system wakes up again.
+  ///
+  /// Wake lock permissions should be obtained first by using a permissions
+  /// library.
+  final bool enableWakeLock;
+
+  /// When enabled, the displayed notification is persistent and
+  /// the user cannot dismiss it
+  final bool setOngoing;
+
+  /// Accent color (an ARGB integer like the constants in Color) to be applied
+  /// by the standard Style templates when presenting this notification.
+  ///
+  /// The current template design constructs a colorful header image by
+  /// overlaying the icon image (stenciled in white) atop a field of this color.
+  /// Alpha components are ignored.
+  ///
+  /// If this color is null, a system default color is used.
+  final Color? color;
+
+  /// Returns a JSON representation of this class.
+  Map<String, dynamic> toJson() {
+    return {
+      'enableWakeLock': enableWakeLock,
+      'enableWifiLock': enableWifiLock,
+      'notificationTitle': notificationTitle,
+      'notificationIcon': notificationIcon.toJson(),
+      'notificationText': notificationText,
+      'notificationChannelName': notificationChannelName,
+      'setOngoing': setOngoing,
+      'color': color?.toARGB32(),
+    };
+  }
+}

--- a/third_party/geolocator_android/pubspec.yaml
+++ b/third_party/geolocator_android/pubspec.yaml
@@ -1,0 +1,33 @@
+name: geolocator_android
+description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 5.0.3
+
+environment:
+  sdk: ^3.5.0
+  flutter: ">=2.17.0"
+
+flutter:
+  plugin:
+    implements: geolocator
+    platforms:
+      android:
+        package: com.baseflow.geolocator
+        pluginClass: GeolocatorPlugin
+        dartPluginClass: GeolocatorAndroid
+
+dependencies:
+  flutter:
+    sdk: flutter
+  geolocator_platform_interface: ^4.1.0
+  meta: ^1.10.0
+  uuid: ">=4.0.0 <6.0.0"
+
+dev_dependencies:
+  async: ^2.8.2
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  mockito: ^5.2.0
+  plugin_platform_interface: ^2.1.2


### PR DESCRIPTION
Third GMS source removed via the per-flavor swap (#3484). `geolocator_android`'s `FusedLocationClient` + `GeolocationManager` reference `com.google.android.gms.location.*` / `gms.common.api` / `gms.tasks` (rejected by `fdroid scanner`). The app already forces Android's LocationManager on libre (`forceLocationManager=true`), so the GMS fused path is dead weight.

## What
Vendors `geolocator_android` 5.0.3 under `third_party/` and patches it:
- delete `FusedLocationClient.java`;
- `GeolocationManager.createLocationClient()` always returns `LocationManagerClient` (drop the `GoogleApiAvailability` probe + Fused branch);
- drop the `play-services-location` gradle dependency.

Swapped in only for the fdroid build via the libre-only `pubspec_overrides`. geolocator's Dart API (`Position`/`LocationSettings`) is unchanged → no app-side refactor. `analysis_options.yaml` excludes `third_party/**` (vendored upstream keeps its own conventions).

## Verified
Dex-scan of the fdroid **release** APK: **all** `gms.location` references drop (**39 → 27**). Runtime path is identical to the current libre build (LocationManager) — validated working on-device. No effect on Play/iOS.

Part of #3473 / #3476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)