### PR TITLE
fix: field findings 2026-07-11 evening — hard-accel zero-count lesson + suspended-vs-wedged connect classification

### DIFF
--- a/lib/features/consumption/data/lessons/rules/hard_accel_rule.dart
+++ b/lib/features/consumption/data/lessons/rules/hard_accel_rule.dart
@@ -49,6 +49,12 @@ class HardAccelRule implements DrivingLessonRule {
     final eventCount = summary.imuActive
         ? summary.harshAccelerations
         : (insight.metadata['eventCount'] ?? 0).toInt();
+    // #3557 — zero events refutes the lesson's premise: when the trusted
+    // (IMU-preferred) count is 0, the analyzer's litres are GPS
+    // speed-derivative noise and the card would read the absurd
+    // "0 hard accelerations: 2.3 L wasted". Mirror of [HardBrakeRule]'s
+    // guard, which #2789 kept there but dropped here.
+    if (eventCount <= 0) return null;
     final count = eventCount.toString();
     return DrivingLesson(
       id: id,

--- a/lib/features/obd2/data/classic_connect_timeout_message.dart
+++ b/lib/features/obd2/data/classic_connect_timeout_message.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// #3558 — phrase the whole-ladder connect timeout by HOW it fired.
+///
+/// A timer that fires within a small jitter of its [deadline] is the
+/// genuine #3421 wedge signature (the platform never answered inside the
+/// budget). One that fires far past it means the ISOLATE was not running —
+/// Android froze the backgrounded process (no FGS, #3417) and the dial
+/// simply stretched over the frozen window. The two need different words,
+/// or a field trace reads like a native fault that never happened.
+String classicConnectTimeoutMessage({
+  required int budgetMs,
+  required Duration deadline,
+  required Duration actualElapsed,
+}) {
+  final overrun = actualElapsed - deadline;
+  if (overrun > const Duration(seconds: 5)) {
+    return 'classic connect timer fired ${overrun.inSeconds}s late '
+        '(${actualElapsed.inSeconds}s wall for a ${deadline.inSeconds}s '
+        'deadline) — app was suspended in background mid-dial (#3558), '
+        'not a platform wedge';
+  }
+  return 'classic connect exceeded the whole-ladder budget '
+      '(${budgetMs}ms) + grace — platform thread wedged (#3421)';
+}

--- a/lib/features/obd2/data/classic_elm_channel.dart
+++ b/lib/features/obd2/data/classic_elm_channel.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'classic_connect_cooldown.dart';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
+import 'classic_connect_timeout_message.dart';
 import 'obd2_platform_budgets.dart';
 import '../../../../core/utils/event_channel_cancel.dart';
 import 'obd2_comm_diagnostics.dart';
@@ -141,6 +142,12 @@ class ClassicElmChannel implements ElmByteChannel {
       // budget + [deadlineGrace]. The TimeoutException takes the existing
       // thrown-failure classification below.
       final deadline = Duration(milliseconds: nativeBudgetMs) + deadlineGrace;
+      // #3558 — wall-clock anchor for the timeout wording: when the app is
+      // background-frozen (no FGS), this 23 s timer can fire MINUTES late,
+      // and stamping that as "platform thread wedged" sent a whole field
+      // investigation down the wrong path. DateTime (not Stopwatch): the
+      // monotonic clock pauses in deep sleep, wall time doesn't.
+      final dialedAt = DateTime.now();
       connectResult = await _plugin
           .connectDetailed(
             address: address,
@@ -150,8 +157,11 @@ class ClassicElmChannel implements ElmByteChannel {
           .timeout(
             deadline,
             onTimeout: () => throw TimeoutException(
-              'classic connect exceeded the whole-ladder budget '
-              '(${nativeBudgetMs}ms) + grace — platform thread wedged (#3421)',
+              classicConnectTimeoutMessage(
+                budgetMs: nativeBudgetMs,
+                deadline: deadline,
+                actualElapsed: DateTime.now().difference(dialedAt),
+              ),
               deadline,
             ),
           );

--- a/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
+++ b/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
@@ -336,6 +336,32 @@ void main() {
       expect(hardAccel.title, startsWith('2 hard accelerations'));
     });
 
+    test('hard-accel lesson is SUPPRESSED when the IMU ran and counted ZERO '
+        'events — no "0 hard accelerations: 2.3 L wasted" card (#3557)', () {
+      // Field export 2026-07-11: the IMU (trusted source) counted 0 hard
+      // accelerations, but the noisy GPS speed-derivative cost line still
+      // carried litres — and the card rendered the absurd zero-count
+      // headline. Zero trusted events refutes the premise: no lesson.
+      const zeroImuSummary = TripSummary(
+        distanceKm: 5,
+        maxRpm: 4000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0, // IMU ran and counted NOTHING
+        kind: TripKind.gpsOnly,
+        distanceSource: 'gps',
+        imuHardAccelCount: 0,
+        imuActive: true,
+      );
+      final reg = DrivingLessonRegistry.standard();
+      // The GPS derivative still "sees" 5 events worth of litres in the
+      // sample stream — exactly the field condition.
+      final lessons = reg.evaluate(zeroImuSummary, hardAccelSamples(), l);
+      expect(lessons.map((e) => e.id), isNot(contains(hardAccelLessonId)),
+          reason: 'zero trusted events must suppress the cost line');
+    });
+
     test('hard-accel lesson keeps the GPS-derived count when the IMU did NOT '
         'run (#2789 C5 fallback)', () {
       // imuActive=false → no inertial signal → fall back to the (clamped)

--- a/test/features/obd2/data/classic_connect_timeout_message_test.dart
+++ b/test/features/obd2/data/classic_connect_timeout_message_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/classic_connect_timeout_message.dart';
+
+/// #3558 — the whole-ladder timeout wording must tell a genuine platform
+/// wedge (the timer fired on schedule with no native answer) apart from a
+/// background-frozen isolate (the timer fired MINUTES late because Android
+/// suspended the process — field traces showed 10–25 min "wedges" that
+/// were nothing of the kind).
+void main() {
+  const deadline = Duration(seconds: 23);
+
+  test('an on-schedule fire keeps the #3421 wedge wording', () {
+    final msg = classicConnectTimeoutMessage(
+      budgetMs: 20000,
+      deadline: deadline,
+      actualElapsed: const Duration(seconds: 23, milliseconds: 400),
+    );
+    expect(msg, contains('platform thread wedged (#3421)'));
+    expect(msg, isNot(contains('suspended')));
+  });
+
+  test('a fire minutes late is phrased as app-suspended, not a wedge', () {
+    final msg = classicConnectTimeoutMessage(
+      budgetMs: 20000,
+      deadline: deadline,
+      actualElapsed: const Duration(minutes: 24, seconds: 59),
+    );
+    expect(msg, contains('suspended in background'));
+    expect(msg, contains('(#3558)'));
+    expect(msg, isNot(contains('wedged')));
+  });
+
+  test('small jitter under the 5 s threshold stays a wedge verdict', () {
+    final msg = classicConnectTimeoutMessage(
+      budgetMs: 20000,
+      deadline: deadline,
+      actualElapsed: const Duration(seconds: 27),
+    );
+    expect(msg, contains('#3421'));
+  });
+}


### PR DESCRIPTION
Two fixes from tonight's field exports, one commit each:

- **#3557** — the hard-acceleration lesson rendered `0 accélérations brusques : 2.3 L gaspillés`: the #2789 IMU-count migration dropped the zero-guard that `HardBrakeRule` kept, so GPS-derivative noise litres showed under an IMU-verified zero-event headline. Guard restored; regression test locks it.
- **#3558** — connect traces showed 10–25 minute steps stamped `platform thread wedged (#3421)`; the 23 s timeout had actually fired minutes late because Android froze the backgrounded process (no FGS — #3417). The timeout wording now derives from the timer's wall-clock late-fire: past a 5 s overrun it reads app-suspended-in-background. Pure message builder + 3 unit tests.

Test plan: obd2 + consumption + lint dirs green (5222 tests); analyze clean.

Closes #3557
Closes #3558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvivCxVDeCjNNzQtqdPAbS