### PR TITLE
fix(obd2): staleness fence — no engine values stamped without a live parse (#3602)

### DIFF
--- a/lib/features/obd2/data/trip_recording_controller.dart
+++ b/lib/features/obd2/data/trip_recording_controller.dart
@@ -259,6 +259,27 @@ class TripRecordingController {
   PidScheduler? _scheduler;
   Timer? _emitTimer;
   DateTime? _startedAt;
+
+  /// #3602 — wall time of the last successful high-priority engine parse.
+  /// The staleness fence: [_emit] refuses to stamp snapshot engine values
+  /// onto samples when no fresh parse landed within
+  /// [_engineDataStalenessLimit] — a scheduler that never started (link
+  /// never opened: the 76.5 km field trip recorded 49 min of ghost
+  /// engine data from a rehydrated snapshot at 0.0 Hz) produces no parse
+  /// events at all, so the null-parse silent-failure detector is
+  /// structurally blind to it (it counts null PARSES, not absent polls).
+  DateTime? _lastFreshEngineParseAt;
+  bool _staleEngineEscalated = false;
+
+  /// Oldest a high-priority engine parse may be before the snapshot is
+  /// treated as a ghost. Generous vs the 5 Hz dynamics tier and the
+  /// K-line's ~4-6 reads/s: even a struggling ISO 9141 link refreshes
+  /// rpm every ~1-2 s.
+  static const Duration _engineDataStalenessLimit = Duration(seconds: 15);
+
+  /// Grace after recording start before the fence may fire — the first
+  /// connect + scheduler spin-up takes a few seconds legitimately.
+  static const Duration _engineDataStartGrace = Duration(seconds: 30);
   DateTime? _lastSampleAt;
 
   // #2509 — timestamps of the FIRST and LATEST valid GPS fixes that
@@ -1206,6 +1227,8 @@ class TripRecordingController {
     if (parsedValue != null) {
       // ANY successful high-priority parse clears the window — we're
       // detecting "ECU is dead", not "this one PID is unsupported".
+      _lastFreshEngineParseAt = _now(); // #3602 — the staleness fence anchor
+      _staleEngineEscalated = false;
       _dropDetector.observeHighPriorityParse(parsedValue);
       return;
     }
@@ -1261,6 +1284,34 @@ class TripRecordingController {
 
     final snap = _liveSampleSnapshot;
     final nowTs = _now();
+
+    // #3602 — staleness fence: never stamp snapshot engine values without
+    // a recent successful parse backing them. A link that never opened
+    // (or died without a transport error) leaves the scheduler at 0 Hz;
+    // the null-parse detector is starved blind, and 49 min of a real
+    // field drive got ghost engine data (rpm 0, resting throttle) stamped
+    // onto every GPS fix — classified 'full OBD2, measured fuel'.
+    // Escalate ONCE through the same silent-failure drop path (pause with
+    // grace → reconnect → #2565 GPS-only degrade), and skip this tick so
+    // nothing stale reaches the recorder.
+    final fresh = _lastFreshEngineParseAt;
+    final started = _startedAt;
+    final pastGrace = started == null ||
+        nowTs.difference(started) > _engineDataStartGrace;
+    final engineStale = pastGrace &&
+        (fresh == null ||
+            nowTs.difference(fresh) > _engineDataStalenessLimit);
+    if (engineStale) {
+      if (!_staleEngineEscalated) {
+        _staleEngineEscalated = true;
+        debugPrint(
+          'TripRecordingController: engine data stale '
+          '(lastParse=$fresh) — escalating as silent failure (#3602)',
+        );
+        _onSilentFailure();
+      }
+      return;
+    }
     final fuelRate = snap.deriveFuelRateLPerHour();
     // #1858 — fold this tick into the trip's η_v recompute provenance.
     // Speed-density fuel is the only η_v-derived branch; PID 5E / MAF

--- a/test/features/obd2/data/trip_recording_controller_stale_engine_test.dart
+++ b/test/features/obd2/data/trip_recording_controller_stale_engine_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3602 — the staleness fence. A link that never opens (or dies without
+// a transport error) leaves the PID scheduler at 0 Hz: the null-parse
+// silent-failure detector counts null PARSES and is structurally blind
+// to ABSENT polls. On a real 76.5 km field drive that produced 49 min
+// of ghost engine data (rpm 0, resting throttle, 'measured' fuel)
+// stamped from a stale snapshot onto every GPS fix. The fence refuses
+// to stamp snapshot engine values without a recent successful parse and
+// escalates once through the silent-failure drop path.
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+import 'package:tankstellen/features/obd2/data/paused_trip_repository.dart';
+import 'package:tankstellen/features/obd2/data/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+
+void main() {
+  group('engine-data staleness fence (#3602)', () {
+    late Directory tmpDir;
+    late Box<String> pausedBox;
+    late Box<String> historyBox;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('stale_engine_test_');
+      Hive.init(tmpDir.path);
+      pausedBox = await Hive.openBox<String>(
+        'paused_${DateTime.now().microsecondsSinceEpoch}',
+      );
+      historyBox = await Hive.openBox<String>(
+        'history_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await pausedBox.deleteFromDisk();
+      await historyBox.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    Map<String, String> initResponses() => {
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          '01A6': 'NO DATA>',
+        };
+
+    Future<TripRecordingController> startCtl(DateTime Function() now) async {
+      final transport = FakeObd2Transport(initResponses());
+      await transport.connect();
+      final ctl = TripRecordingController(
+        service: Obd2Service(transport),
+        pollInterval: const Duration(minutes: 1),
+        now: now,
+        pausedRepo: PausedTripRepository(box: pausedBox),
+        historyRepo: TripHistoryRepository(box: historyBox),
+      );
+      await ctl.start();
+      return ctl;
+    }
+
+    test('no parses ever + past grace → ONE silent-failure escalation, '
+        'no stale sample stamped', () async {
+      var clock = DateTime(2026, 7, 25, 18, 37);
+      final ctl = await startCtl(() => clock);
+      final samplesBefore = ctl.capturedSamples.length;
+
+      // Within the start grace: the fence must NOT fire while the
+      // connect/scheduler legitimately spin up.
+      clock = clock.add(const Duration(seconds: 10));
+      ctl.debugEmitNow();
+      expect(ctl.currentState, TripRecordingControllerState.recording,
+          reason: 'inside the 30 s start grace nothing escalates');
+
+      // Past grace with zero successful parses — the 0 Hz ghost link.
+      clock = clock.add(const Duration(seconds: 60));
+      ctl.debugEmitNow();
+
+      expect(ctl.currentState, TripRecordingControllerState.pausedDueToDrop,
+          reason: 'a scheduler that never delivered a parse must surface '
+              'as the silent-failure drop, not record ghost engine data');
+      expect(ctl.capturedSamples.length, samplesBefore,
+          reason: 'the stale tick must stamp NOTHING');
+
+      // The escalation is once-latched — further ticks don't re-fire.
+      clock = clock.add(const Duration(seconds: 30));
+      ctl.debugEmitNow();
+      expect(
+          ctl.currentState, TripRecordingControllerState.pausedDueToDrop);
+
+      await ctl.stop();
+    });
+
+    test('fresh parses keep the fence open — recording continues', () async {
+      var clock = DateTime(2026, 7, 25, 18, 37);
+      final ctl = await startCtl(() => clock);
+
+      // Simulate the dynamics tier delivering real parses as time moves.
+      for (var i = 0; i < 8; i++) {
+        clock = clock.add(const Duration(seconds: 10));
+        ctl.debugObserveHighPriorityParse(1500.0); // fresh rpm parse
+        ctl.debugEmitNow();
+        expect(ctl.currentState, TripRecordingControllerState.recording,
+            reason: 'recent parses (<15 s) must keep normal emission');
+      }
+
+      await ctl.stop();
+    });
+
+    test('a parse drought AFTER healthy streaming also trips the fence',
+        () async {
+      var clock = DateTime(2026, 7, 25, 18, 37);
+      final ctl = await startCtl(() => clock);
+
+      clock = clock.add(const Duration(seconds: 40));
+      ctl.debugObserveHighPriorityParse(1500.0);
+      ctl.debugEmitNow();
+      expect(ctl.currentState, TripRecordingControllerState.recording);
+
+      // Link silently dies: 20 s with no parse (> the 15 s limit).
+      clock = clock.add(const Duration(seconds: 20));
+      ctl.debugEmitNow();
+      expect(ctl.currentState, TripRecordingControllerState.pausedDueToDrop,
+          reason: 'mid-trip parse drought = the same ghost-link shape');
+
+      await ctl.stop();
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -661,8 +661,11 @@ void main() {
     // episode handler (pause → recoverVehicleProtocol → resume, throttled)
     // + stop-time stamping of the live GPS-physics estimate figures.
     'lib/features/obd2/data/trip_recording_controller.dart': (
-      lines: 1780,
-      bumps: 19,
+      // #3602 — the engine-data staleness fence (freshness anchor, two
+      // constants, the _emit gate + once-latched escalation, +51).
+      // Decomposition tracked by #3140.
+      lines: 1831,
+      bumps: 20,
       decompositionIssue: 3140,
     ),
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR


### PR DESCRIPTION
A real 76.5 km drive recorded 49 min of ghost engine telemetry from a rehydrated snapshot while the link never opened (1 attempt / 0 successes / 0.0 Hz). The null-parse silent-failure detector is blind to an absent scheduler; the fence gates sample assembly on parse freshness (15 s limit, 30 s start grace) and escalates once through the existing silent-failure → reconnect → GPS-only-degrade path. Part of #3602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G