### PR TITLE
fix(ci): cache + retry-pre-install the Android NDK (#3543)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,34 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      # #3543 — the AGP's on-demand NDK download (flutter_zxing needs
+      # ndk;27.0.12077973) flaked 4× on 2026-07-09 alone (corrupt zip /
+      # InstallFailedException), killing otherwise-green runs and stalling
+      # serialized auto-merges. Restore the installed NDK from cache; on a
+      # miss, pre-install with bounded retries so a transient CDN failure
+      # never reaches the Gradle layer. ANDROID_HOME is
+      # /usr/local/lib/android/sdk on the ubuntu runner images.
+      - name: Cache Android NDK
+        id: ndk-cache
+        uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/android/sdk/ndk/27.0.12077973
+          key: ${{ runner.os }}-ndk-27.0.12077973
+      - name: Pre-install Android NDK (bounded retries)
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        run: |
+          for attempt in 1 2 3; do
+            if "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install 'ndk;27.0.12077973' < /dev/null > /dev/null; then
+              break
+            fi
+            echo "NDK install attempt $attempt failed — cleaning + retrying in 20s (#3543)"
+            rm -rf "$ANDROID_HOME/ndk/27.0.12077973"
+            sleep 20
+          done
+          if [ ! -d "$ANDROID_HOME/ndk/27.0.12077973" ]; then
+            echo "::error::NDK 27.0.12077973 install failed after 3 attempts (#3543)" >&2
+            exit 1
+          fi
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       # #48 — Decode the release keystore from a GitHub secret into a temp

--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -94,6 +94,31 @@ jobs:
           echo "ANDROID_KEYSTORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS" >> "$GITHUB_ENV"
 
+      # #3543 — cache + retry-pre-install the NDK the AGP would otherwise
+      # download on demand (flaked 4× on 2026-07-09; see ci.yml for the
+      # full rationale). A flaky CDN must not kill the daily upload.
+      - name: Cache Android NDK
+        id: ndk-cache
+        uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/android/sdk/ndk/27.0.12077973
+          key: ${{ runner.os }}-ndk-27.0.12077973
+      - name: Pre-install Android NDK (bounded retries)
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        run: |
+          for attempt in 1 2 3; do
+            if "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install 'ndk;27.0.12077973' < /dev/null > /dev/null; then
+              break
+            fi
+            echo "NDK install attempt $attempt failed — cleaning + retrying in 20s (#3543)"
+            rm -rf "$ANDROID_HOME/ndk/27.0.12077973"
+            sleep 20
+          done
+          if [ ! -d "$ANDROID_HOME/ndk/27.0.12077973" ]; then
+            echo "::error::NDK 27.0.12077973 install failed after 3 attempts (#3543)" >&2
+            exit 1
+          fi
+
       - name: Flutter pub get
         run: flutter pub get
 

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -144,6 +144,31 @@ jobs:
             echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS"
           } >> "$GITHUB_ENV"
 
+      # #3543 — cache + retry-pre-install the NDK the AGP would otherwise
+      # download on demand (flaked 4× on 2026-07-09; see ci.yml for the
+      # full rationale). A flaky CDN must not kill the nightly release.
+      - name: Cache Android NDK
+        id: ndk-cache
+        uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/android/sdk/ndk/27.0.12077973
+          key: ${{ runner.os }}-ndk-27.0.12077973
+      - name: Pre-install Android NDK (bounded retries)
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        run: |
+          for attempt in 1 2 3; do
+            if "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install 'ndk;27.0.12077973' < /dev/null > /dev/null; then
+              break
+            fi
+            echo "NDK install attempt $attempt failed — cleaning + retrying in 20s (#3543)"
+            rm -rf "$ANDROID_HOME/ndk/27.0.12077973"
+            sleep 20
+          done
+          if [ ! -d "$ANDROID_HOME/ndk/27.0.12077973" ]; then
+            echo "::error::NDK 27.0.12077973 install failed after 3 attempts (#3543)" >&2
+            exit 1
+          fi
+
       - name: Flutter pub get
         run: flutter pub get
 


### PR DESCRIPTION
The on-demand NDK download failed 4× today across three PRs (#3538/#3541/#3542), each needing a manual re-run. All three Android-building workflows now cache the installed NDK and pre-install it with bounded retries on a miss — a flaky CDN can no longer kill a green run or a nightly upload.

Closes #3543.

Auto-merge arms after #3542 lands (serialized queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)