### PR TITLE
fix(ci): one wall-clock-derived Android versionCode across all release workflows (#3513)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,12 +700,26 @@ jobs:
       - name: Build APK (debug — PR validation)
         if: github.event_name == 'pull_request'
         run: flutter build apk --debug --flavor play
+      - name: Compute monotonic versionCode
+        if: github.event_name != 'pull_request'
+        id: bn
+        # #3513 — ONE shared, wall-clock-derived versionCode across every
+        # release-build workflow: minutes since 2025-07-06 UTC on a 2026100000
+        # base. Strictly monotonic across ALL workflows (the per-workflow
+        # run_number counters could leapfrog each other and trip Play's
+        # no-downgrade rule, as the v6.0.3 tag deploy did), above every shipped
+        # code, ~230 years under Android's 2_147_483_647 cap. The official
+        # F-Droid catalog keeps pubspec's static codes (separate install base).
+        run: |
+          BN=$(( 2026100000 + ( $(date -u +%s) - 1751760000 ) / 60 ))
+          echo "build_number=$BN" >> "$GITHUB_OUTPUT"
+          echo "versionCode: $BN"
       - name: Build APK (release, split per ABI)
         if: github.event_name != 'pull_request'
-        run: flutter build apk --release --split-per-abi --flavor play
+        run: flutter build apk --release --split-per-abi --flavor play --build-number=${{ steps.bn.outputs.build_number }}
       - name: Build App Bundle (release)
         if: github.event_name != 'pull_request'
-        run: flutter build appbundle --release --flavor play
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }}
       # #2947 — assert the MERGED play manifest declares ZERO
       # FOREGROUND_SERVICE* permissions, so a future accidental FGS re-merge
       # (the Android Auto v2 live bridge is a BOUND service, no FGS) trips CI

--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -57,14 +57,13 @@ jobs:
         id: bn
         run: |
           # #1882 — the old YYYYMMDDHH scheme gave only hour resolution,
-          # so two runs in the same hour produced the same code and Play
-          # rejected the duplicate. Derive it from the monotonic run
-          # counter instead: unique per run, unique per re-run attempt,
-          # strictly increasing. Base 2_026_060_000 is just above the
-          # last YYYYMMDDHH code ever uploaded (2026051719); the *10
-          # leaves room for re-run attempts. Max stays well under
-          # Android's 2_100_000_000 cap.
-          BN=$(( 2026060000 + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
+          # #3513 — ONE shared wall-clock scheme across every release-build
+          # workflow (minutes since 2025-07-06 UTC on a 2026100000 base):
+          # per-workflow run counters could leapfrog each other and trip
+          # Play's no-downgrade rule (the v6.0.3 tag deploy did exactly
+          # that). Strictly monotonic everywhere, above every shipped code,
+          # ~230 years under the 2_147_483_647 cap.
+          BN=$(( 2026100000 + ( $(date -u +%s) - 1751760000 ) / 60 )) # #3513 shared scheme
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Build number: $BN" \
             "(run ${{ github.run_number }}, attempt ${{ github.run_attempt }})"

--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -108,12 +108,10 @@ jobs:
         id: bn
         # F-Droid updates purely on versionCode, so a rebuild of the static
         # pubspec `+NNNN` produces the SAME code and F-Droid offers no update.
-        # Inject the same monotonic run-counter scheme daily-beta.yml uses
-        # (2026060000 + run_number*10 + run_attempt): strictly increasing per
-        # run, unique per re-run, well under Android's 2_100_000_000 cap and
-        # above the last static pubspec code (5133) the repo shipped.
+        # #3513 — the ONE shared wall-clock versionCode scheme (see
+        # daily-beta.yml): strictly monotonic across all workflows.
         run: |
-          BN=$(( 2026060000 + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
+          BN=$(( 2026100000 + ( $(date -u +%s) - 1751760000 ) / 60 )) # #3513 shared scheme
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "F-Droid versionCode: $BN"
 


### PR DESCRIPTION
Closes #3513. The v6.0.3 tag deploy hit Play's no-downgrade rule (static 5136 vs the ~2.026B beta codes); per-workflow run counters would just leapfrog each other. All release builds now share one minutes-since-epoch scheme (today ≈ 2026626284 > every shipped code), strictly monotonic across workflows. After merge: dispatch deploy-internal against the fresh master CI AAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UkotUZc94NFHYB2rrvVuP