### PR TITLE
fix(consumption): tank-level estimate uses the vehicle's real avg, not a fixed 7.0 (#1191)

### DIFF
--- a/lib/features/consumption/domain/services/tank_level_estimator.dart
+++ b/lib/features/consumption/domain/services/tank_level_estimator.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../core/domain/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
 import '../entities/fill_up.dart';
+import 'trip_length_aggregator.dart';
 
 /// How a [TankLevelEstimate] was derived (#1195).
 ///
@@ -140,9 +141,15 @@ TankLevelEstimate estimateTankLevel({
   final capacityL = vehicle.tankCapacityL;
   final upperBound = capacityL ?? double.infinity;
 
-  // TODO(#1191): replace with vehicle.tripLengthAggregates
-  //   ?.overallAvgLPer100Km once the carbon-dashboard aggregates land.
-  const avgLPer100Km = _defaultAvgLPer100Km;
+  // #1191 — ground the estimate in the vehicle's REAL average consumption
+  // from its trip history (measured litres, else the GPS estimate — see
+  // [aggregateByTripLength]), falling back to the fleet default only when
+  // there is no usable trip data for this vehicle yet. This makes the
+  // tank-level and range estimates track how THIS car actually drinks,
+  // instead of a fixed 7.0 L/100 km fleet average.
+  final avgLPer100Km =
+      aggregateByTripLength(trips, vehicleId: vehicle.id).overallAvgLPer100Km ??
+          _defaultAvgLPer100Km;
 
   // Compute the starting level right after [lastFillUp] (#1360 partial-
   // fill branch). For full fills this is just capacity; for partials

--- a/lib/features/consumption/domain/services/trip_length_aggregator.dart
+++ b/lib/features/consumption/domain/services/trip_length_aggregator.dart
@@ -128,6 +128,20 @@ class TripLengthBreakdown {
   /// waste vertical space.
   bool get isEmpty =>
       short.tripCount == 0 && medium.tripCount == 0 && long.tripCount == 0;
+
+  /// The vehicle's overall average consumption across every bucket:
+  /// `(Σ totalLitres / Σ totalDistanceKm) × 100`. Null when no bucket has a
+  /// qualifying trip (total distance zero), so the caller can fall back to a
+  /// default. Grounded in the same measured-litres-else-GPS-estimate figures
+  /// the buckets use — so it reflects the vehicle's real history rather than a
+  /// fixed constant. Consumed by the tank-level estimator (#1191).
+  double? get overallAvgLPer100Km {
+    final totalKm =
+        short.totalDistanceKm + medium.totalDistanceKm + long.totalDistanceKm;
+    if (totalKm <= 0) return null;
+    final totalL = short.totalLitres + medium.totalLitres + long.totalLitres;
+    return totalL / totalKm * 100.0;
+  }
 }
 
 /// Fold the [trips] iterable into a three-bucket [TripLengthBreakdown].

--- a/test/features/consumption/domain/services/tank_level_estimator_test.dart
+++ b/test/features/consumption/domain/services/tank_level_estimator_test.dart
@@ -195,8 +195,11 @@ void main() {
         trips: trips,
       );
 
-      // 50 - 2.5 - (40 × 7.0 / 100) = 50 - 2.5 - 2.8 = 44.7
-      expect(result.levelL, closeTo(44.7, 0.001));
+      // #1191 — the distance-only t2 is now estimated with THIS vehicle's
+      // real average from its history, not the 7.0 fleet default: t1 measures
+      // 2.5 L over 30 km ⇒ 2.5/30×100 = 8.333 L/100 km. So:
+      //   50 - 2.5 - (40 × 8.333 / 100) = 50 - 2.5 - 3.333 = 44.167
+      expect(result.levelL, closeTo(44.1667, 0.001));
       expect(result.method, TankLevelEstimationMethod.mixed);
     });
   });
@@ -311,7 +314,7 @@ void main() {
       expect(result.rangeKm, closeTo(714.2857, 0.01));
     });
 
-    test('rangeKm responds to consumption — half tank = ~half range', () {
+    test('rangeKm reflects the vehicle real consumption (#1191)', () {
       final trips = [
         trip(
           id: 't1',
@@ -327,8 +330,10 @@ void main() {
         trips: trips,
       );
 
-      // levelL = 25 → 25 / 7.0 × 100 ≈ 357.1 km
-      expect(result.rangeKm, closeTo(357.142, 0.01));
+      // #1191 — t1 burns 25 L over 100 km ⇒ real avg 25 L/100 km, and the
+      // range now tracks THIS car's thirst instead of the 7.0 fleet default:
+      // levelL 50 - 25 = 25 → 25 / 25 × 100 = 100 km.
+      expect(result.rangeKm, closeTo(100.0, 0.01));
     });
   });
 

--- a/test/features/consumption/domain/services/trip_length_aggregator_test.dart
+++ b/test/features/consumption/domain/services/trip_length_aggregator_test.dart
@@ -230,6 +230,29 @@ void main() {
       expect(breakdown.long.avgLPer100Km!, closeTo(5.0, 0.001));
     });
   });
+
+  group('overallAvgLPer100Km (#1191 — tank-level estimator input)', () {
+    test('null when no bucket has a qualifying trip', () {
+      expect(TripLengthBreakdown.empty.overallAvgLPer100Km, isNull);
+      // All-null-litres trips are dropped ⇒ still no qualifying distance.
+      final breakdown = aggregateByTripLength([
+        _entry(id: 't1', distanceKm: 3.0, fuelLitersConsumed: null),
+        _entry(id: 't2', distanceKm: 40.0, fuelLitersConsumed: null),
+      ]);
+      expect(breakdown.overallAvgLPer100Km, isNull);
+    });
+
+    test('pools litres and distance across ALL buckets, not per-bucket', () {
+      // short 3km/0.4L + medium 12km/0.9L + long 40km/2.4L:
+      //   Σlitres = 3.7, Σkm = 55 ⇒ 3.7 / 55 × 100 = 6.7273 L/100 km.
+      final breakdown = aggregateByTripLength([
+        _entry(id: 'short', distanceKm: 3.0, fuelLitersConsumed: 0.4),
+        _entry(id: 'medium', distanceKm: 12.0, fuelLitersConsumed: 0.9),
+        _entry(id: 'long', distanceKm: 40.0, fuelLitersConsumed: 2.4),
+      ]);
+      expect(breakdown.overallAvgLPer100Km!, closeTo(6.7273, 0.001));
+    });
+  });
 }
 
 /// Convenience constructor for a [TripHistoryEntry] in this file's


### PR DESCRIPTION
Resolves the standing `TODO(#1191)` in `tank_level_estimator`. The estimator hard-coded a **7.0 L/100 km fleet default** for its distance-based consumed-fuel and range math. It now derives the average from the vehicle's **own trip history** via `aggregateByTripLength` (measured litres, else the GPS estimate), falling back to 7.0 only when there's no usable trip data yet.

- New `TripLengthBreakdown.overallAvgLPer100Km` getter — pools litres/distance across all three buckets (null when no qualifying trip).
- `estimateTankLevel()` uses it, so tank level + range now track how **this** car actually drinks (a thirsty engine shows a shorter range, a frugal one a longer range) instead of one fleet constant.

Tests: added `overallAvgLPer100Km` coverage (pooled avg + null); updated the two estimator tests that asserted the old fixed-7.0 math to the data-driven values (the no-trip test still exercises the 7.0 fallback). All pass; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)