### PR TITLE
perf: summary-only trip decode, banner select, cache byte-stamp, gated widget heartbeat (#3613)

### DIFF
--- a/lib/app/startup/launch_sync_pulls.dart
+++ b/lib/app/startup/launch_sync_pulls.dart
@@ -118,7 +118,13 @@ class LaunchSyncPulls {
       final repo = TripHistoryRepository(
         box: Hive.box<String>(HiveBoxes.obd2TripHistory),
       );
-      changed = await mergeAndPruneTrips(repo, TripsSync.merge);
+      // #3613 — the merge input is summary-only decoded; the details-heal
+      // upload inside TripsSync.merge re-hydrates the (rare) local-only
+      // entries one by one via loadById.
+      changed = await mergeAndPruneTrips(
+        repo,
+        (local) => TripsSync.merge(local, loadFull: repo.loadById),
+      );
       await TripsSync.pruneOldDetails();
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.sync, e, st,
@@ -151,8 +157,15 @@ class LaunchSyncPulls {
     TripHistoryRepository repo,
     Future<List<TripHistoryEntry>> Function(List<TripHistoryEntry>) merge,
   ) async {
-    final local = repo.loadAll();
-    final localIds = local.map((e) => e.id).toSet();
+    // #3613 — the "is it already stored?" check reads the raw box keys
+    // (the box is keyed by entry.id) instead of decoding every entry,
+    // and the merge reconciles at summary level: [merge] only reads
+    // ids + summaries here (its details-heal upload hydrates the rare
+    // local-only entries itself — see TripsSync.merge/loadFull). The
+    // merged local entries are never written back below, so their empty
+    // samples lists can't clobber stored telemetry.
+    final localIds = repo.storedIds.toSet();
+    final local = repo.loadSummaries();
     final merged = await merge(local);
     final mergedIds = merged.map((e) => e.id).toSet();
     var changed = 0;

--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -41,12 +41,22 @@ class CacheEntry {
   /// the stale/offline fallback via [CacheManager.get]).
   final String? appBuild;
 
+  /// JSON-encoded size of [payload], stamped once at `put()` time
+  /// (#3613), or `null` for an entry persisted by a build that predates
+  /// the stamp. The eviction byte sweep used to `jsonEncode` EVERY
+  /// surviving payload on EVERY 30-min pass just to estimate its size;
+  /// stamping at write time makes the sweep read a stored int instead.
+  /// Legacy entries without the stamp fall back to one re-encode per
+  /// sweep until they age out (3× TTL) or are overwritten.
+  final int? approxBytes;
+
   CacheEntry({
     required this.payload,
     required this.storedAt,
     required this.originalSource,
     required this.ttl,
     this.appBuild,
+    this.approxBytes,
   });
 
   bool get isExpired => DateTime.now().difference(storedAt) > ttl;
@@ -123,6 +133,12 @@ class CacheManager implements CacheStrategy {
         // #3219 follow-up — stamp the writing build so [getFresh] can
         // refuse to serve another build's PARSED payload as fresh.
         'appBuild': AppConstants.appVersion,
+        // #3613 — stamp the payload's encoded byte length once here so
+        // the eviction byte sweep never has to re-encode it. `dataset:`
+        // entries are exempt from the byte sweep (#3155), so encoding
+        // their multi-MB payloads just to stamp a never-read number
+        // would be waste — they stay unstamped.
+        if (!key.startsWith('dataset:')) 'bytes': _encodedLength(data),
       });
     } on FileSystemException catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
@@ -158,6 +174,8 @@ class CacheManager implements CacheStrategy {
       originalSource: _sourceFrom(raw['source']),
       ttl: Duration(milliseconds: raw['ttlMs'] as int? ?? 300000),
       appBuild: raw['appBuild'] as String?,
+      // #3613 — absent on pre-stamp entries → null (sweep re-encodes).
+      approxBytes: raw['bytes'] as int?,
     );
   }
 
@@ -311,13 +329,22 @@ class CacheManager implements CacheStrategy {
     return i < 0 ? key : key.substring(0, i + 1);
   }
 
-  /// Cheap byte estimate for an entry — the length of its JSON-encoded
-  /// payload. Avoids re-encoding the Hive envelope; good enough to drive the
-  /// LRU ceiling.
-  static int _approxBytes(CacheEntry entry) {
+  /// Cheap byte estimate for an entry — the byte length stamped at
+  /// `put()` time (#3613), falling back to a one-off re-encode for
+  /// legacy entries persisted before the stamp existed. Good enough to
+  /// drive the LRU ceiling.
+  static int _approxBytes(CacheEntry entry) =>
+      entry.approxBytes ?? _encodedLength(entry.payload);
+
+  /// JSON-encoded length of [payload]; 0 when it can't be encoded (an
+  /// unencodable payload contributes nothing to the byte ceiling —
+  /// pre-#3613 behaviour).
+  static int _encodedLength(Map<String, dynamic> payload) {
     try {
-      return jsonEncode(entry.payload).length;
-    } on Object {
+      return jsonEncode(payload).length;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'CacheManager: payload byte estimate'}));
       return 0;
     }
   }

--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -179,9 +179,19 @@ class TripsSync {
   ///   phase 4).
   /// - Decode failures are skipped silently — one corrupt row should
   ///   never block the whole merge.
+  ///
+  /// #3613 — [localEntries] may be SUMMARY-ONLY decoded (empty `samples`
+  /// with the stored count on `sampleCount`): the reconcile itself only
+  /// reads ids + summaries. The one step that needs the heavy payload —
+  /// the local-only `trip_details` heal upload — hydrates each candidate
+  /// through [loadFull] (typically `TripHistoryRepository.loadById`)
+  /// right before uploading, so in the steady state (no local-only
+  /// entries) not a single sample is ever materialised. Pass null when
+  /// [localEntries] are already fully decoded.
   static Future<List<TripHistoryEntry>> merge(
-    List<TripHistoryEntry> localEntries,
-  ) async {
+    List<TripHistoryEntry> localEntries, {
+    TripHistoryEntry? Function(String id)? loadFull,
+  }) async {
     final client = TankSyncClient.client;
     final userId = client?.auth.currentUser?.id;
     if (client == null || userId == null) {
@@ -211,7 +221,16 @@ class TripsSync {
       // one upsert each instead of a serial per-entry loop.
       final localOnly =
           liveLocal.where((e) => !serverIds.contains(e.id)).toList();
-      await _uploadBatch(client, userId, localOnly);
+      // #3613 — re-hydrate summary-only entries so the details-heal
+      // upload still carries the samples/gpsd blob. A failed hydrate
+      // falls back to the entry we have (summary heals, details retry
+      // on the next pass — same as a pre-#3613 0-sample entry).
+      final uploadable = loadFull == null
+          ? localOnly
+          : localOnly
+              .map((e) => loadFull(e.id) ?? e)
+              .toList(growable: false);
+      await _uploadBatch(client, userId, uploadable);
 
       // Decode server-only rows (off the UI isolate, #3451) and return the
       // union the launch caller persists back to Hive (#2239 pins mergeRows).

--- a/lib/features/consumption/data/trip_dedup.dart
+++ b/lib/features/consumption/data/trip_dedup.dart
@@ -44,16 +44,19 @@ List<TripHistoryEntry> dedupeGhostTrips(List<TripHistoryEntry> entries) {
 
   // Index the sampled entries by their summary key so the membership
   // test is O(1) per candidate ghost rather than O(n²) overall.
+  // #3613 — sampled-ness is read off `sampleCount`, not `samples`, so
+  // the de-dupe stays correct on summary-only decoded entries (whose
+  // samples list is deliberately never materialised).
   final sampledByKey = <String, List<TripHistoryEntry>>{};
   for (final e in entries) {
-    if (e.samples.isEmpty) continue;
+    if (e.sampleCount == 0) continue;
     (sampledByKey[_summaryKey(e.summary)] ??= <TripHistoryEntry>[]).add(e);
   }
   if (sampledByKey.isEmpty) return entries;
 
   final result = <TripHistoryEntry>[];
   for (final e in entries) {
-    if (e.samples.isEmpty && _hasSampledTwin(e, sampledByKey)) {
+    if (e.sampleCount == 0 && _hasSampledTwin(e, sampledByKey)) {
       // Drop the ghost — its full-sample twin survives.
       continue;
     }
@@ -74,12 +77,12 @@ Future<bool> guardGhostDoubleSave({
   required List<TripHistoryEntry> existing,
   required Future<void> Function(String id) deleteById,
 }) async {
-  if (entry.samples.isEmpty) {
+  if (entry.sampleCount == 0) {
     final survivors = dedupeGhostTrips([...existing, entry]);
     return !survivors.any((e) => identical(e, entry) || e.id == entry.id);
   }
   for (final other in existing) {
-    if (other.id == entry.id || other.samples.isNotEmpty) continue;
+    if (other.id == entry.id || other.sampleCount > 0) continue;
     final survivors = dedupeGhostTrips([entry, other]);
     if (!survivors.any((e) => e.id == other.id)) {
       await deleteById(other.id);

--- a/lib/features/consumption/data/trip_history_entry.dart
+++ b/lib/features/consumption/data/trip_history_entry.dart
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import '../domain/entities/gps_sample_diagnostic.dart';
+import '../domain/entities/recording_lifecycle_mark.dart';
+import '../domain/trip_recorder.dart';
+import '../../obd2/api.dart';
+import 'trip_sample_codec.dart';
+import 'trip_summary_codec.dart';
+
+/// One finalised trip as shown in the Trip history list (#726).
+///
+/// Wraps a [TripSummary] with the persisted bookkeeping fields — a
+/// stable id so list widgets can key on it, and the vehicleId so the
+/// list can be filtered down the road. The summary already carries
+/// `startedAt` / `endedAt`; we don't duplicate those here.
+///
+/// Extracted from `trip_history_repository.dart` (#3613) so the
+/// repository could gain the summary-only decode path without breaching
+/// the 400-line cap; that file re-exports this one, so every existing
+/// import keeps working.
+@immutable
+class TripHistoryEntry {
+  final String id;
+  final String? vehicleId;
+  final TripSummary summary;
+
+  /// Whether this trip was captured by the auto-record path
+  /// (#1004 phase 4). Drives the badge-decrement call when the user
+  /// opens the detail screen — manual trips don't decrement because
+  /// they were never counted as "unseen". Defaults to false so all
+  /// pre-#1004 entries deserialise as manual.
+  final bool automatic;
+
+  /// Per-tick recording profile used by the trip-detail charts (#1040).
+  ///
+  /// Captured by [TripRecordingController] at ~1 Hz throughout the
+  /// recording — the speed / RPM / fuel-rate fields render the
+  /// speed / fuel-rate / RPM line charts in the trip-detail screen.
+  /// Empty for legacy trips written before #1040 landed: the charts
+  /// fall back to the shared "No samples recorded" caption in that
+  /// case, which is the honest answer for trips whose buffer was
+  /// never persisted.
+  ///
+  /// Storage budget: ~1 Hz × 8 fields, so a 39-min trip is roughly
+  /// 19 KB compressed. A year of daily commutes is around 7 MB —
+  /// well below the rolling-log cap.
+  ///
+  /// #3613 — ALWAYS empty on entries produced by
+  /// [TripHistoryRepository.loadSummaries]; use [sampleCount] (not
+  /// `samples.length` / `samples.isEmpty`) wherever the *stored*
+  /// sample count matters (ghost de-dupe, badges), because it stays
+  /// truthful on the summary-only decode path.
+  final List<TripSample> samples;
+
+  /// The number of samples the PERSISTED entry carries (#3613).
+  ///
+  /// On a fully-decoded entry this is simply `samples.length`. On a
+  /// summary-only entry (from [TripHistoryRepository.loadSummaries])
+  /// the samples list is deliberately not materialised, but the stored
+  /// count is preserved here so summary-level consumers — most
+  /// importantly the #2833 ghost de-dupe, which distinguishes 0-sample
+  /// ghosts from their sampled twins — keep working unchanged.
+  int get sampleCount => _persistedSampleCount ?? samples.length;
+  final int? _persistedSampleCount;
+
+  /// Stable BLE remote-id / Classic MAC of the OBD2 adapter that was
+  /// connected when this trip was recorded (#1312). Lets the trip
+  /// detail summary card name the suspect device when the user files
+  /// a bug report about adapter-specific PID gaps. Null for trips
+  /// recorded before #1312 landed and for any trip whose connect path
+  /// didn't stamp the service (e.g. test fakes).
+  final String? adapterMac;
+  /// Friendly device name advertised by the OBD2 adapter, falling
+  /// back to the registry's display label when the advertisement was
+  /// empty (#1312). Same null-semantics as [adapterMac].
+  final String? adapterName;
+  /// ELM327 firmware string returned by `ATI` during the init
+  /// sequence, when the connect path captured one (#1312). Currently
+  /// always null in production; persisted as a forward-compat field
+  /// so a future enhancement that snapshots `ATI` doesn't have to
+  /// migrate the trip-history schema again.
+  final String? adapterFirmware;
+
+  /// Per-sample GPS cadence diagnostics captured under phone-sleep
+  /// conditions (#1458 phase 2). Records the wall-clock timestamp and
+  /// app-lifecycle state at every position fix, plus a monotonic index
+  /// — lets a future diagnostics sheet (or a power user inspecting
+  /// the persisted entry) reconstruct exactly when the OS throttled or
+  /// paused the GPS stream during an unpinned recording. Empty for
+  /// trips recorded before #1458 phase 2 landed and for trips whose
+  /// `Feature.gpsTripPath` flag was off at recording start.
+  final List<GpsSampleDiagnostic> gpsSampleDiagnostics;
+
+  /// Foreground↔background transitions observed during the recording,
+  /// windowed to the trip (#3465). A tiny list (one entry per transition,
+  /// led by a clamped trip-start anchor — see
+  /// `RecordingLifecycleMarksRecorder.marksForWindow`) that lets the
+  /// post-hoc GPS coverage report attribute a track gap to OS background
+  /// throttling on a no-FGS build. Empty for legacy trips recorded before
+  /// this field landed.
+  final List<RecordingLifecycleMark> lifecycleMarks;
+
+  /// OBD2 communication-health diagnostic snapshotted at trip finish
+  /// (#2912, Epic #2904). The dev-only trip-detail comm-health card was
+  /// **always empty** because it read the process-wide in-memory
+  /// `Obd2CommDiagnostics.instance` singleton — wiped on restart and never
+  /// tied to a trip — instead of the viewed trip's own diagnostic. This
+  /// field persists the per-trip snapshot (connection attempts + the #2905
+  /// reconnect timeline / session-state transitions / fallback markers,
+  /// captured even when the adapter never connected) so the card can render
+  /// THIS trip's health after a restart.
+  ///
+  /// Null for GPS-only trips that never touched OBD2, for production builds
+  /// (the collector is disarmed unless `Feature.debugMode` is on), and for
+  /// every legacy trip recorded before this field landed — in all of which
+  /// the card keeps self-hiding. Round-trips via the existing JSON
+  /// persistence under the compact key `'obd2d'`; the nested freezed model
+  /// carries its own `toJson`/`fromJson` (heeding the #2776 round-trip
+  /// lesson — it is a real serialised field, not `@JsonKey`-excluded).
+  final Obd2SessionDiagnostic? obd2Diagnostic;
+
+  /// The driver's own post-trip verdict (#3501) — `TripVerdict.name`, or
+  /// null while the prompt hasn't been answered. `skipped` records a
+  /// dismissal so the prompt never nags twice for the same trip.
+  final String? verdict;
+
+  const TripHistoryEntry({
+    required this.id,
+    required this.vehicleId,
+    required this.summary,
+    this.automatic = false,
+    this.samples = const [],
+    int? sampleCount,
+    this.adapterMac,
+    this.adapterName,
+    this.adapterFirmware,
+    this.gpsSampleDiagnostics = const [],
+    this.lifecycleMarks = const [],
+    this.obd2Diagnostic,
+    this.verdict,
+  }) : _persistedSampleCount = sampleCount;
+
+  /// Returns a copy with the given fields replaced (#1858). The
+  /// retroactive η_v recompute uses it to swap in a rescaled [summary]
+  /// while leaving the id / vehicle / samples / adapter identity
+  /// untouched.
+  TripHistoryEntry copyWith({TripSummary? summary, String? verdict}) =>
+      TripHistoryEntry(
+        id: id,
+        vehicleId: vehicleId,
+        summary: summary ?? this.summary,
+        automatic: automatic,
+        samples: samples,
+        sampleCount: _persistedSampleCount,
+        adapterMac: adapterMac,
+        adapterName: adapterName,
+        adapterFirmware: adapterFirmware,
+        gpsSampleDiagnostics: gpsSampleDiagnostics,
+        lifecycleMarks: lifecycleMarks,
+        obd2Diagnostic: obd2Diagnostic,
+        verdict: verdict ?? this.verdict,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'vehicleId': vehicleId,
+        'summary': tripSummaryToJson(summary),
+        if (automatic) 'automatic': true,
+        if (samples.isNotEmpty)
+          'samples': samples.map(sampleToJson).toList(growable: false),
+        // #1312 — adapter identity. Compact keys so the per-trip JSON
+        // payload doesn't balloon (most trips carry one MAC + one
+        // name; firmware stays null until the connect path captures
+        // it). Each key is omitted when null so legacy entries
+        // round-trip unchanged.
+        if (adapterMac != null) 'adapterMac': adapterMac,
+        if (adapterName != null) 'adapterName': adapterName,
+        if (adapterFirmware != null) 'adapterFirmware': adapterFirmware,
+        // #1458 phase 2 — GPS cadence diagnostics. Compact key 'gpsd'
+        // keeps the per-trip JSON tight; emitted only when at least one
+        // diagnostic was recorded so legacy trips and flag-off trips
+        // round-trip unchanged.
+        if (gpsSampleDiagnostics.isNotEmpty)
+          'gpsd': gpsSampleDiagnostics
+              .map((d) => d.toJson())
+              .toList(growable: false),
+        // #3465 — recording lifecycle marks. Compact key 'lcm', emitted
+        // only when at least one mark was captured, so legacy trips
+        // round-trip unchanged (the mq/ep additive-optional precedent).
+        if (lifecycleMarks.isNotEmpty)
+          'lcm':
+              lifecycleMarks.map((m) => m.toJson()).toList(growable: false),
+        // #2912 — per-trip OBD2 comm-health diagnostic. Compact key 'obd2d'.
+        // Emitted only when a diagnostic was captured (debug-mode trips that
+        // touched OBD2), so production / GPS-only / legacy trips round-trip
+        // with zero bytes added. The nested freezed model serialises itself
+        // via its own short-keyed toJson, so the persisted snapshot reloads
+        // intact (NOT @JsonKey-dropped — #2776 lesson).
+        if (obd2Diagnostic != null) 'obd2d': obd2Diagnostic!.toJson(),
+        // #3501 — the driver's post-trip verdict. Omitted when unanswered so
+        // legacy entries round-trip unchanged. A synced-entity FIELD add is
+        // TankSync-transparent (JSONB data column, #2929).
+        if (verdict != null) 'verdict': verdict,
+      };
+
+  static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
+      TripHistoryEntry(
+        id: json['id'] as String,
+        vehicleId: json['vehicleId'] as String?,
+        summary: tripSummaryFromJson(
+          (json['summary'] as Map).cast<String, dynamic>(),
+        ),
+        automatic: (json['automatic'] as bool?) ?? false,
+        samples: (json['samples'] as List?)
+                ?.map(
+                    (e) => sampleFromJson((e as Map).cast<String, dynamic>()))
+                .toList(growable: false) ??
+            const [],
+        // #1312 — adapter identity. Reads as `String?` so legacy
+        // entries written before this field landed deserialise with
+        // null rather than throwing (mirrors the schema-drift lesson
+        // from #1301).
+        adapterMac: json['adapterMac'] as String?,
+        adapterName: json['adapterName'] as String?,
+        adapterFirmware: json['adapterFirmware'] as String?,
+        // #1458 phase 2 — GPS cadence diagnostics. Missing key →
+        // empty list so trips recorded before this PR (and flag-off
+        // trips that never recorded a diagnostic) deserialise cleanly.
+        gpsSampleDiagnostics: (json['gpsd'] as List?)
+                ?.map((e) => GpsSampleDiagnostic.fromJson(
+                      (e as Map).cast<String, dynamic>(),
+                    ))
+                .toList(growable: false) ??
+            const [],
+        // #3465 — recording lifecycle marks. Missing key → empty list so
+        // legacy trips deserialise cleanly (and the coverage report reads
+        // "no marks" as its honest unknown-attribution input).
+        lifecycleMarks: (json['lcm'] as List?)
+                ?.map((e) => RecordingLifecycleMark.fromJson(
+                      (e as Map).cast<String, dynamic>(),
+                    ))
+                .toList(growable: false) ??
+            const [],
+        // #2912 — per-trip OBD2 comm-health diagnostic. Missing key → null
+        // so legacy trips, GPS-only trips and production (gate-off) trips
+        // deserialise cleanly and the card keeps self-hiding for them.
+        obd2Diagnostic: json['obd2d'] == null
+            ? null
+            : Obd2SessionDiagnostic.fromJson(
+                (json['obd2d'] as Map).cast<String, dynamic>(),
+              ),
+        // #3501 — missing key → null (unanswered) on legacy entries.
+        verdict: json['verdict'] as String?,
+      );
+
+  /// Summary-only decode (#3613) — everything [fromJson] produces
+  /// EXCEPT the heavy per-tick payloads: `samples`, `gpsd`, `lcm` and
+  /// `obd2d` are NOT materialised (jsonDecode has already parsed them
+  /// into raw maps; the dominant cost this path avoids is constructing
+  /// a [TripSample] / [GpsSampleDiagnostic] object per tick — tens of
+  /// thousands per long trip). The stored sample count is preserved on
+  /// [sampleCount] so the #2833 ghost de-dupe stays correct.
+  ///
+  /// Only [TripHistoryRepository.loadSummaries] should call this;
+  /// consumers that render samples must go through the full decode.
+  static TripHistoryEntry summaryFromJson(Map<String, dynamic> json) =>
+      TripHistoryEntry(
+        id: json['id'] as String,
+        vehicleId: json['vehicleId'] as String?,
+        summary: tripSummaryFromJson(
+          (json['summary'] as Map).cast<String, dynamic>(),
+        ),
+        automatic: (json['automatic'] as bool?) ?? false,
+        samples: const [],
+        sampleCount: (json['samples'] as List?)?.length ?? 0,
+        adapterMac: json['adapterMac'] as String?,
+        adapterName: json['adapterName'] as String?,
+        adapterFirmware: json['adapterFirmware'] as String?,
+        verdict: json['verdict'] as String?,
+      );
+}

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -7,238 +7,23 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
-import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/trip_verdict.dart';
-import '../domain/entities/recording_lifecycle_mark.dart';
-import '../domain/trip_recorder.dart';
-import '../../obd2/api.dart';
 import 'trip_dedup.dart';
-import 'trip_sample_codec.dart';
-import 'trip_summary_codec.dart';
+import 'trip_history_entry.dart';
 import '../../../core/logging/error_logger.dart';
 
-/// One finalised trip as shown in the Trip history list (#726).
-///
-/// Wraps a [TripSummary] with the persisted bookkeeping fields — a
-/// stable id so list widgets can key on it, and the vehicleId so the
-/// list can be filtered down the road. The summary already carries
-/// `startedAt` / `endedAt`; we don't duplicate those here.
-@immutable
-class TripHistoryEntry {
-  final String id;
-  final String? vehicleId;
-  final TripSummary summary;
+// #3613 — TripHistoryEntry moved into its own file so this one stays
+// under the 400-line cap; the re-export keeps every existing
+// `trip_history_repository.dart` import working.
+export 'trip_history_entry.dart';
 
-  /// Whether this trip was captured by the auto-record path
-  /// (#1004 phase 4). Drives the badge-decrement call when the user
-  /// opens the detail screen — manual trips don't decrement because
-  /// they were never counted as "unseen". Defaults to false so all
-  /// pre-#1004 entries deserialise as manual.
-  final bool automatic;
-
-  /// Per-tick recording profile used by the trip-detail charts (#1040).
-  ///
-  /// Captured by [TripRecordingController] at ~1 Hz throughout the
-  /// recording — the speed / RPM / fuel-rate fields render the
-  /// speed / fuel-rate / RPM line charts in the trip-detail screen.
-  /// Empty for legacy trips written before #1040 landed: the charts
-  /// fall back to the shared "No samples recorded" caption in that
-  /// case, which is the honest answer for trips whose buffer was
-  /// never persisted.
-  ///
-  /// Storage budget: ~1 Hz × 8 fields, so a 39-min trip is roughly
-  /// 19 KB compressed. A year of daily commutes is around 7 MB —
-  /// well below the rolling-log cap.
-  final List<TripSample> samples;
-
-  /// Stable BLE remote-id / Classic MAC of the OBD2 adapter that was
-  /// connected when this trip was recorded (#1312). Lets the trip
-  /// detail summary card name the suspect device when the user files
-  /// a bug report about adapter-specific PID gaps. Null for trips
-  /// recorded before #1312 landed and for any trip whose connect path
-  /// didn't stamp the service (e.g. test fakes).
-  final String? adapterMac;
-  /// Friendly device name advertised by the OBD2 adapter, falling
-  /// back to the registry's display label when the advertisement was
-  /// empty (#1312). Same null-semantics as [adapterMac].
-  final String? adapterName;
-  /// ELM327 firmware string returned by `ATI` during the init
-  /// sequence, when the connect path captured one (#1312). Currently
-  /// always null in production; persisted as a forward-compat field
-  /// so a future enhancement that snapshots `ATI` doesn't have to
-  /// migrate the trip-history schema again.
-  final String? adapterFirmware;
-
-  /// Per-sample GPS cadence diagnostics captured under phone-sleep
-  /// conditions (#1458 phase 2). Records the wall-clock timestamp and
-  /// app-lifecycle state at every position fix, plus a monotonic index
-  /// — lets a future diagnostics sheet (or a power user inspecting
-  /// the persisted entry) reconstruct exactly when the OS throttled or
-  /// paused the GPS stream during an unpinned recording. Empty for
-  /// trips recorded before #1458 phase 2 landed and for trips whose
-  /// `Feature.gpsTripPath` flag was off at recording start.
-  final List<GpsSampleDiagnostic> gpsSampleDiagnostics;
-
-  /// Foreground↔background transitions observed during the recording,
-  /// windowed to the trip (#3465). A tiny list (one entry per transition,
-  /// led by a clamped trip-start anchor — see
-  /// `RecordingLifecycleMarksRecorder.marksForWindow`) that lets the
-  /// post-hoc GPS coverage report attribute a track gap to OS background
-  /// throttling on a no-FGS build. Empty for legacy trips recorded before
-  /// this field landed.
-  final List<RecordingLifecycleMark> lifecycleMarks;
-
-  /// OBD2 communication-health diagnostic snapshotted at trip finish
-  /// (#2912, Epic #2904). The dev-only trip-detail comm-health card was
-  /// **always empty** because it read the process-wide in-memory
-  /// `Obd2CommDiagnostics.instance` singleton — wiped on restart and never
-  /// tied to a trip — instead of the viewed trip's own diagnostic. This
-  /// field persists the per-trip snapshot (connection attempts + the #2905
-  /// reconnect timeline / session-state transitions / fallback markers,
-  /// captured even when the adapter never connected) so the card can render
-  /// THIS trip's health after a restart.
-  ///
-  /// Null for GPS-only trips that never touched OBD2, for production builds
-  /// (the collector is disarmed unless `Feature.debugMode` is on), and for
-  /// every legacy trip recorded before this field landed — in all of which
-  /// the card keeps self-hiding. Round-trips via the existing JSON
-  /// persistence under the compact key `'obd2d'`; the nested freezed model
-  /// carries its own `toJson`/`fromJson` (heeding the #2776 round-trip
-  /// lesson — it is a real serialised field, not `@JsonKey`-excluded).
-  final Obd2SessionDiagnostic? obd2Diagnostic;
-
-  /// The driver's own post-trip verdict (#3501) — `TripVerdict.name`, or
-  /// null while the prompt hasn't been answered. `skipped` records a
-  /// dismissal so the prompt never nags twice for the same trip.
-  final String? verdict;
-
-  const TripHistoryEntry({
-    required this.id,
-    required this.vehicleId,
-    required this.summary,
-    this.automatic = false,
-    this.samples = const [],
-    this.adapterMac,
-    this.adapterName,
-    this.adapterFirmware,
-    this.gpsSampleDiagnostics = const [],
-    this.lifecycleMarks = const [],
-    this.obd2Diagnostic,
-    this.verdict,
-  });
-
-  /// Returns a copy with the given fields replaced (#1858). The
-  /// retroactive η_v recompute uses it to swap in a rescaled [summary]
-  /// while leaving the id / vehicle / samples / adapter identity
-  /// untouched.
-  TripHistoryEntry copyWith({TripSummary? summary, String? verdict}) =>
-      TripHistoryEntry(
-        id: id,
-        vehicleId: vehicleId,
-        summary: summary ?? this.summary,
-        automatic: automatic,
-        samples: samples,
-        adapterMac: adapterMac,
-        adapterName: adapterName,
-        adapterFirmware: adapterFirmware,
-        gpsSampleDiagnostics: gpsSampleDiagnostics,
-        lifecycleMarks: lifecycleMarks,
-        obd2Diagnostic: obd2Diagnostic,
-        verdict: verdict ?? this.verdict,
-      );
-
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'vehicleId': vehicleId,
-        'summary': tripSummaryToJson(summary),
-        if (automatic) 'automatic': true,
-        if (samples.isNotEmpty)
-          'samples': samples.map(sampleToJson).toList(growable: false),
-        // #1312 — adapter identity. Compact keys so the per-trip JSON
-        // payload doesn't balloon (most trips carry one MAC + one
-        // name; firmware stays null until the connect path captures
-        // it). Each key is omitted when null so legacy entries
-        // round-trip unchanged.
-        if (adapterMac != null) 'adapterMac': adapterMac,
-        if (adapterName != null) 'adapterName': adapterName,
-        if (adapterFirmware != null) 'adapterFirmware': adapterFirmware,
-        // #1458 phase 2 — GPS cadence diagnostics. Compact key 'gpsd'
-        // keeps the per-trip JSON tight; emitted only when at least one
-        // diagnostic was recorded so legacy trips and flag-off trips
-        // round-trip unchanged.
-        if (gpsSampleDiagnostics.isNotEmpty)
-          'gpsd': gpsSampleDiagnostics
-              .map((d) => d.toJson())
-              .toList(growable: false),
-        // #3465 — recording lifecycle marks. Compact key 'lcm', emitted
-        // only when at least one mark was captured, so legacy trips
-        // round-trip unchanged (the mq/ep additive-optional precedent).
-        if (lifecycleMarks.isNotEmpty)
-          'lcm':
-              lifecycleMarks.map((m) => m.toJson()).toList(growable: false),
-        // #2912 — per-trip OBD2 comm-health diagnostic. Compact key 'obd2d'.
-        // Emitted only when a diagnostic was captured (debug-mode trips that
-        // touched OBD2), so production / GPS-only / legacy trips round-trip
-        // with zero bytes added. The nested freezed model serialises itself
-        // via its own short-keyed toJson, so the persisted snapshot reloads
-        // intact (NOT @JsonKey-dropped — #2776 lesson).
-        if (obd2Diagnostic != null) 'obd2d': obd2Diagnostic!.toJson(),
-        // #3501 — the driver's post-trip verdict. Omitted when unanswered so
-        // legacy entries round-trip unchanged. A synced-entity FIELD add is
-        // TankSync-transparent (JSONB data column, #2929).
-        if (verdict != null) 'verdict': verdict,
-      };
-
-  static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
-      TripHistoryEntry(
-        id: json['id'] as String,
-        vehicleId: json['vehicleId'] as String?,
-        summary: tripSummaryFromJson(
-          (json['summary'] as Map).cast<String, dynamic>(),
-        ),
-        automatic: (json['automatic'] as bool?) ?? false,
-        samples: (json['samples'] as List?)
-                ?.map(
-                    (e) => sampleFromJson((e as Map).cast<String, dynamic>()))
-                .toList(growable: false) ??
-            const [],
-        // #1312 — adapter identity. Reads as `String?` so legacy
-        // entries written before this field landed deserialise with
-        // null rather than throwing (mirrors the schema-drift lesson
-        // from #1301).
-        adapterMac: json['adapterMac'] as String?,
-        adapterName: json['adapterName'] as String?,
-        adapterFirmware: json['adapterFirmware'] as String?,
-        // #1458 phase 2 — GPS cadence diagnostics. Missing key →
-        // empty list so trips recorded before this PR (and flag-off
-        // trips that never recorded a diagnostic) deserialise cleanly.
-        gpsSampleDiagnostics: (json['gpsd'] as List?)
-                ?.map((e) => GpsSampleDiagnostic.fromJson(
-                      (e as Map).cast<String, dynamic>(),
-                    ))
-                .toList(growable: false) ??
-            const [],
-        // #3465 — recording lifecycle marks. Missing key → empty list so
-        // legacy trips deserialise cleanly (and the coverage report reads
-        // "no marks" as its honest unknown-attribution input).
-        lifecycleMarks: (json['lcm'] as List?)
-                ?.map((e) => RecordingLifecycleMark.fromJson(
-                      (e as Map).cast<String, dynamic>(),
-                    ))
-                .toList(growable: false) ??
-            const [],
-        // #2912 — per-trip OBD2 comm-health diagnostic. Missing key → null
-        // so legacy trips, GPS-only trips and production (gate-off) trips
-        // deserialise cleanly and the card keeps self-hiding for them.
-        obd2Diagnostic: json['obd2d'] == null
-            ? null
-            : Obd2SessionDiagnostic.fromJson(
-                (json['obd2d'] as Map).cast<String, dynamic>(),
-              ),
-        // #3501 — missing key → null (unanswered) on legacy entries.
-        verdict: json['verdict'] as String?,
-      );
-}
+/// #3613 — above this stored-sample count, [TripHistoryRepository.save]
+/// runs `jsonEncode` on a background isolate via `compute()` (mirroring
+/// the sync layer's one-`compute()`-per-payload pattern, #3451). A
+/// 2000-sample trip is ~33 min at 1 Hz; encoding payloads that size on
+/// the UI isolate was measurably janking the stop-trip flow, while the
+/// isolate hop (~10 ms) dominates for anything smaller.
+const int kTripSaveComputeSampleThreshold = 2000;
 
 /// Hive-backed list of finalised trips (#726).
 ///
@@ -274,6 +59,13 @@ class TripHistoryRepository {
   /// Box name used by the production wiring.
   static const String boxName = 'obd2_trip_history';
 
+  /// The ids of every persisted trip — the raw box keys (#3613). The
+  /// box is keyed by `entry.id` (see [save]), so this answers "which
+  /// trips are stored?" with ZERO JSON decoding. Includes ghost
+  /// duplicates and corrupt rows; callers that need the de-duped,
+  /// decodable truth use [loadSummaries] / [loadAll].
+  Iterable<String> get storedIds => _box.keys.whereType<String>();
+
   /// Persist [entry]. Drops the oldest trip when the box reaches [cap].
   /// Errors are logged but swallowed. #2833 — a 0-sample ghost whose
   /// sampled twin already exists is a no-op; a sampled twin deletes any
@@ -281,9 +73,13 @@ class TripHistoryRepository {
   Future<void> save(TripHistoryEntry entry) async {
     try {
       // A guard hiccup must never block the save — fall through to a write.
+      // #3613 — the guard only reads summary-level fields (ids, summary
+      // metrics, startedAt, the stored sample COUNT), so it rides the
+      // cheap summary-only decode instead of materialising every stored
+      // sample on every save.
       final skip = await guardGhostDoubleSave(
         entry: entry,
-        existing: loadAll(dedupe: false),
+        existing: loadSummaries(dedupe: false),
         deleteById: _box.delete,
       );
       if (skip) return;
@@ -292,7 +88,15 @@ class TripHistoryRepository {
           context: const {'where': 'TripHistoryRepository.save ghost-guard'}));
     }
     try {
-      await _box.put(entry.id, jsonEncode(entry.toJson()));
+      // #3613 — a long trip's JSON encode is O(samples) and was running
+      // on the UI isolate inside the stop-trip flow; big payloads hop to
+      // a background isolate (the map built by toJson() is plain
+      // JSON-safe data, so it crosses the isolate boundary cheaply).
+      final json = entry.toJson();
+      final encoded = entry.samples.length > kTripSaveComputeSampleThreshold
+          ? await compute(jsonEncode, json)
+          : jsonEncode(json);
+      await _box.put(entry.id, encoded);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripHistoryRepository.save'}));
       return;
@@ -317,12 +121,14 @@ class TripHistoryRepository {
 
   /// Deserialise the row stored under [key], or null when absent or
   /// corrupt (a single bad write is logged + skipped, never thrown).
-  TripHistoryEntry? _decode(Object key) {
+  TripHistoryEntry? _decode(Object key, {bool summaryOnly = false}) {
     final raw = _box.get(key);
     if (raw == null || raw.isEmpty) return null;
     try {
       final json = (jsonDecode(raw) as Map).cast<String, dynamic>();
-      return TripHistoryEntry.fromJson(json);
+      return summaryOnly
+          ? TripHistoryEntry.summaryFromJson(json)
+          : TripHistoryEntry.fromJson(json);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st,
           context: {'where': 'TripHistoryRepository._decode: skipping $key'}));
@@ -334,10 +140,27 @@ class TripHistoryRepository {
   /// are silently skipped. #2833 — by default ghost 0-sample duplicates
   /// are removed so the list, the aggregates (`loadAll().length`) and the
   /// re-export see the de-duped truth; `dedupe: false` is the raw set.
-  List<TripHistoryEntry> loadAll({bool dedupe = true}) {
+  List<TripHistoryEntry> loadAll({bool dedupe = true}) =>
+      _loadSorted(dedupe: dedupe, summaryOnly: false);
+
+  /// Summary-only variant of [loadAll] (#3613): same entries, same
+  /// order, same ghost de-dupe — but the heavy per-tick payloads
+  /// (`samples`, `gpsd`, `lcm`, `obd2d`) are never materialised into
+  /// objects. `entry.samples` is always empty here; the stored sample
+  /// count survives on `entry.sampleCount`. Use this wherever only the
+  /// summary/bookkeeping fields are consumed (list totals, per-vehicle
+  /// summary math, the save-time ghost guard); consumers that render or
+  /// recompute samples stay on [loadAll] / [loadById].
+  List<TripHistoryEntry> loadSummaries({bool dedupe = true}) =>
+      _loadSorted(dedupe: dedupe, summaryOnly: true);
+
+  List<TripHistoryEntry> _loadSorted({
+    required bool dedupe,
+    required bool summaryOnly,
+  }) {
     final result = <TripHistoryEntry>[];
     for (final key in _box.keys) {
-      final entry = _decode(key as Object);
+      final entry = _decode(key as Object, summaryOnly: summaryOnly);
       if (entry != null) result.add(entry);
     }
     result.sort((a, b) {
@@ -389,7 +212,9 @@ class TripHistoryRepository {
 
   Future<void> _trim() async {
     if (_box.length <= cap) return;
-    final entries = loadAll(); // newest-first
+    // #3613 — trimming only needs ids ordered by startedAt; the
+    // summary-only decode is enough.
+    final entries = loadSummaries(); // newest-first
     final toDrop = entries.skip(cap).map((e) => e.id).toList();
     for (final id in toDrop) {
       await _box.delete(id);

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -44,7 +44,34 @@ class TripRecordingBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(tripRecordingProvider);
+    // #3613 — this wrapper sits above EVERY screen and the recording
+    // state emits at ~1 Hz, so watch only the fields the banner strip
+    // actually renders: phase (isActive / paused / palette), situation,
+    // band, liveDeltaFraction and the live reading (distance / elapsed /
+    // instant consumption / coaching hint / a11y label). Mutations to
+    // the non-rendered fields (dropReason, reconnectPassiveWaiting,
+    // gpsCoachingHint, connectStage, saveStage — each drawn by its own
+    // dedicated widget) no longer rebuild the whole app subtree. The
+    // record's == is structural, so an identical projection is a no-op.
+    // The PiP branch below re-watches the full state: the PiP tile is
+    // the ONLY thing on screen there, so selecting buys nothing.
+    final view = ref.watch(tripRecordingProvider.select((s) => (
+          phase: s.phase,
+          live: s.live,
+          situation: s.situation,
+          band: s.band,
+          liveDeltaFraction: s.liveDeltaFraction,
+        )));
+    // Re-assembled projection carrying exactly the rendered fields —
+    // keeps TripRecordingBannerContent/_semanticsLabel signatures (and
+    // behaviour) identical.
+    final state = TripRecordingState(
+      phase: view.phase,
+      live: view.live,
+      situation: view.situation,
+      band: view.band,
+      liveDeltaFraction: view.liveDeltaFraction,
+    );
     final obd2 = ref.watch(obd2ConnectionStatusProvider);
 
     // #3170 — arm the iOS Live Activity sync here, where every screen
@@ -127,7 +154,9 @@ class TripRecordingBanner extends ConsumerWidget {
 
       return _pipView(
         context,
-        state,
+        // #3613 — the compact tile is the whole UI in PiP; hand it the
+        // full state so it can keep reading any field it needs.
+        ref.watch(tripRecordingProvider),
         approachState: approach,
         fuelType: fuel,
         radarStation: radarStation,

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -293,7 +293,7 @@ class FillUpList extends _$FillUpList {
     if (repo == null) return const <String>[];
     return const FillUpTripLinker().linkedTripIdsInWindow(
       fillUp: fillUp,
-      history: repo.loadAll(),
+      history: repo.loadSummaries(), // #3613 — linker reads ids+summaries
       allFills: ref.read(fillUpRepositoryProvider).getAll(),
     );
   }
@@ -375,7 +375,7 @@ class FillUpList extends _$FillUpList {
       if (tripRepo == null) return null;
       final fillRepo = ref.read(fillUpRepositoryProvider);
       final allFills = fillRepo.getAll();
-      final history = tripRepo.loadAll();
+      final history = tripRepo.loadSummaries(); // #3613 — summary reconcile
       final trips = tripSummariesForVehicle(
         vehicleId: vehicleId,
         history: history,
@@ -658,7 +658,7 @@ class FillUpList extends _$FillUpList {
   String? _latestAdapterFirmwareFor(String vehicleId) {
     final repo = ref.read(tripHistoryRepositoryProvider);
     if (repo == null) return null;
-    final history = repo.loadAll();
+    final history = repo.loadSummaries(); // #3613 — firmware+times only
     DateTime? bestWhen;
     String? best;
     for (final entry in history) {

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -467,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'99a6abc6445acf15e09631e07a86981077b09df4';
+String _$fillUpListHash() => r'9bb819ddf2750a1d20fb08ab49a8f6e905978067';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/vehicle/presentation/widgets/vehicle_edit_form.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_edit_form.dart
@@ -254,7 +254,8 @@ class VehicleEditForm extends ConsumerWidget {
                 // #2837 — when this vehicle reports fuel rate directly (PID 5E /
                 // MAF), the η_v calibration is irrelevant; de-emphasise it.
                 final directFuelRate = vehicleReportsDirectFuelRate(
-                  ref.watch(tripHistoryRepositoryProvider)?.loadAll() ??
+                  // #3613 — the detector reads vehicleId + summary only.
+                  ref.watch(tripHistoryRepositoryProvider)?.loadSummaries() ??
                       const [],
                   vehicleId: profile.id,
                 );

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -40,6 +40,11 @@ part 'nearest_widget_refresh_provider.g.dart';
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
 /// releases both in onDispose.
+///
+/// #3613 — the heartbeat is presence- and lifecycle-gated: the periodic
+/// timer only runs while at least one home-screen widget is actually
+/// installed (probe fails open), pauses when the app is backgrounded,
+/// and re-probes + resumes on foreground.
 @Riverpod(keepAlive: true)
 class NearestWidgetRefresh extends _$NearestWidgetRefresh {
   Timer? _timer;
@@ -65,6 +70,16 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
   @visibleForTesting
   Future<void> debugTick() => _tick();
 
+  /// #3613 — whether the periodic heartbeat is currently armed. Lets the
+  /// tests pin the presence gate + lifecycle pause without waiting out
+  /// the 2-minute cadence.
+  @visibleForTesting
+  bool get debugTimerActive => _timer != null;
+
+  /// #3613 — drive one presence-gated (re-)arm directly in tests.
+  @visibleForTesting
+  Future<void> debugArm() => _armIfWidgetsPresent();
+
   @override
   void build() {
     ref.onDispose(() {
@@ -73,17 +88,62 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
       _lifecycle?.dispose();
       _lifecycle = null;
     });
+    // #1803 — refresh again whenever the app returns to the foreground,
+    // so the widget's refresh button (which opens the app, #1801) and
+    // any ordinary resume leave the widget up to date. #3613 — the
+    // resume hook also re-runs the presence check (the user may have
+    // added/removed the home-screen widget while we were backgrounded),
+    // and `paused` cancels the heartbeat outright: a backgrounded app
+    // must not burn a station search every 2 minutes for a widget the
+    // OS repaints from its own WorkManager task anyway.
+    _lifecycle ??= AppLifecycleListener(
+      onResume: () => unawaited(_armIfWidgetsPresent()),
+      onPause: _cancelTimer,
+    );
+    // #3613 — arm the heartbeat (and fire the immediate first refresh)
+    // only when a home-screen widget is actually installed; a phone
+    // without one was paying the full 2-min refresh loop for nothing.
+    unawaited(_armIfWidgetsPresent());
+  }
+
+  /// Start (or stop) the heartbeat according to widget presence (#3613):
+  /// when at least one home-screen widget is installed, ensure the
+  /// periodic timer runs and fire an immediate tick (don't wait two
+  /// minutes); when none is, cancel the timer. The presence probe fails
+  /// OPEN — an errored `getInstalledWidgets` keeps the pre-#3613
+  /// always-on behaviour, because a stale widget is worse than a few
+  /// spare ticks.
+  Future<void> _armIfWidgetsPresent() async {
+    if (!await _widgetsPresent()) {
+      _cancelTimer();
+      return;
+    }
     _timer ??= Timer.periodic(
       kNearestWidgetForegroundInterval,
       (_) => _tick(),
     );
-    // #1803 — refresh again whenever the app returns to the foreground,
-    // so the widget's refresh button (which opens the app, #1801) and
-    // any ordinary resume leave the widget up to date.
-    _lifecycle ??= AppLifecycleListener(onResume: () => unawaited(_tick()));
-    // Fire one immediate refresh so the widget reflects the current
-    // session as soon as the user opens the app (don't wait two minutes).
-    unawaited(_tick());
+    await _tick();
+  }
+
+  void _cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// True when at least one home-screen widget (any variant) is pinned,
+  /// read through the same `home_widget` bridge [HomeWidgetService]
+  /// uses for its per-widget keys. Fails open (true) so a broken probe
+  /// never strands the widget stale.
+  Future<bool> _widgetsPresent() async {
+    try {
+      final widgets = await HomeWidget.getInstalledWidgets();
+      return widgets.isNotEmpty;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {
+        'where': 'NearestWidgetRefresh: widget presence probe failed',
+      }));
+      return true;
+    }
   }
 
   Future<void> _tick() async {

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -28,6 +28,11 @@ part of 'nearest_widget_refresh_provider.dart';
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
 /// releases both in onDispose.
+///
+/// #3613 — the heartbeat is presence- and lifecycle-gated: the periodic
+/// timer only runs while at least one home-screen widget is actually
+/// installed (probe fails open), pauses when the app is backgrounded,
+/// and re-probes + resumes on foreground.
 
 @ProviderFor(NearestWidgetRefresh)
 final nearestWidgetRefreshProvider = NearestWidgetRefreshProvider._();
@@ -52,6 +57,11 @@ final nearestWidgetRefreshProvider = NearestWidgetRefreshProvider._();
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
 /// releases both in onDispose.
+///
+/// #3613 — the heartbeat is presence- and lifecycle-gated: the periodic
+/// timer only runs while at least one home-screen widget is actually
+/// installed (probe fails open), pauses when the app is backgrounded,
+/// and re-probes + resumes on foreground.
 final class NearestWidgetRefreshProvider
     extends $NotifierProvider<NearestWidgetRefresh, void> {
   /// Foreground heartbeat that rebuilds the home-screen widget — both the
@@ -74,6 +84,11 @@ final class NearestWidgetRefreshProvider
   /// Reading the provider once (e.g. from the app's root widget) starts
   /// the tick; the provider owns its Timer + [AppLifecycleListener] and
   /// releases both in onDispose.
+  ///
+  /// #3613 — the heartbeat is presence- and lifecycle-gated: the periodic
+  /// timer only runs while at least one home-screen widget is actually
+  /// installed (probe fails open), pauses when the app is backgrounded,
+  /// and re-probes + resumes on foreground.
   NearestWidgetRefreshProvider._()
     : super(
         from: null,
@@ -102,7 +117,7 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'5fc55400421ae8efc10a112b5e01e85ca36600bf';
+    r'74c3e86d1775832ab8e04d1abc4e18afa183def2';
 
 /// Foreground heartbeat that rebuilds the home-screen widget — both the
 /// favorites and the nearest variants — every
@@ -124,6 +139,11 @@ String _$nearestWidgetRefreshHash() =>
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
 /// releases both in onDispose.
+///
+/// #3613 — the heartbeat is presence- and lifecycle-gated: the periodic
+/// timer only runs while at least one home-screen widget is actually
+/// installed (probe fails open), pauses when the app is backgrounded,
+/// and re-probes + resumes on foreground.
 
 abstract class _$NearestWidgetRefresh extends $Notifier<void> {
   void build();

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -793,6 +794,103 @@ void main() {
               'the byte ceiling, so sizing it is pure waste (#3155)');
       expect(cache.get('dataset:FR:stations'), isNotNull,
           reason: 'the dataset entry itself still survives the sweep');
+    });
+  });
+
+  // #3613 — the byte-stamp: `put()` records the payload's encoded length
+  // on the envelope so the eviction byte sweep reads a stored int instead
+  // of re-encoding every surviving payload on every 30-min pass. Legacy
+  // (pre-stamp) envelopes fall back to the re-encode — the whole
+  // `evictBounded` group above stores stamp-less envelopes and still
+  // passes, which pins that fallback.
+  group('CacheManager - byte stamp at put() (#3613)', () {
+    test('put stamps the encoded payload byte length onto the envelope '
+        'and get() surfaces it', () async {
+      const payload = {'v': 'abc'};
+      await cache.put('search:x', payload,
+          ttl: const Duration(minutes: 5), source: ServiceSource.cache);
+
+      final raw = fakeStorage.getCachedData('search:x');
+      expect(raw!['bytes'], jsonEncode(payload).length,
+          reason: 'the stored envelope must carry the write-time stamp');
+      expect(cache.get('search:x')!.approxBytes, jsonEncode(payload).length);
+    });
+
+    test('dataset: entries stay unstamped — they are exempt from the byte '
+        'sweep, so encoding their multi-MB payload would be waste (#3155)',
+        () async {
+      await cache.put('dataset:FR:stations', {'stations': <dynamic>[]},
+          ttl: const Duration(hours: 6), source: ServiceSource.cache);
+      final raw = fakeStorage.getCachedData('dataset:FR:stations');
+      expect(raw!.containsKey('bytes'), isFalse);
+    });
+
+    test('the byte sweep uses the stamped value — the payload is NOT '
+        're-encoded, and eviction follows the stamp', () async {
+      final now = DateTime.now();
+      final oldProbe = _EncodeProbe();
+      final newProbe = _EncodeProbe();
+      // Two stamped envelopes whose stamps (5000 / 10) dwarf their real
+      // encoded size (~20 bytes). If the sweep re-encoded, the total
+      // would be ~40 bytes — far under the 1000-byte ceiling — and
+      // nothing would be evicted; honouring the stamps forces exactly
+      // the oldest one out.
+      Future<void> storeStamped(
+          String key, DateTime storedAt, Object probe, int bytes) {
+        return fakeStorage.cacheData(key, {
+          'payload': {'p': probe},
+          'storedAt': storedAt.millisecondsSinceEpoch,
+          'source': ServiceSource.cache.name,
+          'ttlMs': const Duration(hours: 1).inMilliseconds,
+          'bytes': bytes,
+        });
+      }
+
+      await storeStamped('search:old',
+          now.subtract(const Duration(minutes: 10)), oldProbe, 5000);
+      await storeStamped('search:new', now, newProbe, 10);
+
+      final evicted = await cache.evictBounded(
+        policy: const CacheEvictionPolicy(prefixBudget: 100, maxBytes: 1000),
+      );
+
+      expect(oldProbe.toJsonCalls, 0,
+          reason: 'a stamped entry must never be re-encoded by the sweep');
+      expect(newProbe.toJsonCalls, 0,
+          reason: 'a stamped entry must never be re-encoded by the sweep');
+      expect(evicted, 1,
+          reason: 'the 5000-byte stamp exceeds the 1000-byte ceiling, so '
+              'the sweep must evict the oldest stamped entry');
+      expect(cache.get('search:old'), isNull);
+      expect(cache.get('search:new'), isNotNull);
+    });
+
+    test('a legacy entry without the stamp is re-encoded once and still '
+        'evicted correctly under byte pressure', () async {
+      final now = DateTime.now();
+      // Legacy (no 'bytes') envelopes with real ~1 KB payloads.
+      Future<void> storeLegacy(String key, DateTime storedAt) {
+        return fakeStorage.cacheData(key, {
+          'payload': {'p': 'x' * 1000},
+          'storedAt': storedAt.millisecondsSinceEpoch,
+          'source': ServiceSource.cache.name,
+          'ttlMs': const Duration(hours: 1).inMilliseconds,
+        });
+      }
+
+      await storeLegacy(
+          'search:old', now.subtract(const Duration(minutes: 10)));
+      await storeLegacy('search:new', now);
+
+      final evicted = await cache.evictBounded(
+        policy: const CacheEvictionPolicy(prefixBudget: 100, maxBytes: 1200),
+      );
+
+      expect(evicted, 1,
+          reason: 'the re-encode fallback must still size legacy entries');
+      expect(cache.get('search:old'), isNull,
+          reason: 'oldest legacy entry evicted first under byte pressure');
+      expect(cache.get('search:new'), isNotNull);
     });
   });
 

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
@@ -1150,6 +1151,198 @@ void main() {
 
       final loaded = repo.loadById(start.toIso8601String());
       expect(loaded!.summary.isVirtual, isFalse);
+    });
+  });
+
+  // #3613 — the summary-only decode path. jsonDecode still parses the
+  // whole stored string (safe by construction — no string surgery on the
+  // codec output), but the heavy per-tick payloads are never materialised
+  // into TripSample / diagnostic objects, which is the dominant decode
+  // cost for real trips.
+  //
+  // Rough micro-benchmark on this suite's VM (2026-07, Apple Silicon,
+  // JIT; the '5000-sample decode cost' case below, 20 iterations each):
+  // loadAll = 118 ms vs loadSummaries = 25 ms for a single 5000-sample
+  // trip — a ~4.7× cut, growing with sample count since the summary
+  // path is O(1) in object construction per trip.
+  group('summary-only decode path (#3613)', () {
+    List<TripSample> mkSamples(DateTime start, int n) => [
+          for (var i = 0; i < n; i++)
+            TripSample(
+              timestamp: start.add(Duration(seconds: i)),
+              speedKmh: 40 + (i % 50).toDouble(),
+              rpm: 1500 + (i % 900),
+              fuelRateLPerHour: 4.0 + (i % 10) / 10,
+            ),
+        ];
+
+    test('loadSummaries returns the same ids + summary fields as loadAll, '
+        'with empty samples but a truthful sampleCount', () async {
+      final repo = TripHistoryRepository(box: box);
+      final a = DateTime(2026, 7, 1, 8);
+      final b = DateTime(2026, 7, 2, 9);
+      await repo.save(TripHistoryEntry(
+        id: a.toIso8601String(),
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: a, km: 12),
+        samples: mkSamples(a, 40),
+        adapterFirmware: 'ELM327 v1.5',
+        verdict: 'good',
+      ));
+      await repo.save(TripHistoryEntry(
+        id: b.toIso8601String(),
+        vehicleId: 'car-b',
+        summary: mkSummary(startedAt: b, km: 7),
+      ));
+
+      final full = repo.loadAll();
+      final summaries = repo.loadSummaries();
+      expect(summaries.map((e) => e.id), full.map((e) => e.id),
+          reason: 'same entries, same newest-first order');
+      for (var i = 0; i < full.length; i++) {
+        expect(summaries[i].vehicleId, full[i].vehicleId);
+        expect(summaries[i].summary.distanceKm, full[i].summary.distanceKm);
+        expect(summaries[i].summary.startedAt, full[i].summary.startedAt);
+        expect(summaries[i].adapterFirmware, full[i].adapterFirmware);
+        expect(summaries[i].verdict, full[i].verdict);
+        expect(summaries[i].samples, isEmpty,
+            reason: 'the summary path must never materialise samples');
+        expect(summaries[i].sampleCount, full[i].samples.length,
+            reason: 'the stored count survives for the ghost de-dupe');
+      }
+    });
+
+    test('save-time ghost guard (now riding loadSummaries) still skips a '
+        '0-sample ghost whose sampled twin is stored (#2833)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 7, 3, 18);
+      final summary = mkSummary(startedAt: start, km: 9);
+      await repo.save(TripHistoryEntry(
+        id: '${start.toIso8601String()}#sampled',
+        vehicleId: 'car-a',
+        summary: summary,
+        samples: mkSamples(start, 30),
+      ));
+
+      // The finalisation double-save artefact: same summary, ~1 s later,
+      // zero samples. The guard must skip the write.
+      await repo.save(TripHistoryEntry(
+        id: '${start.add(const Duration(seconds: 1)).toIso8601String()}#ghost',
+        vehicleId: 'car-a',
+        summary: mkSummary(
+          startedAt: start.add(const Duration(seconds: 1)),
+          km: 9,
+        ),
+      ));
+
+      expect(box.length, 1, reason: 'the ghost must not be persisted');
+      expect(repo.loadAll().single.samples, hasLength(30));
+    });
+
+    test('save-time ghost guard still deletes a stored 0-sample ghost when '
+        'its sampled twin arrives (#2833)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 7, 4, 18);
+      await repo.save(TripHistoryEntry(
+        id: '${start.toIso8601String()}#ghost',
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start, km: 9),
+      ));
+      await repo.save(TripHistoryEntry(
+        id: '${start.add(const Duration(seconds: 1)).toIso8601String()}#real',
+        vehicleId: 'car-a',
+        summary: mkSummary(
+          startedAt: start.add(const Duration(seconds: 1)),
+          km: 9,
+        ),
+        samples: mkSamples(start, 30),
+      ));
+
+      expect(box.length, 1, reason: 'the sampled twin replaces the ghost');
+      expect(repo.loadAll().single.sampleCount, 30);
+    });
+
+    test('a samples-reading consumer still gets full samples from '
+        'loadAll / loadById after a loadSummaries call', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 7, 5, 7);
+      final id = start.toIso8601String();
+      await repo.save(TripHistoryEntry(
+        id: id,
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start),
+        samples: mkSamples(start, 25),
+      ));
+
+      repo.loadSummaries(); // must not disturb the stored payload
+      expect(repo.loadAll().single.samples, hasLength(25));
+      expect(repo.loadById(id)!.samples, hasLength(25));
+      expect(repo.loadById(id)!.samples.first.speedKmh, 40);
+    });
+
+    test('storedIds mirrors the box keys without decoding', () async {
+      final repo = TripHistoryRepository(box: box);
+      final a = DateTime(2026, 7, 6, 8);
+      final b = DateTime(2026, 7, 7, 8);
+      await repo.save(TripHistoryEntry(
+        id: a.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: a),
+      ));
+      await repo.save(TripHistoryEntry(
+        id: b.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: b),
+      ));
+      expect(repo.storedIds.toSet(),
+          {a.toIso8601String(), b.toIso8601String()});
+    });
+
+    test('a big trip (> compute threshold) round-trips through the '
+        'isolate-encoded save path', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 7, 8, 8);
+      const n = kTripSaveComputeSampleThreshold + 1;
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start, km: 35),
+        samples: mkSamples(start, n),
+      ));
+
+      final loaded = repo.loadById(start.toIso8601String());
+      expect(loaded!.samples, hasLength(n),
+          reason: 'the compute() encode must persist the identical JSON');
+      expect(repo.loadSummaries().single.sampleCount, n);
+    });
+
+    test('5000-sample decode cost: loadSummaries is materially cheaper '
+        'than loadAll (correctness asserted; timings printed)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 7, 9, 8);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-a',
+        summary: mkSummary(startedAt: start, km: 60),
+        samples: mkSamples(start, 5000),
+      ));
+
+      const iterations = 20;
+      final swFull = Stopwatch()..start();
+      for (var i = 0; i < iterations; i++) {
+        expect(repo.loadAll().single.samples, hasLength(5000));
+      }
+      swFull.stop();
+      final swSummary = Stopwatch()..start();
+      for (var i = 0; i < iterations; i++) {
+        expect(repo.loadSummaries().single.sampleCount, 5000);
+      }
+      swSummary.stop();
+      // Timing is environment-dependent — record it, don't gate on it.
+      // (Observed locally: full ≈ 4.7× the summary path; see group doc.)
+      debugPrint('#3613 decode cost, $iterations iters: '
+          'loadAll=${swFull.elapsedMilliseconds}ms '
+          'loadSummaries=${swSummary.elapsedMilliseconds}ms');
     });
   });
 }

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -34,6 +34,18 @@ class _FakeTripRecording extends TripRecording {
   TripRecordingState build() => _initial;
 }
 
+/// Mutable fake — lets the #3613 select() tests emit successor states
+/// and observe whether the banner element got marked dirty.
+class _MutableTripRecording extends TripRecording {
+  final TripRecordingState _initial;
+  _MutableTripRecording(this._initial);
+
+  @override
+  TripRecordingState build() => _initial;
+
+  void emit(TripRecordingState next) => state = next;
+}
+
 /// Fake [PipMode] notifier — pins the app's PiP-mode flag for a test.
 class _FakePipMode extends PipMode {
   final bool _value;
@@ -477,6 +489,44 @@ void main() {
         ),
         findsNothing,
       );
+    });
+
+    testWidgets(
+        'unrelated state mutation does NOT rebuild the banner subtree — '
+        'the select() only projects the rendered fields (#3613)',
+        (tester) async {
+      final base = _activeState(
+        band: ConsumptionBand.normal,
+        delta: 0.05,
+        distance: 3.0,
+      );
+      final notifier = _MutableTripRecording(base);
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [tripRecordingProvider.overrideWith(() => notifier)],
+      );
+      final element = tester.element(find.byType(TripRecordingBanner));
+      expect(element.dirty, isFalse, reason: 'settled after the pump');
+
+      // Mutate a field the banner strip never renders (its consumer is
+      // the separate GpsDegradedBanner). The provider notifies, but the
+      // selected projection is unchanged → the element must stay clean.
+      notifier.emit(base.copyWith(reconnectPassiveWaiting: true));
+      expect(element.dirty, isFalse,
+          reason: 'a non-rendered field mutation must not mark the '
+              'app-wide banner wrapper dirty — that was the 1 Hz '
+              'whole-subtree rebuild #3613 removes');
+
+      // Control: a RENDERED field mutation must still rebuild.
+      notifier.emit(base.copyWith(
+        band: ConsumptionBand.eco,
+        reconnectPassiveWaiting: true,
+      ));
+      expect(element.dirty, isTrue,
+          reason: 'band drives the palette/icon — the banner must react');
+      await tester.pump();
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('GPS-only warm-up (null estimate) → no consumption text',

--- a/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
+++ b/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
@@ -19,6 +19,8 @@
 
 import 'dart:async';
 
+import 'dart:ui' show AppLifecycleState;
+
 import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -59,6 +61,15 @@ void main() {
           return null;
         case 'updateWidget':
           return true;
+        // #3613 — the heartbeat is presence-gated now; the default mock
+        // reports one pinned widget so the pre-existing heartbeat tests
+        // keep modelling the "widget installed" case they always assumed
+        // (the plugin maps a null channel result to an EMPTY list, which
+        // would silently gate everything off).
+        case 'getInstalledWidgets':
+          return <dynamic>[
+            <String, dynamic>{'androidWidgetId': 1},
+          ];
         default:
           return null;
       }
@@ -330,7 +341,14 @@ void main() {
               if (id == kWidgetManualRefreshRequestedAtKey) return iso;
               return null;
             }
-            if (call.method == 'getInstalledWidgets') return <dynamic>[];
+            if (call.method == 'getInstalledWidgets') {
+              // #3613 — keep reporting one pinned widget (matches the
+              // suite default) so a re-probe can't disarm the heartbeat
+              // mid-test.
+              return <dynamic>[
+                <String, dynamic>{'androidWidgetId': 1},
+              ];
+            }
             if (call.method == 'updateWidget') return true;
             return null;
           });
@@ -443,6 +461,153 @@ void main() {
       // Let the unawaited tick run to completion. If the catch in _tick
       // is removed, the test will fail with a zone-uncaught error here.
       await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+
+    // #3613 — the heartbeat is gated on widget presence and the app
+    // lifecycle: no pinned home-screen widget → no timer, no tick;
+    // backgrounding cancels the timer; foregrounding re-probes + re-arms.
+    group('presence + lifecycle gating (#3613)', () {
+      /// Re-wires the home_widget channel so `getInstalledWidgets`
+      /// reports [widgets] (empty = nothing pinned); everything else
+      /// keeps the suite's benign defaults.
+      void wireInstalledWidgets(List<dynamic> widgets) {
+        messenger.setMockMethodCallHandler(homeWidgetChannel, (call) async {
+          switch (call.method) {
+            case 'getInstalledWidgets':
+              return widgets;
+            case 'updateWidget':
+              return true;
+            default:
+              return null;
+          }
+        });
+      }
+
+      // AppLifecycleListener asserts on illegal jumps (e.g. resumed →
+      // paused directly), so walk the legal transition chains the OS
+      // itself produces.
+      void goPaused() {
+        for (final s in const [
+          AppLifecycleState.inactive,
+          AppLifecycleState.hidden,
+          AppLifecycleState.paused,
+        ]) {
+          TestWidgetsFlutterBinding.instance
+              .handleAppLifecycleStateChanged(s);
+        }
+      }
+
+      void goResumed() {
+        for (final s in const [
+          AppLifecycleState.hidden,
+          AppLifecycleState.inactive,
+          AppLifecycleState.resumed,
+        ]) {
+          TestWidgetsFlutterBinding.instance
+              .handleAppLifecycleStateChanged(s);
+        }
+      }
+
+      tearDown(() {
+        // Restore the foreground state so later suites aren't affected
+        // by a test that backgrounded the binding.
+        if (TestWidgetsFlutterBinding.instance.lifecycleState ==
+            AppLifecycleState.paused) {
+          goResumed();
+        }
+      });
+
+      test('no widget pinned → the heartbeat is never armed and no tick '
+          'fires', () async {
+        wireInstalledWidgets(<dynamic>[]);
+
+        container.read(nearestWidgetRefreshProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        final notifier =
+            container.read(nearestWidgetRefreshProvider.notifier);
+        expect(notifier.debugTimerActive, isFalse,
+            reason: 'the 2-min periodic must not run for a widget nobody '
+                'has pinned');
+        expect(countingStorage.getSettingCalls, 0,
+            reason: 'not even the immediate first refresh should run');
+      });
+
+      test('a pinned widget → heartbeat armed + immediate tick (control)',
+          () async {
+        // Suite default mock already reports one pinned widget.
+        container.read(nearestWidgetRefreshProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        final notifier =
+            container.read(nearestWidgetRefreshProvider.notifier);
+        expect(notifier.debugTimerActive, isTrue);
+        expect(countingStorage.getSettingCalls, greaterThanOrEqualTo(1));
+      });
+
+      test('a broken presence probe fails OPEN — the heartbeat still runs',
+          () async {
+        messenger.setMockMethodCallHandler(homeWidgetChannel, (call) async {
+          if (call.method == 'getInstalledWidgets') {
+            throw PlatformException(code: 'probe-broken');
+          }
+          if (call.method == 'updateWidget') return true;
+          return null;
+        });
+
+        container.read(nearestWidgetRefreshProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        expect(
+            container
+                .read(nearestWidgetRefreshProvider.notifier)
+                .debugTimerActive,
+            isTrue,
+            reason: 'a stale widget is worse than a few spare ticks — an '
+                'errored probe must keep the pre-#3613 behaviour');
+      });
+
+      test('AppLifecycleState.paused cancels the heartbeat; resumed '
+          're-arms it and fires a tick', () async {
+        container.read(nearestWidgetRefreshProvider);
+        final notifier =
+            container.read(nearestWidgetRefreshProvider.notifier);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        expect(notifier.debugTimerActive, isTrue);
+        final ticksBeforePause = countingStorage.getSettingCalls;
+
+        goPaused();
+        expect(notifier.debugTimerActive, isFalse,
+            reason: 'a backgrounded app must not burn a station search '
+                'every 2 minutes — the OS-side WorkManager task repaints '
+                'the widget while we are away');
+
+        goResumed();
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        expect(notifier.debugTimerActive, isTrue,
+            reason: 'foregrounding must re-arm the heartbeat');
+        expect(countingStorage.getSettingCalls,
+            greaterThan(ticksBeforePause),
+            reason: 'the resume hook still fires its immediate refresh');
+      });
+
+      test('resume while the widget was REMOVED disarms the heartbeat',
+          () async {
+        container.read(nearestWidgetRefreshProvider);
+        final notifier =
+            container.read(nearestWidgetRefreshProvider.notifier);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        expect(notifier.debugTimerActive, isTrue);
+
+        // The user unpins the widget while the app is backgrounded.
+        wireInstalledWidgets(<dynamic>[]);
+        goPaused();
+        goResumed();
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        expect(notifier.debugTimerActive, isFalse,
+            reason: 'the resume re-probe must notice the widget is gone');
+      });
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -165,9 +165,13 @@ void main() {
     // doesn't resurrect) plus the `deleteSummary` tombstone write — a real
     // fix, not boilerplate. Decomposition of this near-cap file is its own
     // future task.
+    // #3613 — re-grandfathered 414 → 433: `merge` gained the optional
+    // `loadFull` hydration seam (doc + per-entry re-hydrate of the
+    // local-only details-heal upload) so the launch pull can feed it
+    // summary-only decoded entries without losing the trip_details heal.
     'lib/core/sync/trips_sync.dart': (
-      lines: 414,
-      bumps: 0,
+      lines: 433,
+      bumps: 1,
       decompositionIssue: null,
     ),
     // #2415 — background_service.dart graduated: the scan body moved into


### PR DESCRIPTION
Audit child 4: TripHistoryRepository.loadSummaries() (~4.7× cheaper than loadAll on a 5000-sample trip) now serves the ghost-guard, launch sync, fill-up linker and other summary-only consumers with a loadFull hydration seam preserved for TripsSync healing; compute() encode for big trips at stop; the 1 Hz recording banner rebuilds only on rendered-field changes; cache entries carry a byte stamp at write so eviction sweeps stop re-encoding; the 2-min widget heartbeat only runs with a widget installed and pauses in background. Gates ran in the worktree: analyze 0, clean codegen committed, consumption 3163 + obd2 2049 + vehicle 750 + widget/cache/lint suites green. Closes #3613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G