### PR TITLE
fix(consumption): rebuild crash-recovered trip summaries from samples (#3597)

### DIFF
--- a/lib/features/consumption/domain/services/recovered_summary_rebuild.dart
+++ b/lib/features/consumption/domain/services/recovered_summary_rebuild.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../trip_recorder.dart';
+import 'trip_consumption_reliability.dart';
+
+/// Rebuilds a crash-recovered trip's [TripSummary] from its persisted
+/// samples (#3597).
+///
+/// The OBD2 WAL snapshot's summary is deliberately a skeleton — distance,
+/// maxRpm and timestamps only — because computing a full summary on every
+/// flush would be wasted work on the happy path. The salvage path
+/// (`_finalizeRecoveredSnapshot`, #1347) used to save that skeleton
+/// verbatim, so every crash-ended drive lost its consumption figure,
+/// idle/high-RPM time and cold-start flag. With the process dying daily
+/// under the Play integrity wrapper (#3590), that stopped being cosmetic:
+/// a 92 km fully-measured field trip surfaced with `avgLPer100Km: null`.
+///
+/// The rebuild replays the samples through the canonical [TripRecorder]
+/// with the SAME 15 s integration-gap cap the live OBD2 controller uses,
+/// so a mid-trip dropout hole can neither fabricate distance nor ride a
+/// stale fuel rate. Two skeleton fields are kept over the replay, per
+/// #3251: the live controller's gap-capped `distanceKm` and its
+/// `distanceSource` provenance — re-deriving distance from the raw buffer
+/// is exactly the #1927 bug. The consumption average is then recomputed
+/// against that trusted distance. IMU counts stay absent: the inertial
+/// ring died with the process, and pretending otherwise would defeat the
+/// #2895 veto semantics.
+TripSummary rebuildRecoveredSummary({
+  required TripSummary skeleton,
+  required List<TripSample> samples,
+  double maxIntegrationGapSeconds = 15.0,
+}) {
+  if (samples.isEmpty) return skeleton;
+
+  final recorder =
+      TripRecorder(maxIntegrationGapSeconds: maxIntegrationGapSeconds);
+  for (final s in samples) {
+    // Thread the trip's distance provenance so harsh scoring keeps the
+    // #2653/#2895 source gate (suppressed on derived speed) on replay.
+    recorder.onSample(s, distanceSource: skeleton.distanceSource);
+  }
+  final replay = recorder.buildSummary();
+
+  final distanceKm =
+      skeleton.distanceKm > 0 ? skeleton.distanceKm : replay.distanceKm;
+  final liters = replay.fuelLitersConsumed;
+  // Same ratio gates as the live stop path: a sparse fuel cadence already
+  // nulled `liters` inside the replay; a tiny distance suppresses only
+  // the blow-up-prone average, never the measured litres (#2835).
+  final avgLPer100Km = liters != null && isDistanceReliableForRatio(distanceKm)
+      ? liters / distanceKm * 100.0
+      : replay.avgLPer100Km;
+
+  return replay.copyWith(
+    distanceKm: distanceKm,
+    distanceSource: skeleton.distanceSource,
+    avgLPer100Km: avgLPer100Km,
+    startedAt: skeleton.startedAt ?? replay.startedAt,
+    endedAt: skeleton.endedAt ?? replay.endedAt,
+  );
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -21,6 +21,7 @@ import '../data/trip_history_repository.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/entities/trip_save_stage.dart';
 import '../domain/entities/trip_start_stage.dart';
+import '../domain/services/recovered_summary_rebuild.dart';
 import '../domain/services/physics_scale_calibrator.dart';
 import '../domain/trip_recorder.dart';
 import 'active_vehicle_read.dart';
@@ -829,8 +830,17 @@ class TripRecording extends _$TripRecording {
       }
     }
 
+    // #3597 — the snapshot's summary is a skeleton (distance + maxRpm
+    // only); replay the persisted samples through the canonical recorder
+    // so the salvaged trip keeps its consumption figure, idle/high-RPM
+    // time and cold-start flag instead of surfacing avgLPer100Km null.
+    final summary = rebuildRecoveredSummary(
+      skeleton: snapshot.summary,
+      samples: snapshot.samples,
+    );
+
     final result = StoppedTripResult(
-      summary: snapshot.summary,
+      summary: summary,
       odometerStartKm: snapshot.odometerStartKm,
       odometerLatestKm: snapshot.odometerLatestKm,
     );
@@ -844,7 +854,7 @@ class TripRecording extends _$TripRecording {
         await historyRepo.save(TripHistoryEntry(
           id: snapshot.id,
           vehicleId: snapshot.vehicleId,
-          summary: snapshot.summary,
+          summary: summary,
           automatic: snapshot.automatic,
           samples: snapshot.samples,
         ));

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'f1cae9d4c33d0ed58d51087ab1eed1db3b6b7de0';
+String _$tripRecordingHash() => r'52524c99eef0afbfb5e03ebdefde3a5a119282fb';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/domain/services/recovered_summary_rebuild_test.dart
+++ b/test/features/consumption/domain/services/recovered_summary_rebuild_test.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3597 — a crash-recovered OBD2 trip used to save the WAL skeleton
+// summary verbatim (distance + maxRpm only), so a fully-measured 92 km
+// field drive surfaced with avgLPer100Km null. The rebuild replays the
+// persisted samples through the canonical TripRecorder and merges the
+// skeleton's trusted gap-capped distance/provenance (#3251) back in.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/recovered_summary_rebuild.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+void main() {
+  final t0 = DateTime(2026, 7, 24, 17);
+
+  /// A 1 Hz OBD2 sample stream shaped like the field trip: constant
+  /// 60 km/h, 2600 rpm bursts above the high-RPM threshold at the tail,
+  /// and a fuel rate carried on every 6th sample (~0.17 coverage — the
+  /// live 6 s fuel cadence).
+  List<TripSample> samples(int count, {int gapAfter = -1, int gapSec = 0}) {
+    final out = <TripSample>[];
+    var t = t0;
+    for (var i = 0; i < count; i++) {
+      if (i == gapAfter) t = t.add(Duration(seconds: gapSec));
+      out.add(TripSample(
+        timestamp: t,
+        speedKmh: 60,
+        rpm: i > count * 0.8 ? 3800 : 2600,
+        fuelRateLPerHour: i % 6 == 0 ? 6.0 : null,
+        coolantTempC: i < count ~/ 2 ? 55 : 88,
+      ));
+      t = t.add(const Duration(seconds: 1));
+    }
+    return out;
+  }
+
+  TripSummary skeleton({double distanceKm = 10.0}) => TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 3800,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: t0,
+        distanceSource: 'gps',
+      );
+
+  test('the rebuilt summary regains fuel, avg, high-RPM time and the '
+      'cold-start flag the skeleton lost', () {
+    final rebuilt = rebuildRecoveredSummary(
+      skeleton: skeleton(),
+      samples: samples(600), // 10 min at 60 km/h ≈ 10 km
+    );
+
+    // 6.0 L/h over ~599 s ≈ 1.0 L.
+    expect(rebuilt.fuelLitersConsumed, isNotNull);
+    expect(rebuilt.fuelLitersConsumed!, closeTo(1.0, 0.05));
+    // Recomputed against the skeleton's trusted 10 km, not re-derived.
+    expect(rebuilt.avgLPer100Km, isNotNull);
+    expect(rebuilt.avgLPer100Km!, closeTo(10.0, 0.6));
+    expect(rebuilt.highRpmSeconds, greaterThan(60));
+    expect(rebuilt.coldStartSurcharge, isTrue,
+        reason: 'coolant crossed 70°C in the second half — warmedLate');
+    expect(rebuilt.distanceKm, 10.0, reason: 'skeleton distance is kept');
+    expect(rebuilt.distanceSource, 'gps');
+    expect(rebuilt.startedAt, t0);
+  });
+
+  test('a 20-minute dropout hole neither rides the fuel rate nor '
+      'fabricates litres (the #1927 gap cap)', () {
+    final withHole = rebuildRecoveredSummary(
+      skeleton: skeleton(),
+      samples: samples(600, gapAfter: 300, gapSec: 1200),
+    );
+    final without = rebuildRecoveredSummary(
+      skeleton: skeleton(),
+      samples: samples(600),
+    );
+    // The hole interval must contribute ~nothing: 6 L/h over 20 min
+    // would be 2 extra litres.
+    expect(withHole.fuelLitersConsumed!,
+        closeTo(without.fuelLitersConsumed!, 0.05));
+  });
+
+  test('empty samples return the skeleton untouched', () {
+    final sk = skeleton();
+    expect(identical(rebuildRecoveredSummary(skeleton: sk, samples: const []), sk),
+        isTrue);
+  });
+
+  test('harsh scoring stays suppressed on gps-sourced replay (#2895)', () {
+    // A hard speed ramp that WOULD register on direct speed.
+    final ramp = <TripSample>[
+      for (var i = 0; i < 30; i++)
+        TripSample(
+          timestamp: t0.add(Duration(milliseconds: 500 * i)),
+          speedKmh: 20.0 + i * 3.0,
+          rpm: 3000,
+        ),
+    ];
+    final rebuilt =
+        rebuildRecoveredSummary(skeleton: skeleton(), samples: ramp);
+    expect(rebuilt.harshAccelerations, 0,
+        reason: 'gps provenance suppresses derivative harsh scoring');
+  });
+}

--- a/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
@@ -311,6 +311,70 @@ void main() {
   );
 
   test(
+    'the salvaged summary is REBUILT from samples — fuel figure and '
+    'high-RPM time survive a crash-ended trip (#3597)',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      notifier.debugSetActiveRepo(activeRepo);
+
+      final start = DateTime.utc(2026, 7, 24, 17, 0);
+      // 10 minutes at 1 Hz, 5.5 L/h — the WAL skeleton below carries
+      // NONE of it (that is exactly the field bug: a 92 km measured
+      // trip surfaced with avgLPer100Km null after a crash).
+      final samples = List<TripSample>.generate(
+        600,
+        (i) => TripSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 60,
+          rpm: 3800,
+          fuelRateLPerHour: i % 6 == 0 ? 5.5 : null,
+        ),
+      );
+      final snap = ActiveTripSnapshot(
+        id: start.toIso8601String(),
+        vehicleId: 'veh-crashed',
+        vin: 'VIN-CRASHED',
+        automatic: false,
+        phase: 'pausedDueToDrop',
+        summary: const TripSummary(
+          distanceKm: 10.0,
+          maxRpm: 3800,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+          distanceSource: 'gps',
+        ),
+        samples: samples,
+        odometerStartKm: 1000.0,
+        odometerLatestKm: 1010.0,
+        startedAt: start,
+        lastFlushedAt: start.add(const Duration(minutes: 10)),
+      );
+      await activeRepo.saveSnapshot(snap);
+      expect(notifier.restoreFromSnapshot(snap), isTrue);
+
+      final result = await notifier.stop();
+
+      expect(result.summary.fuelLitersConsumed, isNotNull,
+          reason: 'the replay must integrate the persisted fuel rates');
+      expect(result.summary.fuelLitersConsumed!, closeTo(0.91, 0.05));
+      expect(result.summary.avgLPer100Km, isNotNull);
+      expect(result.summary.avgLPer100Km!, closeTo(9.1, 0.6));
+      expect(result.summary.highRpmSeconds, greaterThan(500));
+      expect(result.summary.distanceKm, closeTo(10.0, 0.001),
+          reason: 'the skeleton keeps the gap-capped live distance (#3251)');
+
+      final historyRepo = TripHistoryRepository(box: historyBox);
+      expect(historyRepo.loadAll().single.summary.avgLPer100Km, isNotNull,
+          reason: 'the rebuilt summary — not the skeleton — is persisted');
+    },
+  );
+
+  test(
     'resume() after restoreFromSnapshot also salvages snapshot to '
     'history (#1347)',
     () async {

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -912,8 +912,10 @@ void main() {
     // gate (GPS-only trips must not inherit the process-wide idle-link
     // session) + the debugSaveToHistory test seam that proves it.
     'lib/features/consumption/providers/trip_recording_provider.dart': (
-      lines: 1286,
-      bumps: 9,
+      // #3597 — the salvage path now rebuilds the recovered summary from
+      // samples (comment + call, +10). Decomposition tracked by #3140.
+      lines: 1296,
+      bumps: 10,
       decompositionIssue: 3140,
     ),
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': (


### PR DESCRIPTION
Crash-ended trips saved the WAL skeleton summary verbatim — no fuel figure, no idle/high-RPM/cold-start. Now the salvage replays the persisted samples through the canonical TripRecorder (15s gap cap, source-gated harsh scoring) and keeps the skeleton's trusted distance/provenance. Field bug: 92 km measured trip with avgLPer100Km null. Closes #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G