### PR TITLE
fix(security): PII-scrubber gaps, share-ingestion caps, deep-link id charset, zip decode caps (#3612)

### DIFF
--- a/lib/core/telemetry/pii_scrubber.dart
+++ b/lib/core/telemetry/pii_scrubber.dart
@@ -66,8 +66,23 @@ class PiiScrubber {
   /// search call sites emit. Matches a lat/lng/lon(gitude) KEY followed
   /// by `=` or `:` and a signed decimal, redacting key+value together.
   /// Keyed so a plain price (`diesel: 1.789`) is never touched.
+  /// #3612 — the numeric value may also be an integer (`lat=48`) or
+  /// carry a single decimal (`lat=48.1`): device coordinates get rounded
+  /// before they reach a log line, and a rounded coordinate is still
+  /// PII. The value part is therefore `-?\d{1,3}(?:\.\d+)?`.
   static final RegExp _coordKeyValueRegex = RegExp(
-    r'\b(?:lat|latitude|lng|lon|longitude)\s*[=:]\s*-?\d{1,3}\.\d+',
+    r'\b(?:lat|latitude|lng|lon|longitude)\s*[=:]\s*-?\d{1,3}(?:\.\d+)?',
+    caseSensitive: false,
+  );
+
+  /// #3612 — structured (JSON-ish) coordinate fields: `"lat": 43.4612`,
+  /// `"longitude": 11`, … The quote before the key breaks the
+  /// `\b`-anchored key/value rule above (the closing quote sits between
+  /// the key and the `:`), so serialized request/response bodies leaked
+  /// their coordinates verbatim. Redacts key + value together; accepts
+  /// integers and any number of decimals, same rationale as above.
+  static final RegExp _coordJsonKeyRegex = RegExp(
+    r'"(?:lat|latitude|lng|lon|longitude)"\s*:\s*-?\d{1,3}(?:\.\d+)?',
     caseSensitive: false,
   );
 
@@ -76,6 +91,20 @@ class PiiScrubber {
   /// session ids, and station-id+coord composites. Anchored on word
   /// boundaries so we don't redact half a sentence.
   static final RegExp _tokenRegex = RegExp(r'\b[A-Za-z0-9_-]{20,}\b');
+
+  /// #3612 — a full JWT (`header.payload.signature`, three dot-separated
+  /// base64url segments). The generic token rule only catches segments
+  /// that are individually >= 20 chars, so a JWT with a short header or
+  /// signature segment survived partially, and even a fully-caught one
+  /// left the tell-tale `X.Y.Z` shape behind. Targeted rather than a
+  /// loosened [_tokenRegex]: every real-world JWT header is base64url of
+  /// `{"…` and therefore starts with `eyJ`, which ordinary prose never
+  /// does — so dotted sentences, version strings (`v1.2.3`) and file names
+  /// (`a.b.dart`) are never eaten. Runs BEFORE [_tokenRegex] so the
+  /// whole token collapses into a single marker.
+  static final RegExp _jwtRegex = RegExp(
+    r'\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b',
+  );
 
   // --------------------------------------------------------------------------
   // Public API
@@ -94,6 +123,10 @@ class PiiScrubber {
     var out = text.replaceAll(_emailRegex, emailMarker);
     out = out.replaceAll(_coordRegex, coordMarker);
     out = out.replaceAll(_coordKeyValueRegex, coordMarker);
+    out = out.replaceAll(_coordJsonKeyRegex, coordMarker);
+    // JWT before the generic token rule so the whole three-segment token
+    // collapses into ONE marker instead of per-segment fragments (#3612).
+    out = out.replaceAll(_jwtRegex, tokenMarker);
     out = out.replaceAll(_tokenRegex, tokenMarker);
     return out;
   }

--- a/lib/features/consumption/data/exporters/backup/backup_xml_reader.dart
+++ b/lib/features/consumption/data/exporters/backup/backup_xml_reader.dart
@@ -73,6 +73,11 @@ class BackupXmlReader {
   BackupPayload read(String xml) {
     final XmlDocument doc;
     try {
+      // #3612 — verified against package:xml: `parse` never fetches
+      // external entities/DTDs and keeps a DOCTYPE's internal subset as
+      // an opaque node; only the predefined character entities expand
+      // (default `XmlDefaultEntityMapping.xml()`), so a "billion
+      // laughs" / XXE payload cannot amplify or exfiltrate here.
       doc = XmlDocument.parse(xml);
     } catch (e, st) {
       Error.throwWithStackTrace(

--- a/lib/features/consumption/data/exporters/backup/backup_zip_reader.dart
+++ b/lib/features/consumption/data/exporters/backup/backup_zip_reader.dart
@@ -40,10 +40,24 @@ class BackupZipReadException implements Exception {
 class BackupZipReader {
   const BackupZipReader();
 
+  /// #3612 — hard cap on the number of entries a restore zip may carry.
+  /// A real backup is one `.xml` entry (plus, at worst, a handful of
+  /// hand-re-zip artifacts like `__MACOSX/` forks); thousands of entries
+  /// is a zip-bomb shape, rejected before any content is touched.
+  static const int maxEntries = 64;
+
+  /// #3612 — hard cap on the TOTAL claimed decompressed size across all
+  /// entries (64 MB). The claimed sizes come from the zip's central
+  /// directory, so a decompression bomb (tiny compressed payload
+  /// claiming/holding gigabytes) is rejected BEFORE any entry is
+  /// inflated. 64 MB is orders of magnitude above any real backup XML.
+  static const int maxTotalUncompressedBytes = 64 * 1024 * 1024;
+
   /// Decode [bytes] and return the inner backup XML as a UTF-8 string.
   ///
   /// Throws [BackupZipReadException] when the bytes are not a valid
-  /// zip, carry no `.xml` entry, or hold an empty XML payload.
+  /// zip, exceed the entry-count / decompressed-size caps (#3612),
+  /// carry no `.xml` entry, or hold an empty XML payload.
   String readXml(Uint8List bytes) {
     if (bytes.isEmpty) {
       throw const BackupZipReadException('empty file');
@@ -60,6 +74,25 @@ class BackupZipReader {
         const BackupZipReadException('not a valid zip archive'),
         st,
       );
+    }
+
+    // #3612 — bomb guards. `ZipDecoder.decodeBytes` only parses the
+    // directory headers; each entry's content is inflated lazily on
+    // first `.content` access, so both checks below run BEFORE any
+    // decompression happens. `ArchiveFile.size` is the header's claimed
+    // uncompressed size.
+    if (archive.files.length > maxEntries) {
+      throw const BackupZipReadException('too many entries in the zip');
+    }
+    var totalUncompressed = 0;
+    for (final file in archive.files) {
+      if (!file.isFile) continue;
+      totalUncompressed += file.size;
+      if (totalUncompressed > maxTotalUncompressedBytes) {
+        throw const BackupZipReadException(
+          'zip decompresses beyond the size cap',
+        );
+      }
     }
 
     ArchiveFile? xmlEntry;

--- a/lib/features/consumption/data/share/share_payload_guard.dart
+++ b/lib/features/consumption/data/share/share_payload_guard.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:io';
+
+import '../../../../core/logging/error_logger.dart';
+
+/// #3612 (2026-07-26 audit, wave 2) — inbound-share ingestion caps.
+///
+/// An `ACTION_SEND` / `ACTION_SEND_MULTIPLE` payload is attacker-shaped
+/// input: any app on the device can hand us an arbitrary file, and the
+/// Dart side feeds it straight into the OCR / PDF-rasterise pipeline.
+/// Before a shared file enters that pipeline it must pass
+/// [isAcceptableSharePayload]:
+///
+///   * **size** — at most [kMaxSharePayloadBytes] (16 MB). A receipt
+///     photo is single-digit MB; anything larger is either not a receipt
+///     or a memory-exhaustion attempt.
+///   * **extension** — one of [kAcceptedShareExtensions]. The native
+///     receivers only ever cache `.jpg` / `.png` / `.pdf` names
+///     (`ShareIntentChannel.kt`, `ShareViewController.swift`), so this is
+///     defense-in-depth against a payload that skipped the native
+///     classifier.
+///
+/// The PDF page cap lives downstream in `ReceiptPdfRasterizer.maxPages`
+/// (#2737) — the page count is only knowable after opening the document.
+///
+/// Rejection is silent by design: the payload is dropped and the reason
+/// spooled via [errorLogger] by the caller — no snackbar, no new strings.
+
+/// Hard cap on a shared file's size, in bytes (16 MB).
+const int kMaxSharePayloadBytes = 16 * 1024 * 1024;
+
+/// File extensions (lower-case, without the dot) a shared file may carry
+/// to enter the receipt pipeline.
+const Set<String> kAcceptedShareExtensions = {
+  'jpg',
+  'jpeg',
+  'png',
+  'webp',
+  'pdf',
+};
+
+/// Pure acceptance predicate for one file-backed share payload.
+///
+/// [sizeBytes] is the file's on-disk size, or `null` when it could not
+/// be determined (see [sharePayloadSizeBytes]). An unknown size passes
+/// the size check: a file that cannot be stat-ed cannot be opened by the
+/// OCR / rasterise step either, so it carries no decompression /
+/// memory-exhaustion risk — while a determinable size is bounded strictly.
+/// A zero/negative size is rejected: a 0-byte "receipt" is never valid.
+///
+/// Pure function of its inputs — no I/O — so it unit-tests without a
+/// filesystem.
+bool isAcceptableSharePayload({required int? sizeBytes, required String path}) {
+  final dot = path.lastIndexOf('.');
+  if (dot < 0 || dot == path.length - 1) return false;
+  final ext = path.substring(dot + 1).toLowerCase();
+  if (!kAcceptedShareExtensions.contains(ext)) return false;
+  if (sizeBytes != null &&
+      (sizeBytes <= 0 || sizeBytes > kMaxSharePayloadBytes)) {
+    return false;
+  }
+  return true;
+}
+
+/// Best-effort size probe for [isAcceptableSharePayload]. Returns the
+/// file's length in bytes, or `null` when the file is missing or
+/// unreadable (the guard treats `null` as "unknown", see above).
+/// Never throws.
+int? sharePayloadSizeBytes(String path) {
+  try {
+    return File(path).lengthSync();
+  } catch (e, st) {
+    // Missing / unreadable cache file — the share was already broken
+    // before the guard ran. Spooled for triage, then treated as unknown.
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+      'where': 'sharePayloadSizeBytes',
+    }));
+    return null;
+  }
+}

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
@@ -16,6 +16,7 @@ import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../data/ereceipt/ereceipt_text_parser.dart';
 import '../../data/ocr/receipt_pdf_rasterizer.dart';
+import '../../data/share/share_payload_guard.dart';
 import '../../data/share/shared_receipt_intent.dart';
 import '../../providers/pending_shared_receipt_provider.dart';
 import '../../providers/pending_shared_receipt_text_provider.dart';
@@ -60,12 +61,19 @@ class ShareReceiptHandler {
   final ReceiptPdfRasterizer _pdfRasterizer;
   final EReceiptTextParser _textParser;
 
+  /// Size probe for the #3612 ingestion guard — injectable so tests can
+  /// drive the cap without a real filesystem. Production uses
+  /// [sharePayloadSizeBytes] (a `File.lengthSync` wrapper).
+  final int? Function(String path) _payloadSizeBytes;
+
   ShareReceiptHandler(
     this._ref, {
     ReceiptPdfRasterizer? pdfRasterizer,
     EReceiptTextParser textParser = const EReceiptTextParser(),
+    int? Function(String path)? payloadSizeBytes,
   }) : _pdfRasterizer = pdfRasterizer ?? const ReceiptPdfRasterizer(),
-       _textParser = textParser;
+       _textParser = textParser,
+       _payloadSizeBytes = payloadSizeBytes ?? sharePayloadSizeBytes;
 
   /// Handle one inbound [intent]. No-op for a null intent, an empty item
   /// list, or — defensively — when the feature is gated off.
@@ -90,7 +98,10 @@ class ShareReceiptHandler {
           .where((i) => i.kind == SharedReceiptItemKind.image)
           .firstOrNull;
       if (image?.path != null) {
-        _stashAndRoute(image!.path!);
+        // #3612 ingestion cap — a rejected payload is dropped, not routed.
+        if (_payloadAccepted(image!.path!, 'image')) {
+          _stashAndRoute(image.path!);
+        }
         return;
       }
 
@@ -101,7 +112,12 @@ class ShareReceiptHandler {
           .where((i) => i.kind == SharedReceiptItemKind.pdf)
           .firstOrNull;
       if (pdf?.path != null) {
-        unawaited(_rasterizeAndRoute(pdf!.path!));
+        // #3612 ingestion cap — checked BEFORE the rasteriser opens the
+        // document; the page cap (`ReceiptPdfRasterizer.maxPages`) then
+        // bounds what a size-acceptable PDF may contain.
+        if (_payloadAccepted(pdf!.path!, 'pdf')) {
+          unawaited(_rasterizeAndRoute(pdf.path!));
+        }
         return;
       }
 
@@ -177,6 +193,28 @@ class ShareReceiptHandler {
     _ref.read(pendingSharedReceiptTextProvider.notifier).set(result);
     debugPrint('ShareReceiptHandler.handle stashed parsed text result');
     _push(RoutePaths.addFillUp);
+  }
+
+  /// #3612 — inbound-share ingestion guard. A shared file only enters the
+  /// OCR / rasterise pipeline when [isAcceptableSharePayload] accepts its
+  /// size and extension. Rejection is logged and the payload silently
+  /// ignored — no snackbar: an over-cap or wrong-type payload is
+  /// adversarial or malformed, not a user mistake to message about.
+  bool _payloadAccepted(String path, String kind) {
+    final size = _payloadSizeBytes(path);
+    if (isAcceptableSharePayload(sizeBytes: size, path: path)) return true;
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.ui,
+        StateError('shared $kind payload rejected by the ingestion guard'),
+        StackTrace.current,
+        context: {
+          'where': 'ShareReceiptHandler._payloadAccepted',
+          'sizeBytes': size,
+        },
+      ),
+    );
+    return false;
   }
 
   bool _featureEnabled() {

--- a/lib/features/widget/presentation/widget_uri_parser.dart
+++ b/lib/features/widget/presentation/widget_uri_parser.dart
@@ -31,7 +31,17 @@ String? widgetUriToPath(Uri? uri) {
   if (uri.host != 'station') return null;
   final id = uri.queryParameters['id'];
   if (id == null || id.isEmpty) return null;
+  if (!_stationIdPattern.hasMatch(id)) return null;
   return id.startsWith('ocm-')
       ? RoutePaths.evStationById(id)
       : RoutePaths.station(id);
 }
+
+/// #3612 (2026-07-26 audit, wave 2) — the station id is interpolated
+/// straight into a router path, so an adversarial launch URI (`../`,
+/// spaces, quotes, path separators) could otherwise shape the route.
+/// Constrained to the charset every real id format uses — tankerkoenig
+/// UUIDs (hex + `-`), numeric FR/ES/IT ids, and OpenChargeMap `ocm-<n>`
+/// ids all match — with a 64-char bound. Anything else is rejected like
+/// every other invalid URI (`null` → caller no-op).
+final RegExp _stationIdPattern = RegExp(r'^[A-Za-z0-9_.:-]{1,64}$');

--- a/test/core/telemetry/pii_scrubber_test.dart
+++ b/test/core/telemetry/pii_scrubber_test.dart
@@ -342,6 +342,79 @@ void main() {
     });
   });
 
+  group('structured coordinates + JWT (#3612)', () {
+    // 2026-07-26 audit wave 2: JSON-serialized bodies and rounded device
+    // coordinates leaked through the #3145 key/value rule (the quote
+    // before the key breaks its \b anchor; integers have no `.\d+`).
+
+    test('redacts integer keyed coordinates (lat=48 lng=11)', () {
+      const msg = 'tile request lat=48 lng=11 zoom=12';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('lat=48')));
+      expect(out, isNot(contains('lng=11')));
+      expect(out, contains(PiiScrubber.coordMarker));
+      expect(out, contains('zoom=12'),
+          reason: 'the non-PII zoom hint must survive');
+    });
+
+    test('redacts single-decimal keyed coordinates (lat: 48.1)', () {
+      const msg = 'centered at lat: 48.1 lon: 11.5';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('48.1')));
+      expect(out, isNot(contains('11.5')));
+      expect(out, contains(PiiScrubber.coordMarker));
+    });
+
+    test('redacts JSON-quoted coordinate keys ("lat": 43.4612)', () {
+      const msg = '{"lat": 43.4612, "lng": 5.4321, "station": "total-42"}';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('43.4612')));
+      expect(out, isNot(contains('5.4321')));
+      expect(out, contains(PiiScrubber.coordMarker));
+      expect(out, contains('total-42'),
+          reason: 'non-coordinate JSON fields must survive for triage');
+    });
+
+    test('redacts JSON-quoted latitude/longitude with integer values', () {
+      const msg = '{"latitude": 48, "longitude": 11}';
+      final out = PiiScrubber.scrubText(msg)!;
+      expect(out, isNot(contains('"latitude": 48')));
+      expect(out, isNot(contains('"longitude": 11')));
+      expect(PiiScrubber.coordMarker.allMatches(out).length, 2);
+    });
+
+    test('redacts a full JWT as ONE token marker', () {
+      // Shape of a real HS256 JWT — short header/signature segments used
+      // to survive the >=20-char generic token rule.
+      const jwt = 'eyJhbGciOiJIUzI1NiJ9.'
+          'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.'
+          'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      final out = PiiScrubber.scrubText('auth failed for token $jwt today')!;
+      expect(out, isNot(contains('eyJ')));
+      expect(out, isNot(contains('SflKxwRJ')));
+      expect(PiiScrubber.tokenMarker.allMatches(out).length, 1,
+          reason: 'the three segments must collapse into a single marker, '
+              'not per-segment fragments');
+      expect(out, contains('auth failed for token'));
+      expect(out, contains('today'));
+    });
+
+    test('does NOT eat ordinary dotted prose or version strings', () {
+      const msg = 'Updated to v1.2.3. See file.name.ext and pkg.module.Class. '
+          'End of sentence. Next sentence.';
+      final out = PiiScrubber.scrubText(msg);
+      expect(out, equals(msg),
+          reason: 'the JWT rule is anchored on the eyJ base64url-JSON '
+              'prefix so ordinary sentences are never redacted');
+    });
+
+    test('does NOT redact non-coordinate numeric fields', () {
+      const msg = '{"price": 1.789, "count": 42} and speed=88';
+      final out = PiiScrubber.scrubText(msg);
+      expect(out, equals(msg));
+    });
+  });
+
   group('never-throws contract (#2349 fault injection)', () {
     test('scrubText returns normally on adversarial inputs', () {
       // Pathological strings that stress every regex branch at once:

--- a/test/features/consumption/data/exporters/backup/backup_zip_reader_test.dart
+++ b/test/features/consumption/data/exporters/backup/backup_zip_reader_test.dart
@@ -73,4 +73,94 @@ void main() {
       );
     });
   });
+
+  group('BackupZipReader bomb guards (#3612)', () {
+    const reader = BackupZipReader();
+
+    test('rejects a zip with more entries than the cap (100 > 64)', () {
+      final archive = Archive();
+      for (var i = 0; i < 100; i++) {
+        archive.addFile(ArchiveFile.bytes('entry_$i.txt', utf8.encode('x')));
+      }
+      archive.addFile(
+        ArchiveFile.bytes('backup.xml', utf8.encode('<root>ok</root>')),
+      );
+      final bytes = Uint8List.fromList(ZipEncoder().encode(archive));
+      expect(
+        () => reader.readXml(bytes),
+        throwsA(isA<BackupZipReadException>()),
+        reason: 'a real backup is a single-entry zip; 100 entries is a '
+            'bomb shape and must be rejected before any content access',
+      );
+    });
+
+    test('accepts an entry count at (not above) the cap', () {
+      final archive = Archive();
+      for (var i = 0; i < BackupZipReader.maxEntries - 1; i++) {
+        archive.addFile(ArchiveFile.bytes('entry_$i.txt', utf8.encode('x')));
+      }
+      archive.addFile(
+        ArchiveFile.bytes('backup.xml', utf8.encode('<root>ok</root>')),
+      );
+      final bytes = Uint8List.fromList(ZipEncoder().encode(archive));
+      expect(reader.readXml(bytes), '<root>ok</root>');
+    });
+
+    test('rejects an entry whose header CLAIMS a huge uncompressed size '
+        'without inflating it', () {
+      // Build a perfectly valid small zip, then tamper the uncompressed-
+      // size fields in both the local and central-directory headers so
+      // the entry claims ~1 GB — the exact lie a decompression bomb
+      // tells. The reader must trust the claim and abort BEFORE any
+      // inflate happens.
+      final archive = Archive()
+        ..addFile(
+          ArchiveFile.bytes('backup.xml', utf8.encode('<root>ok</root>')),
+        );
+      final bytes = Uint8List.fromList(ZipEncoder().encode(archive));
+      final tampered = _withClaimedUncompressedSize(bytes, 1024 * 1024 * 1024);
+      expect(
+        () => reader.readXml(tampered),
+        throwsA(isA<BackupZipReadException>()),
+      );
+    });
+
+    test('rejects entries whose claimed sizes SUM beyond the cap', () {
+      // Each entry individually claims ~33 MB (under the 64 MB cap);
+      // together they claim ~66 MB — the total must be what's bounded.
+      final archive = Archive()
+        ..addFile(
+          ArchiveFile.bytes('a.txt', utf8.encode('a')),
+        )
+        ..addFile(
+          ArchiveFile.bytes('backup.xml', utf8.encode('<root>ok</root>')),
+        );
+      final bytes = Uint8List.fromList(ZipEncoder().encode(archive));
+      final tampered = _withClaimedUncompressedSize(bytes, 33 * 1024 * 1024);
+      expect(
+        () => reader.readXml(tampered),
+        throwsA(isA<BackupZipReadException>()),
+      );
+    });
+  });
+}
+
+/// Rewrites the `uncompressed size` field of every local file header
+/// (`PK\x03\x04`, offset +22) and central-directory file header
+/// (`PK\x01\x02`, offset +24) in [zip] to [claimed], leaving everything
+/// else — including the compressed payload — untouched. This forges the
+/// header lie a decompression bomb relies on without needing gigabytes
+/// of real data.
+Uint8List _withClaimedUncompressedSize(Uint8List zip, int claimed) {
+  final out = Uint8List.fromList(zip);
+  final view = ByteData.sublistView(out);
+  for (var i = 0; i + 4 <= out.length; i++) {
+    final signature = view.getUint32(i, Endian.little);
+    if (signature == 0x04034b50 && i + 26 <= out.length) {
+      view.setUint32(i + 22, claimed, Endian.little); // local header
+    } else if (signature == 0x02014b50 && i + 28 <= out.length) {
+      view.setUint32(i + 24, claimed, Endian.little); // central directory
+    }
+  }
+  return out;
 }

--- a/test/features/consumption/data/share/share_payload_guard_test.dart
+++ b/test/features/consumption/data/share/share_payload_guard_test.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'share_payload_guard.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('isAcceptableSharePayload (#3612 ingestion caps)', () {
+    test('accepts every extension the native receivers produce', () {
+      for (final path in [
+        '/cache/shared_receipt_1.jpg',
+        '/cache/shared_receipt_1.jpeg',
+        '/cache/shared_receipt_1.png',
+        '/cache/shared_receipt_1.webp',
+        '/cache/shared_receipt_1.pdf',
+        '/cache/UPPERCASE.JPG',
+        '/cache/mixed.Pdf',
+      ]) {
+        expect(
+          isAcceptableSharePayload(sizeBytes: 1024, path: path),
+          isTrue,
+          reason: '$path must be accepted',
+        );
+      }
+    });
+
+    test('rejects non-receipt extensions and extensionless paths', () {
+      for (final path in [
+        '/cache/statement.docx',
+        '/cache/clip.mp4',
+        '/cache/payload.svg',
+        '/cache/shared_receipt.bin',
+        '/cache/archive.zip',
+        '/cache/no_extension',
+        '/cache/trailing.',
+        '/cache/receipt.pdf.exe',
+      ]) {
+        expect(
+          isAcceptableSharePayload(sizeBytes: 1024, path: path),
+          isFalse,
+          reason: '$path must be rejected',
+        );
+      }
+    });
+
+    test('accepts a file exactly at the 16 MB cap', () {
+      expect(
+        isAcceptableSharePayload(
+          sizeBytes: kMaxSharePayloadBytes,
+          path: '/cache/big.jpg',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a file one byte over the 16 MB cap', () {
+      expect(
+        isAcceptableSharePayload(
+          sizeBytes: kMaxSharePayloadBytes + 1,
+          path: '/cache/bomb.jpg',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects zero-byte and negative sizes', () {
+      expect(
+        isAcceptableSharePayload(sizeBytes: 0, path: '/cache/empty.jpg'),
+        isFalse,
+      );
+      expect(
+        isAcceptableSharePayload(sizeBytes: -1, path: '/cache/weird.jpg'),
+        isFalse,
+      );
+    });
+
+    test('unknown size (null) passes the size check but not the '
+        'extension check', () {
+      // A file that cannot be stat-ed cannot be opened downstream either,
+      // so an unknown size is not a decompression risk — the extension
+      // rule still applies.
+      expect(
+        isAcceptableSharePayload(sizeBytes: null, path: '/gone/receipt.jpg'),
+        isTrue,
+      );
+      expect(
+        isAcceptableSharePayload(sizeBytes: null, path: '/gone/evil.apk'),
+        isFalse,
+      );
+    });
+  });
+
+  group('sharePayloadSizeBytes — never throws (#2349 fault injection)', () {
+    test('a missing / unreadable file yields null, not a throw', () {
+      const missing = '/definitely/not/here/receipt.jpg';
+      expect(() => sharePayloadSizeBytes(missing), returnsNormally,
+          reason: 'the stat failure IS the injected fault — the probe '
+              'must absorb it and report "unknown"');
+      expect(sharePayloadSizeBytes(missing), isNull);
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/share_receipt_handler_test.dart
+++ b/test/features/consumption/presentation/widgets/share_receipt_handler_test.dart
@@ -268,6 +268,120 @@ void main() {
     });
   });
 
+  group('ShareReceiptHandler.handle — ingestion caps (#3612)', () {
+    Future<ProviderContainer> pumpGuarded(
+      WidgetTester tester, {
+      required GoRouter router,
+      required int? Function(String) sizeOf,
+      required ReceiptPdfRasterizer rasterizer,
+    }) async {
+      final container = ProviderContainer(
+        overrides: [
+          enabledFeaturesProvider.overrideWithValue(featureOn),
+          routerProvider.overrideWith((_) => router),
+          shareReceiptHandlerProvider.overrideWith(
+            (ref) => ShareReceiptHandler(
+              ref,
+              pdfRasterizer: rasterizer,
+              payloadSizeBytes: sizeOf,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      return container;
+    }
+
+    testWidgets('an over-cap image is dropped — no stash, no route',
+        (tester) async {
+      final router = _router();
+      final container = await pumpGuarded(
+        tester,
+        router: router,
+        sizeOf: (_) => 17 * 1024 * 1024,
+        rasterizer: _FakeRasterizer(null),
+      );
+
+      container
+          .read(shareReceiptHandlerProvider)
+          .handle(_imageIntent('/tmp/huge.jpg'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(pendingSharedReceiptProvider), isNull,
+          reason: 'a 17 MB payload must never enter the OCR pipeline');
+      expect(find.text('home'), findsOneWidget,
+          reason: 'rejection is silent — no navigation, no snackbar');
+    });
+
+    testWidgets('an in-cap image with a real size still stashes and routes',
+        (tester) async {
+      final router = _router();
+      final container = await pumpGuarded(
+        tester,
+        router: router,
+        sizeOf: (_) => 2 * 1024 * 1024,
+        rasterizer: _FakeRasterizer(null),
+      );
+
+      container
+          .read(shareReceiptHandlerProvider)
+          .handle(_imageIntent('/tmp/receipt.jpg'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(pendingSharedReceiptProvider), '/tmp/receipt.jpg');
+      expect(find.text('add-fill-up'), findsOneWidget);
+    });
+
+    testWidgets('an over-cap PDF never reaches the rasteriser',
+        (tester) async {
+      final router = _router();
+      final fake = _FakeRasterizer('/should/not/be/used.jpg');
+      final container = await pumpGuarded(
+        tester,
+        router: router,
+        sizeOf: (_) => 17 * 1024 * 1024,
+        rasterizer: fake,
+      );
+
+      container
+          .read(shareReceiptHandlerProvider)
+          .handle(_pdfIntent('/tmp/huge.pdf'));
+      await tester.pumpAndSettle();
+
+      expect(fake.receivedPdfPath, isNull,
+          reason: 'the size cap must be enforced BEFORE the document opens');
+      expect(container.read(pendingSharedReceiptProvider), isNull);
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets(
+        'an image whose cache path has a non-receipt extension is dropped',
+        (tester) async {
+      final router = _router();
+      final container = await pumpGuarded(
+        tester,
+        router: router,
+        sizeOf: (_) => 1024,
+        rasterizer: _FakeRasterizer(null),
+      );
+
+      container
+          .read(shareReceiptHandlerProvider)
+          .handle(_imageIntent('/tmp/payload.svg'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(pendingSharedReceiptProvider), isNull,
+          reason: 'only jpg/jpeg/png/webp/pdf may enter the pipeline');
+      expect(find.text('home'), findsOneWidget);
+    });
+  });
+
   group('ShareReceiptHandler — never throws (#2349 fault injection)', () {
     testWidgets('returns normally when a downstream read throws',
         (tester) async {

--- a/test/features/widget/presentation/widget_click_listener_test.dart
+++ b/test/features/widget/presentation/widget_click_listener_test.dart
@@ -82,59 +82,109 @@ void main() {
               'trips this test and forces a review.');
     });
 
-    test('id with URL-encoded slash (ocm-42%2Ffoo) round-trips to '
-        'the decoded form', () {
-      // `%2F` decodes to `/`. The router path will contain a `/`, which
-      // downstream GoRoute parsing may treat as a path separator — but
-      // THAT is the router's concern. Here we only assert the id is
-      // passed through as decoded by `queryParameters`.
+    test('id with URL-encoded slash (ocm-42%2Ffoo) is REJECTED '
+        '(#3612 charset guard)', () {
+      // `%2F` decodes to `/`. Pre-#3612 the decoded slash flowed into
+      // the router path verbatim; the charset guard now rejects it —
+      // no real id format contains a slash, only injection attempts do.
       final path = widgetUriToPath(
         Uri.parse('tankstellenwidget://station?id=ocm-42%2Ffoo'),
       );
-      expect(path, '/ev-station/ocm-42/foo',
-          reason: 'Encoded slash decodes to a literal slash in the id, '
-              'which then becomes part of the router path. If the '
-              'router rejects that, the user sees a no-op instead of a '
-              'wrong station — acceptable trade-off.');
+      expect(path, isNull,
+          reason: 'A slash in an id can shape the router path — the '
+              '#3612 guard turns it into the same no-op as any other '
+              'invalid URI.');
     });
 
-    test('id with URL-encoded space (%20) round-trips to literal space', () {
+    test('id with URL-encoded space (%20) is REJECTED (#3612)', () {
       final path = widgetUriToPath(
         Uri.parse('tankstellenwidget://station?id=it-42%20milano'),
       );
-      expect(path, '/station/it-42 milano',
-          reason: 'Space-in-id is a pathological but legal input; the '
-              'decoder should pass it through unchanged so the router '
-              'decides what to do — rather than silently mangling it '
-              'into a different id.');
+      expect(path, isNull,
+          reason: 'No real station id contains a space; the #3612 '
+              'charset guard rejects it rather than routing a mangled '
+              'path.');
     });
 
-    test('id with a literal space — Uri parse treats as separator; '
-        'behaviour must be deterministic (not random across runs)', () {
+    test('id with a literal space is REJECTED — deterministically (#3612)',
+        () {
       // An un-encoded space in a URI is illegal but `Uri.parse` is
-      // forgiving. Behaviour is deterministic across Dart VM runs;
-      // lock it in so a future `Uri` upgrade doesn't silently change
-      // what the widget tap does.
+      // forgiving and keeps the space in queryParameters. The #3612
+      // guard rejects it; lock the behaviour in so a future `Uri`
+      // upgrade doesn't silently change what the widget tap does.
       final uri = Uri.parse('tankstellenwidget://station?id=de abc');
-      final path = widgetUriToPath(uri);
-      // Dart's Uri parser keeps the space as-is in queryParameters.
-      expect(path, '/station/de abc');
+      expect(widgetUriToPath(uri), isNull);
     });
 
     test('id with `+` decodes to space per `application/x-www-form-urlencoded` '
-        '(form-encoded query — the exact behaviour of Uri.queryParameters)',
-        () {
-      // Not the bug, but #753 diagnostics need to know `+` is not a
-      // literal plus in this decoder. If a country's id ever contains
-      // `+`, the native side must `%2B`-encode it or the Flutter side
-      // will see a space.
+        'and is therefore REJECTED (#3612)', () {
+      // #753 diagnostics need to know `+` is not a literal plus in this
+      // decoder: `Uri.queryParameters` decodes it to a space, which the
+      // #3612 charset guard rejects. If a country's id ever contains
+      // `+`, the native side must `%2B`-encode it — and the guard's
+      // charset must be widened deliberately.
       final path = widgetUriToPath(
         Uri.parse('tankstellenwidget://station?id=a+b'),
       );
-      expect(path, '/station/a b',
-          reason: 'Uri.queryParameters decodes `+` as space. A real id '
-              'containing `+` must be pre-encoded as `%2B` on the '
-              'Kotlin side or the app will open a sibling station.');
+      expect(path, isNull);
+    });
+  });
+
+  group('widgetUriToPath (#3612 — id charset guard)', () {
+    test('accepts an ocm-prefixed EV id', () {
+      expect(
+        widgetUriToPath(
+          Uri.parse('tankstellenwidget://station?id=ocm-149681'),
+        ),
+        '/ev-station/ocm-149681',
+      );
+    });
+
+    test('accepts a tankerkoenig-style UUID id', () {
+      expect(
+        widgetUriToPath(
+          Uri.parse('tankstellenwidget://station'
+              '?id=51d4b671-a095-1aa0-e100-80009459e03a'),
+        ),
+        '/station/51d4b671-a095-1aa0-e100-80009459e03a',
+      );
+    });
+
+    test('rejects a path-traversal shaped id (../)', () {
+      expect(
+        widgetUriToPath(
+          Uri.parse('tankstellenwidget://station?id=..%2F..%2Fsettings'),
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects an id containing quotes', () {
+      expect(
+        widgetUriToPath(
+          Uri.parse('tankstellenwidget://station?id=%22onclick%22'),
+        ),
+        isNull,
+      );
+      expect(
+        widgetUriToPath(
+          Uri.parse("tankstellenwidget://station?id=it-42'or'1"),
+        ),
+        isNull,
+      );
+    });
+
+    test('accepts a 64-char id but rejects 65 chars', () {
+      final ok = 'a' * 64;
+      final tooLong = 'a' * 65;
+      expect(
+        widgetUriToPath(Uri.parse('tankstellenwidget://station?id=$ok')),
+        '/station/$ok',
+      );
+      expect(
+        widgetUriToPath(Uri.parse('tankstellenwidget://station?id=$tooLong')),
+        isNull,
+      );
     });
   });
 


### PR DESCRIPTION
Audit child 3: keyed/integer coordinate + JWT scrubbing, 16MB/mime caps on inbound share payloads, widget deep-link station-id charset guard, backup-zip entry-count + decompressed-size caps (+ verified package:xml no-XXE note). Gates ran in the worktree: analyze 0, clean codegen zero-drift, 1183 adjacent tests green. Closes #3612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G