### PR TITLE
chore(release): v6.0.2+5135 — retag with the catalog-clean fdroid build + reconcile the fdroiddata recipe (#3481)

### DIFF
--- a/docs/guides/fdroid-submission.md
+++ b/docs/guides/fdroid-submission.md
@@ -18,34 +18,46 @@ guide covers both, but they are not the same thing:
    default F-Droid catalogue but is gated on **external review that takes days
    to weeks**.
 
-The GMS-free `fdroid` flavor (#2574, #2584) is what both paths build: it ships
-**no proprietary `com.google.android.gms` / `com.google.mlkit` code** in the dex,
-maps are OpenStreetMap, and positioning is forced through Android's
-`LocationManager` via `--dart-define=FORCE_LOCATION_MANAGER=true`.
+The GMS-free `fdroid` flavor (#2574, epic #3473) is what both paths build: it
+ships **zero references** to `com.google.android.gms`, `com.google.mlkit`,
+`com.google.android.play` or `io.sentry` in the dex, maps are OpenStreetMap,
+and positioning is forced through Android's `LocationManager` via
+`--dart-define=FORCE_LOCATION_MANAGER=true`.
 
-### How GMS/ML Kit stay out of the fdroid dex (#2584)
+### How GMS/ML Kit/Play Core/Sentry stay out of the fdroid dex (epic #3473)
 
-The `:app` module's `exclude(group = …)` (android/app/build.gradle.kts) cleans the
-**app's** dependency graph, but GMS/ML Kit are pulled in by the Flutter **plugin**
-sub-projects (`geolocator_android`, `google_mlkit_commons`,
-`google_mlkit_text_recognition`, `mobile_scanner`), which are un-flavored Android
-library modules whose single AAR AGP merges into both flavors. Those plugins
-`import com.google.android.gms.*` unconditionally, so a blanket exclude breaks
-compilation. The fix (android/build.gradle.kts, gated on the fdroid task graph):
+> Historical note: the earlier #2584 approach (runtime exclude + compile-only
+> stub in android/build.gradle.kts) removed the class *definitions* but left
+> inert dangling *references* in the constant pool, which F-Droid's
+> `check apk` scanner rejects. Epic #3473 replaced it; the sections below
+> describe the current mechanism.
 
-1. **Runtime exclude** — drop the real GMS/ML Kit coordinates from each plugin's
-   fdroid runtime classpath, so the proprietary classes never reach the dex.
-2. **Compile-only stub** — put the GMS/ML Kit *compile* API back on each plugin's
-   compile classpath as `compileOnly`, so the plugin Java still compiles against
-   the real signatures. `compileOnly` is never packaged, so it adds nothing to the
-   dex.
+The proprietary code is pulled in by Flutter **plugin** packages, so the libre
+build swaps the plugins themselves, at the *Dart package graph* level:
 
-Net: **zero `com.google.android.gms` / `com.google.mlkit` class definitions** in the
-fdroid dex. The plugins' own compiled methods still *name* those (now absent) types
-in their signatures, leaving inert dangling type *references* in the constant pool —
-they reference classes that do not exist and the code that would touch them never
-runs (see the OCR caveat below + `forceLocationManager`). The `play` flavor is
-untouched: real GMS, full functionality (fused location + ML Kit OCR/barcode).
+1. **Per-flavor Dart-only stub packages** live under `tool/fdroid_stubs/`
+   (`google_mlkit_text_recognition`, `google_mlkit_commons`, `mobile_scanner`,
+   `sentry_flutter`, …). Each mirrors the real package's Dart API but contains
+   **no Android module at all**, so nothing reaches the Gradle build.
+2. **`pubspec_overrides.fdroid.yaml`** maps those package names onto the stubs.
+   The F-Droid recipe's `prebuild` copies it to `pubspec_overrides.yaml`
+   **before `flutter pub get`** (`tool/apply_fdroid_overrides.dart` does the
+   same for local builds), so the resolved graph — and therefore the dex — is
+   structurally free of the proprietary code. Play + iOS never apply the
+   overrides and keep the real plugins byte-identically.
+3. **Behaviour switches** gate the affected features at runtime:
+   `QrScannerScreen` uses the FOSS `flutter_zxing` camera path on libre
+   (QR scanning still works), `createDefaultOcrTextEngine()` returns a no-op
+   engine (receipt/pump OCR unavailable by the maintainer's explicit choice),
+   and `SentryFlutter.init` is gated on `!AppFlavor.isLibre`.
+4. **R8 keep-rule tuning** (`allowshrinking,allowobfuscation` on the broad
+   Flutter keep in `android/app/proguard-rules.pro`) lets the dead
+   `PlayStoreDeferredComponentManager` tree-shake out of the release dex.
+
+Net: a release fdroid dex audit shows `gms:0 mlkit:0 play:0 sentry:0`
+references (not just definitions). Only the FOSS, Apache-2.0
+`com.google.crypto.tink` remains, which F-Droid allows. The `play` flavor is
+untouched: real GMS, full functionality (fused location + ML Kit OCR).
 
 ## Submitting the official fdroiddata recipe
 
@@ -91,10 +103,14 @@ account.
    ```
    fdroid build -v -l de.tankstellen.fuelprices
    ```
-   This checks out the `v6.0.0` tag, runs the `prebuild` (flutter pub get +
-   `build_runner build`) and the `build` (`flutter build apk --release --flavor
-   fdroid --dart-define=FORCE_LOCATION_MANAGER=true`), and produces
-   `app-fdroid-release.apk`.
+   This checks out the tag pinned in the recipe's `commit:` (currently
+   `v6.0.2`), runs the `prebuild` (**copy the fdroid pubspec overrides**, then
+   flutter pub get + `build_runner build`) and the `build` (`flutter build apk
+   --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true
+   --dart-define=FGS_FORM_APPROVED=true`), and produces
+   `app-fdroid-release.apk`. The pinned tag must contain the epic #3473
+   catalog-clean work — earlier tags fail F-Droid's `check apk` scanner on
+   dangling GMS references.
 5. **Set the NDK**: the recipe leaves `ndk:` commented. After the first clean
    `fdroid build` succeeds, read the exact NDK the buildserver used from the log
    and pin it in the `Builds:` block, then re-run the build.
@@ -104,22 +120,18 @@ account.
 
 ## Caveats to disclose in the MR
 
-- **OCR (and barcode scanning) is unavailable in the fdroid flavor by design.**
+- **Text OCR is unavailable in the fdroid flavor by design; QR scanning works.**
   The pump-display / receipt OCR depends on Google ML Kit
-  (`google_mlkit_text_recognition`), and the barcode path on `mobile_scanner` —
-  both pull `com.google.mlkit` → `com.google.android.gms`. The fdroid flavor keeps
-  ML Kit on the compile classpath only (compile-only stub, #2584) with the real
-  classes absent at runtime, so any OCR call throws and the in-app scan path
-  degrades gracefully (`ReceiptScanService._recogniseRaw` catches it and returns
-  null — no crash, the feature is just inert). Manual fill-up entry is unaffected.
-  Note this in the MR description so reviewers understand the capability gap is
-  intentional.
-- **Sentry.** The app integrates Sentry for *opt-in* crash/diagnostic reporting
-  (off by default). F-Droid reviewers may require either the
-  `AntiFeatures: [Tracking]` flag on the recipe, **or** compiling Sentry out of
-  the fdroid flavor entirely (a build-flavor guard / no-op stub). Decide with
-  the reviewer; the cleanest libre outcome is to exclude Sentry from the fdroid
-  flavor so no `AntiFeatures` flag is needed.
+  (`google_mlkit_text_recognition`), which the libre build replaces with a
+  no-op engine (#3490) — the in-app scan path degrades gracefully and manual
+  fill-up entry is unaffected. Barcode/QR scanning was migrated to the FOSS
+  `flutter_zxing` on libre (#3477), so device pairing and payment QR codes
+  still scan. Note the OCR gap in the MR description so reviewers understand
+  it is intentional.
+- **Sentry is compiled out of the fdroid flavor entirely** (#3492): the libre
+  build resolves a Dart-only `sentry_flutter` stub and never calls
+  `SentryFlutter.init`, so the dex carries zero `io.sentry` references and no
+  `AntiFeatures: [Tracking]` flag is needed.
 - **Maps & location.** Already libre: OpenStreetMap tiles + `flutter_map`, and
   `LocationManager` positioning (no `google_maps_flutter`, no Play-Services
   Location). No disclosure needed.
@@ -134,11 +146,15 @@ Before either submission, prove the flavor is clean:
   --configuration fdroidReleaseRuntimeClasspath ) \
   | grep -E 'com\.google\.android\.gms|com\.google\.mlkit'
 
-# both layers, against a built APK. Layer B asserts no GMS/ML Kit class
-# DEFINITIONS in the dex (no proprietary Google code shipped); inert dangling
-# references to absent classes are reported but are not a failure (#2584).
-flutter build apk --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true
+# both layers, against a built APK. With the epic #3473 pubspec-override
+# mechanism, the RELEASE fdroid dex must carry ZERO references (not just
+# definitions) — the same bar as F-Droid's `check apk` scanner:
+tool/apply_fdroid_overrides.dart  # or: cp pubspec_overrides.fdroid.yaml pubspec_overrides.yaml
+flutter build apk --release --flavor fdroid \
+  --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
 bash scripts/audit_no_gms.sh build/app/outputs/flutter-apk/app-fdroid-release.apk
+unzip -p build/app/outputs/flutter-apk/app-fdroid-release.apk 'classes*.dex' \
+  | strings | grep -cE 'com/google/android/gms|com/google/mlkit|com/google/android/play|Lio/sentry/'  # must be 0
 
 # contrast — the play flavor SHOULD still carry GMS (the exclude is flavor-scoped):
 ( cd android && ./gradlew app:dependencies \

--- a/fastlane/metadata/android/de-DE/changelogs/5135.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2: Verbindungsschicht neu geschrieben — eine Verbindungsinstanz, begrenzte Reconnects, automatische Wiederherstellung blockierter Adapter
+• Fahrten: GPS-Abdeckungsbericht erklärt jede Lücke in der Aufzeichnung
+• Karte: Einfrieren nach der Suche in seltenen Fällen behoben
+• Verbrauch: Tankfüllstands-Schätzung nutzt jetzt den echten Durchschnitt
+• F-Droid-Build: 100 % Google-frei (QR-Scan via ZXing, kein Sentry)

--- a/fastlane/metadata/android/en-US/changelogs/5135.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2: rewritten connection layer — one connection authority, bounded reconnects, automatic recovery of a wedged adapter
+• Trips: GPS coverage report explains every gap in a recorded track
+• Map: fixed a freeze after searching in rare edge cases
+• Consumption: tank-level estimate now uses your vehicle's real average
+• F-Droid build: 100% Google-free (QR scanning via ZXing, no Sentry)

--- a/fastlane/metadata/android/es-ES/changelogs/5135.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2: capa de conexión reescrita — una sola autoridad de conexión, reconexiones acotadas, recuperación automática del adaptador bloqueado
+• Viajes: informe de cobertura GPS que explica cada hueco del trayecto
+• Mapa: corregido un bloqueo tras buscar en casos poco comunes
+• Consumo: la estimación del depósito usa la media real de tu vehículo
+• Compilación F-Droid: 100 % libre de Google (QR con ZXing, sin Sentry)

--- a/fastlane/metadata/android/fr-FR/changelogs/5135.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2 : couche de connexion réécrite — une seule autorité de connexion, reconnexions bornées, récupération automatique d'un adaptateur bloqué
+• Trajets : rapport de couverture GPS expliquant chaque trou d'enregistrement
+• Carte : correction d'un blocage après recherche dans de rares cas
+• Consommation : l'estimation du réservoir utilise la vraie moyenne du véhicule
+• Version F-Droid : 100 % sans Google (QR via ZXing, sans Sentry)

--- a/fastlane/metadata/android/it-IT/changelogs/5135.txt
+++ b/fastlane/metadata/android/it-IT/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2: livello di connessione riscritto — un'unica autorità di connessione, riconnessioni limitate, recupero automatico dell'adattatore bloccato
+• Viaggi: report di copertura GPS che spiega ogni lacuna del percorso
+• Mappa: risolto un blocco dopo la ricerca in rari casi
+• Consumi: la stima del serbatoio usa la media reale del veicolo
+• Build F-Droid: 100% senza Google (scansione QR con ZXing, senza Sentry)

--- a/fastlane/metadata/android/pt-PT/changelogs/5135.txt
+++ b/fastlane/metadata/android/pt-PT/changelogs/5135.txt
@@ -1,0 +1,5 @@
+• OBD2: camada de ligação reescrita — uma única autoridade de ligação, reconexões limitadas, recuperação automática de adaptador bloqueado
+• Viagens: relatório de cobertura GPS que explica cada falha do percurso
+• Mapa: corrigido um bloqueio após pesquisar em casos raros
+• Consumo: a estimativa do depósito usa a média real do teu veículo
+• Build F-Droid: 100% sem Google (leitura de QR via ZXing, sem Sentry)

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -10,10 +10,16 @@
 # This is the REPRODUCIBLE-BUILD recipe: F-Droid's buildserver checks out the
 # tagged source and builds the GMS-free `fdroid` flavor itself (unlike the
 # self-hosted repo under fdroid/, which ships a prebuilt APK).
+#
+# #3481 — this file mirrors the fdroiddata MR !42093 branch `add-sparkilo`
+# byte-for-byte below this comment block (the MR iterations dropped
+# `subdir:`/`gradle:` — the whole-app `flutter build apk --flavor fdroid`
+# needs neither — and Summary/Description, which F-Droid reads from the
+# upstream fastlane/metadata structure instead).
 
 Categories:
-  - Navigation
   - Internet
+  - Navigation
 License: MIT
 AuthorName: Florian DITTGEN
 AuthorEmail: fdittgen@gmail.com
@@ -22,66 +28,16 @@ SourceCode: https://github.com/fdittgen-png/tankstellen
 IssueTracker: https://github.com/fdittgen-png/tankstellen/issues
 
 Name: Sparkilo
-Summary: Find the cheapest fuel and EV charging nearby and cut driving costs
-Description: |-
-  Sparkilo compares real-time fuel and EV-charging prices and helps you spend
-  less to run your car: pay less per litre, burn less per kilometre, and keep a
-  clear record of what you actually spend. It is free, ad-free, has no account
-  and is privacy-first — your GPS position and any API keys never leave the
-  device. The interface is available in 23 languages.
-
-  Prices come from each country's official open-data source, not from
-  crowdsourcing, covering Austria, Argentina, Australia, Chile, Denmark, France,
-  Germany, Greece, Italy, Luxembourg, Mexico, Portugal, Romania, Slovenia, South
-  Korea, Spain and the United Kingdom, plus EV charging worldwide via Open Charge
-  Map.
-
-  '''Find cheaper fuel'''
-
-  * Search nearby or along a route, filtered by fuel type, radius, open-now and amenities.
-  * Petrol, diesel, LPG, CNG, E85 and electric in one unified search and map.
-  * Price pins coloured cheapest-to-priciest; along a route the best-value stops are flagged.
-  * Per-station and radius price alerts, evaluated on the device and only when you are nearby.
-  * Favourites with full price rows, and EV chargers showing power, connectors and availability.
-
-  '''Burn less per kilometre'''
-
-  * Connect any ELM327-compatible OBD-II adapter for live eco-coaching.
-  * Per-trip driving score, throttle and RPM histograms, and hard-acceleration insights.
-  * Hands-free trip logbook over OBD-II or GPS only, with each route coloured by efficiency.
-
-  '''See what you spend'''
-
-  * Consumption tracker: average L/100 km, cost per kilometre, total spent and fill-up history.
-  * Built-in fuel-cost calculator and a CO2 dashboard broken down by trip length and speed band.
-  * Approach overlay, a home-screen widget, and spoken price announcements while you drive.
-
-  '''Privacy'''
-
-  A Privacy Dashboard lets you view, export or delete all of your data at any
-  time. Optional TankSync synchronises favourites, vehicles, fill-ups and alerts
-  to a server you control.
-
-  '''About this F-Droid build'''
-
-  This is the fully free build: no Google Play Services, no other proprietary
-  Google libraries, and no crash-reporting or analytics of any kind. Maps use
-  OpenStreetMap and positioning uses Android's location manager. QR scanning
-  (device pairing, payment codes) works via the free ZXing library. Only the
-  pump-display and receipt text scanners, which rely on Google ML Kit, are
-  unavailable in this build — add those fill-ups by hand instead. Every other
-  feature works as described.
+AutoName: Sparkilo
 
 RepoType: git
 Repo: https://github.com/fdittgen-png/tankstellen.git
 
 Builds:
-  - versionName: 6.0.1
-    versionCode: 5134
-    commit: v6.0.1
-    subdir: android/app
-    gradle:
-      - fdroid
+  - versionName: 6.0.2
+    versionCode: 5135
+    commit: v6.0.2
+    output: build/app/outputs/flutter-apk/app-fdroid-release.apk
     srclibs:
       - flutter@stable
     prebuild:
@@ -100,13 +56,11 @@ Builds:
       # with the stubs above, but the scanner still walks the source tree.
       - third_party/google_mlkit_commons
       - third_party/google_mlkit_text_recognition
-    build: |
-      $$flutter$$/bin/flutter build apk --release --flavor fdroid \
-        --dart-define=FORCE_LOCATION_MANAGER=true \
-        --dart-define=FGS_FORM_APPROVED=true
-    output: build/app/outputs/flutter-apk/app-fdroid-release.apk
+    build: $$flutter$$/bin/flutter build apk --release --flavor fdroid --dart-define=FORCE_LOCATION_MANAGER=true
+      --dart-define=FGS_FORM_APPROVED=true
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9.]+$
-CurrentVersion: 6.0.1
-CurrentVersionCode: 5134
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+CurrentVersion: 6.0.2
+CurrentVersionCode: 5135

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 17 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 6.0.1+5134
+version: 6.0.2+5135
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Closes #3481.

The fdroiddata MR !42093 recipe pinned commit `0bef2334`, which predates the epic #3473 catalog-clean work — F-Droid's check-apk rejected the build on dangling GMS references. This PR prepares the clean retag:

- **pubspec** → `6.0.2+5135` (the `v6.0.2` tag is cut on master after this merges; the recipe's `commit:` points at it).
- **metadata/de.tankstellen.fuelprices.yml** reconciled byte-for-byte with the MR's pipeline-tested form: `subdir:`/`gradle:` dropped (the whole-app `flutter build apk --flavor fdroid` needs neither), Summary/Description sourced from fastlane, `UpdateCheckData` adopted, version block → 6.0.2/5135/`v6.0.2`. The #3493 `prebuild` overrides-copy fix is retained.
- **docs/guides/fdroid-submission.md** updated from the superseded #2584 compile-only-stub description to the epic #3473 pubspec-override mechanism (0 references, ZXing QR, Sentry compiled out).
- **fastlane changelogs 5135.txt** added in all six store locales.

After merge: tag `v6.0.2`, then push the reconciled recipe to the fdroiddata fork branch `add-sparkilo` (MR !42093).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UkotUZc94NFHYB2rrvVuP
