### PR TITLE
chore(fdroid): compile Sentry out of libre + recipe prebuild fix — 0 io.sentry refs (#3492)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -15,6 +15,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import '../features/alerts/background/background_service.dart';
 import '../core/constants/app_constants.dart';
 import '../core/cache/cache_manager.dart';
+import '../core/platform/app_flavor.dart';
 import '../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../core/telemetry/health_counters.dart';
 import '../core/telemetry/storage/startup_failure_store.dart';
@@ -266,22 +267,20 @@ class AppInitializer {
 
     StartupTimer.instance.mark('pre_run_app');
 
-    // #1769 — Sentry no longer wraps `runApp`; the old wrapper forced
-    // both `SentryFlutter.init` and the package-info round-trip it
-    // needs for the release string onto the cold-start critical path.
-    // The app now paints first and Sentry initialises in the first
-    // post-first-frame microtask. Native crash handlers come up a few
-    // hundred ms later — acceptable, since Sentry only needs to be live
-    // before an error is *reported*, not before first paint.
-    // `_installErrorHandlers` is re-run afterwards so the app's
-    // `errorLogger` pipeline stays the authoritative target, matching
-    // today's behaviour where `_launch` overwrote Sentry's own
-    // integration handlers.
+    // #1769 — Sentry no longer wraps `runApp`; the old wrapper forced both
+    // `SentryFlutter.init` and the package-info round-trip onto the cold-start
+    // critical path. The app now paints first and Sentry initialises in the
+    // first post-first-frame microtask — native crash handlers come up a few
+    // hundred ms later, acceptable since Sentry only needs to be live before an
+    // error is *reported*, not before first paint. `_installErrorHandlers` is
+    // re-run afterwards so the `errorLogger` pipeline stays authoritative.
+    // #3492 — libre / F-Droid ships NO Sentry SDK (stub → no `io.sentry`), so
+    // never init there; `AppFlavor.isLibre` is const so R8 folds the block out.
     final dsn = resolveSentryDsn(storage);
     final consentGiven = storage
             .getSetting('consent_error_reporting') as bool? ??
         false;
-    if (dsn.isNotEmpty && consentGiven) {
+    if (!AppFlavor.isLibre && dsn.isNotEmpty && consentGiven) {
       _deferPostFirstFrame(() async {
         final packageInfo = await _resolvePackageInfo();
         await SentryFlutter.init((options) {
@@ -290,18 +289,16 @@ class AppInitializer {
           options.environment = 'production';
           options.release =
               'tankstellen@${packageInfo.version}+${packageInfo.buildNumber}';
-          // #1109 — strip PII (emails, lat/lng, tokens, user/request
-          // blocks, long breadcrumb payloads) from every event before
-          // it leaves the device. The scrubber is a pure function so it
-          // stays unit-tested and shared with `TraceUploader`.
+          // #1109 — strip PII (emails, lat/lng, tokens, user/request blocks,
+          // long breadcrumbs) from every event before it leaves the device.
+          // The scrubber is a pure function shared with `TraceUploader`.
           options.beforeSend = (event, hint) {
             try {
               return PiiScrubber.scrubSentryEvent(event);
             } catch (e, st) {
-              // #3144 — breadcrumb-level (NOT errorLogger): a warn-level
-              // trace from inside beforeSend could recurse through the
-              // Sentry upload path. The breadcrumb still rides inside the
-              // next persisted trace, so the scrub fault is field-visible.
+              // #3144 — breadcrumb-level (NOT errorLogger): a warn trace from
+              // inside beforeSend could recurse through the Sentry upload path.
+              // The breadcrumb still rides the next persisted trace.
               log.info('Sentry beforeSend scrub failed: $e\n$st',
                   tag: 'sentry');
               return event;

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -64,11 +64,13 @@ Description: |-
 
   '''About this F-Droid build'''
 
-  This is the fully free build, with no Google Play Services and no other
-  proprietary Google libraries. Maps use OpenStreetMap and positioning uses
-  Android's location manager. Because the pump-display, receipt and barcode
-  scanners rely on Google ML Kit, scanning is not available in this build — add
-  fill-ups by hand instead. Every other feature works as described.
+  This is the fully free build: no Google Play Services, no other proprietary
+  Google libraries, and no crash-reporting or analytics of any kind. Maps use
+  OpenStreetMap and positioning uses Android's location manager. QR scanning
+  (device pairing, payment codes) works via the free ZXing library. Only the
+  pump-display and receipt text scanners, which rely on Google ML Kit, are
+  unavailable in this build — add those fill-ups by hand instead. Every other
+  feature works as described.
 
 RepoType: git
 Repo: https://github.com/fdittgen-png/tankstellen.git
@@ -83,10 +85,19 @@ Builds:
     srclibs:
       - flutter@stable
     prebuild:
+      # epic #3473 — swap the GMS/ML-Kit/Play-Core/Sentry-pulling plugins for
+      # the Dart-only stubs BEFORE `pub get`, so the resolved graph (and the
+      # dex) is structurally free of com.google.android.gms / com.google.mlkit
+      # / com.google.android.play / io.sentry. Play + iOS never run this.
+      # (`cp` — not `dart run` — so it needs no prior package resolution.)
+      - cp pubspec_overrides.fdroid.yaml pubspec_overrides.yaml
       - $$flutter$$/bin/flutter config --no-analytics
       - $$flutter$$/bin/flutter pub get
       - $$flutter$$/bin/dart run build_runner build --delete-conflicting-outputs
     scanignore:
+      # Vendored real ML-Kit plugin sources (kept for the Play/iOS build) still
+      # name com.google.mlkit in their Java; the fdroid build overrides them
+      # with the stubs above, but the scanner still walks the source tree.
       - third_party/google_mlkit_commons
       - third_party/google_mlkit_text_recognition
     build: |

--- a/pubspec_overrides.fdroid.yaml
+++ b/pubspec_overrides.fdroid.yaml
@@ -27,6 +27,11 @@ dependency_overrides:
   # stub only keeps the Play/iOS mobile_scanner code compiling on libre.
   mobile_scanner:
     path: tool/fdroid_stubs/mobile_scanner
+  # #3492 — no-op sentry_flutter (opt-in crash reporter; F-Droid flags the SDK
+  # as a Tracking anti-feature). Libre ships no Sentry: init is gated off and
+  # the stub keeps app_initializer/pii_scrubber compiling with zero io.sentry.
+  sentry_flutter:
+    path: tool/fdroid_stubs/sentry_flutter
   # #3490 — no-op ML Kit text-OCR (upstream pulls com.google.mlkit.vision.text
   # + gms). Libre OCR is unavailable (NoopOcrTextEngine); Play/iOS keep it.
   google_mlkit_text_recognition:

--- a/tool/fdroid_stubs/sentry_flutter/lib/sentry_flutter.dart
+++ b/tool/fdroid_stubs/sentry_flutter/lib/sentry_flutter.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Libre / F-Droid no-op stub for `sentry_flutter` (#3492, epic #3473).
+///
+/// Provides the exact Dart surface the app compiles against so
+/// `app_initializer.dart` (the `SentryFlutter.init` call) and
+/// `pii_scrubber.dart` (`scrubSentryEvent`) build on the libre flavor, while
+/// carrying NO native `io.sentry` code. It is never reached at runtime on
+/// libre: `SentryFlutter.init` is gated on `!AppFlavor.isLibre` (and there is
+/// no baked DSN), so this only needs to COMPILE.
+library;
+
+import 'dart:async';
+
+/// The `beforeSend` hook signature — mirrors the real typedef closely enough
+/// for the app's `options.beforeSend = (event, hint) => ...` assignment.
+typedef BeforeSendCallback = FutureOr<SentryEvent?> Function(
+  SentryEvent event,
+  Hint hint,
+);
+
+/// Opaque hint object passed to [BeforeSendCallback]. Unused by the app.
+class Hint {
+  const Hint();
+}
+
+/// No-op stand-in for `SentryUser` (only assigned `null` by the scrubber).
+class SentryUser {
+  const SentryUser();
+}
+
+/// No-op stand-in for `SentryRequest` (only assigned `null` by the scrubber).
+class SentryRequest {
+  const SentryRequest();
+}
+
+/// Value stand-in for `SentryMessage` — the scrubber reads/writes [formatted].
+class SentryMessage {
+  SentryMessage(this.formatted);
+
+  String? formatted;
+}
+
+/// Value stand-in for `SentryException` — the scrubber writes [value].
+class SentryException {
+  SentryException({this.value});
+
+  String? value;
+}
+
+/// Value stand-in for `Breadcrumb` — the scrubber reads/writes [message].
+class Breadcrumb {
+  Breadcrumb({this.message});
+
+  String? message;
+}
+
+/// Value stand-in for `SentryEvent` — the scrubber mutates these fields.
+class SentryEvent {
+  SentryEvent();
+
+  SentryUser? user;
+  SentryRequest? request;
+  SentryMessage? message;
+  List<SentryException>? exceptions;
+  List<Breadcrumb>? breadcrumbs;
+}
+
+/// No-op stand-in for `SentryFlutterOptions` — the app sets these fields inside
+/// the `SentryFlutter.init` configure callback.
+class SentryFlutterOptions {
+  String? dsn;
+  double tracesSampleRate = 0;
+  String? environment;
+  String? release;
+  BeforeSendCallback? beforeSend;
+}
+
+/// No-op stand-in for `SentryFlutter`. `init` runs the optional [appRunner] and
+/// otherwise does nothing — no native SDK, no network, no `io.sentry`.
+abstract final class SentryFlutter {
+  static Future<void> init(
+    FutureOr<void> Function(SentryFlutterOptions options) optionsConfiguration, {
+    FutureOr<void> Function()? appRunner,
+  }) async {
+    // Deliberately does NOT invoke optionsConfiguration — the libre build has
+    // no Sentry backend, and running the app's configure callback would touch
+    // only stub fields. Run the app runner if one was supplied.
+    if (appRunner != null) await appRunner();
+  }
+}

--- a/tool/fdroid_stubs/sentry_flutter/pubspec.yaml
+++ b/tool/fdroid_stubs/sentry_flutter/pubspec.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+#
+# Libre / F-Droid drop-in replacement for `sentry_flutter` (#3492, epic #3473).
+# Sentry is an opt-in crash/diagnostic reporter; F-Droid flags the SDK's
+# presence as a Tracking anti-feature. To keep the libre listing free of any
+# anti-feature flag, this no-op stub provides the SAME Dart surface the app
+# compiles against (`SentryFlutter.init`, `SentryFlutterOptions`, `SentryEvent`
+# + the event value types the PII scrubber mutates) with NO native `io.sentry`
+# code and NO `flutter: plugin:` block, so GeneratedPluginRegistrant never
+# registers it and zero `io.sentry` references reach the fdroid dex.
+#
+# The libre build additionally never CALLS `SentryFlutter.init` (gated on
+# `AppFlavor.isLibre`, and there is no baked DSN), so this only needs to COMPILE.
+#
+# Swapped in ONLY for the fdroid build via `pubspec_overrides.yaml` (generated
+# from `pubspec_overrides.fdroid.yaml` by `dart run tool/apply_fdroid_overrides.dart`).
+# Play + iOS builds keep the real `sentry_flutter` (opt-in reporting unchanged).
+name: sentry_flutter
+description: Libre/F-Droid no-op stub for sentry_flutter (no io.sentry). Epic #3473.
+version: 9.22.0
+publish_to: none
+
+environment:
+  sdk: ^3.9.0
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter


### PR DESCRIPTION
Final piece to make the libre build fully catalog-clean, on top of #3491 (which cleared GMS/ML Kit/Play Core).

### #3492 — Sentry compiled out of libre
The release fdroid dex carried ~1331 `io.sentry` refs (a Tracking anti-feature F-Droid flags). Compiled out via the established stub pattern: Dart-only `sentry_flutter` stub (zero native `io.sentry`) swapped in for fdroid, and `SentryFlutter.init` gated behind `!AppFlavor.isLibre`. Play + iOS keep the real opt-in Sentry.

### Recipe prebuild fix (#3473)
The fdroiddata recipe ran `pub get` WITHOUT applying the libre overrides — so the buildserver would resolve the real plugins and fail `check-apk`. `prebuild` now `cp`s the overrides in first. Description refreshed (QR works via ZXing; only pump/receipt OCR unavailable; no crash-reporting).

## Verification (release fdroid APK, R8)
```
gms: 0   mlkit: 0   play: 0   sentry: 0
```
The libre APK is now free of all proprietary + tracking code (only FOSS `com.google.crypto.tink` remains). Play/iOS unaffected; `flutter analyze` + telemetry/app_initializer/file-length tests green.

Closes #3492