### PR TITLE
fix(map): zero-span bounds + non-finite coords → NaN camera freezes search map (#3488)

### DIFF
--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -53,14 +53,32 @@ class DrivingMapView extends StatelessWidget {
         InteractiveFlag.doubleTapZoom,
   );
 
-  /// Geographic centroid of the given stations.
+  /// A finite fallback camera centre (Paris) when there is nothing sane to
+  /// frame — mirrors the map feature's own fallback (#3488). Kept local so
+  /// this feature stays self-contained (no cross-feature import).
+  static const LatLng _fallbackCenter = LatLng(48.8566, 2.3522);
+
+  /// Half-width (~50 m) of the epsilon box padded around a degenerate,
+  /// zero-span bounds so `CameraFit.bounds` never computes an infinite
+  /// fit-zoom (which projects to `LatLng(NaN, NaN)` and throws on every
+  /// tile update — #3488).
+  static const double _boundsEpsilon = 0.0005;
+
+  /// Geographic centroid of the given stations. #3488 — NaN-safe: stations
+  /// with non-finite coords are skipped and an empty / all-non-finite input
+  /// returns [_fallbackCenter] rather than `0/0 = NaN`, so a
+  /// `LatLng(NaN, NaN)` never reaches the camera and freezes the map.
   static LatLng computeCenter(List<Station> stations) {
     double sumLat = 0, sumLng = 0;
+    var count = 0;
     for (final s in stations) {
+      if (!s.lat.isFinite || !s.lng.isFinite) continue;
       sumLat += s.lat;
       sumLng += s.lng;
+      count++;
     }
-    return LatLng(sumLat / stations.length, sumLng / stations.length);
+    if (count == 0) return _fallbackCenter;
+    return LatLng(sumLat / count, sumLng / count);
   }
 
   /// (min, max) price for [fuel] across the given stations. Returns (0, 0)
@@ -72,20 +90,34 @@ class DrivingMapView extends StatelessWidget {
   ) =>
       priceRange(stations, fuel);
 
-  /// The [LatLngBounds] framing all [stations]. A single station gets a tiny
-  /// epsilon box so `CameraFit.bounds` cannot divide-by-zero (mirrors
-  /// `InlineMap._boundsOf` / `RouteMapView._computeRouteBounds`).
+  /// The [LatLngBounds] framing all [stations]. #3488 — drops non-finite
+  /// coords and epsilon-pads any near-zero span (a single station OR several
+  /// co-located / duplicate ones — the field trigger) so `CameraFit.bounds`
+  /// cannot compute an infinite fit-zoom → `LatLng(NaN, NaN)` camera.
   static LatLngBounds _boundsOf(List<Station> stations) {
-    final points = [for (final s in stations) LatLng(s.lat, s.lng)];
-    if (points.length == 1) {
-      final p = points.first;
-      const eps = 0.0005; // ~50 m; fine for any latitude.
-      return LatLngBounds(
-        LatLng(p.latitude - eps, p.longitude - eps),
-        LatLng(p.latitude + eps, p.longitude + eps),
-      );
+    double? minLat, maxLat, minLng, maxLng;
+    for (final s in stations) {
+      if (!s.lat.isFinite || !s.lng.isFinite) continue;
+      minLat = (minLat == null) ? s.lat : (s.lat < minLat ? s.lat : minLat);
+      maxLat = (maxLat == null) ? s.lat : (s.lat > maxLat ? s.lat : maxLat);
+      minLng = (minLng == null) ? s.lng : (s.lng < minLng ? s.lng : minLng);
+      maxLng = (maxLng == null) ? s.lng : (s.lng > maxLng ? s.lng : maxLng);
     }
-    return LatLngBounds.fromPoints(points);
+    if (minLat == null || maxLat == null || minLng == null || maxLng == null) {
+      minLat = _fallbackCenter.latitude;
+      maxLat = _fallbackCenter.latitude;
+      minLng = _fallbackCenter.longitude;
+      maxLng = _fallbackCenter.longitude;
+    }
+    if (maxLat - minLat < _boundsEpsilon) {
+      minLat -= _boundsEpsilon;
+      maxLat += _boundsEpsilon;
+    }
+    if (maxLng - minLng < _boundsEpsilon) {
+      minLng -= _boundsEpsilon;
+      maxLng += _boundsEpsilon;
+    }
+    return LatLngBounds(LatLng(minLat, minLng), LatLng(maxLat, maxLng));
   }
 
   @override

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -237,37 +237,25 @@ class _InlineMapState extends ConsumerState<InlineMap> {
             .map((r) => r.station)
             .toList();
 
-  /// The [LatLngBounds] of the result [stations], with a tiny epsilon box for
-  /// a single result so `CameraFit.bounds` cannot divide-by-zero (mirrors
-  /// `RouteMapView._computeRouteBounds`).
+  /// The [LatLngBounds] of the result [stations]. #3488 — delegates to the
+  /// canonical [StationMapGeometry.boundsOfPoints], which drops non-finite
+  /// points and epsilon-pads any near-zero span (a single result OR several
+  /// co-located stations) so `CameraFit.bounds` cannot compute an infinite
+  /// fit-zoom.
   static LatLngBounds _boundsOf(List<Station> stations) =>
-      _boundsOfPoints([for (final s in stations) LatLng(s.lat, s.lng)]);
+      StationMapGeometry.boundsOfPoints(
+        [for (final s in stations) LatLng(s.lat, s.lng)],
+      );
 
   /// #3033 — the camera bounds for the route map: the along-route STATION
   /// extent, falling back to the route [geometry] (so an empty route still
-  /// frames its line), then a default box. Mirrors
-  /// `RouteMapView._computeRouteBounds`.
+  /// frames its line), then the canonical fallback box.
   static LatLngBounds _routeBoundsOf(
     List<Station> stations,
     List<LatLng> geometry,
   ) {
     final points = <LatLng>[for (final s in stations) LatLng(s.lat, s.lng)];
     if (points.isEmpty) points.addAll(geometry);
-    if (points.isEmpty) points.add(const LatLng(48.8566, 2.3522)); // Paris.
-    return _boundsOfPoints(points);
-  }
-
-  /// Bounds over [points], with a tiny epsilon box for a single point so
-  /// `CameraFit.bounds` cannot divide-by-zero. Assumes [points] is non-empty.
-  static LatLngBounds _boundsOfPoints(List<LatLng> points) {
-    if (points.length == 1) {
-      final p = points.first;
-      const eps = 0.0005; // ~50 m; fine for any latitude.
-      return LatLngBounds(
-        LatLng(p.latitude - eps, p.longitude - eps),
-        LatLng(p.latitude + eps, p.longitude + eps),
-      );
-    }
-    return LatLngBounds.fromPoints(points);
+    return StationMapGeometry.boundsOfPoints(points);
   }
 }

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -23,6 +23,7 @@ import '../../../../core/domain/search_result_item.dart';
 import '../../../../core/domain/station.dart';
 import '../../../search/providers/search_provider.dart';
 import '../../../profile/providers/profile_provider.dart';
+import 'station_map_geometry.dart';
 import 'route_best_stops_list.dart';
 import 'route_info_bar.dart';
 import 'route_view_mode_bar.dart';
@@ -88,21 +89,14 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
     if (points.isEmpty) {
       // No results to frame — fall back to the route geometry so the
       // itinerary is still visible (the build method renders an EmptyState
-      // in this case anyway), then to a Paris-centred box.
+      // in this case anyway), then to the canonical fallback box.
       points.addAll(widget.routeResult.route.geometry);
     }
-    if (points.isEmpty) {
-      points.add(const LatLng(48.8566, 2.3522));
-    }
-    if (points.length == 1) {
-      final p = points.first;
-      const eps = 0.0005; // ~50 m at the equator; fine for any latitude.
-      return LatLngBounds(
-        LatLng(p.latitude - eps, p.longitude - eps),
-        LatLng(p.latitude + eps, p.longitude + eps),
-      );
-    }
-    return LatLngBounds.fromPoints(points);
+    // #3488 — delegates to the canonical NaN-safe / zero-span-safe helper:
+    // it drops non-finite points, falls back to a finite box when empty,
+    // and epsilon-pads any near-zero span (single point OR several
+    // co-located stations) so `CameraFit.bounds` never divides-by-zero.
+    return StationMapGeometry.boundsOfPoints(points);
   }
 
   @override

--- a/lib/features/map/presentation/widgets/station_map_geometry.dart
+++ b/lib/features/map/presentation/widgets/station_map_geometry.dart
@@ -44,6 +44,13 @@ class StationMapGeometry {
   /// search radii we deal with (< 100 km). 1 degree latitude is ~111 km;
   /// the longitude degree shrinks with the cosine of the latitude.
   static LatLngBounds boundsForRadius(LatLng center, double radiusKm) {
+    // #3488 — a non-finite centre (or radius) would propagate NaN into the
+    // camera; fall back to a finite centre / zero radius so the box stays
+    // valid. `boundsOfPoints` then pads any zero span.
+    if (!center.latitude.isFinite || !center.longitude.isFinite) {
+      center = fallbackCenter;
+    }
+    if (!radiusKm.isFinite || radiusKm < 0) radiusKm = 0;
     const double kmPerLatDegree = 111.0;
     final double latDelta = radiusKm / kmPerLatDegree;
     final double cosLat = math.cos(center.latitude * math.pi / 180.0).abs();
@@ -54,20 +61,93 @@ class StationMapGeometry {
     final double north = (center.latitude + latDelta).clamp(-90.0, 90.0);
     final double west = (center.longitude - lngDelta).clamp(-180.0, 180.0);
     final double east = (center.longitude + lngDelta).clamp(-180.0, 180.0);
-    return LatLngBounds(
-      LatLng(south, west),
-      LatLng(north, east),
+    // #3488 — a zero radius yields a zero-span box; route the corners
+    // through `boundsOfPoints` so any near-zero span is epsilon-padded and
+    // `CameraFit.bounds` never computes an infinite fit-zoom.
+    return boundsOfPoints(
+      [LatLng(south, west), LatLng(north, east)],
+      fallback: center,
     );
   }
 
-  /// Calculate center point from a list of stations.
+  /// A finite fallback camera centre when there is nothing sane to frame
+  /// (empty / all-non-finite input). Paris — the historical default box
+  /// centre used by the route/inline fallbacks — so behaviour is uniform.
+  static const LatLng fallbackCenter = LatLng(48.8566, 2.3522);
+
+  /// Half-width of the epsilon box (~50 m) used to pad a degenerate,
+  /// zero-span bounds so `CameraFit.bounds` never computes an infinite
+  /// fit-zoom (which projects to `LatLng(NaN, NaN)` and throws on every
+  /// tile update — #3488). Fine at any latitude.
+  static const double _boundsEpsilon = 0.0005;
+
+  /// Calculate the geographic centroid of a list of stations.
+  ///
+  /// #3488 — hardened to be NaN-safe: stations whose `lat`/`lng` are
+  /// non-finite (bad upstream data) are skipped, and an empty (or
+  /// entirely non-finite) input returns [fallbackCenter] rather than
+  /// `0/0 = NaN`. A `LatLng(NaN, NaN)` reaching the camera makes
+  /// flutter_map throw `LatLng is not finite` on every tile update,
+  /// which visually freezes the map.
   static LatLng centerOf(List<Station> stations) {
     double sumLat = 0, sumLng = 0;
+    var count = 0;
     for (final s in stations) {
+      if (!s.lat.isFinite || !s.lng.isFinite) continue;
       sumLat += s.lat;
       sumLng += s.lng;
+      count++;
     }
-    return LatLng(sumLat / stations.length, sumLng / stations.length);
+    if (count == 0) return fallbackCenter;
+    return LatLng(sumLat / count, sumLng / count);
+  }
+
+  /// The framing [LatLngBounds] over [points], guaranteed finite and
+  /// non-degenerate so `CameraFit.bounds` can never divide-by-zero or
+  /// compute an infinite fit-zoom (#3488).
+  ///
+  /// Contract:
+  ///   * non-finite points are dropped;
+  ///   * an empty result (no points, or all non-finite) frames a small
+  ///     box around [fallback] (default [fallbackCenter]);
+  ///   * a **zero (or near-zero) span in either axis** — a single point
+  ///     OR several identical / co-located points (a chain returning a
+  ///     duplicate station was the #3488 trigger) — is padded to a tiny
+  ///     epsilon box, so the fit always has a finite area to frame.
+  static LatLngBounds boundsOfPoints(
+    List<LatLng> points, {
+    LatLng fallback = fallbackCenter,
+  }) {
+    double? minLat, maxLat, minLng, maxLng;
+    for (final p in points) {
+      if (!p.latitude.isFinite || !p.longitude.isFinite) continue;
+      minLat = (minLat == null) ? p.latitude : math.min(minLat, p.latitude);
+      maxLat = (maxLat == null) ? p.latitude : math.max(maxLat, p.latitude);
+      minLng = (minLng == null) ? p.longitude : math.min(minLng, p.longitude);
+      maxLng = (maxLng == null) ? p.longitude : math.max(maxLng, p.longitude);
+    }
+    // No finite point at all — frame a small box around the fallback.
+    if (minLat == null || maxLat == null || minLng == null || maxLng == null) {
+      final f = fallback.latitude.isFinite && fallback.longitude.isFinite
+          ? fallback
+          : fallbackCenter;
+      return LatLngBounds(
+        LatLng(f.latitude - _boundsEpsilon, f.longitude - _boundsEpsilon),
+        LatLng(f.latitude + _boundsEpsilon, f.longitude + _boundsEpsilon),
+      );
+    }
+    // Pad any near-zero span so the box always has a finite area. Guards
+    // BOTH the single-point case AND >=2 identical / co-located points,
+    // which `LatLngBounds.fromPoints` would collapse to min == max (#3488).
+    if (maxLat - minLat < _boundsEpsilon) {
+      minLat -= _boundsEpsilon;
+      maxLat += _boundsEpsilon;
+    }
+    if (maxLng - minLng < _boundsEpsilon) {
+      minLng -= _boundsEpsilon;
+      maxLng += _boundsEpsilon;
+    }
+    return LatLngBounds(LatLng(minLat, minLng), LatLng(maxLat, maxLng));
   }
 
   /// How many top-ranked stations keep their full price label; the rest

--- a/test/features/driving/presentation/widgets/driving_map_view_test.dart
+++ b/test/features/driving/presentation/widgets/driving_map_view_test.dart
@@ -58,6 +58,33 @@ void main() {
       expect(center.latitude, closeTo(48.137, 1e-9));
       expect(center.longitude, closeTo(11.575, 1e-9));
     });
+
+    // #3488 — NaN-safety: a non-finite centroid propagates
+    // `LatLng(NaN, NaN)` into the driving camera, which then throws on
+    // every tile update and freezes the map.
+    test('empty list returns a finite fallback, never NaN', () {
+      final center = DrivingMapView.computeCenter(const []);
+      expect(center.latitude.isFinite, isTrue);
+      expect(center.longitude.isFinite, isTrue);
+    });
+
+    test('skips a station with non-finite coordinates', () {
+      final center = DrivingMapView.computeCenter([
+        _station(id: 'bad', lat: double.nan, lng: double.nan),
+        _station(id: 'ok', lat: 48.0, lng: 2.0),
+      ]);
+      expect(center.latitude, closeTo(48.0, 1e-9));
+      expect(center.longitude, closeTo(2.0, 1e-9));
+    });
+
+    test('all-non-finite input falls back finite, never NaN', () {
+      final center = DrivingMapView.computeCenter([
+        _station(id: 'a', lat: double.nan, lng: 2.0),
+        _station(id: 'b', lat: 48.0, lng: double.infinity),
+      ]);
+      expect(center.latitude.isFinite, isTrue);
+      expect(center.longitude.isFinite, isTrue);
+    });
   });
 
   group('DrivingMapView.computePriceRange', () {

--- a/test/features/map/presentation/widgets/station_map_geometry_test.dart
+++ b/test/features/map/presentation/widgets/station_map_geometry_test.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_geometry.dart';
+
+/// Regression coverage for the #3488 NaN-camera bug.
+///
+/// Symptom: the fuel-station search "took a lot of time" — really the
+/// results map re-threw `LatLng is not finite: LatLng(NaN, NaN)` on
+/// EVERY tile-update event (50 identical throws in the field log), from
+/// `TileRangeCalculator`. Two failure modes wore the one symptom:
+///
+///   * Mode A — a **zero-span** `LatLngBounds` (a single station, OR
+///     >=2 stations at IDENTICAL coordinates: a chain returning a
+///     duplicate) reached `CameraFit.bounds`, which then computed an
+///     **infinite fit-zoom** → the camera projected to `LatLng(NaN,NaN)`.
+///     The old per-site `_boundsOf*` helpers only epsilon-padded the
+///     `length == 1` case, so co-located duplicates slipped through.
+///   * Mode B — a non-finite station coordinate flowed into the centroid
+///     / bounds and propagated NaN into the camera.
+///
+/// These tests reproduce the mechanism directly: `CameraFit.bounds(...)`
+/// over the geometry helper's output must always yield a FINITE camera.
+void main() {
+  // A camera to fit against — size and starting position are irrelevant
+  // to the fit math; only the resulting centre/zoom finiteness matters.
+  MapCamera fitCameraTo(LatLngBounds bounds) {
+    final base = MapCamera(
+      crs: const Epsg3857(),
+      center: const LatLng(0, 0),
+      zoom: 3,
+      rotation: 0,
+      nonRotatedSize: const Size(400, 800),
+    );
+    return CameraFit.bounds(
+      bounds: bounds,
+      padding: const EdgeInsets.all(32),
+    ).fit(base);
+  }
+
+  void expectFiniteCamera(LatLngBounds bounds) {
+    final camera = fitCameraTo(bounds);
+    expect(camera.center.latitude.isFinite, isTrue,
+        reason: 'camera latitude must be finite');
+    expect(camera.center.longitude.isFinite, isTrue,
+        reason: 'camera longitude must be finite');
+    expect(camera.zoom.isFinite, isTrue, reason: 'camera zoom must be finite');
+  }
+
+  Station stationAt(String id, double lat, double lng) => Station(
+        id: id,
+        name: id,
+        brand: 'Brand',
+        street: 'Street',
+        houseNumber: '1',
+        postCode: '00000',
+        place: 'Place',
+        lat: lat,
+        lng: lng,
+        dist: 1.0,
+        isOpen: true,
+      );
+
+  group('centerOf — NaN-safe centroid (#3488)', () {
+    test('empty list returns the finite fallback, never NaN', () {
+      final c = StationMapGeometry.centerOf(const []);
+      expect(c.latitude.isFinite, isTrue);
+      expect(c.longitude.isFinite, isTrue);
+      expect(c, StationMapGeometry.fallbackCenter);
+    });
+
+    test('a station with non-finite coords is skipped', () {
+      final c = StationMapGeometry.centerOf([
+        stationAt('nan', double.nan, double.nan),
+        stationAt('ok', 48.0, 2.0),
+      ]);
+      expect(c.latitude, closeTo(48.0, 1e-9));
+      expect(c.longitude, closeTo(2.0, 1e-9));
+    });
+
+    test('all-non-finite input falls back finite, never NaN', () {
+      final c = StationMapGeometry.centerOf([
+        stationAt('a', double.nan, 2.0),
+        stationAt('b', 48.0, double.infinity),
+      ]);
+      expect(c.latitude.isFinite, isTrue);
+      expect(c.longitude.isFinite, isTrue);
+      expect(c, StationMapGeometry.fallbackCenter);
+    });
+
+    test('normal input still averages correctly', () {
+      final c = StationMapGeometry.centerOf([
+        stationAt('a', 48.0, 2.0),
+        stationAt('b', 50.0, 4.0),
+      ]);
+      expect(c.latitude, closeTo(49.0, 1e-9));
+      expect(c.longitude, closeTo(3.0, 1e-9));
+    });
+  });
+
+  group('boundsOfPoints — never degenerate for CameraFit (#3488)', () {
+    test('Mode A: >=2 IDENTICAL points → non-zero span → finite camera', () {
+      // The field trigger: duplicate/co-located stations.
+      final bounds = StationMapGeometry.boundsOfPoints(const [
+        LatLng(48.8566, 2.3522),
+        LatLng(48.8566, 2.3522),
+        LatLng(48.8566, 2.3522),
+      ]);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('single point → epsilon box → finite camera', () {
+      final bounds =
+          StationMapGeometry.boundsOfPoints(const [LatLng(45.0, 5.0)]);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('empty input → finite fallback box → finite camera', () {
+      final bounds = StationMapGeometry.boundsOfPoints(const []);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('Mode B: non-finite points dropped, degenerate remainder padded', () {
+      final bounds = StationMapGeometry.boundsOfPoints(const [
+        LatLng(double.nan, double.nan),
+        LatLng(48.0, 2.0),
+        LatLng(double.infinity, 2.0),
+      ]);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('all-non-finite input → fallback box → finite camera', () {
+      final bounds = StationMapGeometry.boundsOfPoints(const [
+        LatLng(double.nan, 1.0),
+        LatLng(2.0, double.infinity),
+      ]);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('two DISTINCT points keep their real span (not over-padded)', () {
+      final bounds = StationMapGeometry.boundsOfPoints(const [
+        LatLng(48.0, 2.0),
+        LatLng(49.0, 3.0),
+      ]);
+      expect(bounds.south, closeTo(48.0, 1e-9));
+      expect(bounds.north, closeTo(49.0, 1e-9));
+      expect(bounds.west, closeTo(2.0, 1e-9));
+      expect(bounds.east, closeTo(3.0, 1e-9));
+      expectFiniteCamera(bounds);
+    });
+  });
+
+  group('boundsForRadius — finite even at zero / non-finite input (#3488)', () {
+    test('zero radius → padded, non-degenerate, finite camera', () {
+      final bounds =
+          StationMapGeometry.boundsForRadius(const LatLng(48.0, 2.0), 0);
+      expect(bounds.north, greaterThan(bounds.south));
+      expect(bounds.east, greaterThan(bounds.west));
+      expectFiniteCamera(bounds);
+    });
+
+    test('non-finite centre falls back to a finite box', () {
+      final bounds = StationMapGeometry.boundsForRadius(
+        const LatLng(double.nan, double.nan),
+        5,
+      );
+      expect(bounds.north.isFinite, isTrue);
+      expect(bounds.south.isFinite, isTrue);
+      expectFiniteCamera(bounds);
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Searching for fuel stations "took a lot of time" — the results map was frozen. The field error log had **50 identical** throws:

```
LatLng is not finite: LatLng(NaN, NaN)
  Crs.checkLatLng → Epsg3857.latLngToOffset → MapCamera.projectAtZoom
  → TileRangeCalculator → _TileLayerState._onTileUpdateEvent
```

Startup itself was fine (trace: 299 ms). The map re-threw on **every** tile-update event because the camera was non-finite.

## Root cause (recurring-bug protocol — two modes, one symptom)
- **Mode A (field trigger):** a **zero-span** `LatLngBounds` reached `CameraFit.bounds`, which computes an **infinite fit-zoom** → the camera projects to `LatLng(NaN, NaN)`. All three framing helpers (`InlineMap._boundsOfPoints`, `DrivingMapView._boundsOf`, `RouteMapView._computeRouteBounds`) only epsilon-padded the `length == 1` case, so **≥2 stations at identical coordinates** (a chain returning a duplicate) collapsed `LatLngBounds.fromPoints` to `min == max` and slipped through.
- **Mode B (defensive):** a non-finite station coordinate propagating NaN into the centroid / bounds.

Proven RED on the old path: `CameraFit.bounds(fromPoints([identical, identical]))` throws `Camera zoom must be finite` (in release that becomes the field's NaN tile-range throw).

## Fix
- New canonical `StationMapGeometry.boundsOfPoints` — drops non-finite points, finite fallback box when empty, and **epsilon-pads any near-zero span in either axis** (single point OR co-located duplicates). `inline_map` + `route_map_view` delegate to it (removes 2 copies of the buggy logic); `boundsForRadius` routes its corners through it so a zero radius is safe too.
- `centerOf` skips non-finite members and returns a finite fallback instead of `0/0 = NaN`.
- `DrivingMapView` keeps its **own** self-contained NaN-safe centroid + bounds — no cross-feature import, so the `driving → map` feature-boundary baseline stays at 3.

## Tests
- New `station_map_geometry_test.dart` (13 cases): identical points, single point, empty, non-finite, zero radius — each must yield a **finite `CameraFit` camera**.
- `driving_map_view_test.dart`: NaN-safe `computeCenter` cases.
- Full `flutter analyze` clean; map + driving + lint suites green.

## Constraints honoured
- Pure geometry fix — **no new user-facing strings**.
- Keeps working on iPhone, Android **and** F-Droid (no plugin / platform surface touched).

Closes #3488