### PR TITLE
fix(canary): GR + RO probes become documented skips (#3508)

### DIFF
--- a/test/tool/endpoint_canary_targets_test.dart
+++ b/test/tool/endpoint_canary_targets_test.dart
@@ -25,7 +25,14 @@ void main() {
     test('RO probe mirrors RomaniaStationService.defaultBaseUrl + searchPath',
         () {
       final ro = targetFor('RO');
-      expect(ro.skip, isNull, reason: 'RO has a live keyless endpoint');
+      // #3508 — the endpoint is alive for real users, but its WCF
+      // front-end rejects the TLS handshake from GitHub-runner IPs (two
+      // consecutive weekly false DEADs), so the probe is skip-with-reason.
+      // The URL + quirks below stay pinned to the service so a manual
+      // residential re-probe (and a future un-skip) can't drift.
+      expect(ro.skip, SkipReason.geoBlocked,
+          reason: 'CI cannot reach the WAF-fronted endpoint (#3508); the '
+              'drift checks below still guard the probe recipe');
       expect(
         ro.url,
         startsWith(

--- a/tool/endpoint_canary.dart
+++ b/tool/endpoint_canary.dart
@@ -224,9 +224,13 @@ const List<CanaryTarget> targets = [
     country: 'GR',
     name: 'fuelpricesgr community API',
     url: 'https://fuelpricesgr.com/api/prices/today',
-    bodyMarker: '"prices"',
-    note: 'greece/greece_station_service.dart — NXDOMAIN as of 2026-06-10; '
-        'kept ACTIVE on purpose so the canary keeps tracking the outage.',
+    skip: SkipReason.noEndpoint,
+    note: 'greece/greece_station_service.dart — fuelpricesgr.com has been '
+        'NXDOMAIN since 2026-06-10 with no public replacement (the upstream '
+        'repo documents self-hosting only, re-verified 2026-07-09). The app '
+        'already degrades cleanly (#3194 short-circuit; self-hosted baseUrl '
+        're-enables). A month of weekly DEADs tracked nothing new — the '
+        'restore is #3539; re-activate this probe with the new host then.',
   ),
   CanaryTarget(
     country: 'RO',
@@ -236,12 +240,15 @@ const List<CanaryTarget> targets = [
         '&OrderBy=dist',
     headers: {'Accept': 'application/json'},
     bodyMarker: '"Stations"',
-    note: 'romania/romania_station_service.dart — #3457: the service was '
-        'rebased onto the official Competition Council observatory in #3193, '
-        'but this probe still pointed at the dead third-party '
-        'pretcarburant.ro. Mirrors defaultBaseUrl + searchPath (Bucharest '
-        'centre, Benzină standard). The Accept header forces JSON — the WCF '
-        'backend otherwise serves XML.',
+    skip: SkipReason.geoBlocked,
+    note: 'romania/romania_station_service.dart — the endpoint is ALIVE for '
+        'real users (verified 2026-07-09 via Dart HttpClient from a '
+        'residential network: HTTP 200 + full Stations payload) but the WCF '
+        'front-end rejects the TLS handshake from GitHub-runner/datacenter '
+        'IPs (HandshakeException on 2026-07-06 AND 2026-07-09 runs — two '
+        'consecutive false DEADs, #3508). Same probeable-not-from-CI family '
+        'as the AR geo-block; re-probe manually from a residential network '
+        'when touching the RO service (#3457 has the probe recipe).',
   ),
 ];
 


### PR DESCRIPTION
Resolves the weekly canary's two standing DEAD reports (#3508):

- **GR** — `fuelpricesgr.com` NXDOMAIN since 2026-06-10, no public replacement (upstream is self-host-only, re-verified today). The app already degrades cleanly (#3194 short-circuit; self-hosted `baseUrl` re-enables). Probe → SKIP (no live endpoint); restoration tracked in #3539.
- **RO** — the official observatory is alive for real users (verified today via Dart HttpClient from a residential network: HTTP 200, full `Stations` payload) but its WCF front-end rejects TLS handshakes from GitHub-runner IPs — two consecutive weekly false DEADs. Probe → SKIP (geo-blocked), like AR. The #3457 drift guards still pin the probe recipe to the service.

Local: `dart run tool/endpoint_canary.dart --dry-run` shows 11 active probes / 6 documented skips; drift-guard tests green; analyze clean.

Closes #3508.

Note: auto-merge deliberately not armed yet — #3541 (the OBD2 epic bundle) is the one serialized merge in flight; this arms after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
