### PR TITLE
fix(consumption): lossless TripDetailSample round-trip — export regains fuel provenance (#3594)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_detail_sample_converter.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_sample_converter.dart
@@ -9,6 +9,10 @@ import '../widgets/trip_detail_charts.dart';
 /// the trip-detail charts consume (#1040). Lives in its own file so
 /// `trip_detail_screen.dart` stays under the 400-line guard.
 TripDetailSample toDetailSample(TripSample s) => TripDetailSample(
+      // #3594 — carry the WHOLE domain sample; the reverse converter
+      // returns it verbatim, so the persisted-trip round-trip can never
+      // drop a field again (it happened five times field-by-field).
+      domain: s,
       timestamp: s.timestamp,
       speedKmh: s.speedKmh,
       rpm: s.rpm,

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../../../l10n/app_localizations.dart';
+import '../../domain/trip_recorder.dart';
 
 // #2431 — the CustomPainter + its point model live in a part file so this
 // widget file stays under the 400-line guard after the estimated-series
@@ -140,6 +141,15 @@ class TripDetailSample {
   /// fix (same semantics as [latitude]).
   final double? hAccuracyM;
 
+  /// The originating domain [TripSample] when this instance was produced
+  /// by `toDetailSample` (#3594). The reverse converter returns it
+  /// VERBATIM, making the persisted-trip round-trip lossless by
+  /// construction — no more field-by-field carrying (this pair dropped
+  /// fields five separate times: #2460, #2790, #2931, #2963, #3594).
+  /// Null only for hand-built instances (tests); those fall back to the
+  /// explicit field copy in `tripDetailToTripSample`.
+  final TripSample? domain;
+
   const TripDetailSample({
     required this.timestamp,
     required this.speedKmh,
@@ -157,6 +167,7 @@ class TripDetailSample {
     this.stft,
     this.ltft,
     this.hAccuracyM,
+    this.domain,
   });
 }
 

--- a/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
@@ -12,7 +12,12 @@ import 'trip_detail_charts.dart';
 /// #2692 C4-G — rpm threads through nullable (NOT `?? 0`): a GPS-only
 /// sample stays rpm null so the source-aware score re-weight + the
 /// GPS-efficiency card fire instead of seeing a fabricated 0.
-TripSample tripDetailToTripSample(TripDetailSample s) => TripSample(
+TripSample tripDetailToTripSample(TripDetailSample s) =>
+    // #3594 — a sample that came from persistence carries its domain
+    // original; return it VERBATIM (lossless by construction). The field
+    // copy below only serves hand-built TripDetailSamples in tests.
+    s.domain ??
+    TripSample(
       timestamp: s.timestamp,
       speedKmh: s.speedKmh,
       rpm: s.rpm,

--- a/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
@@ -9,6 +9,7 @@
 // converter (toDetailSample) that keeps altitude. RED before the fix
 // (climbEnergyPerKm == 0), GREEN after.
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_sample_codec.dart';
 import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
 import 'package:tankstellen/features/consumption/domain/trip_sample.dart';
@@ -95,5 +96,52 @@ void main() {
     expect(features!.climbEnergyPerKm, greaterThan(0),
         reason: 'altitude must survive the converter so a real climb is not '
             'reported as 0 m/km on the trip-detail GPS-efficiency card');
+  });
+  test(
+      'LOSSLESS round-trip for EVERY TripSample field (#3594) — the codec '
+      'map pins completeness so a future field can never silently drop', () {
+    // Every field non-null. If TripSample gains a field, sampleToJson gains
+    // its key, and this test fails until the converter pair carries it.
+    final full = TripSample(
+      timestamp: DateTime(2026, 7, 23, 8, 30),
+      speedKmh: 72.5,
+      rpm: 2450,
+      fuelRateLPerHour: 6.4,
+      estimatedFuelRateLPerHour: 6.1,
+      throttlePercent: 31.0,
+      engineLoadPercent: 48.0,
+      coolantTempC: 88.0,
+      latitude: 43.4612,
+      longitude: 3.4238,
+      altitudeM: 112.0,
+      hAccuracyM: 4.5,
+      bearingDeg: 181.0,
+      accelG: 0.12,
+      lambda: 0.98,
+      measuredPhi: 1.01,
+      ethanolPercent: 8.5,
+      fuelSource: 'pid9D',
+      baroKpa: 99.4,
+      absLoadPercent: 55.0,
+      pedalPercent: 28.0,
+      oilTempC: 95.0,
+      ambientTempC: 24.0,
+      mafGramsPerSecond: 7.8,
+      mapKpa: 61.0,
+      stft: 2.3,
+      ltft: 25.0,
+    );
+
+    final roundTripped = tripDetailToTripSample(toDetailSample(full));
+
+    expect(
+      sampleToJson(roundTripped),
+      sampleToJson(full),
+      reason: 'the saved-trip analysis path (fromSamples over the '
+          'round-tripped list) must see exactly what the recorder persisted '
+          '— fuelSourceShares was {} in every field export because the pair '
+          'dropped fs (and el/mq/ep/bp/aL/ot/am/mf/mp/be/ag/fe on one side '
+          'or the other)',
+    );
   });
 }


### PR DESCRIPTION
Field exports carried empty fuelSourceShares and zero coverage for the whole precision family because the persisted-trip analysis path round-trips samples through the presentation twin, which dropped unlisted fields — 5th recurrence on this pair. Structural fix: the detail sample carries its domain original; reverse conversion returns it verbatim. Codec-map round-trip test locks every current and future field. Closes #3594

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G