### PR TITLE
fix(ev): map overlay sources the OCM key from ApiKeyStorage (#3592)

### DIFF
--- a/lib/features/ev/providers/ev_providers.dart
+++ b/lib/features/ev/providers/ev_providers.dart
@@ -30,9 +30,14 @@ EvStationRepository evStationRepository(Ref ref) {
 /// in a real API key without a restart.
 @Riverpod(keepAlive: true)
 EvStationService evStationService(Ref ref) {
-  final storage = ref.watch(settingsStorageProvider);
-  final rawKey = storage.getSetting(StorageKeys.evApiKey);
-  final apiKey = rawKey is String && rawKey.trim().isNotEmpty ? rawKey : null;
+  // #3592 — the EV key lives in SECURE storage and ships with a default;
+  // [ApiKeyStorage.getEvApiKey] is the accessor that carries both (the
+  // generic settings-box read returned null forever, so the map overlay
+  // served demo stations even for configured users — the search side
+  // was already on the correct accessor).
+  final storage = ref.watch(apiKeyStorageProvider);
+  final rawKey = storage.getEvApiKey();
+  final apiKey = rawKey != null && rawKey.trim().isNotEmpty ? rawKey : null;
   return OpenChargeMapService(apiKey: apiKey);
 }
 

--- a/lib/features/ev/providers/ev_providers.g.dart
+++ b/lib/features/ev/providers/ev_providers.g.dart
@@ -119,7 +119,7 @@ final class EvStationServiceProvider
   }
 }
 
-String _$evStationServiceHash() => r'1d977c9206aebfb49e6f452730f35e05f49b83b6';
+String _$evStationServiceHash() => r'0122deaf9d47120b8ef9102bd9655297017bf644';
 
 /// Whether EV charging stations should be overlaid on the map.
 ///

--- a/test/features/ev/providers/ev_station_service_key_test.dart
+++ b/test/features/ev/providers/ev_station_service_key_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3592 — the MAP-side [evStationService] provider must source the OCM
+// key from [ApiKeyStorage.getEvApiKey] (secure store + shipped default),
+// exactly like the search side. The regression it pins: the old generic
+// settings-box read returned null forever, so the map overlay silently
+// served demo stations even for configured users.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/ev/data/services/open_charge_map_service.dart';
+import 'package:tankstellen/features/ev/providers/ev_providers.dart';
+
+void main() {
+  group('evStationService key sourcing (#3592)', () {
+    test('uses the ApiKeyStorage key — the secure store, not the plain box',
+        () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith(
+            (_) => _FakeApiKeyStorage('ocm-map-key')),
+      ]);
+      addTearDown(container.dispose);
+
+      final service = container.read(evStationServiceProvider);
+      expect(service, isA<OpenChargeMapService>());
+      expect((service as OpenChargeMapService).apiKey, 'ocm-map-key',
+          reason: 'the map overlay must query real OCM with the '
+              'configured/default key, not fall back to demo data');
+    });
+
+    test('a null key still constructs the service (demo fallback inside)',
+        () {
+      final container = ProviderContainer(overrides: [
+        apiKeyStorageProvider.overrideWith((_) => _FakeApiKeyStorage(null)),
+      ]);
+      addTearDown(container.dispose);
+
+      final service = container.read(evStationServiceProvider);
+      expect(service, isA<OpenChargeMapService>());
+      expect((service as OpenChargeMapService).apiKey, isNull);
+    });
+  });
+}
+
+class _FakeApiKeyStorage implements ApiKeyStorage {
+  final String? _evKey;
+  _FakeApiKeyStorage(this._evKey);
+
+  @override
+  String? getEvApiKey() => _evKey;
+
+  @override
+  bool hasEvApiKey() => _evKey != null && _evKey.isNotEmpty;
+
+  @override
+  Future<void> setEvApiKey(String key) async {}
+
+  @override
+  String? getApiKey() => null;
+  @override
+  bool hasApiKey() => false;
+  @override
+  bool hasCustomApiKey() => false;
+  @override
+  bool hasCustomEvApiKey() => false;
+  @override
+  Future<void> setApiKey(String key) async {}
+  @override
+  Future<void> deleteApiKey() async {}
+  @override
+  String? getSupabaseAnonKey() => null;
+  @override
+  Future<void> setSupabaseAnonKey(String key) async {}
+  @override
+  Future<void> deleteSupabaseAnonKey() async {}
+}
+


### PR DESCRIPTION
The map overlay read the plain settings box for the EV key (always null) while the key lives in secure storage with a shipped default — so it silently served demo charging stations for everyone. Now uses the same ApiKeyStorage accessor as the search side; regression test added. Closes #3592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G