### PR TITLE
fix(obd2): close 4 residual link-authority gaps found by the deep post-arbiter review (#3495)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -256,7 +256,7 @@ object Obd2ClassicPlugin {
                 null
             }
             if (s != null) {
-                val r = tryConnectSocket(s, attempt)
+                val r = tryConnectSocket(s, attempt, ::budgetSpent)
                 if (r == null) return connectResult(true, "secure")
                 lastError = r
             }
@@ -284,7 +284,7 @@ object Obd2ClassicPlugin {
             null
         }
         if (insecure != null) {
-            val r = tryConnectSocket(insecure, MAX_RFCOMM_ATTEMPTS + 1)
+            val r = tryConnectSocket(insecure, MAX_RFCOMM_ATTEMPTS + 1, ::budgetSpent)
             if (r == null) return connectResult(true, "insecure")
             lastError = r
         }
@@ -296,7 +296,7 @@ object Obd2ClassicPlugin {
         }
         val reflected = reflectChannelOneSocket(device)
         if (reflected != null) {
-            val r = tryConnectSocket(reflected, MAX_RFCOMM_ATTEMPTS + 2)
+            val r = tryConnectSocket(reflected, MAX_RFCOMM_ATTEMPTS + 2, ::budgetSpent)
             if (r == null) return connectResult(true, "reflection")
             lastError = r
         }
@@ -323,8 +323,21 @@ object Obd2ClassicPlugin {
 
     /** Attempt to connect [s], adopt it as the live socket + start the reader
      *  on success, or close it on failure. Returns null on success, or the
-     *  IOException message on failure (#2969 — was a bare Boolean). */
-    private fun tryConnectSocket(s: BluetoothSocket, attempt: Int): String? {
+     *  IOException message on failure (#2969 — was a bare Boolean).
+     *
+     *  #3495 F2 — [budgetSpent] is re-checked AFTER the blocking `connect()`
+     *  returns: a rung that started just under the whole-ladder budget can
+     *  complete up to the 7 s watchdog later, PAST the Dart caller's
+     *  budget+grace deadline — the Dart `.timeout` has already thrown, so
+     *  adopting here would create a live socket + reader with no Dart owner
+     *  (a ghost holding the adapter's single SPP channel until the next
+     *  connect's teardown). When the budget is spent at completion, the
+     *  socket is closed instead of adopted. */
+    private fun tryConnectSocket(
+        s: BluetoothSocket,
+        attempt: Int,
+        budgetSpent: () -> Boolean = { false },
+    ): String? {
         // #3348 — bound the blocking connect() with a watchdog. `connect()` has
         // no timeout; closing the socket from another thread is the documented
         // way to abort it (it throws immediately). The watchdog only fires when
@@ -354,6 +367,15 @@ object Obd2ClassicPlugin {
                     " (attempt $attempt)"
             }
             watchdog.interrupt()
+            if (budgetSpent()) {
+                // #3495 F2 — completed past the whole-ladder budget: the Dart
+                // caller has already timed out and moved on. Close, don't adopt.
+                Log.w(TAG, "connect: RFCOMM open completed after the whole-ladder" +
+                    " budget (attempt $attempt) — not adopting (#3495)")
+                try { s.close() } catch (_: IOException) {}
+                return "RFCOMM open completed after the whole-ladder budget" +
+                    " (attempt $attempt)"
+            }
             socket = s
             startReader()
             null

--- a/lib/features/obd2/data/obd2_link_arbiter.dart
+++ b/lib/features/obd2/data/obd2_link_arbiter.dart
@@ -10,7 +10,10 @@ import 'obd2_wedge_detector.dart';
 
 /// Priority of an [Obd2LinkLease], ordered low → high. A [tryAcquire] with a
 /// STRICTLY higher priority preempts the current holder; an equal-or-lower
-/// request is refused (the caller keeps its existing fallback behaviour).
+/// request is refused (the caller keeps its existing fallback behaviour) —
+/// EXCEPT interactive-over-interactive and recording-over-recording, where
+/// the newest claim wins (#3495 F1: a stale holder must not wedge the newer
+/// one of its own kind).
 ///
 /// `idle` is deliberately NOT a lease: the #3019 idle reconnector registers
 /// as the FALLBACK drop policy via [Obd2LinkArbiter.registerIdlePolicy] and
@@ -146,15 +149,21 @@ class Obd2LinkArbiter {
     if (current != null && current.isActive) {
       // Interactive-vs-interactive: the LATEST user gesture wins — a hung
       // earlier attempt (e.g. a native connect blocked for minutes, #3415
-      // trace t8) must not wedge every later tap. All other equal-or-lower
+      // trace t8) must not wedge every later tap. Recording-vs-recording
+      // (#3495 F1): same newest-wins rule — the only reachable equal case is
+      // a prior trip's stop() still holding its lease through the final
+      // disconnect (race 2) when the next trip starts; refusing there left
+      // the NEW recording lease-less, routing its drops to the idle loop
+      // (the war, resurrected for one session). All other equal-or-lower
       // acquires are refused: loops (idle/auto-record) retry on their own
       // schedule and must never tear down a live holder.
-      final gestureOverGesture = priority == Obd2LinkPriority.interactive &&
-          current.priority == Obd2LinkPriority.interactive;
-      if (priority.rank <= current.priority.rank && !gestureOverGesture) {
+      final newestWins = current.priority == priority &&
+          (priority == Obd2LinkPriority.interactive ||
+              priority == Obd2LinkPriority.recording);
+      if (priority.rank <= current.priority.rank && !newestWins) {
         return null;
       }
-      // Strictly higher (or gesture-over-gesture) — revoke, then notify the
+      // Strictly higher (or same-kind newest-wins) — revoke, then notify the
       // ousted holder.
       current._active = false;
       _holder = null;

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -14,6 +14,7 @@ import '../data/obd2_comm_diagnostics.dart';
 import '../data/obd2_connect_trace.dart';
 import '../data/obd2_connect_trace_log.dart';
 import '../data/obd2_connection_service.dart';
+import '../data/obd2_disconnect_quietly.dart';
 import '../data/obd2_link_arbiter.dart';
 import '../data/obd2_reconnect_controller.dart';
 import '../data/obd2_service.dart';
@@ -220,11 +221,26 @@ class Obd2Reconnect extends _$Obd2Reconnect {
         transportDecisionReason:
             pinned.isClassic ? 'reconnect-pinned-classic' : 'reconnect-pinned-ble',
       );
+      if (_abandonIfStopped(svc)) return Obd2ReconnectAttemptResult.failed;
       return _onResult(svc);
     } catch (e, st) {
       _logSeam('pinned', e, st);
       return Obd2ReconnectAttemptResult.failed;
     }
+  }
+
+  /// #3495 F4 — the loop was stopped (a lease grant's stand-down / dispose)
+  /// while this seam's connect was in flight. `_runCycle` aborts on its state
+  /// guard AFTER the seam resolves, so without this the just-established
+  /// session leaked open (holding the adapter's single SPP channel) and the
+  /// status dot had already been marked connected. Disconnect the fresh
+  /// service quietly and report `failed` instead. False (keep the session)
+  /// while the controller is still reconnecting.
+  bool _abandonIfStopped(Obd2Service? svc) {
+    if (svc == null) return false;
+    if (_controller?.state == Obd2ReconnectState.reconnecting) return false;
+    unawaited(svc.disconnectQuietly());
+    return true;
   }
 
   /// Re-scan fallback: scan + match the pinned MAC (#1188), so a changed /
@@ -243,6 +259,7 @@ class Obd2Reconnect extends _$Obd2Reconnect {
             : connection.connectBest(),
         transportDecisionReason: 'reconnect-rescan',
       );
+      if (_abandonIfStopped(svc)) return Obd2ReconnectAttemptResult.failed;
       return _onResult(svc);
     } catch (e, st) {
       _logSeam('rescan', e, st);

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -151,7 +151,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'a3e58c53e05fcf19c14715346960c928891709c0';
+String _$obd2ReconnectHash() => r'638d0d5c851179aefffd6c51962af20f9e450d65';
 
 /// App-wide owner of the trip-INDEPENDENT auto-reconnect controller (#3019 /
 /// Epic #3013 phase 3).

--- a/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
+++ b/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
@@ -128,7 +128,26 @@ class VinAdapterPairAutoPopulator {
   /// Run the post-pair flow against [pairedAdapterMac], merging into
   /// [profile]. The returned outcome carries either a non-null updated
   /// profile (caller persists it) or an `aborted` sentinel.
+  ///
+  /// #3495 F3 — runs under a short-lived interactive link lease: this was
+  /// the one remaining production connect path with no arbiter claim, so it
+  /// could open a second session against a link a recording / auto-record
+  /// watch owns. Refused (an equal-or-higher holder keeps the link) ⇒ the
+  /// auto-population is skipped, exactly like a failed connect.
   Future<VinAdapterPairAutoPopulationOutcome> run({
+    required String pairedAdapterMac,
+    required VehicleProfile profile,
+  }) async {
+    final outcome = await Obd2LinkArbiter.instance.runInteractive(
+      'post-pair-populate',
+      () => _runLeased(pairedAdapterMac: pairedAdapterMac, profile: profile),
+    );
+    return outcome ?? VinAdapterPairAutoPopulationOutcome.aborted();
+  }
+
+  /// The pre-#3495 [run] body, unchanged — connect → VIN → PIDs → optional
+  /// broken-MAP probe → disconnect — now always executing under the lease.
+  Future<VinAdapterPairAutoPopulationOutcome> _runLeased({
     required String pairedAdapterMac,
     required VehicleProfile profile,
   }) async {

--- a/test/features/obd2/data/obd2_link_arbiter_test.dart
+++ b/test/features/obd2/data/obd2_link_arbiter_test.dart
@@ -46,4 +46,54 @@ void main() {
     expect(Obd2LinkArbiter.instance.recordingLeaseHeld, isFalse);
     lease!.release();
   });
+
+  group('#3495 F1 — recording-over-recording newest-wins', () {
+    test(
+        'a new recording acquire PREEMPTS a stale recording lease instead of '
+        'being refused (the stop()-in-teardown race)', () {
+      var oldPreempted = false;
+      final stale = Obd2LinkArbiter.instance.tryAcquire(
+        'recording',
+        Obd2LinkPriority.recording,
+        onPreempted: () => oldPreempted = true,
+      );
+      expect(stale, isNotNull);
+
+      // The previous trip's stop() still holds its lease through the final
+      // disconnect when the next trip starts. Refusing here left the NEW
+      // recording lease-less — its drops routed to the idle loop (the war,
+      // resurrected). Newest-wins: the fresh claim is granted.
+      final fresh = Obd2LinkArbiter.instance
+          .tryAcquire('recording', Obd2LinkPriority.recording);
+      expect(fresh, isNotNull,
+          reason: 'a recording acquire must NEVER silently fail — the '
+              'pipeline claims it before its first await and does not '
+              'null-check (#3495 F1)');
+      expect(oldPreempted, isTrue);
+      expect(stale!.isActive, isFalse);
+      expect(Obd2LinkArbiter.instance.holder, same(fresh));
+      expect(Obd2LinkArbiter.instance.recordingLeaseHeld, isTrue);
+
+      // The stale holder's own release (stop() finishing later) is the
+      // idempotent no-op release of a revoked lease — the fresh holder keeps
+      // the link.
+      stale.release();
+      expect(Obd2LinkArbiter.instance.holder, same(fresh));
+      expect(Obd2LinkArbiter.instance.recordingLeaseHeld, isTrue);
+      fresh!.release();
+    });
+
+    test('auto-record-over-auto-record is still refused (loops must not '
+        'tear each other down)', () {
+      final first = Obd2LinkArbiter.instance
+          .tryAcquire('auto-record', Obd2LinkPriority.autoRecord);
+      expect(first, isNotNull);
+      final second = Obd2LinkArbiter.instance
+          .tryAcquire('auto-record', Obd2LinkPriority.autoRecord);
+      expect(second, isNull,
+          reason: 'newest-wins is deliberate for user-driven kinds only '
+              '(interactive, recording); loops retry on their own schedule');
+      first!.release();
+    });
+  });
 }

--- a/test/features/obd2/providers/obd2_reconnect_provider_test.dart
+++ b/test/features/obd2/providers/obd2_reconnect_provider_test.dart
@@ -1,11 +1,22 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/obd2/data/adapter_registry.dart';
+import 'package:tankstellen/features/obd2/data/bluetooth_facade.dart';
+import 'package:tankstellen/features/obd2/data/elm_byte_channel.dart';
+import 'package:tankstellen/features/obd2/data/last_good_adapter_store.dart';
+import 'package:tankstellen/features/obd2/data/obd2_connection_service.dart';
 import 'package:tankstellen/features/obd2/data/obd2_link_arbiter.dart';
 import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
+import 'package:tankstellen/features/obd2/data/obd2_permissions.dart';
 import 'package:tankstellen/features/obd2/data/obd2_reconnect_controller.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
 import 'package:tankstellen/features/obd2/providers/obd2_reconnect_provider.dart';
 import '../../../helpers/silence_error_logger.dart';
 
@@ -109,5 +120,144 @@ void main() {
       expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
           reason: 'a recording claiming the link must stop the app-wide loop');
     });
+
+    test(
+        '#3495 F4 — a pinned connect that resolves AFTER stop() is '
+        'disconnected, not leaked as an unowned open session', () async {
+      // Pin a Classic adapter so the loop's first move is the pinned direct
+      // connect (which the fake connection blocks until told to resolve).
+      final settings = _MapSettings();
+      await LastGoodAdapterStore(settings).recordFrom(
+        mac: 'AA:BB:CC:DD:EE:FF',
+        transportKind: 'classic',
+        name: 'vLinker FS',
+      );
+      final connection = _BlockingClassicConnection();
+      final container = ProviderContainer(overrides: [
+        obd2ConnectionProvider.overrideWith((ref) => connection),
+        lastGoodAdapterStoreProvider
+            .overrideWith((ref) => LastGoodAdapterStore(settings)),
+      ]);
+      addTearDown(container.dispose);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      // An idle drop starts the bounded loop; its first cycle reaches the
+      // fake's pinned Classic connect and blocks there.
+      Obd2LinkDropSignal.instance.notifyDrop(
+          transportKind: 'classic',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          reason: 'classic-socket-error');
+      await pumpEventQueue();
+      expect(container.read(obd2ReconnectProvider),
+          Obd2ReconnectState.reconnecting);
+      await connection.dialled.future;
+
+      // A recording lease grant stands the loop down MID-CONNECT — the
+      // production race: `_runCycle` only notices after the seam resolves.
+      final lease = Obd2LinkArbiter.instance
+          .tryAcquire('recording', Obd2LinkPriority.recording);
+      expect(lease, isNotNull);
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle);
+
+      // The in-flight connect NOW lands a live session.
+      final svc = await connection.resolveWithLiveSession();
+      await pumpEventQueue();
+
+      expect(svc.isConnected, isFalse,
+          reason: 'the just-established session belongs to a loop that was '
+              'stopped — leaving it open leaks the adapter\'s single SPP '
+              'channel (#3495 F4)');
+      expect(container.read(obd2ReconnectProvider), Obd2ReconnectState.idle,
+          reason: 'the stopped loop must not resurrect as connected');
+      lease!.release();
+    });
   });
+}
+
+/// Minimal in-memory [SettingsStorage] backing the pin store in tests.
+class _MapSettings implements SettingsStorage {
+  final Map<String, dynamic> _map = {};
+  @override
+  dynamic getSetting(String key) => _map[key];
+  @override
+  Future<void> putSetting(String key, dynamic value) async => _map[key] = value;
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+/// Fake connection whose pinned Classic direct connect BLOCKS until the test
+/// resolves it — reproducing the seam-still-in-flight window stop() races.
+class _BlockingClassicConnection extends Obd2ConnectionService {
+  _BlockingClassicConnection()
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _GrantedPermissions(),
+          bluetooth: _UnusedBluetoothFacade(),
+        );
+
+  /// Completes when the loop's pinned connect reaches the fake.
+  final Completer<void> dialled = Completer<void>();
+  final Completer<Obd2Service?> _gate = Completer<Obd2Service?>();
+
+  /// Let the blocked connect resolve with a freshly-connected live session,
+  /// returned so the test can assert its post-abandon state.
+  Future<Obd2Service> resolveWithLiveSession() async {
+    final service = Obd2Service(FakeObd2Transport({
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      'ATI': 'ELM327 v1.5>',
+      'ATRV': '12.4V>',
+      '0100': '41 00 BE 3F A8 13>',
+    }))
+      ..adapterMac = 'AA:BB:CC:DD:EE:FF'
+      ..linkKind = 'classic';
+    await service.connect();
+    _gate.complete(service);
+    return service;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacClassicDirect(String mac,
+      {String? adapterName}) {
+    if (!dialled.isCompleted) dialled.complete();
+    return _gate.future;
+  }
+}
+
+class _GrantedPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _UnusedBluetoothFacade implements BluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+  @override
+  Future<void> stopScan() async {}
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      throw UnimplementedError();
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      throw UnimplementedError();
 }

--- a/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
+++ b/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/features/obd2/data/broken_map_belief.dart';
 import 'package:tankstellen/features/obd2/data/broken_map_detector.dart';
 import 'package:tankstellen/features/obd2/data/elm_byte_channel.dart';
 import 'package:tankstellen/features/obd2/data/obd2_connection_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_arbiter.dart';
 import 'package:tankstellen/features/obd2/data/obd2_permissions.dart';
 import 'package:tankstellen/features/obd2/data/obd2_service.dart';
 import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
@@ -199,6 +200,60 @@ void main() {
 
       expect(outcome.profile, isNull);
       expect(outcome.readVin, isFalse);
+    });
+  });
+
+  group('#3495 F3 — arbiter link lease', () {
+    setUp(Obd2LinkArbiter.instance.resetForTest);
+    tearDown(Obd2LinkArbiter.instance.resetForTest);
+
+    test(
+        'a held recording lease REFUSES the post-pair populate: no connect is '
+        'attempted and the outcome is aborted', () async {
+      final service = buildConnectedService({'0902': 'NO DATA>'});
+      final connection = _FakeConnection(connectByMacResult: service);
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+      );
+
+      final lease = Obd2LinkArbiter.instance
+          .tryAcquire('recording', Obd2LinkPriority.recording);
+      addTearDown(() => lease?.release());
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.profile, isNull);
+      expect(outcome.readVin, isFalse);
+      expect(connection.connectByMacCalls, 0,
+          reason: 'the populator was the one remaining connect path with no '
+              'arbiter claim — it must never dial into a link a recording '
+              'owns (#3495 F3)');
+      expect(Obd2LinkArbiter.instance.holder?.owner, 'recording',
+          reason: 'the recording keeps the link');
+    });
+
+    test('with the link free, the populate runs under a short-lived '
+        'interactive lease and releases it', () async {
+      final service = buildConnectedService({'0902': 'NO DATA>'});
+      final connection = _FakeConnection(connectByMacResult: service);
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(connection.connectByMacCalls, 1);
+      expect(outcome.readVin, isFalse); // NO DATA VIN — same as before
+      expect(Obd2LinkArbiter.instance.holder, isNull,
+          reason: 'the interactive lease is released when the run settles');
     });
   });
 
@@ -666,12 +721,17 @@ class _FakeConnection extends Obd2ConnectionService {
   /// propagates the typed [Obd2AdapterUnresponsive] on an engine-off pair).
   final Object? connectByMacError;
 
+  /// #3495 F3 — how many times the populator actually dialled. A refused
+  /// arbiter lease must leave this at 0.
+  int connectByMacCalls = 0;
+
   @override
   Future<Obd2Service?> connectByMac(
     String mac, {
     Duration timeout = const Duration(seconds: 5),
     String? adapterName,
   }) async {
+    connectByMacCalls++;
     if (connectByMacError != null) throw connectByMacError!;
     final s = connectByMacResult;
     if (s == null) return null;


### PR DESCRIPTION
Closes #3495.

A full deep review of the post-#3415 OBD2 connection stack (arbiter → supervisor → connection service → Classic/BLE channels → native plugin → idle + in-trip reconnect → wedge machinery) traced every connect initiator and drop reactor. The architecture holds — one drop reaches exactly one reactor by construction — but four residual gaps could each re-create a second connect authority or strand the adapter's single SPP channel:

- **F1 (high)** — `Obd2RecordingPipeline.start` never null-checks its lease acquire; a prior trip's `stop()` holding its lease through the final disconnect refused the next trip's claim, leaving the new recording lease-less (drops → idle loop → the war, resurrected for one session). Fixed in the arbiter: recording-over-recording = newest-wins, mirroring the existing gesture-over-gesture rule, so a recording acquire can never silently fail.
- **F2 (medium)** — the native Classic ladder could adopt a socket after the Dart caller's budget+grace deadline had already thrown, creating a ghost socket + reader with no Dart owner that held the adapter's single SPP channel (feeding the wedge streak / "connects only randomly"). `tryConnectSocket` now re-checks the whole-ladder budget at adoption time and closes instead.
- **F3 (medium)** — `VinAdapterPairAutoPopulator.run` was the one remaining production connect path with no arbiter claim; it now runs under a short-lived interactive lease (refused ⇒ auto-population skipped, like a failed connect). Zero feature-boundary impact — the arbiter is already exported via `obd2/api.dart`.
- **F4 (low-med)** — a pinned/rescan connect resolving after `stop()` raced it leaked the fresh session open and had already marked the status dot connected; the seams now disconnect the abandoned session and report `failed`.

Tests: arbiter newest-wins (+ auto-record still strictly refused), populator lease refusal/grant, and a provider-level race test that drives a real drop → blocked pinned connect → lease-grant stand-down → late resolve, asserting the session is torn down. All 36 tests across the five touched suites green; `compilePlayDebugKotlin` green.

Validation additions for the on-device protocol are posted on #3425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UkotUZc94NFHYB2rrvVuP
