### PR TITLE
fix(reliability): 14 silent-failure sites now instrumented (#3610)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -158,7 +158,12 @@ class AppInitializer {
       unawaited(HiveBoxes.initDeferred());
       // #2264 — bounded eviction (expiry + per-prefix budget + LRU byte
       // ceiling) replaces the one-shot 500-key expiry cap.
-      await CacheManager(storage).evictBounded();
+      final evicted = await CacheManager(storage).evictBounded();
+      // #3610 — eviction volume is a field signal (a runaway cache shows
+      // up as a growing per-day count); record it instead of dropping it.
+      if (evicted > 0) {
+        healthCounters.increment('cache.evicted', by: evicted);
+      }
       // #2317 — trim price-history rows past the 30-day retention window
       // once per cold start. The foreground record path (station detail)
       // never trims, so without this hook a heavy user accumulates

--- a/lib/features/consumption/data/ocr/mlkit_ocr_text_engine.dart
+++ b/lib/features/consumption/data/ocr/mlkit_ocr_text_engine.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import 'ocr_text_engine.dart';
 import 'recognized_text_adapter.dart';
 
@@ -28,9 +31,17 @@ class MlKitOcrTextEngine implements OcrTextEngine {
     bool languageCorrection = true,
     List<String> languages = const [],
   }) async {
-    final recognized =
-        await _recognizer.processImage(InputImage.fromFilePath(imagePath));
-    return (text: recognized.text, blocks: mapRecognizedText(recognized));
+    try {
+      final recognized =
+          await _recognizer.processImage(InputImage.fromFilePath(imagePath));
+      return (text: recognized.text, blocks: mapRecognizedText(recognized));
+    } catch (e, st) {
+      // Upstream (`ReceiptScanService`) already catches — log here so the
+      // recognizer-level failure reason survives into the trace export.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'ocrFailureReason': 'recognizerThrow'}));
+      rethrow;
+    }
   }
 
   @override

--- a/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../../../../core/domain/fuel_type.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../ocr/pump_ocr_config.dart';
 import 'receipt_currency_profile.dart';
 
@@ -336,6 +339,13 @@ DateTime? buildDate(String dayStr, String monthStr, String yearStr) {
     return DateTime(year, month, day);
   } on FormatException catch (e, st) {
     debugPrint('Receipt date parse failed for "$dayStr/$monthStr/$yearStr": $e\n$st');
+    // The captured groups are digit-only regex matches — no PII.
+    unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+      'where': 'receipt buildDate',
+      'day': dayStr,
+      'month': monthStr,
+      'year': yearStr,
+    }));
     return null;
   }
 }

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -292,7 +292,9 @@ class ReceiptScanService {
     final recognised =
         await _recogniseRaw(path, enhanceContrast: enhanceContrast, roi: roi);
     if (recognised == null) return null;
-    debugPrint('OCR text (${recognised.text.length} chars):\n${recognised.text}');
+    // #3610 — never print the recognised text itself: a receipt can carry
+    // PII (card fragments, loyalty ids). Character count only.
+    debugPrint('OCR text: ${recognised.text.length} chars');
     // #2848 — the engine already carries the per-line block geometry so the
     // receipt path can route a fuel-station receipt to the label-anchored
     // extractor (ML Kit via mapRecognizedText, Vision via the channel).

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -56,7 +59,14 @@ class _EvMapLayerState extends ConsumerState<EvMapLayer> {
     return async.when(
       data: _buildLayer,
       loading: () => const SizedBox.shrink(),
-      error: (_, _) => const SizedBox.shrink(),
+      error: (e, st) {
+        // #3610 — the EV layer silently vanishing looked identical to
+        // "no stations here"; log so field triage can tell them apart.
+        // The empty-state UI behaviour is unchanged.
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+            context: const {'where': 'EvMapLayer evStationsProvider'}));
+        return const SizedBox.shrink();
+      },
     );
   }
 

--- a/lib/features/glide_coach/data/osm_traffic_signal_client.dart
+++ b/lib/features/glide_coach/data/osm_traffic_signal_client.dart
@@ -92,8 +92,13 @@ class OsmTrafficSignalClient {
     } on DioException catch (e, st) {
       debugPrint('OsmTrafficSignalClient.fetchInBoundingBox dio error: '
           '${e.message}\n$st');
-      throw OsmTrafficSignalException(
-        'Overpass request failed: ${e.message ?? e.type.name}',
+      // #3610 — rethrow with the ORIGINAL stack so the trace points at
+      // the dio failure, not at this wrapper.
+      Error.throwWithStackTrace(
+        OsmTrafficSignalException(
+          'Overpass request failed: ${e.message ?? e.type.name}',
+        ),
+        st,
       );
     }
 
@@ -128,7 +133,11 @@ class OsmTrafficSignalClient {
     } catch (e, st) {
       debugPrint('OsmTrafficSignalClient.fetchInBoundingBox parse error: '
           '$e\n$st');
-      throw OsmTrafficSignalException('Failed to parse Overpass response: $e');
+      // #3610 — keep the original stack across the wrap.
+      Error.throwWithStackTrace(
+        OsmTrafficSignalException('Failed to parse Overpass response: $e'),
+        st,
+      );
     }
   }
 

--- a/lib/features/obd2/data/bluetooth_obd2_transport.dart
+++ b/lib/features/obd2/data/bluetooth_obd2_transport.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 
 import 'ble_disconnect_classifier.dart';
 import 'elm_byte_channel.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../../../core/telemetry/health_counters.dart';
 import '../../../../core/utils/event_channel_cancel.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_read_timeout.dart';
@@ -160,7 +162,10 @@ class BluetoothObd2Transport
         try {
           await _channel.close();
         } catch (_) {
-          // ignore: silent_catch — best-effort teardown of a half-open link before retrying
+          // Best-effort teardown, swallowed by design — counted (#3610).
+          healthCounters.increment('bt.teardown_fail');
+          BreadcrumbCollector.add('bt.teardown_fail',
+              detail: 'channel.close during open retry');
         }
         // #3014 — GATT-133 recovery: on a 133 (cache-poisoned device — a clone
         // whose GATT table mutated, or a stale cache from the aborted attempt),
@@ -173,7 +178,10 @@ class BluetoothObd2Transport
             try {
               await (ch as Obd2GattRecoverable).refreshGattCache();
             } catch (_) {
-              // ignore: silent_catch — OEM-variable reflection; swallow — the retry proceeds anyway.
+              // OEM-variable reflection, swallowed — counted (#3610).
+              healthCounters.increment('bt.teardown_fail');
+              BreadcrumbCollector.add('bt.teardown_fail',
+                  detail: 'refreshGattCache during open retry');
             }
           }
         }

--- a/lib/features/obd2/data/supported_pids_resolver.dart
+++ b/lib/features/obd2/data/supported_pids_resolver.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../../../core/telemetry/health_counters.dart';
 import 'elm327_protocol.dart';
 import 'obd2_comm_diagnostics.dart';
 import 'pid_probation.dart';
@@ -167,6 +169,10 @@ class SupportedPidsResolver {
       // must NOT pollute the user error log.
       debugPrint('OBD2 supported-PID cache prime failed — '
           'scanning blindly this session');
+      // #3610 — still best-effort, but counted so a chronically failing
+      // prime is visible in the field export.
+      healthCounters.increment('bt.teardown_fail');
+      BreadcrumbCollector.add('bt.teardown_fail', detail: 'pid cache prime');
     }
   }
 
@@ -186,6 +192,9 @@ class SupportedPidsResolver {
       // recoverable — we fall back to [_vehicleFallbackKey] below, so a
       // transient here must NOT pollute the user error log.
       debugPrint('OBD2 VIN read for cache key failed — using fallback key');
+      // #3610 — best-effort, but counted (see prime()).
+      healthCounters.increment('bt.teardown_fail');
+      BreadcrumbCollector.add('bt.teardown_fail', detail: 'vin cache key read');
     }
     return _vehicleFallbackKey;
   }
@@ -270,6 +279,10 @@ class SupportedPidsResolver {
           // already answered, so the bus state is settled here.
           debugPrint('OBD2 discoverSupportedPids failed on $command — '
               'returning ${supported.length} PIDs gathered so far');
+          // #3610 — best-effort, but counted (see prime()).
+          healthCounters.increment('bt.teardown_fail');
+          BreadcrumbCollector.add('bt.teardown_fail',
+              detail: 'pid group probe');
           break;
         }
       }

--- a/lib/features/payment/presentation/scan_payment_dispatcher.dart
+++ b/lib/features/payment/presentation/scan_payment_dispatcher.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../domain/qr_payment_decoder.dart';
 
@@ -109,6 +112,8 @@ class ScanPaymentDispatcher {
       return ok ? ScanPaymentOutcome.launched : ScanPaymentOutcome.launchFailed;
     } on Exception catch (e, st) {
       debugPrint('ScanPaymentDispatcher launch failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+          context: const {'where': 'scanPayment launch'}));
       return ScanPaymentOutcome.launchFailed;
     }
   }
@@ -152,6 +157,8 @@ class ScanPaymentDispatcher {
         }
       } on Exception catch (e, st) {
         debugPrint('tryLaunchEpc $scheme failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+            context: {'where': 'scanPayment epc $scheme'}));
       }
     }
 
@@ -166,6 +173,8 @@ class ScanPaymentDispatcher {
       return EpcLaunchOutcome.copiedToClipboard;
     } on Exception catch (e, st) {
       debugPrint('tryLaunchEpc clipboard failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
+          context: const {'where': 'scanPayment epc clipboard'}));
       return EpcLaunchOutcome.failed;
     }
   }

--- a/lib/features/price_history/data/tflite_interpreter.dart
+++ b/lib/features/price_history/data/tflite_interpreter.dart
@@ -1,8 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:tflite_flutter/tflite_flutter.dart' as tfl;
+
+import '../../../core/logging/error_logger.dart';
 
 /// Thin abstraction over `tflite_flutter`'s [tfl.Interpreter]. Created
 /// for #1117 phase 2 so tests can inject a fake without loading the
@@ -58,6 +62,8 @@ class TfliteFlutterInterpreter implements TfliteInterpreter {
       debugPrint(
         'TfliteFlutterInterpreter.fromBuffer: failed to parse model bytes: $e\n$st',
       );
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'stage': 'load', 'where': 'tflite fromBuffer'}));
       return null;
     }
   }
@@ -68,6 +74,8 @@ class TfliteFlutterInterpreter implements TfliteInterpreter {
       _delegate.run(input, output);
     } catch (e, st) {
       debugPrint('TfliteFlutterInterpreter.run: inference failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'stage': 'shape', 'where': 'tflite run'}));
     }
   }
 
@@ -77,6 +85,8 @@ class TfliteFlutterInterpreter implements TfliteInterpreter {
       _delegate.close();
     } catch (e, st) {
       debugPrint('TfliteFlutterInterpreter.close: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'stage': 'teardown', 'where': 'tflite close'}));
     }
   }
 }

--- a/lib/features/price_history/data/tflite_price_predictor.dart
+++ b/lib/features/price_history/data/tflite_price_predictor.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import '../../../core/logging/error_logger.dart';
 import '../domain/entities/feature_vector.dart';
 import 'tflite_interpreter.dart';
 
@@ -178,6 +181,8 @@ class TflitePricePredictor {
       debugPrint(
         'TflitePricePredictor.fromAsset: missing asset "$path": $e\n$st',
       );
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'stage': 'load', 'where': 'tflite assetLoad'}));
       return null;
     }
 
@@ -188,6 +193,8 @@ class TflitePricePredictor {
       debugPrint(
         'TflitePricePredictor.fromAsset: interpreter build failed: $e\n$st',
       );
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'stage': 'load', 'where': 'tflite interpreterBuild'}));
       return null;
     }
     if (interpreter == null) return null;
@@ -224,6 +231,12 @@ class TflitePricePredictor {
     final raw = output[0][0];
     if (!raw.isFinite) {
       debugPrint('TflitePricePredictor.predict: non-finite output ($raw)');
+      unawaited(errorLogger.log(
+        ErrorLayer.services,
+        StateError('TflitePricePredictor: non-finite output ($raw)'),
+        StackTrace.current,
+        context: const {'stage': 'inference', 'where': 'tflite predict'},
+      ));
       return null;
     }
     if (raw < _kMinPredictedCents || raw > _kMaxPredictedCents) {
@@ -231,6 +244,12 @@ class TflitePricePredictor {
         'TflitePricePredictor.predict: out-of-band output ($raw cents) — '
         'rejecting per static confidence gate',
       );
+      unawaited(errorLogger.log(
+        ErrorLayer.services,
+        StateError('TflitePricePredictor: out-of-band output ($raw cents)'),
+        StackTrace.current,
+        context: const {'stage': 'inference', 'where': 'tflite predict'},
+      ));
       return null;
     }
 

--- a/lib/features/route_search/data/strategies/balanced_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/balanced_search_strategy.dart
@@ -38,7 +38,11 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
     RouteSearchCriterion criterion = RouteSearchCriterion.cheapest,
     void Function(List<SearchResultItem> partial)? onPartial,
   }) async {
-    debugPrint('BalancedSearch: querying ${route.samplePoints.length} points with radius=${searchRadiusKm}km');
+    // #3610 — gated so release builds skip the string interpolation.
+    if (kDebugMode) {
+      debugPrint(
+          'BalancedSearch: querying ${route.samplePoints.length} points with radius=${searchRadiusKm}km');
+    }
 
     const batchHelper = BatchQueryHelper();
     final results = await batchHelper.queryAll(

--- a/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
@@ -45,7 +45,12 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
         route.samplePoints[i],
     ];
 
-    debugPrint('CheapestSearch: querying ${sampledPoints.length} points with radius=${effectiveRadius.toStringAsFixed(1)}km');
+    // #3610 — gated so release builds skip the string interpolation
+    // (debugPrint itself is already a release no-op here).
+    if (kDebugMode) {
+      debugPrint(
+          'CheapestSearch: querying ${sampledPoints.length} points with radius=${effectiveRadius.toStringAsFixed(1)}km');
+    }
 
     const batchHelper = BatchQueryHelper();
     final results = await batchHelper.queryAll(

--- a/lib/features/route_search/data/strategies/uniform_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/uniform_search_strategy.dart
@@ -50,9 +50,12 @@ class UniformSearchStrategy implements RouteSearchStrategy {
     RouteSearchCriterion criterion = RouteSearchCriterion.cheapest,
     void Function(List<SearchResultItem> partial)? onPartial,
   }) async {
-    debugPrint('UniformSearch: querying ${route.samplePoints.length} '
-        'sample points with radius=${searchRadiusKm}km, '
-        'topN=$topNPerSamplePoint, criterion=${criterion.key}');
+    // #3610 — gated so release builds skip the string interpolation.
+    if (kDebugMode) {
+      debugPrint('UniformSearch: querying ${route.samplePoints.length} '
+          'sample points with radius=${searchRadiusKm}km, '
+          'topN=$topNPerSamplePoint, criterion=${criterion.key}');
+    }
 
     const batchHelper = BatchQueryHelper();
     final results = await batchHelper.queryAll(

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -78,10 +78,16 @@ class RouteSearchState extends _$RouteSearchState {
       final criterion =
           profile?.routeSearchCriterion ?? RouteSearchCriterion.cheapest;
       final routingService = RoutingService();
-      debugPrint('RouteSearch: fetching route for ${usableWaypoints.length} waypoints, avoidHighways=$avoidHighways, strategy=${strategyType.key}');
+      if (kDebugMode) { // #3610 — release skips the interpolation.
+        debugPrint(
+            'RouteSearch: fetching route for ${usableWaypoints.length} waypoints, avoidHighways=$avoidHighways, strategy=${strategyType.key}');
+      }
       final routeResult = await routingService.getRoute(usableWaypoints, avoidHighways: avoidHighways);
       final route = routeResult.data;
-      debugPrint('RouteSearch: route=${route.distanceKm.round()}km, ${route.geometry.length} polyline pts, ${route.samplePoints.length} sample pts');
+      if (kDebugMode) {
+        debugPrint(
+            'RouteSearch: route=${route.distanceKm.round()}km, ${route.geometry.length} polyline pts, ${route.samplePoints.length} sample pts');
+      }
 
       // 2. Search stations using the selected strategy.
       // Use at least 15km radius for route searches to ensure coverage

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'801f60c5d6c388d6f6c6286dbb2d01ce7b9ce442';
+String _$routeSearchStateHash() => r'965d1ec4b7e594c0a9d6957476beace911ccd702';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -165,7 +165,14 @@ Future<AsyncValue<ServiceResult<List<SearchResultItem>>>>
     ref.read(eVSearchStateProvider).when(
           data: wrapEvResultAsSearchItems,
           loading: _emptyEvSearchResult,
-          error: (e, _) => _emptyEvSearchResult(evError: e),
+          error: (e, st) {
+            // #3610 — an EV-side failure only became a banner hint; log
+            // it so the OpenChargeMap outage is visible in field traces.
+            // The empty-result UI behaviour is unchanged.
+            unawaited(errorLogger.log(ErrorLayer.services, e, st,
+                context: const {'where': 'finalizeUnifiedResult ev'}));
+            return _emptyEvSearchResult(evError: e);
+          },
         ),
   );
 }

--- a/lib/features/vehicle/data/repositories/service_reminder_repository.dart
+++ b/lib/features/vehicle/data/repositories/service_reminder_repository.dart
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/storage/hive_boxes.dart';
 import '../../domain/entities/service_reminder.dart';
 
@@ -60,14 +62,36 @@ class ServiceReminderRepository {
   }
 
   /// Add or update a single reminder (matched by id).
+  ///
+  /// Callers fire-and-forget this write, so a failure is logged rather
+  /// than rethrown — rethrowing would surface as an unhandled zone
+  /// error with nobody awaiting it.
   Future<void> save(ServiceReminder reminder) async {
-    await _box.put(reminder.id, jsonEncode(reminder.toJson()));
+    try {
+      await _box.put(reminder.id, jsonEncode(reminder.toJson()));
+    } catch (e, st) {
+      // TODO(#3610-follow-up): surface to user
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'ServiceReminderRepository.save',
+        'reminderId': reminder.id,
+      }));
+    }
   }
 
   /// Delete a reminder by id. No-op when it does not exist.
+  ///
+  /// Same fire-and-forget contract as [save]: log, never rethrow.
   Future<void> delete(String id) async {
-    if (_box.containsKey(id)) {
-      await _box.delete(id);
+    try {
+      if (_box.containsKey(id)) {
+        await _box.delete(id);
+      }
+    } catch (e, st) {
+      // TODO(#3610-follow-up): surface to user
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'ServiceReminderRepository.delete',
+        'reminderId': id,
+      }));
     }
   }
 

--- a/lib/features/vehicle/data/ve_learner.dart
+++ b/lib/features/vehicle/data/ve_learner.dart
@@ -237,15 +237,22 @@ class VeLearner {
     }
 
     if (distance < minDistanceKm) {
-      debugPrint('VeLearner: skip — distance $distance < $minDistanceKm km');
+      // #3610 — gated so release builds skip the string interpolation.
+      if (kDebugMode) {
+        debugPrint('VeLearner: skip — distance $distance < $minDistanceKm km');
+      }
       return null;
     }
     if (samples < minObd2Samples) {
-      debugPrint('VeLearner: skip — samples $samples < $minObd2Samples');
+      if (kDebugMode) {
+        debugPrint('VeLearner: skip — samples $samples < $minObd2Samples');
+      }
       return null;
     }
     if (integrated <= 0) {
-      debugPrint('VeLearner: skip — no integrated fuel on trips');
+      if (kDebugMode) {
+        debugPrint('VeLearner: skip — no integrated fuel on trips');
+      }
       return null;
     }
     final gap = (integrated - pumpedLiters).abs() / pumpedLiters;

--- a/lib/features/vehicle/data/vin_decoder.dart
+++ b/lib/features/vehicle/data/vin_decoder.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../../../core/services/dio_factory.dart';
 import '../domain/entities/vin_data.dart';
 import 'wmi_table.dart' as wmi;
@@ -93,8 +96,12 @@ class VinDecoder {
       } on DioException catch (e, st) {
         debugPrint(
             'VinDecoder: vPIC failed (${e.type}): falling back to WMI\n$st');
+        unawaited(errorLogger.log(ErrorLayer.services, e, st,
+            context: const {'where': 'vpic', 'fallback': 'wmi'}));
       } on Object catch (e, st) {
         debugPrint('VinDecoder: unexpected error $e — falling back to WMI\n$st');
+        unawaited(errorLogger.log(ErrorLayer.services, e, st,
+            context: const {'where': 'vpic', 'fallback': 'wmi'}));
       }
     } else {
       debugPrint(

--- a/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
+++ b/lib/features/vehicle/presentation/widgets/service_reminder_section.dart
@@ -93,10 +93,14 @@ class ServiceReminderSection extends ConsumerWidget {
       intervalKm: intervalKm,
       lastServiceOdometerKm: currentOdometerKm,
     );
+    // TODO(#3610-follow-up): surface to user — a failed save is only
+    // error-logged by the repository, the UI stays unaware.
     unawaited(ref.read(serviceReminderListProvider.notifier).save(reminder));
   }
 
   void _delete(WidgetRef ref, String id) {
+    // TODO(#3610-follow-up): surface to user — a failed delete is only
+    // error-logged by the repository, the UI stays unaware.
     unawaited(ref.read(serviceReminderListProvider.notifier).remove(id));
   }
 

--- a/test/features/vehicle/data/repositories/service_reminder_repository_test.dart
+++ b/test/features/vehicle/data/repositories/service_reminder_repository_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3610 — save()/delete() document a log-never-rethrow contract (their
+// call sites fire-and-forget), so the #2349 gate demands the fault
+// injection: a throwing box must not propagate.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/vehicle/data/repositories/service_reminder_repository.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/service_reminder.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+class _ThrowingBox extends Fake implements Box<String> {
+  @override
+  Future<void> put(dynamic key, String value) async =>
+      throw HiveError('disk full');
+
+  @override
+  bool containsKey(dynamic key) => true;
+
+  @override
+  Future<void> delete(dynamic key) async => throw HiveError('disk full');
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  const reminder = ServiceReminder(
+    id: 'r1',
+    vehicleId: 'v1',
+    label: 'Oil change',
+    intervalKm: 15000,
+  );
+
+  test('save() returns normally when the box write throws (#2349 fault '
+      'injection — logged, never rethrown)', () async {
+    final repo = ServiceReminderRepository(_ThrowingBox());
+    await expectLater(repo.save(reminder), completes);
+  });
+
+  test('delete() returns normally when the box delete throws', () async {
+    final repo = ServiceReminderRepository(_ThrowingBox());
+    await expectLater(repo.delete('r1'), completes);
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -155,8 +155,10 @@ void main() {
     // #3580 — re-grandfathered 678 → 695: the crash-forensics
     // startup wiring (breadcrumb persistence init + exit-info harvest).
     'lib/app/app_initializer.dart': (
-      lines: 695,
-      bumps: 15,
+      // #3610 — the eviction sweep's yield now lands in the health
+      // counters (cache.evicted, +5). Decomposition tracked by #3139.
+      lines: 700,
+      bumps: 16,
       decompositionIssue: 3139,
     ),
     // #3078 — grandfathered at 414 (was 400, right at the cap on master). The
@@ -660,6 +662,22 @@ void main() {
     // #3575/#3576 — re-grandfathered 1728 → 1780: the no-protocol
     // episode handler (pause → recoverVehicleProtocol → resume, throttled)
     // + stop-time stamping of the live GPS-physics estimate figures.
+    'lib/features/obd2/data/bluetooth_obd2_transport.dart': (
+      // #3610 — the two best-effort teardown catches now count a
+      // bt.teardown_fail health counter + breadcrumb (+8 over the cap).
+      // Decomposition candidate: the #3014 GATT-133 recovery block.
+      lines: 408,
+      bumps: 1,
+      decompositionIssue: 3141,
+    ),
+    'lib/features/route_search/providers/route_search_provider.dart': (
+      // #3610 — kDebugMode gates around the per-search debugPrints
+      // (+6 over the cap). Decomposition candidate: the strategy-run
+      // orchestration helpers.
+      lines: 406,
+      bumps: 1,
+      decompositionIssue: 3141,
+    ),
     'lib/features/obd2/data/trip_recording_controller.dart': (
       // #3602 — the engine-data staleness fence (freshness anchor, two
       // constants, the _emit gate + once-latched escalation, +51).


### PR DESCRIPTION
Audit child 1: silent failures across reminders, payments, TFLite, OCR, VIN decode, EV surfaces, receipt parsing and Overpass now reach the exportable error log with context; original stacks preserved on rethrow; cache-eviction + BT-teardown counters; hot-path debugPrints gated; #2349 fault-injection test for the reminder repo's log-never-rethrow contract. Closes #3610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G