### PR TITLE
fix(obd2): reattach never hands the trip a corpse + reconnect grace; IMU micro-jolt floor (#3625)

### DIFF
--- a/lib/features/consumption/domain/imu_event_record.dart
+++ b/lib/features/consumption/domain/imu_event_record.dart
@@ -10,6 +10,16 @@ import 'gps_driving_features.dart' show kSharpCornerYawRateRadPerSec;
 /// past the cap are counted, not stored.
 const int kImuEventRecordCap = 48;
 
+/// Micro-jolt floor (#3589 field tuning): the first field trips flooded
+/// the cap with 600-700 road-vibration blips (duration ≈ 0.0-0.1 s at
+/// barely-over-threshold magnitude), drowning the informative stretches.
+/// A stretch shorter than [kImuMicroJoltMaxDuration] whose peak stayed
+/// under [kImuMicroJoltMaxPeak] is counted into `dropped`, not stored —
+/// it carries no calibration signal a histogram of one 'tooShort' blip
+/// after another wouldn't.
+const double kImuMicroJoltMaxDuration = 0.15;
+const double kImuMicroJoltMaxPeak = 4.5;
+
 /// One strong-manoeuvre stretch as the IMU detector saw it (#3589) —
 /// confirmed events AND rejected near-misses, so the accel/brake
 /// thresholds can be calibrated against labeled magnitude distributions
@@ -96,7 +106,8 @@ class ImuStretchTracker {
   /// [finish] first at harvest time).
   List<ImuEventRecord> get records => List.unmodifiable(_records);
 
-  /// Stretches past [kImuEventRecordCap] — counted, not stored.
+  /// Stretches not stored: past [kImuEventRecordCap], or sub-noise
+  /// micro-jolts under the #3589 field-tuning floor.
   int get dropped => _dropped;
 
   /// Fold one sample's stretch state. [strong] mirrors the detector's
@@ -151,6 +162,14 @@ class ImuStretchTracker {
 
   void _finalize() {
     _open = false;
+    // Micro-jolt: a road-vibration blip, counted but not stored — see
+    // [kImuMicroJoltMaxDuration]. Confirmed events are always stored.
+    if (_confirmedOutcome == null &&
+        _duration < kImuMicroJoltMaxDuration &&
+        _peakMps2 < kImuMicroJoltMaxPeak) {
+      _dropped++;
+      return;
+    }
     final outcome = _confirmedOutcome ??
         (_duration < kAccelEventMinSustainedSec
             ? 'tooShort'

--- a/lib/features/obd2/data/obd2_reattach_source.dart
+++ b/lib/features/obd2/data/obd2_reattach_source.dart
@@ -71,16 +71,27 @@ class SupervisorReattachSource implements Obd2ReattachSource {
   Future<void> start() async {
     if (_sub != null || _fired) return;
     // The supervisor may have re-attached BEFORE the manager finished
-    // its drop bookkeeping and started us — deliver immediately.
+    // its drop bookkeeping and started us — deliver immediately. BUT
+    // (#3625) only a service whose transport is actually open counts:
+    // after an in-trip drop the supervisor can still HOLD the very
+    // corpse the trip just dropped (disconnectDroppedService closed its
+    // transport; the reference lingers until the next dial). Firing
+    // with it resumed the scheduler onto a dead socket → instant
+    // re-drop → new reattach source → same corpse — the ~4.7 s
+    // success-flap loop that recorded a whole field trip with zero
+    // engine data. A held-but-dead service waits for the next genuine
+    // ready below.
     final live = _supervisor.service;
-    if (live != null) {
+    if (live != null && live.isConnected) {
       _fire(live);
       return;
     }
     _sub = _supervisor.states.listen((next) {
       if (next == Obd2LinkState.ready) {
+        // #3625 — same guard: a ready racing a teardown must not hand
+        // the trip a corpse.
         final svc = _supervisor.service;
-        if (svc != null) _fire(svc);
+        if (svc != null && svc.isConnected) _fire(svc);
         return;
       }
       if (next == Obd2LinkState.reconnecting &&

--- a/lib/features/obd2/data/trip_recording_controller.dart
+++ b/lib/features/obd2/data/trip_recording_controller.dart
@@ -617,10 +617,25 @@ class TripRecordingController {
   /// Best-effort: a disconnect failure on the already-dead old link must
   /// never derail the just-recovered recording, so it is swallowed to a
   /// breadcrumb.
+  /// #3625 — until this instant, transport errors and null parses do
+  /// NOT count toward a drop. A freshly adopted reconnect session on a
+  /// K-line car (ISO 9141, 10.4 kbaud) performs its slow bus init on
+  /// the FIRST poll; without the grace the drop detector declared a
+  /// silent failure before the #3575 quiet-window protocol recovery
+  /// could run, tearing the session down and producing the field flap:
+  /// dial(≈4.7 s) → adopt → first-poll fail → drop → redial, forever —
+  /// a whole trip recorded with zero engine data.
+  DateTime? _reconnectGraceUntil;
+
+  /// Generous vs the ~2.5 s ISO 9141 5-baud init plus one #3575
+  /// recovery pass.
+  static const Duration _reconnectGrace = Duration(seconds: 8);
+
   void replaceService(Obd2Service service) {
     final old = _service;
     if (identical(old, service)) return;
     _service = service;
+    _reconnectGraceUntil = _now().add(_reconnectGrace);
     // #2907 — the reconnected link is healthy: clear the drop detector's
     // error window (incl. any dead-transport short-circuits the [_runTransport]
     // gate logged against the OLD service) so the first poll on the new live
@@ -1204,9 +1219,18 @@ class TripRecordingController {
   /// pausing?" state.
   void _registerTransportError(Object error) {
     if (_pausedDueToDrop || _stopped) return;
+    // #3625 — inside the post-reconnect grace the fresh session is
+    // still bringing the bus up; failures feed the #3575 protocol
+    // episode instead of the drop verdict.
+    if (_inReconnectGrace) return;
     if (_dropDetector.registerTransportError(error)) {
       _droppedSession.handleDrop();
     }
+  }
+
+  bool get _inReconnectGrace {
+    final until = _reconnectGraceUntil;
+    return until != null && _now().isBefore(until);
   }
 
   /// Bookkeeping for the silent-failure heuristic (#1330 phase 3).
@@ -1236,6 +1260,9 @@ class TripRecordingController {
     // of nulls double-fire into a second drop. The lifecycle guard
     // stays here; the detector just counts.
     if (_pausedDueToDrop || _stopped) return;
+    // #3625 — bus-init nulls during the post-reconnect grace are the
+    // K-line waking up, not a dead ECU.
+    if (_inReconnectGrace) return;
     if (_dropDetector.observeHighPriorityParse(parsedValue)) {
       _onSilentFailure();
     }

--- a/test/features/consumption/domain/services/imu_event_detector_test.dart
+++ b/test/features/consumption/domain/services/imu_event_detector_test.dart
@@ -294,6 +294,31 @@ void main() {
       expect(det.eventRecords.single.outcome, 'accel');
     });
 
+    test('a road-vibration micro-jolt (one 50ms blip at 3.2) is counted, '
+        'not stored — the field flood fix', () {
+      final det = ImuEventDetector();
+      final t = feed(det,
+          start: t0,
+          count: 2, // 0.05s over threshold — the field blip shape
+          mag: 3.2,
+          startSpeedKmh: 40);
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 40);
+
+      expect(det.eventRecords, isEmpty,
+          reason: 'sub-0.15s sub-4.5 blips carry no calibration signal');
+      expect(det.droppedEventRecords, 1);
+    });
+
+    test('a short but VIOLENT jolt (0.05s at 6.0) is still recorded', () {
+      final det = ImuEventDetector();
+      final t = feed(det,
+          start: t0, count: 2, mag: 6.0, startSpeedKmh: 40);
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 40);
+
+      expect(det.eventRecords, hasLength(1),
+          reason: 'high peak clears the micro-jolt floor');
+    });
+
     test('records past the cap are counted, not stored', () {
       final det = ImuEventDetector();
       var t = t0;

--- a/test/features/obd2/data/obd2_reattach_corpse_test.dart
+++ b/test/features/obd2/data/obd2_reattach_corpse_test.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3625 — the reattach source must never hand the trip layer a corpse.
+// Field flap: after an in-trip drop the supervisor still HELD the very
+// service the trip had just dropped (transport closed, reference
+// lingering in the ready state); the immediate-fire path delivered it,
+// the resumed scheduler polled a dead socket, re-dropped instantly, and
+// the dial → adopt → drop cycle recorded a whole trip with zero engine
+// data. Only a service whose transport is actually open may fire.
+import 'dart:async';
+import 'dart:math';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_supervisor.dart';
+import 'package:tankstellen/features/obd2/data/obd2_reattach_source.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+
+void main() {
+  late StreamController<Obd2LinkDropEvent> drops;
+
+  setUp(() => drops = StreamController<Obd2LinkDropEvent>.broadcast());
+  tearDown(() => drops.close());
+
+  Obd2LinkSupervisor build(Future<Obd2Service?> Function() dial) =>
+      Obd2LinkSupervisor(
+        dial: dial,
+        drops: drops.stream,
+        initialBackoff: const Duration(milliseconds: 500),
+        maxBackoff: const Duration(seconds: 30),
+        jitter: Random(42),
+      );
+
+  Future<Obd2Service> connectedService() async {
+    final transport = FakeObd2Transport();
+    await transport.connect();
+    return Obd2Service(transport);
+  }
+
+  test('a held-but-DEAD service does not immediate-fire; the next genuine '
+      'ready with a live service does', () {
+    fakeAsync((async) {
+      late Obd2Service svcA;
+      late Obd2Service svcB;
+      var dialCount = 0;
+      unawaited(connectedService().then((s) => svcA = s));
+      unawaited(connectedService().then((s) => svcB = s));
+      async.flushMicrotasks();
+
+      final sup = build(() async => ++dialCount == 1 ? svcA : svcB);
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+      expect(sup.service, same(svcA));
+
+      // The trip drops the link: its transport closes, but the
+      // supervisor still holds the reference in the ready state.
+      unawaited(svcA.disconnect());
+      async.flushMicrotasks();
+      expect(svcA.isConnected, isFalse);
+      expect(sup.service, same(svcA),
+          reason: 'the corpse scenario: ready state, dead transport');
+
+      final fired = <Obd2Service>[];
+      final src = SupervisorReattachSource(
+        sup,
+        onConnected: fired.add,
+        onReconnect: () {},
+      );
+      unawaited(src.start());
+      async.flushMicrotasks();
+      expect(fired, isEmpty,
+          reason: 'firing with the dropped service is the #3625 flap — '
+              'a dead transport must wait for the next genuine ready');
+
+      // The shared drop signal reaches the supervisor → it redials and
+      // comes back ready with a LIVE service → the source fires now.
+      drops.add(const Obd2LinkDropEvent(
+          transportKind: 'classic', reason: 'socket-error'));
+      async.flushMicrotasks();
+      async.elapse(const Duration(seconds: 2));
+      expect(fired, [same(svcB)],
+          reason: 'the fresh, connected service is the one to adopt');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('a held-and-LIVE service still immediate-fires (#3531 fast path)',
+      () {
+    fakeAsync((async) {
+      late Obd2Service svc;
+      unawaited(connectedService().then((s) => svc = s));
+      async.flushMicrotasks();
+
+      final sup = build(() async => svc);
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+
+      final fired = <Obd2Service>[];
+      final src = SupervisorReattachSource(
+        sup,
+        onConnected: fired.add,
+        onReconnect: () {},
+      );
+      unawaited(src.start());
+      async.flushMicrotasks();
+      expect(fired, [same(svc)]);
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+}

--- a/test/features/obd2/data/obd2_single_owner_invariant_test.dart
+++ b/test/features/obd2/data/obd2_single_owner_invariant_test.dart
@@ -30,7 +30,13 @@ import 'package:tankstellen/features/obd2/data/obd2_reattach_source.dart';
 import 'package:tankstellen/features/obd2/data/obd2_service.dart';
 import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
 
-Obd2Service _liveService() => Obd2Service(FakeObd2Transport());
+// #3625 — the reattach source only delivers a service whose transport
+// is actually OPEN; the fake must be connected to count as live.
+Obd2Service _liveService() {
+  final transport = FakeObd2Transport();
+  unawaited(transport.connect());
+  return Obd2Service(transport);
+}
 
 /// Counting dialer: returns whatever [outcome] currently produces
 /// (null = miss) and counts every invocation — the probe that proves

--- a/test/features/obd2/data/trip_recording_controller_stale_engine_test.dart
+++ b/test/features/obd2/data/trip_recording_controller_stale_engine_test.dart
@@ -132,5 +132,50 @@ void main() {
 
       await ctl.stop();
     });
+
+  group('post-reconnect grace (#3625)', () {
+      test('null parses right after replaceService do NOT drop the fresh '
+          'session — the K-line gets its bus-init window', () async {
+        var clock = DateTime(2026, 7, 26, 6, 40);
+        final ctl = await startCtl(() => clock);
+
+        // Healthy streaming past the start grace.
+        clock = clock.add(const Duration(seconds: 40));
+        ctl.debugObserveHighPriorityParse(1500.0);
+        ctl.debugEmitNow();
+        expect(ctl.currentState, TripRecordingControllerState.recording);
+
+        // The reconnect adopts a fresh service…
+        final transport = FakeObd2Transport({
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+        });
+        await transport.connect();
+        ctl.replaceService(Obd2Service(transport));
+
+        // …whose first polls all fail (bus init in progress): a storm of
+        // null parses inside the grace must not fire the silent-failure
+        // drop — this exact storm produced the 4.7 s field flap.
+        clock = clock.add(const Duration(seconds: 3));
+        for (var i = 0; i < 40; i++) {
+          ctl.debugObserveHighPriorityParse(null);
+        }
+        expect(ctl.currentState, TripRecordingControllerState.recording,
+            reason: 'inside the 8 s grace the fresh session must survive '
+                'its bus init');
+
+        // Past the grace, a bus that STILL never produced a parse is a
+        // genuinely dead session — the #3604 staleness fence (15 s since
+        // the last fresh parse) takes over and drops it.
+        clock = clock.add(const Duration(seconds: 14));
+        ctl.debugEmitNow();
+        expect(
+            ctl.currentState, TripRecordingControllerState.pausedDueToDrop,
+            reason: 'the grace is a window, not immunity — the fence '
+                'still ends a session whose bus never came up');
+
+        await ctl.stop();
+      });
+    });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -683,11 +683,12 @@ void main() {
       decompositionIssue: 3141,
     ),
     'lib/features/obd2/data/trip_recording_controller.dart': (
-      // #3602 — the engine-data staleness fence (freshness anchor, two
-      // constants, the _emit gate + once-latched escalation, +51).
+      // #3625 — post-reconnect grace: replaceService opens an 8 s window
+      // during which transport errors / null parses feed the #3575
+      // protocol recovery instead of the drop verdict (+27).
       // Decomposition tracked by #3140.
-      lines: 1831,
-      bumps: 20,
+      lines: 1858,
+      bumps: 21,
       decompositionIssue: 3140,
     ),
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR


### PR DESCRIPTION
## What
The reattach source never hands the trip layer a dead service, and a freshly adopted reconnect session gets an 8 s bus-init grace before transport errors / null parses count toward a drop. Rider: micro-jolt floor on the #3589 IMU calibration records.

## Why
Field trip 2026-07-26: the second recording after a short break logged 13 min with zero engine data — 20 consecutive liveReconnect "successes" at ~4.7 s cadence. `SupervisorReattachSource.start()` immediate-fired with the very service the trip had just dropped (transport closed, reference lingering in the supervisor's ready state); the resumed scheduler polled the dead socket, re-dropped instantly, and the loop starved every genuinely fresh connect. Same field session flooded the IMU record cap with 600-700 road-vibration blips.

## How
- Both delivery paths (immediate-fire and ready-event) now require `service.isConnected`; a held-but-dead service waits for the supervisor's next genuine ready (`obd2_reattach_source.dart`).
- `replaceService` opens an 8 s `_reconnectGrace` during which `_registerTransportError` and null high-priority parses feed the #3575 protocol recovery instead of the drop verdict — generous vs the ~2.5 s ISO 9141 5-baud init. The #3604 staleness fence still ends a session whose bus never comes up (window, not immunity).
- IMU (Refs #3589 — field-tuning follow-up; issue-create is blocked from this session): a stretch < 0.15 s with peak < 4.5 m/s² is counted into `dropped`, not stored; confirmed events and short-but-violent jolts still record.

## Testing
- [x] Unit: held-but-dead service does NOT immediate-fire and the next genuine ready with a live service does; held-and-live still immediate-fires (#3531 fast path) — `obd2_reattach_corpse_test.dart`
- [x] Unit: null-parse storm inside the grace survives; past the grace the #3604 fence still drops — `trip_recording_controller_stale_engine_test.dart`
- [x] Unit: 50 ms/3.2 blip counted-not-stored; 50 ms/6.0 jolt still recorded — `imu_event_detector_test.dart`
- [x] Pre-push gates green (clean codegen, l10n, analyze, lint suite)

## Completeness checklist
- [x] **Pattern audit** — both reattach delivery paths guarded; both drop inputs (transport error + silent parse) graced
- [x] **Producer + consumer** — grace set by `replaceService` (producer) and read by both drop inputs (consumers) in this PR
- [x] **Affordances tested** — n/a, no UI
- [x] **Superseded code deleted** — n/a

Closes #3625
Refs #3589

Left open per the issue: supervisor nulling `_service` on the shared drop signal (defense-in-depth vs #3035 park semantics) and success-flap stand-down accounting (#3603 — next up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g2Ybjri7MwVoFrTSvh98
