### PR TITLE
fix(obd2): adapter switch no longer strands the supervisor on the OLD device (#3553)

### DIFF
--- a/lib/features/obd2/data/obd2_link_supervisor.dart
+++ b/lib/features/obd2/data/obd2_link_supervisor.dart
@@ -236,10 +236,25 @@ class Obd2LinkSupervisor {
   /// The single dial path. Every connect — user tap, drop reaction,
   /// backoff tick — funnels here; `_attemptInFlight` makes it single
   /// flight (a second caller joins the same future).
+  ///
+  /// #3553 — a caller carrying a [dialer] OVERRIDE must never have its
+  /// dial policy silently swallowed by whatever attempt is already in
+  /// flight: field evidence showed auto-record's dial for the ACTIVE
+  /// vehicle's adapter joining the backoff loop's dial to the PREVIOUS
+  /// (last-good) adapter, returning the wrong target's failure — and the
+  /// requested device never being dialed at all. The override now joins
+  /// for the result first (a live link satisfies everyone — one link
+  /// only), and chains its own attempt strictly AFTER a missed in-flight
+  /// completes. Still never two concurrent dials.
   Future<Obd2Service?> _attempt(
       {required bool userInitiated, Obd2LinkDialer? dialer}) {
     final inFlight = _attemptInFlight;
-    if (inFlight != null) return inFlight;
+    if (inFlight != null) {
+      if (dialer == null) return inFlight;
+      return inFlight.then((svc) => svc != null || _disposed
+          ? svc
+          : _attempt(userInitiated: userInitiated, dialer: dialer));
+    }
     final future = _attemptOnce(userInitiated: userInitiated, dialer: dialer);
     _attemptInFlight = future;
     return future.whenComplete(() {

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -8,6 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../../vehicle/api.dart' show activeVehicleProfileProvider;
 import '../data/last_good_adapter_store.dart';
 import '../data/obd2_comm_diagnostics.dart';
 import '../data/obd2_connect_trace.dart';
@@ -152,6 +153,31 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     }
     final pinned = pinStore.recall();
 
+    // #3553 — the ACTIVE vehicle's pinned adapter is authoritative user
+    // intent; the last-good pin is only an optimization (it updates
+    // exclusively on a SUCCESSFUL connect, so after a vehicle/adapter
+    // switch it points at the PREVIOUS device until the new one connects
+    // — which this loop then prevented by always dialing the stale pin).
+    // When the two disagree, dial the vehicle's adapter FIRST
+    // (transport-aware); the last-good + rescan paths below stay the
+    // fallbacks.
+    final vehicleMac = _activeVehicleAdapterMac();
+    if (vehicleMac != null && vehicleMac != pinned?.mac) {
+      final byVehicle = await Obd2ConnectTraceLog.runWithOrigin(
+        Obd2ConnectOrigin.liveReconnect,
+        () => connection.connectByMacTransportAware(
+          vehicleMac,
+          adapterName: _activeVehicleAdapterName(),
+          fallbackToScan: false,
+        ),
+        transportDecisionReason: 'reconnect-active-vehicle',
+      );
+      final classified = _classify(byVehicle);
+      if (classified != null || _supervisor?.userRequestedDisconnect == true) {
+        return classified;
+      }
+    }
+
     // Pinned fast path — transport-correct direct connect.
     if (pinned != null) {
       final direct = await Obd2ConnectTraceLog.runWithOrigin(
@@ -178,6 +204,29 @@ class Obd2Reconnect extends _$Obd2Reconnect {
       transportDecisionReason: 'reconnect-rescan',
     );
     return _classify(rescanned);
+  }
+
+  /// The active vehicle's pinned adapter MAC (#3553), or null when no
+  /// vehicle is active / none is pinned / the graph isn't up (shell
+  /// safety — same degradation contract as the dependency reads above).
+  String? _activeVehicleAdapterMac() {
+    try {
+      final mac = ref.read(activeVehicleProfileProvider)?.obd2AdapterMac;
+      return (mac == null || mac.trim().isEmpty) ? null : mac;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The active vehicle's pinned adapter NAME (#3553) — feeds the
+  /// transport registry's name-based Classic/BLE inference. Null on any
+  /// failure, mirroring [_activeVehicleAdapterMac].
+  String? _activeVehicleAdapterName() {
+    try {
+      return ref.read(activeVehicleProfileProvider)?.obd2AdapterName;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Engine-off gate for a dial result. Returns the service to keep, or

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'8814bbe7420381c3dda7dc57da5f995065c9e8bb';
+String _$obd2ReconnectHash() => r'01c0e905b68f724feda84a1fd226613781a5abfb';
 
 /// App-wide owner of THE [Obd2LinkSupervisor] (#3529, Epic #3527).
 ///

--- a/test/features/obd2/obd2_link_supervisor_test.dart
+++ b/test/features/obd2/obd2_link_supervisor_test.dart
@@ -237,6 +237,84 @@ void main() {
     });
   });
 
+  test(
+      'connectWith joining a MISSED in-flight dial still dials its own '
+      'target afterwards — the override is never swallowed (#3553)', () {
+    fakeAsync((async) {
+      final gate = Completer<Obd2Service?>();
+      var defaultDials = 0;
+      final sup = Obd2LinkSupervisor(
+        dial: () {
+          defaultDials++;
+          return gate.future;
+        },
+        drops: drops.stream,
+        jitter: Random(42),
+      );
+      // The backoff loop dials (the stale last-good adapter) and hangs.
+      drops.add(const Obd2LinkDropEvent(
+          transportKind: 'classic', reason: 'socket-error'));
+      async.flushMicrotasks();
+      expect(defaultDials, 1);
+
+      // Auto-record dials the ACTIVE vehicle's (different) adapter.
+      var overrideDials = 0;
+      final live = _liveService();
+      Obd2Service? got;
+      unawaited(sup.connectWith(() async {
+        overrideDials++;
+        return live;
+      }).then((s) => got = s));
+      async.flushMicrotasks();
+      expect(overrideDials, 0,
+          reason: 'never two concurrent dials — the override waits');
+
+      gate.complete(null); // the stale-target dial MISSES
+      async.flushMicrotasks();
+      expect(overrideDials, 1,
+          reason: 'the override dial must run right after the miss');
+      expect(identical(got, live), isTrue,
+          reason: 'the caller gets ITS OWN dial result, not the miss');
+      expect(sup.state.value, Obd2LinkState.ready);
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test(
+      'connectWith joining an in-flight dial that SUCCEEDS returns the '
+      'live link without a second dial (#3553 — one link satisfies all)',
+      () {
+    fakeAsync((async) {
+      final gate = Completer<Obd2Service?>();
+      final sup = Obd2LinkSupervisor(
+        dial: () => gate.future,
+        drops: drops.stream,
+        jitter: Random(42),
+      );
+      drops.add(const Obd2LinkDropEvent(
+          transportKind: 'classic', reason: 'socket-error'));
+      async.flushMicrotasks();
+
+      var overrideDials = 0;
+      Obd2Service? got;
+      unawaited(sup.connectWith(() async {
+        overrideDials++;
+        return _liveService();
+      }).then((s) => got = s));
+      async.flushMicrotasks();
+
+      final live = _liveService();
+      gate.complete(live);
+      async.flushMicrotasks();
+      expect(overrideDials, 0,
+          reason: 'a live link from the in-flight dial satisfies everyone');
+      expect(identical(got, live), isTrue);
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
   test('a dial FAULT (not just a miss) also feeds the backoff loop', () {
     fakeAsync((async) {
       dialer.enqueue(StateError('rfcomm refused'));

--- a/test/features/obd2/providers/obd2_reconnect_provider_test.dart
+++ b/test/features/obd2/providers/obd2_reconnect_provider_test.dart
@@ -13,6 +13,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
 import 'package:tankstellen/features/obd2/data/obd2_link_supervisor.dart';
 import 'package:tankstellen/features/obd2/providers/obd2_reconnect_provider.dart';
+import 'package:tankstellen/features/obd2/data/last_good_adapter_store.dart';
+import 'package:tankstellen/features/obd2/data/obd2_connection_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 void main() {
@@ -136,4 +141,147 @@ void main() {
       );
     });
   });
+
+  group('default dial adapter identity (#3553)', () {
+    ProviderContainer buildContainer({
+      required _FakeConnection connection,
+      required LastGoodAdapter? pinned,
+      required VehicleProfile? vehicle,
+    }) {
+      final container = ProviderContainer(overrides: [
+        obd2ConnectionProvider.overrideWith((_) => connection),
+        lastGoodAdapterStoreProvider.overrideWithValue(_FakePinStore(pinned)),
+        activeVehicleProfileProvider.overrideWith(() => _StubVehicle(vehicle)),
+      ]);
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test(
+        'the ACTIVE vehicle adapter is dialed FIRST when it differs from '
+        'the stale last-good pin — the pin/rescan stay the fallbacks', () async {
+      final connection = _FakeConnection();
+      final container = buildContainer(
+        connection: connection,
+        pinned: const LastGoodAdapter(
+            mac: 'D4:OLD', transportKind: 'classic', name: 'vLinker FS'),
+        vehicle: const VehicleProfile(
+          id: 'veh-2',
+          name: 'Second car',
+          obd2AdapterMac: 'DC:NEW',
+          obd2AdapterName: 'vLinker BM-Android',
+        ),
+      );
+      final sup = container.read(obd2ReconnectProvider.notifier).supervisor;
+
+      final got = await sup.connect();
+
+      expect(got, isNull, reason: 'every fake dial misses');
+      expect(connection.calls.first, 'transport-aware:DC:NEW',
+          reason: 'vehicle intent is authoritative — dialed before the pin');
+      expect(connection.calls, contains('classic-direct:D4:OLD'),
+          reason: 'the last-good pin remains the fallback');
+    });
+
+    test(
+        'when the vehicle adapter and the pin AGREE, no extra dial is '
+        'added — the pinned fast path runs first as before', () async {
+      final connection = _FakeConnection();
+      final container = buildContainer(
+        connection: connection,
+        pinned: const LastGoodAdapter(
+            mac: 'D4:SAME', transportKind: 'classic', name: 'vLinker FS'),
+        vehicle: const VehicleProfile(
+          id: 'veh-1',
+          name: 'Clio',
+          obd2AdapterMac: 'D4:SAME',
+        ),
+      );
+      final sup = container.read(obd2ReconnectProvider.notifier).supervisor;
+
+      await sup.connect();
+
+      expect(connection.calls.first, 'classic-direct:D4:SAME');
+      expect(
+        connection.calls.where((c) => c.startsWith('transport-aware:')),
+        isEmpty,
+        reason: 'an agreeing pin keeps the single pinned fast path',
+      );
+    });
+  });
+}
+
+/// Records every dial in order; all dials miss (return null) so the
+/// #3553 ordering is observable without a live link.
+class _FakeConnection implements Obd2ConnectionService {
+  final List<String> calls = [];
+
+  @override
+  Future<Obd2Service?> connectByMacTransportAware(
+    String mac, {
+    String? adapterName,
+    bool fallbackToScan = true,
+  }) async {
+    calls.add('transport-aware:$mac');
+    return null;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacClassicDirect(String mac,
+      {String? adapterName}) async {
+    calls.add('classic-direct:$mac');
+    return null;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration? timeout,
+    bool fallbackToScan = true,
+    String? adapterName,
+  }) async {
+    calls.add('ble-direct:$mac');
+    return null;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMac(
+    String mac, {
+    Duration timeout = const Duration(seconds: 5),
+    String? adapterName,
+  }) async {
+    calls.add('rescan:$mac');
+    return null;
+  }
+
+  @override
+  Future<Obd2Service?> connectBest() async {
+    calls.add('connect-best');
+    return null;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Pin store returning a fixed recall; writes are ignored.
+class _FakePinStore implements LastGoodAdapterStore {
+  _FakePinStore(this._pinned);
+  final LastGoodAdapter? _pinned;
+
+  @override
+  LastGoodAdapter? recall() => _pinned;
+
+  @override
+  Future<void> record(LastGoodAdapter adapter) async {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _StubVehicle extends ActiveVehicleProfile {
+  _StubVehicle(this._v);
+  final VehicleProfile? _v;
+  @override
+  VehicleProfile? build() => _v;
 }


### PR DESCRIPTION
Field evidence from today's new-stack error log: after the auto-record coordinator re-armed for the active vehicle's adapter, every dial for ~50 minutes still hit the previous adapter's MAC and the new device was never dialed. Root cause and fix per #3553 — (1) the single-flight join in the supervisor dropped `connectWith` dialer overrides; (2) the default dial policy only ever consulted the last-good pin, which can't update until the new adapter connects.

Test plan: 2 new supervisor tests (override chains after a missed in-flight; a successful in-flight satisfies the joiner without a second dial) + 2 new provider tests (vehicle adapter dialed first when it differs from the pin; agreeing pin keeps the single fast path). Full obd2 + consumption + lint dirs green (5215 tests); analyze clean.

Closes #3553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvivCxVDeCjNNzQtqdPAbS