### PR TITLE
feat(consumption): per-stretch IMU magnitude records for threshold calibration (#3589)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace.dart
@@ -123,6 +123,10 @@ class DrivingAnalysisTrace {
           'hardAccelPerKm': _round(summary.imuHardAccelPerKm, 3),
           'hardBrakePerKm': _round(summary.imuHardBrakePerKm, 3),
           'sharpCornersPerKm': _round(summary.sharpCornersPerKm, 3),
+          // #3589 — per-stretch magnitude records (confirmed + rejected
+          // near-misses) for threshold calibration against verdicts.
+          'events': [for (final r in summary.imuEventRecords) r.toJson()],
+          'droppedEvents': summary.imuEventRecordsDropped,
         },
         'gpsFeatures': gpsFeatures == null
             ? null

--- a/lib/features/consumption/data/trip_summary_codec.dart
+++ b/lib/features/consumption/data/trip_summary_codec.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import '../domain/trip_recorder.dart';
+import '../domain/imu_event_record.dart';
 
 /// JSON codec for the persisted [TripSummary] (#726).
 ///
@@ -69,6 +70,10 @@ Map<String, dynamic> tripSummaryToJson(TripSummary s) => {
       if (s.imuHardBrakeCount != 0) 'ihb': s.imuHardBrakeCount,
       if (s.sharpCornerCount != 0) 'sc': s.sharpCornerCount,
       if (s.imuActive) 'ima': true, // #2895 IMU-ran bit (prefer IMU zero)
+      // #3589 — per-stretch IMU calibration records + past-cap counter.
+      if (s.imuEventRecords.isNotEmpty)
+        'ier': [for (final r in s.imuEventRecords) r.toJson()],
+      if (s.imuEventRecordsDropped != 0) 'ierd': s.imuEventRecordsDropped,
     };
 
 TripSummary tripSummaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -124,4 +129,9 @@ TripSummary tripSummaryFromJson(Map<String, dynamic> j) => TripSummary(
       imuHardBrakeCount: (j['ihb'] as num?)?.toInt() ?? 0,
       sharpCornerCount: (j['sc'] as num?)?.toInt() ?? 0,
       imuActive: (j['ima'] as bool?) ?? false, // #2895 IMU-ran bit
+      imuEventRecords: [
+        for (final e in (j['ier'] as List?) ?? const [])
+          if (e is Map<String, dynamic>) ?ImuEventRecord.fromJson(e),
+      ],
+      imuEventRecordsDropped: (j['ierd'] as num?)?.toInt() ?? 0,
     );

--- a/lib/features/consumption/domain/imu_event_record.dart
+++ b/lib/features/consumption/domain/imu_event_record.dart
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'accel_event_gate.dart';
+import 'gps_driving_features.dart' show kSharpCornerYawRateRadPerSec;
+
+/// Hard cap on per-trip [ImuEventRecord]s (#3589). A normal trip produces
+/// a handful; the cap only exists so a pathological signal (loose mount,
+/// sensor fault) cannot grow the persisted summary without bound. Records
+/// past the cap are counted, not stored.
+const int kImuEventRecordCap = 48;
+
+/// One strong-manoeuvre stretch as the IMU detector saw it (#3589) —
+/// confirmed events AND rejected near-misses, so the accel/brake
+/// thresholds can be calibrated against labeled magnitude distributions
+/// instead of bare counts (the 2026-07-21 verdict captures contradicted
+/// the counters in both directions). Aggregate-only by construction:
+/// a stretch is O(1) state folded from the 50 Hz stream, never samples.
+class ImuEventRecord {
+  /// What the stretch became: `accel` / `brake` / `corner` (confirmed) or
+  /// the rejection reason — `tooShort` (magnitude held under the 1 s
+  /// sustained floor), `cornerGeometry` (high yaw at constant speed:
+  /// centripetal, not longitudinal), `ambiguous` (sustained but the net
+  /// GPS-speed change never picked a direction).
+  final String outcome;
+
+  /// Peak horizontal linear-accel magnitude over the stretch, m/s².
+  final double peakMps2;
+
+  /// How long the magnitude held above the accel threshold, seconds.
+  final double durationSec;
+
+  /// GPS ground speed when the stretch began, km/h — the speed band.
+  final double startSpeedKmh;
+
+  /// Net GPS-speed change over the stretch, km/h (sign = direction).
+  final double netSpeedDeltaKmh;
+
+  /// Peak |yaw rate| over the stretch, rad/s — the cornering context.
+  final double peakYawRadPerSec;
+
+  const ImuEventRecord({
+    required this.outcome,
+    required this.peakMps2,
+    required this.durationSec,
+    required this.startSpeedKmh,
+    required this.netSpeedDeltaKmh,
+    required this.peakYawRadPerSec,
+  });
+
+  double _r(double v) => (v * 100).roundToDouble() / 100;
+
+  /// Compact persisted form (o/p/d/s/n/y), rounded to 2 decimals — the
+  /// calibration only needs magnitude-distribution resolution.
+  Map<String, Object?> toJson() => {
+        'o': outcome,
+        'p': _r(peakMps2),
+        'd': _r(durationSec),
+        's': _r(startSpeedKmh),
+        'n': _r(netSpeedDeltaKmh),
+        'y': _r(peakYawRadPerSec),
+      };
+
+  static ImuEventRecord? fromJson(Map<String, dynamic> j) {
+    final o = j['o'];
+    if (o is! String) return null;
+    double num_(Object? v) => v is num ? v.toDouble() : 0.0;
+    return ImuEventRecord(
+      outcome: o,
+      peakMps2: num_(j['p']),
+      durationSec: num_(j['d']),
+      startSpeedKmh: num_(j['s']),
+      netSpeedDeltaKmh: num_(j['n']),
+      peakYawRadPerSec: num_(j['y']),
+    );
+  }
+}
+
+/// Folds the detector's per-sample stretch state into bounded
+/// [ImuEventRecord]s (#3589). Owned by `ImuEventDetector`; kept in its own
+/// file so the detector stays under the 400-line guard.
+class ImuStretchTracker {
+  final List<ImuEventRecord> _records = [];
+  int _dropped = 0;
+
+  bool _open = false;
+  double _peakMps2 = 0;
+  double _peakYaw = 0;
+  double _duration = 0;
+  double _startSpeedKmh = 0;
+  double _lastNetDeltaKmh = 0;
+  bool _sawCornerGeometry = false;
+  String? _confirmedOutcome;
+
+  /// Records finalized so far (open stretch not included — call
+  /// [finish] first at harvest time).
+  List<ImuEventRecord> get records => List.unmodifiable(_records);
+
+  /// Stretches past [kImuEventRecordCap] — counted, not stored.
+  int get dropped => _dropped;
+
+  /// Fold one sample's stretch state. [strong] mirrors the detector's
+  /// `horizMag >= kHardAccelThresholdMps2` stretch predicate.
+  void onSample({
+    required bool strong,
+    required double dt,
+    required double horizMag,
+    required double yawRate,
+    required double speedKmh,
+    required double netSpeedDeltaKmh,
+    required bool cornerGeometry,
+  }) {
+    if (strong) {
+      if (!_open) {
+        _open = true;
+        _peakMps2 = 0;
+        _peakYaw = 0;
+        _duration = 0;
+        _startSpeedKmh = speedKmh;
+        _sawCornerGeometry = false;
+        _confirmedOutcome = null;
+      }
+      _duration += dt;
+      if (horizMag > _peakMps2) _peakMps2 = horizMag;
+      if (yawRate > _peakYaw) _peakYaw = yawRate;
+      _lastNetDeltaKmh = netSpeedDeltaKmh;
+      if (cornerGeometry) _sawCornerGeometry = true;
+    } else if (_open) {
+      _finalize();
+    }
+  }
+
+  /// Mark the open stretch (if any) as having confirmed as [outcome]
+  /// (`accel` / `brake` / `corner`). First confirmation wins.
+  void confirm(String outcome) {
+    if (_open) _confirmedOutcome ??= outcome;
+  }
+
+  /// A gap / standstill / trip stop broke every episode — close the open
+  /// stretch exactly like a below-threshold sample would.
+  void breakEpisodes() {
+    if (_open) _finalize();
+  }
+
+  /// Finalize any open stretch and return the full record list — the
+  /// harvest call at trip stop.
+  List<ImuEventRecord> finish() {
+    if (_open) _finalize();
+    return records;
+  }
+
+  void _finalize() {
+    _open = false;
+    final outcome = _confirmedOutcome ??
+        (_duration < kAccelEventMinSustainedSec
+            ? 'tooShort'
+            : _sawCornerGeometry && _peakYaw >= kSharpCornerYawRateRadPerSec
+                ? 'cornerGeometry'
+                : 'ambiguous');
+    if (_records.length >= kImuEventRecordCap) {
+      _dropped++;
+      return;
+    }
+    _records.add(ImuEventRecord(
+      outcome: outcome,
+      peakMps2: _peakMps2,
+      durationSec: _duration,
+      startSpeedKmh: _startSpeedKmh,
+      netSpeedDeltaKmh: _lastNetDeltaKmh,
+      peakYawRadPerSec: _peakYaw,
+    ));
+  }
+}

--- a/lib/features/consumption/domain/services/imu_event_detector.dart
+++ b/lib/features/consumption/domain/services/imu_event_detector.dart
@@ -8,6 +8,7 @@ import '../accel_event_gate.dart';
 import '../gps_driving_features.dart'
     show kSharpCornerThresholdMps2, kSharpCornerYawRateRadPerSec;
 import '../harsh_event.dart';
+import '../imu_event_record.dart';
 
 /// Pure, plugin-free harsh-accel / harsh-brake / sharp-corner detector for
 /// the dongle-optional GPS+IMU pipeline (#2760).
@@ -89,6 +90,18 @@ class ImuEventDetector {
   int _hardAccelCount = 0;
   int _hardBrakeCount = 0;
   int _sharpCornerCount = 0;
+
+  /// #3589 — per-stretch magnitude records (confirmed events AND rejected
+  /// near-misses) for threshold calibration. Bounded by
+  /// [kImuEventRecordCap]; harvest via [eventRecords] at trip stop.
+  final ImuStretchTracker _stretches = ImuStretchTracker();
+
+  /// Finalized per-stretch records, including the stretch still open at
+  /// call time (trip stop happens mid-drive).
+  List<ImuEventRecord> get eventRecords => _stretches.finish();
+
+  /// Stretches beyond the record cap — counted, not stored (#3589).
+  int get droppedEventRecords => _stretches.dropped;
 
   /// Total samples handed to [onSample]. The first only seeds the dt anchor;
   /// `isActive` therefore requires > 1 so a single stray emit doesn't claim
@@ -179,6 +192,19 @@ class ImuEventDetector {
     final netSpeedDeltaKmh = speedKmh - _maneuverStartSpeedKmh;
     final constantSpeed = netSpeedDeltaKmh.abs() <= _constantSpeedDeltaKmh;
 
+    // #3589 — fold this sample's stretch state into the calibration
+    // records BEFORE scoring, so a confirmation in this same tick lands
+    // on the already-open stretch.
+    _stretches.onSample(
+      strong: strong,
+      dt: dt,
+      horizMag: horizMag,
+      yawRate: yawRate,
+      speedKmh: speedKmh,
+      netSpeedDeltaKmh: netSpeedDeltaKmh,
+      cornerGeometry: highYaw && constantSpeed,
+    );
+
     _scoreCorner(
       dt: dt,
       horizMag: horizMag,
@@ -217,6 +243,7 @@ class ImuEventDetector {
       if (!_inCorner && _cornerDur >= _cornerMinSustainedSec) {
         _sharpCornerCount++;
         _inCorner = true;
+        _stretches.confirm('corner');
         // #3504 — the confirmed corner reaches the live bus too, so the
         // voice coach can cue cornering (brakes/accels already did).
         _emit(HarshEventType.corner, horizMag, t, speedKmh);
@@ -264,6 +291,7 @@ class ImuEventDetector {
       if (!_inAccel) {
         _hardAccelCount++;
         _inAccel = true;
+        _stretches.confirm('accel');
         _emit(HarshEventType.acceleration, horizMag, t, speedKmh);
       }
     } else {
@@ -281,6 +309,7 @@ class ImuEventDetector {
       if (!_inBrake) {
         _hardBrakeCount++;
         _inBrake = true;
+        _stretches.confirm('brake');
         _emit(HarshEventType.brake, horizMag, t, speedKmh);
       }
     } else {
@@ -324,6 +353,7 @@ class ImuEventDetector {
   }
 
   void _breakEpisodes() {
+    _stretches.breakEpisodes();
     _maneuverDur = 0;
     _cornerDur = 0;
     _accelBelowDur = 0;

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'harsh_event.dart';
+import 'imu_event_record.dart';
 
 export 'harsh_event.dart';
 
@@ -177,6 +178,16 @@ class TripSummary {
   /// score falls back to the (clamped) GPS-derived counts.
   final bool imuActive;
 
+  /// #3589 — per-stretch IMU magnitude records (confirmed accel / brake /
+  /// corner AND the rejected near-misses with their reasons), capped at
+  /// [kImuEventRecordCap]. Feeds the driving-analysis export so the harsh
+  /// thresholds can be calibrated against labeled magnitude distributions.
+  /// Empty for OBD2-era legacy trips and IMU-less devices.
+  final List<ImuEventRecord> imuEventRecords;
+
+  /// Stretches past the record cap — counted, not stored (#3589).
+  final int imuEventRecordsDropped;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -202,6 +213,8 @@ class TripSummary {
     this.imuHardBrakeCount = 0,
     this.sharpCornerCount = 0,
     this.imuActive = false,
+    this.imuEventRecords = const [],
+    this.imuEventRecordsDropped = 0,
   });
 
   /// IMU hard-accel episodes per km (#2760). Derived, not stored — the raw
@@ -249,6 +262,8 @@ class TripSummary {
     int? imuHardAccelCount,
     int? imuHardBrakeCount,
     int? sharpCornerCount,
+    List<ImuEventRecord>? imuEventRecords,
+    int? imuEventRecordsDropped,
     bool? imuActive,
   }) =>
       TripSummary(
@@ -279,6 +294,9 @@ class TripSummary {
         imuHardAccelCount: imuHardAccelCount ?? this.imuHardAccelCount,
         imuHardBrakeCount: imuHardBrakeCount ?? this.imuHardBrakeCount,
         sharpCornerCount: sharpCornerCount ?? this.sharpCornerCount,
+        imuEventRecords: imuEventRecords ?? this.imuEventRecords,
+        imuEventRecordsDropped:
+            imuEventRecordsDropped ?? this.imuEventRecordsDropped,
         imuActive: imuActive ?? this.imuActive,
       );
 }

--- a/lib/features/consumption/providers/trip_imu_fusion.dart
+++ b/lib/features/consumption/providers/trip_imu_fusion.dart
@@ -10,6 +10,7 @@ import '../../../core/sensors/imu_sample.dart';
 import '../../../core/sensors/imu_sensor_source.dart';
 import '../domain/services/imu_event_detector.dart';
 import '../domain/trip_summary.dart';
+import '../domain/imu_event_record.dart';
 
 /// One per-trip IMU sensor-fusion lifecycle, shared by BOTH recording
 /// pipelines (#3500, epic #3498).
@@ -59,6 +60,10 @@ class TripImuFusion {
   int get hardAccelCount => _detector.hardAccelCount;
   int get hardBrakeCount => _detector.hardBrakeCount;
   int get sharpCornerCount => _detector.sharpCornerCount;
+
+  /// #3589 — per-stretch calibration records (confirmed + near-misses).
+  List<ImuEventRecord> get eventRecords => _detector.eventRecords;
+  int get droppedEventRecords => _detector.droppedEventRecords;
 
   /// Subscribe the detector to the inertial stream. Idempotent. A throwing
   /// sensor layer (no IMU hardware, plugin not bound, no services binding in
@@ -113,6 +118,10 @@ class TripImuFusion {
         imuHardBrakeCount: hardBrakeCount,
         sharpCornerCount: sharpCornerCount,
         imuActive: isActive,
+        // #3589 — the magnitude records ride the summary only when the
+        // sensor ran; an IMU-less trip keeps its empty default.
+        imuEventRecords: isActive ? eventRecords : null,
+        imuEventRecordsDropped: isActive ? droppedEventRecords : null,
         harshAccelerations: isActive ? hardAccelCount : null,
         harshBrakes: isActive ? hardBrakeCount : null,
       );

--- a/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
+++ b/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
@@ -112,6 +112,9 @@ void main() {
       expect(imu['sharpCornerCount'], 3);
       expect(imu['hardAccelPerKm'], 0.1);
       expect(imu['sharpCornersPerKm'], 0.15);
+      // #3589 — the per-stretch calibration records ride the imu block.
+      expect(imu['events'], isA<List<dynamic>>());
+      expect(imu['droppedEvents'], 0);
 
       final gps = json['gpsFeatures'] as Map<String, dynamic>;
       expect(gps['rpa'], 0.224);

--- a/test/features/consumption/data/trip_summary_codec_imu_records_test.dart
+++ b/test/features/consumption/data/trip_summary_codec_imu_records_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_summary_codec.dart';
+import 'package:tankstellen/features/consumption/domain/imu_event_record.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #3589 — the per-stretch IMU calibration records must survive the Hive
+/// JSON round-trip (the #2776 lesson), and record-less trips must
+/// round-trip byte-identical (no `ier`/`ierd` keys).
+void main() {
+  TripSummary mk({
+    List<ImuEventRecord> records = const [],
+    int dropped = 0,
+  }) =>
+      TripSummary(
+        distanceKm: 12.0,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 10,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        imuActive: records.isNotEmpty,
+        imuEventRecords: records,
+        imuEventRecordsDropped: dropped,
+        startedAt: DateTime(2026, 7, 23, 8),
+      );
+
+  const rec = ImuEventRecord(
+    outcome: 'tooShort',
+    peakMps2: 5.0,
+    durationSec: 0.55,
+    startSpeedKmh: 41.0,
+    netSpeedDeltaKmh: 1.5,
+    peakYawRadPerSec: 0.05,
+  );
+
+  test('records + dropped counter round-trip through the codec', () {
+    final json = tripSummaryToJson(mk(records: const [rec], dropped: 3));
+    final back = tripSummaryFromJson(json);
+    expect(back.imuEventRecordsDropped, 3);
+    final r = back.imuEventRecords.single;
+    expect(r.outcome, 'tooShort');
+    expect(r.peakMps2, 5.0);
+    expect(r.durationSec, 0.55);
+    expect(r.startSpeedKmh, 41.0);
+    expect(r.netSpeedDeltaKmh, 1.5);
+    expect(r.peakYawRadPerSec, 0.05);
+  });
+
+  test('a record-less trip adds no keys (legacy byte-parity)', () {
+    final json = tripSummaryToJson(mk());
+    expect(json.containsKey('ier'), isFalse);
+    expect(json.containsKey('ierd'), isFalse);
+    final back = tripSummaryFromJson(json);
+    expect(back.imuEventRecords, isEmpty);
+    expect(back.imuEventRecordsDropped, 0);
+  });
+
+  test('a malformed persisted entry is skipped, not fatal', () {
+    final json = tripSummaryToJson(mk(records: const [rec]));
+    (json['ier'] as List).add({'p': 'garbage'}); // no outcome string
+    final back = tripSummaryFromJson(json);
+    expect(back.imuEventRecords, hasLength(1));
+  });
+}

--- a/test/features/consumption/domain/services/imu_event_detector_test.dart
+++ b/test/features/consumption/domain/services/imu_event_detector_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sensors/imu_sample.dart';
 import 'package:tankstellen/features/consumption/domain/harsh_event.dart';
+import 'package:tankstellen/features/consumption/domain/imu_event_record.dart';
 import 'package:tankstellen/features/consumption/domain/services/imu_event_detector.dart';
 
 /// Reuse-fidelity tests for the pure [ImuEventDetector] (#2760). No
@@ -223,5 +224,89 @@ void main() {
     expect(fired[1].type, HarshEventType.brake);
     // Magnitude is reported in g, derived from the 4.0 m/s² horizontal mag.
     expect(fired[0].magnitudeG, closeTo(4.0 / standardGravityMps2, 1e-6));
+  });
+
+  group('per-stretch calibration records (#3589)', () {
+    test('a confirmed accel stretch records outcome/peak/duration/speeds',
+        () {
+      final det = ImuEventDetector();
+      final t = feed(det,
+          start: t0,
+          count: 30, // 1.5 s at 4.0 m/s², speed rising -> confirmed accel
+          mag: 4.0,
+          startSpeedKmh: 30,
+          speedStepKmh: 0.5);
+      // Close the stretch with calm samples so it finalizes.
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 45);
+
+      final rec = det.eventRecords.single;
+      expect(rec.outcome, 'accel');
+      expect(rec.peakMps2, closeTo(4.0, 0.001));
+      expect(rec.durationSec, closeTo(1.5, 0.1));
+      expect(rec.startSpeedKmh, closeTo(30, 1.0));
+      expect(rec.netSpeedDeltaKmh, greaterThan(5));
+    });
+
+    test('a strong burst UNDER the 1 s floor is a tooShort near-miss — '
+        'the calibration sees what the counter rejected', () {
+      final det = ImuEventDetector();
+      final t = feed(det,
+          start: t0,
+          count: 10, // 0.5 s at 5.0 m/s² — strong but too short
+          mag: 5.0,
+          startSpeedKmh: 40,
+          speedStepKmh: 0.5);
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 45);
+
+      expect(det.hardAccelCount, 0, reason: 'the counter must still reject');
+      final rec = det.eventRecords.single;
+      expect(rec.outcome, 'tooShort');
+      expect(rec.peakMps2, closeTo(5.0, 0.001));
+      expect(rec.durationSec, lessThan(1.0));
+    });
+
+    test('a sustained strong stretch with CONSTANT speed and no yaw is '
+        'ambiguous — recorded, not counted', () {
+      final det = ImuEventDetector();
+      final t = feed(det,
+          start: t0,
+          count: 40, // 2 s at 3.6 m/s², speed flat -> no direction
+          mag: 3.6,
+          startSpeedKmh: 50);
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 50);
+
+      expect(det.hardAccelCount, 0);
+      expect(det.hardBrakeCount, 0);
+      expect(det.eventRecords.single.outcome, 'ambiguous');
+    });
+
+    test('the open stretch at trip stop is included by the harvest getter',
+        () {
+      final det = ImuEventDetector();
+      feed(det,
+          start: t0,
+          count: 30,
+          mag: 4.0,
+          startSpeedKmh: 30,
+          speedStepKmh: 0.5);
+      // No calm tail — the trip stops mid-manoeuvre.
+      expect(det.eventRecords, hasLength(1));
+      expect(det.eventRecords.single.outcome, 'accel');
+    });
+
+    test('records past the cap are counted, not stored', () {
+      final det = ImuEventDetector();
+      var t = t0;
+      for (var i = 0; i < kImuEventRecordCap + 5; i++) {
+        t = feed(det,
+            start: t,
+            count: 10, // short bursts -> tooShort records
+            mag: 5.0,
+            startSpeedKmh: 40);
+        t = feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 40);
+      }
+      expect(det.eventRecords, hasLength(kImuEventRecordCap));
+      expect(det.droppedEventRecords, 5);
+    });
   });
 }


### PR DESCRIPTION
The IMU harsh-event counters contradicted the driver's verdicts in both directions and counts alone can't be calibrated. Every strong stretch now yields a bounded record (outcome incl. rejection reason, peak m/s², duration, speed band, net Δv, peak yaw) persisted on TripSummary and exported in the drivingAnalysis imu block. Aggregate-only constraint preserved. Closes #3589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G