### PR TITLE
chore(fdroid): sync the recipe mirror with MR !42093 final review form (#3481)

### DIFF
--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -23,7 +23,6 @@ Categories:
 License: MIT
 AuthorName: Florian DITTGEN
 AuthorEmail: fdittgen@gmail.com
-WebSite: https://github.com/fdittgen-png/tankstellen
 SourceCode: https://github.com/fdittgen-png/tankstellen
 IssueTracker: https://github.com/fdittgen-png/tankstellen/issues
 
@@ -36,12 +35,13 @@ Repo: https://github.com/fdittgen-png/tankstellen.git
 Builds:
   - versionName: 6.0.4
     versionCode: 51371
-    commit: v6.0.4
+    commit: f85f238007aa7a85e6b52ebd24ac94604fb34051
     output: build/app/outputs/flutter-apk/app-*-fdroid-release.apk
     srclibs:
       - flutter@stable
     prebuild:
-      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' .github/workflows/fdroid.yml)
+      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' 
+        .github/workflows/fdroid.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
       - cp pubspec_overrides.fdroid.yaml pubspec_overrides.yaml
@@ -57,23 +57,20 @@ Builds:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      # One block shape for all ABIs: the target platform + the flutter
-      # base build number derive from this block's versionCode (flutter's
-      # --split-per-abi offsets are +1000 armeabi-v7a / +2000 arm64-v8a /
-      # +4000 x86_64), so checkupdates-cloned blocks stay correct.
-      - case $(( $$VERCODE$$ % 10 )) in 1) abi=android-arm;; 2) abi=android-arm64;;
-        *) abi=android-x64;; esac
-      - $$flutter$$/bin/flutter build apk --release --flavor fdroid --split-per-abi
-        --target-platform $abi --build-number=$(( $$VERCODE$$ / 10 ))
-        --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
+      - $$flutter$$/bin/flutter build apk --release --flavor fdroid 
+        --split-per-abi --target-platform android-arm --build-number=$(( 
+        $$VERCODE$$ / 10 )) --dart-define=FORCE_LOCATION_MANAGER=true 
+        --dart-define=FGS_FORM_APPROVED=true
+
   - versionName: 6.0.4
     versionCode: 51372
-    commit: v6.0.4
+    commit: f85f238007aa7a85e6b52ebd24ac94604fb34051
     output: build/app/outputs/flutter-apk/app-*-fdroid-release.apk
     srclibs:
       - flutter@stable
     prebuild:
-      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' .github/workflows/fdroid.yml)
+      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' 
+        .github/workflows/fdroid.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
       - cp pubspec_overrides.fdroid.yaml pubspec_overrides.yaml
@@ -89,23 +86,20 @@ Builds:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      # One block shape for all ABIs: the target platform + the flutter
-      # base build number derive from this block's versionCode (flutter's
-      # --split-per-abi offsets are +1000 armeabi-v7a / +2000 arm64-v8a /
-      # +4000 x86_64), so checkupdates-cloned blocks stay correct.
-      - case $(( $$VERCODE$$ % 10 )) in 1) abi=android-arm;; 2) abi=android-arm64;;
-        *) abi=android-x64;; esac
-      - $$flutter$$/bin/flutter build apk --release --flavor fdroid --split-per-abi
-        --target-platform $abi --build-number=$(( $$VERCODE$$ / 10 ))
-        --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
+      - $$flutter$$/bin/flutter build apk --release --flavor fdroid 
+        --split-per-abi --target-platform android-arm64 --build-number=$(( 
+        $$VERCODE$$ / 10 )) --dart-define=FORCE_LOCATION_MANAGER=true 
+        --dart-define=FGS_FORM_APPROVED=true
+
   - versionName: 6.0.4
     versionCode: 51373
-    commit: v6.0.4
+    commit: f85f238007aa7a85e6b52ebd24ac94604fb34051
     output: build/app/outputs/flutter-apk/app-*-fdroid-release.apk
     srclibs:
       - flutter@stable
     prebuild:
-      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' .github/workflows/fdroid.yml)
+      - flutterVersion=$(sed -n -E 's/.*flutter-version:\ "(.*)"/\1/p' 
+        .github/workflows/fdroid.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
       - cp pubspec_overrides.fdroid.yaml pubspec_overrides.yaml
@@ -121,22 +115,17 @@ Builds:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      # One block shape for all ABIs: the target platform + the flutter
-      # base build number derive from this block's versionCode (flutter's
-      # --split-per-abi offsets are +1000 armeabi-v7a / +2000 arm64-v8a /
-      # +4000 x86_64), so checkupdates-cloned blocks stay correct.
-      - case $(( $$VERCODE$$ % 10 )) in 1) abi=android-arm;; 2) abi=android-arm64;;
-        *) abi=android-x64;; esac
-      - $$flutter$$/bin/flutter build apk --release --flavor fdroid --split-per-abi
-        --target-platform $abi --build-number=$(( $$VERCODE$$ / 10 ))
-        --dart-define=FORCE_LOCATION_MANAGER=true --dart-define=FGS_FORM_APPROVED=true
+      - $$flutter$$/bin/flutter build apk --release --flavor fdroid 
+        --split-per-abi --target-platform android-x64 --build-number=$(( 
+        $$VERCODE$$ / 10 )) --dart-define=FORCE_LOCATION_MANAGER=true 
+        --dart-define=FGS_FORM_APPROVED=true
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9.]+$
-UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
 VercodeOperation:
   - '%c * 10 + 1'
   - '%c * 10 + 2'
   - '%c * 10 + 3'
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
 CurrentVersion: 6.0.4
 CurrentVersionCode: 51373


### PR DESCRIPTION
The fdroiddata MR branch moved twice during review: `fdroid rewritemeta` canonical formatting, then linsui's suggestion to hardcode each build block's `--target-platform` (android-arm / android-arm64 / android-x64) instead of the `case` derivation. This syncs the in-repo mirror byte-for-byte with the MR's final form below the header comment, per the mirror contract stated in the header.

No code paths touched — documentation/mirror file only.

Refs #3481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UkotUZc94NFHYB2rrvVuP