### PR TITLE
fix(l10n): hand-French for combustion-health lessons + upshift-cruise insight (#3587)

### DIFF
--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4567,7 +4567,7 @@
       }
     }
   },
-  "lessonCombustionHealthLeanBorderline": "Mixture looks a little lean — the engine added fuel ({pctTrim}% trim) to compensate",
+  "lessonCombustionHealthLeanBorderline": "Mélange légèrement pauvre — le moteur a ajouté du carburant ({pctTrim} % de correction) pour compenser",
   "@lessonCombustionHealthLeanBorderline": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -4577,7 +4577,7 @@
       }
     }
   },
-  "lessonCombustionHealthLeanMarked": "Mixture looks lean — the engine sustained a large {pctTrim}% fuel addition, a possible inefficiency",
+  "lessonCombustionHealthLeanMarked": "Mélange pauvre — le moteur a maintenu un ajout de carburant important de {pctTrim} %, une inefficacité possible",
   "@lessonCombustionHealthLeanMarked": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -4587,7 +4587,7 @@
       }
     }
   },
-  "lessonCombustionHealthRichBorderline": "Mixture looks a little rich — the engine pulled fuel ({pctTrim}% trim) to compensate",
+  "lessonCombustionHealthRichBorderline": "Mélange légèrement riche — le moteur a réduit le carburant ({pctTrim} % de correction) pour compenser",
   "@lessonCombustionHealthRichBorderline": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -4597,7 +4597,7 @@
       }
     }
   },
-  "lessonCombustionHealthRichMarked": "Mixture looks rich — the engine sustained a large {pctTrim}% fuel cut, a possible inefficiency",
+  "lessonCombustionHealthRichMarked": "Mélange riche — le moteur a maintenu une réduction de carburant importante de {pctTrim} %, une inefficacité possible",
   "@lessonCombustionHealthRichMarked": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -4607,7 +4607,7 @@
       }
     }
   },
-  "lessonCombustionHealthEnrichment": "Engine ran rich under load ({pctShare}% of the warm drive) — possible wasted fuel",
+  "lessonCombustionHealthEnrichment": "Moteur enrichi sous charge ({pctShare} % du trajet à chaud) — carburant potentiellement gaspillé",
   "@lessonCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -4617,7 +4617,7 @@
       }
     }
   },
-  "lessonCombustionHealthSubtitle": "Heuristic health signal, not a diagnosis",
+  "lessonCombustionHealthSubtitle": "Signal de santé heuristique, pas un diagnostic",
   "@lessonCombustionHealthSubtitle": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
@@ -5070,7 +5070,7 @@
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
   },
-  "insightUpshiftCruise": "High-RPM cruising ({pctTime}% of trip): shifting up earlier could save {liters} L",
+  "insightUpshiftCruise": "Croisière à haut régime ({pctTime} % du trajet) : passer les rapports plus tôt économiserait {liters} L",
   "@insightUpshiftCruise": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review",
@@ -5131,7 +5131,7 @@
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
   },
-  "fuelBreakdownHighRpmCruise": "High-RPM cruising",
+  "fuelBreakdownHighRpmCruise": "Croisière à haut régime",
   "@fuelBreakdownHighRpmCruise": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4736,32 +4736,32 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String lessonCombustionHealthLeanBorderline(String pctTrim) {
-    return 'Mixture looks a little lean — the engine added fuel ($pctTrim% trim) to compensate';
+    return 'Mélange légèrement pauvre — le moteur a ajouté du carburant ($pctTrim % de correction) pour compenser';
   }
 
   @override
   String lessonCombustionHealthLeanMarked(String pctTrim) {
-    return 'Mixture looks lean — the engine sustained a large $pctTrim% fuel addition, a possible inefficiency';
+    return 'Mélange pauvre — le moteur a maintenu un ajout de carburant important de $pctTrim %, une inefficacité possible';
   }
 
   @override
   String lessonCombustionHealthRichBorderline(String pctTrim) {
-    return 'Mixture looks a little rich — the engine pulled fuel ($pctTrim% trim) to compensate';
+    return 'Mélange légèrement riche — le moteur a réduit le carburant ($pctTrim % de correction) pour compenser';
   }
 
   @override
   String lessonCombustionHealthRichMarked(String pctTrim) {
-    return 'Mixture looks rich — the engine sustained a large $pctTrim% fuel cut, a possible inefficiency';
+    return 'Mélange riche — le moteur a maintenu une réduction de carburant importante de $pctTrim %, une inefficacité possible';
   }
 
   @override
   String lessonCombustionHealthEnrichment(String pctShare) {
-    return 'Engine ran rich under load ($pctShare% of the warm drive) — possible wasted fuel';
+    return 'Moteur enrichi sous charge ($pctShare % du trajet à chaud) — carburant potentiellement gaspillé';
   }
 
   @override
   String get lessonCombustionHealthSubtitle =>
-      'Heuristic health signal, not a diagnosis';
+      'Signal de santé heuristique, pas un diagnostic';
 
   @override
   String get lessonAdviceCombustionHealthLean =>
@@ -4878,7 +4878,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String insightUpshiftCruise(String pctTime, String liters) {
-    return 'High-RPM cruising ($pctTime% of trip): shifting up earlier could save $liters L';
+    return 'Croisière à haut régime ($pctTime % du trajet) : passer les rapports plus tôt économiserait $liters L';
   }
 
   @override
@@ -4909,7 +4909,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fuelBreakdownHarshAccel => 'Hard accelerations';
 
   @override
-  String get fuelBreakdownHighRpmCruise => 'High-RPM cruising';
+  String get fuelBreakdownHighRpmCruise => 'Croisière à haut régime';
 
   @override
   String get fuelBreakdownCoastingSaved => 'Saved by coasting';

--- a/test/l10n/french_required_prefixes.dart
+++ b/test/l10n/french_required_prefixes.dart
@@ -57,6 +57,15 @@ const List<String> kFrenchRequiredPrefixes = <String>[
   // #1374 phase 2 — the GPS trip-path overlay card on the trip detail screen.
   'tripPath',
 
+  // #3587 — the driving-lessons combustion-health family + the
+  // upshift-cruise insight + the fuel-breakdown label were caught
+  // rendering ENGLISH on a French device (field captures 2026-07-21):
+  // the MT autofill had copied the source text verbatim. These lesson
+  // surfaces are core French-reachable — hand-French required.
+  'lessonCombustionHealth',
+  'insightUpshiftCruise',
+  'fuelBreakdownHighRpmCruise',
+
   // #1401 phase 6 — the adapter-capability card on the Edit vehicle screen.
   'obd2Capability',
 


### PR DESCRIPTION
Field captures on a French device showed English lesson titles mixed into the French lessons list. Hand-translated the 8 keys; the french-required-prefixes gate now covers the family. Closes #3587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G