### PR TITLE
fix(ci): app-store-listing dry_run — fastlane precheck instead of the binary-only --verify_only (#3523)

### DIFF
--- a/.github/workflows/app-store-listing.yml
+++ b/.github/workflows/app-store-listing.yml
@@ -139,10 +139,18 @@ jobs:
           fi
 
           if [ "$DRY_RUN" = "true" ]; then
-            # --verify_only validates the metadata against App Store Connect
-            # WITHOUT uploading. submit_for_review is irrelevant here.
-            echo "::notice::Dry run — deliver --verify_only (validate metadata, no upload)."
-            ARGS+=( --verify_only true --submit_for_review false )
+            # #3523 — deliver's --verify_only is a BINARY verification mode:
+            # it builds an IPA upload package, and with --skip_binary_upload
+            # and no IPA it crashes digesting a nil path. The read-only
+            # metadata validation is `fastlane precheck`, which scans the
+            # App Store Connect metadata for rule violations WITHOUT
+            # uploading or changing anything.
+            echo "::notice::Dry run — fastlane precheck (read-only metadata scan, no upload)."
+            bundle exec fastlane precheck \
+              --api_key_path "$ASC_API_KEY_JSON" \
+              --app_identifier de.tankstellen.tankstellen \
+              --include_in_app_purchases false
+            exit 0
           else
             # Real upload. submit_for_review is true ONLY when the maintainer
             # explicitly set the submit input; otherwise metadata is staged

--- a/docs/guides/app-store-listing.md
+++ b/docs/guides/app-store-listing.md
@@ -90,9 +90,11 @@ Apple listing changes are tied to a specific app version + the review process,
 so an auto-publish on every metadata commit (the way Play does) is too risky.
 
 1. **Validate first (dry run).** Dispatch with `dry_run` = **true** (the
-   default). This runs `deliver --verify_only`, which validates the metadata
-   against App Store Connect — checks lengths, locale coverage, forbidden
-   content — **without uploading anything**.
+   default). This runs `fastlane precheck`, a read-only scan of the App
+   Store Connect metadata for rule violations — **without uploading
+   anything**. (It used to pass `deliver --verify_only`, but that flag is
+   a *binary* verification mode: with `skip_binary_upload` and no IPA it
+   crashes digesting a nil path, #3523.)
 2. **Real run.** Dispatch with `dry_run` = **false** to upload the text
    metadata. Leave `submit` = false (the default) so the copy is *staged*
    for the editable version and a human reviews + submits in the console.


### PR DESCRIPTION
deliver's `--verify_only` is a binary verification mode — it builds an IPA upload package, and this workflow always runs with `--skip_binary_upload true` and no IPA, so it crashed digesting a nil path (run 28835883857, fastlane 2.233.1). The dry-run now runs `fastlane precheck` — the actual read-only App Store Connect metadata scan. Real-run path untouched.

Closes #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UkotUZc94NFHYB2rrvVuP