### PR TITLE
fix(trips): re-probe a stale silent-bus verdict before declaring engine-off at recording start (#3551)

### DIFF
--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
@@ -204,6 +205,27 @@ class RecordingStartCoordinator {
       // EVERY retry); a `transient` / `answered` / `notProbed` (warm
       // cache-hit) connect starts and lets the scheduler pick up PIDs once the
       // protocol search converges.
+      // #3551 — the verdict below may be STALE: with #3527 KEEP-LINK the
+      // service is often REUSED (prewarm dialed when the screen opened, or
+      // the supervisor kept the link up), so `busProbe` is a snapshot from
+      // that earlier connect — typically taken before the user turned the
+      // ignition on. Re-run the resilient #3035 probe ONCE before
+      // concluding engine-off; a bus that answers now proceeds normally.
+      // Only the silent path pays for this (the path that used to bail
+      // instantly with a wrong error).
+      if (service.busProbe == Obd2BusProbeResult.probedSilent) {
+        BreadcrumbCollector.add(
+          'OBD2 start: stale silent-bus verdict — re-probing',
+        );
+        try {
+          await service.discoverSupportedPids();
+        } on Object catch (e, st) {
+          // A thrown probe is link weather, not a verdict — the gate
+          // below re-reads whatever the probe left behind.
+          recordObd2ConnectFailure(e, st,
+              where: 'RecordingStart re-probe (#3551)');
+        }
+      }
       if (service.busProbe == Obd2BusProbeResult.probedSilent) {
         notifier.cancelConnecting();
         onConnectionError(const Obd2EngineOff());

--- a/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
@@ -95,6 +95,46 @@ void main() {
         reason: 'the unusable link must be disconnected');
     expect(recording.cancelConnectingCallCount, greaterThanOrEqualTo(1),
         reason: 'the connecting phase must roll back to idle');
+
+    // #3551 — the verdict was re-checked with ONE fresh probe before the
+    // engine-off conclusion (it stayed silent here, so the error stands).
+    expect(service.reprobeCallCount, 1,
+        reason: 'a silent verdict must be re-probed once before bailing');
+  });
+
+  testWidgets(
+      'a STALE silent verdict that answers on the fresh re-probe starts '
+      'the trip — no engine-off error (#3551: prewarm dialed before the '
+      'ignition was on; the user started the engine since)', (tester) async {
+    final service = _FakeObd2Service(
+      busAnswered: false,
+      busProbe: Obd2BusProbeResult.probedSilent,
+      busProbeAfterReprobe: Obd2BusProbeResult.answered,
+    );
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        openPicker: () async => service,
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    expect(service.reprobeCallCount, 1,
+        reason: 'the stale silent verdict must trigger one fresh probe');
+    expect(errors, isEmpty,
+        reason: 'a bus that answers the re-probe is NOT engine-off');
+    expect(recording.startCallCount, 1,
+        reason: 'the trip must start once the fresh probe answered');
+    expect(service.disconnectCallCount, 0,
+        reason: 'a live, answering link must not be torn down');
   });
 
   testWidgets(
@@ -272,18 +312,33 @@ class _FakeObd2Service implements Obd2Service {
   _FakeObd2Service({
     required bool busAnswered,
     required Obd2BusProbeResult busProbe,
+    this.busProbeAfterReprobe,
   })  : busAnsweredValue = busAnswered,
         busProbeValue = busProbe;
 
   final bool busAnsweredValue;
-  final Obd2BusProbeResult busProbeValue;
+  Obd2BusProbeResult busProbeValue;
+
+  /// #3551 — when non-null, [discoverSupportedPids] flips [busProbe] to
+  /// this value, modelling a stale silent verdict refreshed by the
+  /// start-gate's re-probe (engine turned on since the prewarm dial).
+  final Obd2BusProbeResult? busProbeAfterReprobe;
   int disconnectCallCount = 0;
+  int reprobeCallCount = 0;
 
   @override
   bool get busAnswered => busAnsweredValue;
 
   @override
   Obd2BusProbeResult get busProbe => busProbeValue;
+
+  @override
+  Future<Set<int>> discoverSupportedPids() async {
+    reprobeCallCount++;
+    final next = busProbeAfterReprobe;
+    if (next != null) busProbeValue = next;
+    return const <int>{};
+  }
 
   @override
   Future<void> disconnect() async {


### PR DESCRIPTION
Field report 2026-07-11: start-recording errored instantly with the engine-off message, no connect attempt, engine running. Root cause + fix in #3551 — the #3527 link reuse made the start gate's busProbe verdict stale; the silent path now re-probes once before concluding engine-off.

Test plan: coordinator suite extended (stale→answered starts the trip; stays-silent still errors, with exactly one re-probe asserted); analyze clean; consumption + lint dirs green.

Closes #3551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvivCxVDeCjNNzQtqdPAbS