### PR TITLE
fix(obd2,trips): protocol-search livelock recovery + persisted GPS estimates

### DIFF
--- a/lib/features/consumption/data/trip_summary_codec.dart
+++ b/lib/features/consumption/data/trip_summary_codec.dart
@@ -20,6 +20,12 @@ Map<String, dynamic> tripSummaryToJson(TripSummary s) => {
       if (s.avgLPer100Km != null) 'avgLPer100Km': s.avgLPer100Km,
       if (s.fuelLitersConsumed != null)
         'fuelLitersConsumed': s.fuelLitersConsumed,
+      // #3576: GPS-physics estimate figures, stamped only when the
+      // measured fields are null. Compact keys 'eAvg'/'eFuel'; omitted
+      // when null so measured / legacy trips round-trip byte-identical.
+      if (s.estimatedAvgLPer100Km != null) 'eAvg': s.estimatedAvgLPer100Km,
+      if (s.estimatedFuelLitersConsumed != null)
+        'eFuel': s.estimatedFuelLitersConsumed,
       if (s.startedAt != null) 'startedAt': s.startedAt!.toIso8601String(),
       if (s.endedAt != null) 'endedAt': s.endedAt!.toIso8601String(),
       // #800: provenance of distanceKm — `'real'` for odometer-backed
@@ -74,6 +80,8 @@ TripSummary tripSummaryFromJson(Map<String, dynamic> j) => TripSummary(
       harshAccelerations: (j['harshAccelerations'] as num).toInt(),
       avgLPer100Km: (j['avgLPer100Km'] as num?)?.toDouble(),
       fuelLitersConsumed: (j['fuelLitersConsumed'] as num?)?.toDouble(),
+      estimatedAvgLPer100Km: (j['eAvg'] as num?)?.toDouble(),
+      estimatedFuelLitersConsumed: (j['eFuel'] as num?)?.toDouble(),
       startedAt: j['startedAt'] == null
           ? null
           : DateTime.parse(j['startedAt'] as String),

--- a/lib/features/consumption/domain/services/gps_live_estimate_folder.dart
+++ b/lib/features/consumption/domain/services/gps_live_estimate_folder.dart
@@ -88,6 +88,18 @@ class GpsLiveEstimateFolder {
   final GpsLiveFuelEstimator _estimator;
   final Duration _coachingWindow;
 
+  /// #3576 — final trip-level estimate figures for stop-time persistence
+  /// onto [TripSummary.estimatedAvgLPer100Km] /
+  /// [TripSummary.estimatedFuelLitersConsumed]. Null until the physics
+  /// has warmed up (mirrors the live view's dash).
+  double? get finalAvgLPer100Km => _estimator.runningAvgLPer100Km;
+
+  /// See [finalAvgLPer100Km]. Zero litres reads as "no estimate".
+  double? get finalFuelLiters {
+    final liters = _estimator.litersSoFar;
+    return liters > 0 ? liters : null;
+  }
+
   /// Road-grade estimator (#2654) — driven IDENTICALLY to
   /// [BaselineRollingState]: 150 m window, 0.2 exp-smoothing,
   /// minSamplesInWindow=5 confidence gate. Fed the running horizontal

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -24,6 +24,19 @@ class TripSummary {
   /// trip carried no fuel-rate samples. This is what the "save as
   /// fill-up" flow pre-fills into the liters field (#726).
   final double? fuelLitersConsumed;
+
+  /// #3576 — GPS-physics ESTIMATE of the average consumption (L/100 km),
+  /// stamped at stop time from the shared [GpsLiveEstimateFolder] when —
+  /// and only when — no measured fuel figure exists ([avgLPer100Km] is
+  /// null). The live recording view showed these `~` figures the whole
+  /// drive; discarding them at save read as "the data got lost". UI must
+  /// always render them with the `~` estimate prefix, never as measured.
+  final double? estimatedAvgLPer100Km;
+
+  /// #3576 — GPS-physics ESTIMATE of the litres burned; same contract as
+  /// [estimatedAvgLPer100Km]. Never pre-fills the fill-up flow (#726
+  /// stays measured-only).
+  final double? estimatedFuelLitersConsumed;
   final DateTime? startedAt;
   final DateTime? endedAt;
 
@@ -173,6 +186,8 @@ class TripSummary {
     required this.harshAccelerations,
     this.avgLPer100Km,
     this.fuelLitersConsumed,
+    this.estimatedAvgLPer100Km,
+    this.estimatedFuelLitersConsumed,
     this.startedAt,
     this.endedAt,
     this.distanceSource = 'virtual',
@@ -219,6 +234,8 @@ class TripSummary {
     int? harshAccelerations,
     double? avgLPer100Km,
     double? fuelLitersConsumed,
+    double? estimatedAvgLPer100Km,
+    double? estimatedFuelLitersConsumed,
     DateTime? startedAt,
     DateTime? endedAt,
     String? distanceSource,
@@ -243,6 +260,10 @@ class TripSummary {
         harshAccelerations: harshAccelerations ?? this.harshAccelerations,
         avgLPer100Km: avgLPer100Km ?? this.avgLPer100Km,
         fuelLitersConsumed: fuelLitersConsumed ?? this.fuelLitersConsumed,
+        estimatedAvgLPer100Km:
+            estimatedAvgLPer100Km ?? this.estimatedAvgLPer100Km,
+        estimatedFuelLitersConsumed:
+            estimatedFuelLitersConsumed ?? this.estimatedFuelLitersConsumed,
         startedAt: startedAt ?? this.startedAt,
         endedAt: endedAt ?? this.endedAt,
         distanceSource: distanceSource ?? this.distanceSource,

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -979,6 +979,11 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   ) {
     final s = r.summary;
     final liters = s.fuelLitersConsumed;
+    // #3576 — no measured fuel: fall back to the persisted GPS-physics
+    // estimate the live view showed all drive, `~`-prefixed (estimate
+    // convention shared with the recording screen), instead of a dash.
+    final estLiters = s.estimatedFuelLitersConsumed;
+    final estAvg = s.estimatedAvgLPer100Km;
     final endKm = r.endOdometerKm;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -992,15 +997,21 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         _MetricCard(
           icon: Icons.local_gas_station,
           label: l.tripMetricFuelUsed,
-          value: liters == null ? '—' : '${liters.toStringAsFixed(2)} L',
+          value: liters != null
+              ? '${liters.toStringAsFixed(2)} L'
+              : estLiters != null
+                  ? '~${estLiters.toStringAsFixed(2)} L'
+                  : '—',
         ),
         const SizedBox(height: 8),
         _MetricCard(
           icon: Icons.eco,
           label: l.tripMetricAvgConsumption,
-          value: s.avgLPer100Km == null
-              ? '—'
-              : UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: false),
+          value: s.avgLPer100Km != null
+              ? UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: false)
+              : estAvg != null
+                  ? '~${UnitFormatter.formatConsumption(estAvg, isEv: false)}'
+                  : '—',
         ),
         const SizedBox(height: 8),
         _MetricCard(

--- a/lib/features/consumption/presentation/widgets/trajet_row.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_row.dart
@@ -126,6 +126,16 @@ class TrajetRow extends StatelessWidget {
                               s.avgLPer100Km!.toStringAsFixed(1),
                               avgUnit,
                             ),
+                          )
+                        // #3576 — persisted GPS-physics estimate,
+                        // `~`-prefixed per the estimate convention.
+                        else if (s.estimatedAvgLPer100Km != null)
+                          _Chip(
+                            icon: Icons.eco,
+                            text: l.trajetsRowAvgConsumption(
+                              '~${s.estimatedAvgLPer100Km!.toStringAsFixed(1)}',
+                              avgUnit,
+                            ),
                           ),
                         if (s.coldStartSurcharge)
                           _Chip(

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -66,12 +66,19 @@ class TripSummaryCard extends ConsumerWidget {
             s.endedAt!.isAfter(s.startedAt!)
         ? _fmtDuration(s.endedAt!.difference(s.startedAt!))
         : unknown;
-    final avgConsumption = s.avgLPer100Km == null
-        ? unknown
-        : UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: isEv);
-    final fuelUsed = s.fuelLitersConsumed == null
-        ? unknown
-        : '${s.fuelLitersConsumed!.toStringAsFixed(2)} L';
+    // #3576 — measured wins; a persisted GPS-physics estimate renders
+    // `~`-prefixed (the live view's estimate convention); dash only when
+    // neither exists.
+    final avgConsumption = s.avgLPer100Km != null
+        ? UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: isEv)
+        : s.estimatedAvgLPer100Km != null
+            ? '~${UnitFormatter.formatConsumption(s.estimatedAvgLPer100Km!, isEv: isEv)}'
+            : unknown;
+    final fuelUsed = s.fuelLitersConsumed != null
+        ? '${s.fuelLitersConsumed!.toStringAsFixed(2)} L'
+        : s.estimatedFuelLitersConsumed != null
+            ? '~${s.estimatedFuelLitersConsumed!.toStringAsFixed(2)} L'
+            : unknown;
     final avgSpeed = _avgSpeedLabel(samples, unknown);
     final maxSpeed = _maxSpeedLabel(samples, unknown);
 

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -8,16 +8,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/logging/error_logger.dart';
 import '../../driving/providers/live_harsh_event_bus_provider.dart';
-import '../../../core/domain/gps_calibration_matrix.dart';
 import '../../obd2/api.dart';
 import 'active_vehicle_read.dart';
 import '../domain/entities/trip_save_stage.dart';
-import '../domain/gps_driving_features.dart';
-import '../domain/services/gps_fuel_estimator.dart';
 import '../domain/services/gps_live_estimate_folder.dart';
 import '../domain/trip_recorder.dart';
 import 'gps_only_trip_wal.dart';
 import 'gps_movement_wake_nudge.dart';
+import 'gps_trip_fuel_backfill.dart';
 import 'gps_sample_diagnostics_recorder.dart';
 import 'motion_gated_gps_source.dart';
 import 'recording_pipeline.dart';
@@ -191,9 +189,7 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     );
   }
 
-  // #3570 — movement-wake nudge for a parked link (counter + throttle
-  // live in [GpsMovementWakeNudge]; the wake callback resolves THE
-  // supervisor lazily so tests without the reconnect graph stay green).
+  // #3570 — movement-wake nudge for a parked link ([GpsMovementWakeNudge]).
   late final GpsMovementWakeNudge _wakeNudge = GpsMovementWakeNudge(
     wake: () {
       try {
@@ -321,33 +317,17 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // #3500 — the stamp + #2895 veto now live on the shared fusion, so the
     // OBD2 pipeline applies the exact same semantics.
     if (imuFusion != null) summary = imuFusion.applyTo(summary);
-    // #2080 — for GPS-only / hybrid trips (no OBD2 fuel-rate
-    // coverage), feed the sample stream through GpsDrivingFeatures +
-    // the active vehicle's GpsCalibrationMatrix to impute
-    // `avgLPer100Km` and `fuelLitersConsumed`. The fields stay null
-    // when no active vehicle exists, when the trajet has no
-    // distance, or when the OBD2 path already populated them
-    // (gpsPlusObd2 trips skip this branch — `summary.kind` is the
-    // gate).
-    if (summary.kind == TripKind.gpsOnly && summary.avgLPer100Km == null) {
-      final features = GpsDrivingFeatures.from(samples);
-      if (features != null) {
-        final vehicle = tryReadActiveVehicleProfile(_ref,
-        where: 'GpsOnlyRecordingPipeline: active vehicle unavailable');
-        final matrix =
-            vehicle?.gpsCalibration ?? GpsCalibrationMatrix.coldStart();
-        final est = GpsFuelEstimator.estimate(
-          matrix: matrix,
-          features: features,
-        );
-        if (est != null) {
-          summary = summary.copyWith(
-            avgLPer100Km: est.lPer100Km,
-            fuelLitersConsumed: est.lPer100Km * summary.distanceKm / 100, // #3252
-          );
-        }
-      }
-    }
+    // #2080/#3252/#3576 — stop-time fuel backfill (batch estimate into
+    // the measured fields, live-folder estimate into the `~` fields
+    // when the batch declines); see [backfillGpsTripFuel].
+    summary = backfillGpsTripFuel(
+      summary,
+      samples: samples,
+      vehicleCalibration: tryReadActiveVehicleProfile(_ref,
+              where: 'GpsOnlyRecordingPipeline: active vehicle unavailable')
+          ?.gpsCalibration,
+      liveFolder: _estimateFolder,
+    );
     // #2548 — second beat: writing the finished trip to Hive history.
     _host.setSaveStage(TripSaveStage.savingToHistory);
     // #2509 — each GPS fix feeds one sample through the recorder, so the

--- a/lib/features/consumption/providers/gps_trip_fuel_backfill.dart
+++ b/lib/features/consumption/providers/gps_trip_fuel_backfill.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../core/domain/gps_calibration_matrix.dart';
+import '../domain/gps_driving_features.dart';
+import '../domain/services/gps_fuel_estimator.dart';
+import '../domain/services/gps_live_estimate_folder.dart';
+import '../domain/trip_recorder.dart';
+
+/// Stop-time fuel backfill for trips without OBD2 fuel-rate coverage —
+/// extracted from `GpsOnlyRecordingPipeline` (#3576, 400-line guard).
+///
+/// Two layers, measured-first:
+///  1. #2080/#3252 — the batch estimator: GpsDrivingFeatures over the
+///     sample stream + the vehicle's GpsCalibrationMatrix impute
+///     `avgLPer100Km`/`fuelLitersConsumed` for gpsOnly trips.
+///  2. #3576 — when the batch estimator declines (no features / no
+///     estimate), the LIVE GpsLiveEstimateFolder figures the user
+///     watched during the drive are persisted onto the ESTIMATED
+///     fields (`~`-rendered) instead of saving dashes.
+TripSummary backfillGpsTripFuel(
+  TripSummary summary, {
+  required List<TripSample> samples,
+  required GpsCalibrationMatrix? vehicleCalibration,
+  required GpsLiveEstimateFolder? liveFolder,
+}) {
+  var s = summary;
+  if (s.kind == TripKind.gpsOnly && s.avgLPer100Km == null) {
+    final features = GpsDrivingFeatures.from(samples);
+    if (features != null) {
+      final matrix = vehicleCalibration ?? GpsCalibrationMatrix.coldStart();
+      final est = GpsFuelEstimator.estimate(matrix: matrix, features: features);
+      if (est != null) {
+        s = s.copyWith(
+          avgLPer100Km: est.lPer100Km,
+          fuelLitersConsumed: est.lPer100Km * s.distanceKm / 100, // #3252
+        );
+      }
+    }
+  }
+  if (s.avgLPer100Km == null) {
+    s = s.copyWith(
+      estimatedAvgLPer100Km: liveFolder?.finalAvgLPer100Km,
+      estimatedFuelLitersConsumed: liveFolder?.finalFuelLiters,
+    );
+  }
+  return s;
+}

--- a/lib/features/obd2/data/obd2_service.dart
+++ b/lib/features/obd2/data/obd2_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../core/domain/vehicle_profile.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import 'adapter_capability.dart';
 import 'auto_record_trace_log.dart';
 import 'bluetooth_obd2_transport.dart';
@@ -860,6 +861,48 @@ class Obd2Service implements Obd2RawCommandPort, Obd2FuelRateReads {
   /// doesn't implement. One walk per trip-recording session is
   /// enough.
   Future<Set<int>> discoverSupportedPids() => _pids.discoverSupportedPids();
+
+  /// #3575 — in-session vehicle-protocol recovery for the ELM
+  /// UNABLE-TO-CONNECT livelock. When the adapter connected before the
+  /// ignition was on, the first auto protocol search fails and the chip
+  /// answers every later command instantly with UNABLE TO CONNECT /
+  /// STOPPED — and the polling cadence keeps interrupting any restarted
+  /// search, so it can never converge. Recovery: reset to the auto
+  /// search (`ATSP0`), clear the per-connection PID state, and re-run
+  /// the resilient first-`0100` discovery (which owns the #3035/#3037
+  /// search window) with NO other traffic in flight — the caller must
+  /// pause its poll scheduler around this call. On an answering bus the
+  /// negotiated protocol is re-read and re-cached (#2261).
+  ///
+  /// Returns true when the bus answered (protocol re-established);
+  /// false on a still-silent bus or any transport fault. Never throws.
+  Future<bool> recoverVehicleProtocol() async {
+    if (!_transport.isConnected) return false;
+    try {
+      await _send(Elm327Protocol.autoProtocolCommand);
+      _pids.resetForNewConnection();
+      await discoverSupportedPids();
+      final answered = busProbe == Obd2BusProbeResult.answered;
+      if (answered) {
+        await _resolveAndCacheProtocol(warmConnect: false);
+      }
+      BreadcrumbCollector.add(
+        'OBD2 protocol recovery (#3575)',
+        detail: answered ? 'bus answered — protocol re-established' : 'bus still silent',
+      );
+      return answered;
+    } catch (e, st) {
+      // An expected link condition mid-recovery (adapter asleep, socket
+      // died) — breadcrumb, not an ERROR trace; the scheduler episode
+      // will re-signal if the link is actually alive.
+      BreadcrumbCollector.add(
+        'OBD2 protocol recovery failed (#3575)',
+        detail: '${e.runtimeType}',
+      );
+      debugPrint('Obd2Service.recoverVehicleProtocol: $e\n$st');
+      return false;
+    }
+  }
 
   /// Read current engine RPM.
   @override

--- a/lib/features/obd2/data/pid_no_protocol_episode.dart
+++ b/lib/features/obd2/data/pid_no_protocol_episode.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// #3575 — session-wide "no vehicle protocol" livelock detection for the
+/// [PidScheduler].
+///
+/// When the adapter connects before the ignition is on, the ELM's first
+/// auto protocol search fails and the chip answers every later command
+/// instantly with `UNABLE TO CONNECT` / `STOPPED` — and the polling
+/// cadence keeps interrupting any restarted search, so it can never
+/// converge (field trip 2026-07-13: 21 minutes of 100% err at ~151 ms
+/// per reply, 0% completeness). These replies arrive as SUCCESSFUL
+/// transport round-trips, so the scheduler's per-PID failure streaks
+/// never see them; this tracker classifies the CONTENT instead.
+///
+/// After [threshold] consecutive no-protocol replies it fires
+/// [onEpisode] once and resets, so with the owner's throttle a
+/// persistent condition re-signals rather than storms. The owner (the
+/// recording controller) pauses polling and re-runs protocol discovery.
+class PidNoProtocolEpisode {
+  PidNoProtocolEpisode({required this.threshold, this.onEpisode});
+
+  /// Consecutive no-protocol replies before [onEpisode] fires — ≈4–8 s
+  /// at the 5–10 Hz effective cadence: fast enough to rescue a trip,
+  /// slow enough to ignore a lone search hiccup.
+  final int threshold;
+
+  final void Function()? onEpisode;
+
+  int _streak = 0;
+
+  /// The ELM's "no vehicle protocol" reply family. NO DATA is
+  /// deliberately NOT here — an alive bus NO-DATAs unsupported PIDs.
+  static bool isNoProtocolReply(String response) {
+    final u = response.toUpperCase();
+    return u.contains('UNABLE TO CONNECT') ||
+        u.contains('STOPPED') ||
+        u.contains('BUS INIT');
+  }
+
+  /// Feed one successful reply's raw content.
+  void note(String response) {
+    if (isNoProtocolReply(response)) {
+      if (++_streak >= threshold) {
+        _streak = 0;
+        onEpisode?.call();
+      }
+    } else {
+      _streak = 0;
+    }
+  }
+}

--- a/lib/features/obd2/data/pid_scheduler.dart
+++ b/lib/features/obd2/data/pid_scheduler.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import '../../../core/logging/error_logger.dart';
 import 'obd2_comm_diagnostics.dart';
 import 'pid_bandwidth_governor.dart';
+import 'pid_no_protocol_episode.dart';
 import 'pid_scheduler_comm_diagnostics.dart';
 import 'pid_subscription.dart';
 import 'scheduled_pid.dart';
@@ -31,25 +32,16 @@ export 'scheduled_pid.dart';
 /// ## Transient-failure handling (#2379)
 ///
 /// Per-PID transport failures (timeout, NO DATA, adapter dropped) are
-/// **expected and recoverable** — engine-off cars NO-DATA half their
-/// PIDs, and a slow clone times out intermittently. They are NOT error-
-/// logged one-per-PID-per-tick (which flooded a real user's error log
-/// with ~50 of 54 traces). Instead:
-///
-/// - Each subscription counts consecutive failures. After
-///   [_maxConsecutiveFailures] in a row the PID is **backed off**: its
-///   selection weight is recomputed at [_backoffHz] (≈ once per 30 s)
-///   instead of its configured hz, so it neither floods the adapter nor
-///   starves healthy PIDs. A single successful read resets the counter
-///   and restores full cadence. The `lastReadAt` anti-starvation stamp
-///   is kept on every attempt (success OR failure), so a backed-off PID
-///   still climbs weight and is retried — just rarely.
-/// - When the adapter looks broadly unresponsive ([_backoffThreshold]+
-///   PIDs backed off) a SINGLE rate-limited aggregated diagnostic is
-///   emitted, at most once per [_diagnosticWindow].
-///
-/// Recording is unaffected — a backed-off PID simply contributes fewer
-/// samples; the loop never stalls.
+/// **expected and recoverable** — never error-logged per-PID-per-tick.
+/// After [_maxConsecutiveFailures] in a row a PID is backed off to
+/// [_backoffHz] (one success restores full cadence; the `lastReadAt`
+/// anti-starvation stamp is kept on every attempt so it is still
+/// retried, just rarely). [_backoffThreshold]+ simultaneous backoffs
+/// emit ONE aggregated diagnostic per [_diagnosticWindow]. Recording is
+/// unaffected — a backed-off PID simply contributes fewer samples.
+/// Sustained no-protocol REPLIES (successful round-trips whose content
+/// is UNABLE TO CONNECT / STOPPED) are a separate condition — see
+/// [PidNoProtocolEpisode] (#3575).
 ///
 /// ## Bandwidth governor (#2457)
 ///
@@ -72,7 +64,15 @@ class PidScheduler {
     required this.transport,
     this.tickRate = const Duration(milliseconds: 100),
     DateTime Function()? clock,
-  }) : _clock = clock ?? DateTime.now;
+    void Function()? onNoProtocolEpisode,
+    int noProtocolEpisodeThreshold = 40,
+  })  : _clock = clock ?? DateTime.now,
+        _noProtocolEpisode = PidNoProtocolEpisode(
+            threshold: noProtocolEpisodeThreshold,
+            onEpisode: onNoProtocolEpisode);
+
+  /// #3575 — see [PidNoProtocolEpisode].
+  final PidNoProtocolEpisode _noProtocolEpisode;
 
   /// Consecutive per-PID transport failures before the PID is backed off
   /// to [_backoffHz]. Three covers a brief blip (one slow round-trip,
@@ -343,6 +343,7 @@ class PidScheduler {
       // A successful read clears any accumulated failure streak so the
       // PID resumes its configured cadence immediately (#2379).
       sub.consecutiveFailures = 0;
+      _noProtocolEpisode.note(response); // #3575 — content-classified.
       if (diag.enabled) {
         PidSchedulerCommDiagnostics.noteSuccess(command, response,
             dispatchedAt: now, completedAt: completedAt);

--- a/lib/features/obd2/data/trip_recording_controller.dart
+++ b/lib/features/obd2/data/trip_recording_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../core/domain/vehicle_profile.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../consumption/domain/driving_coaching.dart' show DrivingCoachingHint;
 import '../../consumption/domain/entities/gps_sample_diagnostic.dart';
 import '../../consumption/domain/services/gear_inference.dart';
@@ -916,6 +917,14 @@ class TripRecordingController {
     // scoring on the `gps`/`virtual` source in `onSample`, so base.harsh* is
     // 0 for a no-speed-PID GPS trip (no phantom) and reflects the direct OBD2
     // speed PID on a `real` trip (preserved). Pass-through is correct here.
+    // #3576 — persist the live GPS-physics estimate the user watched all
+    // drive (the #2506 overlay) when NO measured fuel exists: the field
+    // trip showed ~2.01 L / ~11.0 L/100 km live and dashes after save.
+    // Measured data always wins — a single real fuel-rate sample keeps
+    // the estimate fields null.
+    final estimateFolder = _gpsEstimateFolder;
+    final stampEstimates =
+        base.fuelLitersConsumed == null && !_fuelRateSeen;
     return TripSummary(
       distanceKm: distanceKm,
       maxRpm: base.maxRpm,
@@ -925,6 +934,10 @@ class TripRecordingController {
       harshAccelerations: base.harshAccelerations,
       avgLPer100Km: avg,
       fuelLitersConsumed: base.fuelLitersConsumed,
+      estimatedAvgLPer100Km:
+          stampEstimates ? estimateFolder?.finalAvgLPer100Km : null,
+      estimatedFuelLitersConsumed:
+          stampEstimates ? estimateFolder?.finalFuelLiters : null,
       startedAt: startedAt,
       endedAt: endedAt,
       distanceSource: source,
@@ -1060,7 +1073,48 @@ class TripRecordingController {
       transport: _runTransport,
       tickRate: _schedulerTickRate,
       clock: _now,
+      onNoProtocolEpisode: () => unawaited(_recoverVehicleProtocol()),
     );
+  }
+
+  /// #3575 — quiet-window protocol recovery for the UNABLE-TO-CONNECT
+  /// livelock: the scheduler signalled a sustained no-protocol reply
+  /// streak (adapter connected before ignition-on → failed auto search →
+  /// every command errs instantly, and the polling cadence keeps
+  /// interrupting a restarted search). Pause polling so the `0100`
+  /// search finally gets an uninterrupted window, re-run discovery, and
+  /// resume. Throttled to one attempt per [_protocolRecoveryInterval] —
+  /// the scheduler episode re-signals while the condition persists, so a
+  /// car whose engine starts mid-trip recovers within a minute instead
+  /// of erring for the whole drive (field log 2026-07-13, 21 min of
+  /// 100% err at 0% completeness).
+  bool _protocolRecoveryInFlight = false;
+  DateTime? _lastProtocolRecoveryAt;
+  static const Duration _protocolRecoveryInterval = Duration(seconds: 45);
+
+  Future<void> _recoverVehicleProtocol() async {
+    if (_protocolRecoveryInFlight) return;
+    final now = _now();
+    final last = _lastProtocolRecoveryAt;
+    if (last != null && now.difference(last) < _protocolRecoveryInterval) {
+      return;
+    }
+    _lastProtocolRecoveryAt = now;
+    _protocolRecoveryInFlight = true;
+    final scheduler = _scheduler;
+    scheduler?.pause();
+    try {
+      final recovered = await _service.recoverVehicleProtocol();
+      BreadcrumbCollector.add(
+        'OBD2 recording: no-protocol episode (#3575)',
+        detail: recovered
+            ? 'recovered — polling resumes with a live protocol'
+            : 'still no protocol — retrying in ${_protocolRecoveryInterval.inSeconds}s',
+      );
+    } finally {
+      _protocolRecoveryInFlight = false;
+      scheduler?.resume();
+    }
   }
 
   /// Wrap [Obd2Service.sendCommand] with drop-detection bookkeeping

--- a/test/features/consumption/data/trip_summary_codec_estimates_test.dart
+++ b/test/features/consumption/data/trip_summary_codec_estimates_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_summary_codec.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #3576 — the GPS-physics estimate figures must survive the Hive JSON
+/// round-trip (the #2776 lesson: a field that any toJson path drops is a
+/// field the app silently loses), and legacy/measured trips must
+/// round-trip byte-identical (no `eAvg`/`eFuel` keys).
+void main() {
+  TripSummary mk({double? estAvg, double? estFuel, double? measured}) =>
+      TripSummary(
+        distanceKm: 18.2,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 30,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        avgLPer100Km: measured,
+        estimatedAvgLPer100Km: estAvg,
+        estimatedFuelLitersConsumed: estFuel,
+        startedAt: DateTime(2026, 7, 13, 21, 37),
+      );
+
+  test('estimate figures round-trip through the codec', () {
+    final json = tripSummaryToJson(mk(estAvg: 11.0, estFuel: 2.01));
+    expect(json['eAvg'], 11.0);
+    expect(json['eFuel'], 2.01);
+    final back = tripSummaryFromJson(json);
+    expect(back.estimatedAvgLPer100Km, 11.0);
+    expect(back.estimatedFuelLitersConsumed, 2.01);
+  });
+
+  test('trips without estimates serialise with zero extra bytes', () {
+    final json = tripSummaryToJson(mk(measured: 6.4));
+    expect(json.containsKey('eAvg'), isFalse);
+    expect(json.containsKey('eFuel'), isFalse);
+    final back = tripSummaryFromJson(json);
+    expect(back.estimatedAvgLPer100Km, isNull);
+    expect(back.estimatedFuelLitersConsumed, isNull);
+    expect(back.avgLPer100Km, 6.4);
+  });
+}

--- a/test/features/obd2/data/obd2_protocol_recovery_test.dart
+++ b/test/features/obd2/data/obd2_protocol_recovery_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3575 — [Obd2Service.recoverVehicleProtocol]: the in-session recovery
+/// for the ELM UNABLE-TO-CONNECT livelock (adapter connected before
+/// ignition-on → failed auto search → every command errs instantly).
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('re-establishes the protocol on an answering bus and reports true',
+      () async {
+    final transport = FakeObd2Transport({
+      'ATSP0': 'OK',
+      // Engine now running: the uninterrupted 0100 search converges.
+      '0100': '41 00 BE 3E B8 11',
+      'ATDPN': 'A6',
+    });
+    final service = Obd2Service(transport);
+    await service.connect();
+    transport.sentCommands.clear();
+
+    final recovered = await service.recoverVehicleProtocol();
+
+    expect(recovered, isTrue);
+    expect(transport.sentCommands.first, 'ATSP0',
+        reason: 'recovery must reset the failed auto search first');
+    expect(transport.sentCommands, contains('0100'),
+        reason: 'recovery must re-run the supported-PID discovery');
+    expect(service.busProbe, Obd2BusProbeResult.answered);
+  });
+
+  test('a still-silent bus reports false (engine genuinely off)', () async {
+    final transport = FakeObd2Transport({
+      'ATSP0': 'OK',
+      '0100': 'UNABLE TO CONNECT',
+    });
+    final service = Obd2Service(transport);
+    await service.connect();
+
+    final recovered = await service.recoverVehicleProtocol();
+
+    expect(recovered, isFalse);
+  });
+
+  test('a disconnected transport reports false without sending', () async {
+    final transport = FakeObd2Transport();
+    final service = Obd2Service(transport);
+    // Never connected.
+    final recovered = await service.recoverVehicleProtocol();
+    expect(recovered, isFalse);
+    expect(transport.sentCommands, isEmpty);
+  });
+}

--- a/test/features/obd2/data/pid_scheduler_test.dart
+++ b/test/features/obd2/data/pid_scheduler_test.dart
@@ -919,4 +919,37 @@ void main() {
           reason: 'headroom returned → demotions are unwound');
     });
   });
+
+  group('no-protocol episode (#3575)', () {
+    test(
+        'fires after threshold consecutive UNABLE TO CONNECT replies, '
+        'and a healthy reply resets the streak', () async {
+      var episodes = 0;
+      var healthy = false;
+      final scheduler = PidScheduler(
+        transport: (_) async =>
+            healthy ? '41 0C 1A F8' : 'UNABLE TO CONNECT',
+        tickRate: const Duration(milliseconds: 1),
+        onNoProtocolEpisode: () => episodes++,
+        noProtocolEpisodeThreshold: 5,
+      );
+      scheduler.subscribe('010C', ScheduledPid(hz: 10.0), (_) {});
+      scheduler.start();
+
+      // The ELM's cached failed-search answers instantly — the field
+      // livelock. Enough ticks for well over 5 consecutive replies.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(episodes, greaterThanOrEqualTo(1),
+          reason: 'a sustained no-protocol streak must signal the owner');
+
+      // A healthy bus resets the streak: no further episodes fire.
+      healthy = true;
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final settled = episodes;
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      scheduler.stop();
+      expect(episodes, settled,
+          reason: 'healthy replies must stop the episode signal');
+    });
+  });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -517,9 +517,12 @@ void main() {
     // obd2_fuel_rate_reader.dart, the odometer strategy/catalog chain to
     // obd2_odometer_reader.dart, and the #1418 PSA listen-mode stream to
     // obd2_can_frame_stream.dart; the service keeps thin delegators.
+    // #3575 — re-grandfathered 1317 → 1357: recoverVehicleProtocol(),
+    // the in-session ATSP0 + 0100 + ATDPN recovery for the
+    // UNABLE-TO-CONNECT livelock (2026-07-13 field trip).
     'lib/features/obd2/data/obd2_service.dart': (
-      lines: 1317,
-      bumps: 13,
+      lines: 1357,
+      bumps: 14,
       decompositionIssue: 3540,
     ),
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
@@ -652,9 +655,12 @@ void main() {
     // 18 bumps (the worst offender in this map) — decomposition forced
     // (#3141), tracked by the OPEN #3140 (TripRecordingController is
     // named in that issue's breakdown).
+    // #3575/#3576 — re-grandfathered 1728 → 1780: the no-protocol
+    // episode handler (pause → recoverVehicleProtocol → resume, throttled)
+    // + stop-time stamping of the live GPS-physics estimate figures.
     'lib/features/obd2/data/trip_recording_controller.dart': (
-      lines: 1728,
-      bumps: 18,
+      lines: 1780,
+      bumps: 19,
       decompositionIssue: 3140,
     ),
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR
@@ -761,8 +767,10 @@ void main() {
     // line; no logic added.
     // 8 bumps — decomposition forced (#3141), tracked by the OPEN #3138
     // (trips/fillups feature split; this screen is trips).
+    // #3576 — re-grandfathered 1107 → 1110: the stop summary sheet
+    // renders the `~` estimate fallback for fuel + average.
     'lib/features/consumption/presentation/screens/trip_recording_screen.dart':
-        (lines: 1107, bumps: 8, decompositionIssue: 3138),
+        (lines: 1110, bumps: 9, decompositionIssue: 3138),
     'lib/features/consumption/presentation/widgets/broken_map_widgets.dart': (
       lines: 439,
       bumps: 0,


### PR DESCRIPTION
Field trip 2026-07-13 21:37 ("the recording was promising and then the data got lost"): the adapter connected before ignition-on, the ELM's auto protocol search failed once, and the chip then answered every command with UNABLE TO CONNECT at ~151 ms — while the 10 Hz polling cadence interrupted every restarted search. 21 minutes, ~1,145 polls per PID, 0 ok, 0% completeness, "protocole —". The session fell back to the live GPS-physics estimates (the "promising" ~2.01 L / ~11.0 L/100 figures) which were then discarded at save — dashes.

- **#3575** — session-wide no-protocol livelock detection ([PidNoProtocolEpisode]) + `Obd2Service.recoverVehicleProtocol()` (ATSP0 + resilient 0100 in a quiet window + ATDPN re-cache) + controller orchestration (pause → recover → resume, 45 s throttle). An engine started mid-trip now yields real data within a minute.
- **#3576** — the live GPS estimates persist onto `TripSummary` (`eAvg`/`eFuel` codec keys, measured-first) and render `~`-prefixed on the stop sheet, history card, and trajets row — never dashes when the user watched figures all drive.

Local gates: analyze clean, lint + obd2 + consumption suites green (5,234 tests), file-length guard satisfied (2 extractions + 3 ratchet bumps), new unit tests for the episode detector, the recovery primitive, and the codec round-trip.

Closes #3575
Closes #3576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G