### PR TITLE
feat(app): hold the splash until the first screen settles (#3607)

### DIFF
--- a/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -24,7 +24,8 @@
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="YRO-k0-Ey4">
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <!-- #3607 - brand green matching AnimatedSplash.brandBackground (0xFF2E7D32) and the Android launch drawable, so the native-to-Flutter splash handoff is seamless on iOS too (it flashed white before). -->
+                        <color key="backgroundColor" red="0.1804" green="0.4902" blue="0.1961" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="1a2-6s-vTC"/>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4X2-HB-R7a"/>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -20,6 +20,7 @@ import '../features/widget/presentation/widget_click_listener.dart';
 import '../l10n/app_localizations.dart';
 import 'router.dart';
 import 'theme.dart';
+import 'widgets/startup_reveal.dart';
 
 /// Top-level Material app for Tankstellen. This is the *only* widget
 /// constructed directly from `main()` (via [AppInitializer]); everything
@@ -77,8 +78,14 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
           .onAppLifecycleStateChanged(state);
     } catch (e, st) {
       // #3143 — release-visible: debugPrint is no-opped in release.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: {'where': 'onAppLifecycleStateChanged'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {'where': 'onAppLifecycleStateChanged'},
+        ),
+      );
     }
     // #3169 — every foreground resume is a free execution window: fire an
     // opportunistic alert scan (iOS headless one-off; Android no-op — its
@@ -104,8 +111,14 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
       final notifier = ref.read(tripRecordingProvider.notifier);
       unawaited(notifier.onAppBackgrounded());
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: {'where': 'onAppBackgrounded'}));
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {'where': 'onAppBackgrounded'},
+        ),
+      );
     }
   }
 
@@ -142,19 +155,26 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
         // detail screen. Sits at the same layer as the home-widget
         // click listener so both deep-link sources share the same
         // post-builder navigation context.
-        return NotificationLaunchListener(
-          child: WidgetClickListener(
-            // #2735 — inbound OS share-intent receiver. Sits beside the
-            // notification + widget deep-link listeners so all three
-            // deep-link sources share the same post-builder navigation
-            // context. A receipt image shared from another app is
-            // stashed + routed to /consumption/add, where the form is
-            // prefilled from its OCR (#2734). Opt-in via
-            // Feature.addFillUpShareIntentReceipt (gated in the handler).
-            child: ShareReceiptListener(
-              child: CountrySwitchListener(
-                child: TripRecordingBanner(
-                  child: child ?? const SizedBox.shrink(),
+        // #3607 — StartupReveal holds the branded splash as an overlay
+        // until the first screen has settled (min hold + frame
+        // quiescence, hard-capped), so the user never watches the form
+        // being constructed. One reveal per process — the language-key
+        // tree rebuild does not re-play it.
+        return StartupReveal(
+          child: NotificationLaunchListener(
+            child: WidgetClickListener(
+              // #2735 — inbound OS share-intent receiver. Sits beside the
+              // notification + widget deep-link listeners so all three
+              // deep-link sources share the same post-builder navigation
+              // context. A receipt image shared from another app is
+              // stashed + routed to /consumption/add, where the form is
+              // prefilled from its OCR (#2734). Opt-in via
+              // Feature.addFillUpShareIntentReceipt (gated in the handler).
+              child: ShareReceiptListener(
+                child: CountrySwitchListener(
+                  child: TripRecordingBanner(
+                    child: child ?? const SizedBox.shrink(),
+                  ),
                 ),
               ),
             ),

--- a/lib/app/widgets/animated_splash.dart
+++ b/lib/app/widgets/animated_splash.dart
@@ -41,7 +41,13 @@ import '../../l10n/app_localizations.dart';
 /// splash as the root, then again with [TankstellenApp] once
 /// `AppInitializer.run()` resolves.
 class AnimatedSplash extends StatefulWidget {
-  const AnimatedSplash({super.key});
+  const AnimatedSplash({super.key, this.animateIn = true});
+
+  /// When false, the intro scale/fade is skipped and the splash renders
+  /// at its settled end state immediately (#3607) — used by the
+  /// [StartupReveal] overlay, where the intro already played under the
+  /// pre-init host and replaying it would read as a restart.
+  final bool animateIn;
 
   /// Matches `android/app/src/main/res/values/colors.xml →
   /// ic_launcher_background`. Kept in both places so the native splash
@@ -102,8 +108,9 @@ class _AnimatedSplashState extends State<AnimatedSplash>
     _started = true;
     // #2972 — reduced-motion guard. With the OS "remove animations" flag on,
     // jump the controller straight to its end (logo full-size, fully opaque)
-    // instead of running the 650 ms scale+fade reveal.
-    if (AppMotion.enabled(context)) {
+    // instead of running the 650 ms scale+fade reveal. #3607 — the
+    // continuation overlay skips the intro the same way.
+    if (widget.animateIn && AppMotion.enabled(context)) {
       unawaited(_controller.forward());
     } else {
       _controller.value = 1.0;
@@ -168,7 +175,14 @@ class _AnimatedSplashState extends State<AnimatedSplash>
                     const SizedBox(height: 28),
                     FadeTransition(
                       opacity: _fade,
-                      child: const _SplashProgressBar(),
+                      // #3607 — the StartupReveal continuation overlay
+                      // renders a STATIC brand frame: an indeterminate
+                      // bar schedules a frame forever, which would defeat
+                      // the reveal's frame-quiescence detection (and by
+                      // that point init is done — nothing is "loading").
+                      child: widget.animateIn
+                          ? const _SplashProgressBar()
+                          : const SizedBox.shrink(),
                     ),
                   ],
                 ),

--- a/lib/app/widgets/startup_reveal.dart
+++ b/lib/app/widgets/startup_reveal.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+import 'animated_splash.dart';
+
+/// Minimum time the splash overlay stays up after the real tree's first
+/// frame (#3607). The initial pop-in cascade — boxes opening, providers
+/// resolving, tiles appearing — happens in the first few hundred ms; a
+/// floor guarantees none of it is ever visible, even on fast devices.
+const Duration kStartupRevealMinHold = Duration(milliseconds: 350);
+
+/// Hard cap on the overlay after the first frame. A screen with a
+/// permanently-animating widget (an indeterminate spinner) never goes
+/// frame-quiescent, and a wedged provider must not trap the user on the
+/// splash — past this point the app is revealed regardless.
+const Duration kStartupRevealCap = Duration(milliseconds: 2500);
+
+/// Fade-out duration of the reveal itself.
+const Duration kStartupRevealFade = Duration(milliseconds: 250);
+
+/// One reveal per process: the app tree is keyed on the language code and
+/// fully rebuilds on a locale change — the splash must not re-play then.
+bool _revealDoneThisProcess = false;
+
+/// Test seam — widget tests re-run the reveal in one process.
+@visibleForTesting
+void resetStartupRevealForTests() => _revealDoneThisProcess = false;
+
+/// Holds the branded splash as an overlay ON TOP of the real app until
+/// the first screen has actually settled (#3607), so the user never
+/// watches the form being constructed.
+///
+/// The #795 splash covers `AppInitializer.run`; this widget covers the
+/// gap AFTER it — the real tree's own async composition. Reveal fires
+/// when ALL of:
+///   1. [kStartupRevealMinHold] elapsed since the first frame under the
+///      overlay, AND
+///   2. the tree went frame-quiescent (a frame completed with no next
+///      frame scheduled — nothing is still rebuilding or animating),
+/// OR the [kStartupRevealCap] elapsed (the escape hatch for screens that
+/// animate forever). The overlay then fades out over
+/// [kStartupRevealFade] and unmounts.
+class StartupReveal extends StatefulWidget {
+  const StartupReveal({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<StartupReveal> createState() => _StartupRevealState();
+}
+
+class _StartupRevealState extends State<StartupReveal> {
+  bool _minHoldElapsed = false;
+  bool _quiescent = false;
+  bool _fading = false;
+  bool _gone = false;
+  Timer? _minHoldTimer;
+  Timer? _capTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_revealDoneThisProcess) {
+      _gone = true;
+      return;
+    }
+    _minHoldTimer = Timer(kStartupRevealMinHold, () {
+      _minHoldElapsed = true;
+      _maybeReveal();
+    });
+    _capTimer = Timer(kStartupRevealCap, _reveal);
+    // Quiescence watch: after each frame, another frame being scheduled
+    // means the tree is still mutating — re-arm and keep waiting. A frame
+    // that ends with nothing scheduled is the settled first screen.
+    // Re-arming only when a frame IS coming makes this self-terminating.
+    SchedulerBinding.instance.addPostFrameCallback(_onFrame);
+  }
+
+  void _onFrame(Duration _) {
+    if (!mounted || _fading || _gone) return;
+    if (SchedulerBinding.instance.hasScheduledFrame) {
+      SchedulerBinding.instance.addPostFrameCallback(_onFrame);
+      return;
+    }
+    _quiescent = true;
+    _maybeReveal();
+  }
+
+  void _maybeReveal() {
+    if (_minHoldElapsed && _quiescent) _reveal();
+  }
+
+  void _reveal() {
+    if (!mounted || _fading || _gone) return;
+    _minHoldTimer?.cancel();
+    _capTimer?.cancel();
+    _revealDoneThisProcess = true;
+    setState(() => _fading = true);
+    Timer(kStartupRevealFade, () {
+      if (mounted) setState(() => _gone = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _minHoldTimer?.cancel();
+    _capTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_gone) return widget.child;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        // The overlay swallows taps while up — the screen underneath is
+        // deliberately not interactive until it is fully presented.
+        IgnorePointer(
+          ignoring: _fading,
+          child: AnimatedOpacity(
+            opacity: _fading ? 0.0 : 1.0,
+            duration: kStartupRevealFade,
+            curve: Curves.easeOut,
+            // The splash resumes at its settled end state — the intro
+            // scale/fade already played under the #795 pre-init host,
+            // and replaying it here would read as a restart.
+            child: const AnimatedSplash(animateIn: false),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/app/widgets/startup_reveal_test.dart
+++ b/test/app/widgets/startup_reveal_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3607 — the StartupReveal overlay must hold the branded splash over
+// the real tree until the first screen settles (min hold + frame
+// quiescence), force-reveal at the hard cap when the screen animates
+// forever, and never re-play within the same process (the language-key
+// tree rebuild).
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/widgets/animated_splash.dart';
+import 'package:tankstellen/app/widgets/startup_reveal.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+Widget host(Widget child) => MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: StartupReveal(child: child),
+    );
+
+void main() {
+  setUp(resetStartupRevealForTests);
+
+  testWidgets('splash overlays the child, then reveals once the min hold '
+      'elapses on a settled tree', (tester) async {
+    await tester.pumpWidget(host(const Scaffold(body: Text('home'))));
+
+    expect(find.byType(AnimatedSplash), findsOneWidget,
+        reason: 'the overlay must cover the child from the first frame');
+    // The child is BUILT under the overlay (loading happens behind the
+    // splash) — it is present, just not visible to the user.
+    expect(find.text('home'), findsOneWidget);
+
+    // Before the min hold: still covered even though the tree is settled.
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.byType(AnimatedSplash), findsOneWidget);
+
+    // Past the min hold + fade: revealed and the overlay unmounted.
+    await tester.pump(kStartupRevealMinHold);
+    await tester.pump(kStartupRevealFade);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.byType(AnimatedSplash), findsNothing,
+        reason: 'settled tree + min hold elapsed = reveal');
+  });
+
+  testWidgets('a forever-animating screen is force-revealed at the cap',
+      (tester) async {
+    // An indeterminate spinner keeps a frame scheduled on every frame, so
+    // quiescence never arrives — only the cap can reveal.
+    await tester.pumpWidget(host(
+      const Scaffold(body: Center(child: CircularProgressIndicator())),
+    ));
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(AnimatedSplash), findsOneWidget,
+        reason: 'no quiescence yet and the cap has not elapsed');
+
+    await tester.pump(kStartupRevealCap);
+    await tester.pump(kStartupRevealFade);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.byType(AnimatedSplash), findsNothing,
+        reason: 'the hard cap must free the user from the splash');
+  });
+
+  testWidgets('one reveal per process — a rebuilt tree (language change) '
+      'shows no second splash', (tester) async {
+    await tester.pumpWidget(host(const Scaffold(body: Text('home'))));
+    await tester.pump(kStartupRevealMinHold);
+    await tester.pump(kStartupRevealFade);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.byType(AnimatedSplash), findsNothing);
+
+    // Simulate the ValueKey(language.code) rebuild: a brand-new
+    // StartupReveal instance in the same process.
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpWidget(host(const Scaffold(body: Text('home2'))));
+    expect(find.byType(AnimatedSplash), findsNothing,
+        reason: 'the reveal already played this process');
+    expect(find.text('home2'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
StartupReveal keeps the branded splash as an overlay over the real tree until min-hold + frame quiescence (hard cap 2.5s), so the user never sees the home screen being constructed; one reveal per process; static brand frame in continuation mode. Plus: iOS launch storyboard goes brand-green — no more white flash. Closes #3607

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G