### PR TITLE
fix(obd2): reconnect stand-down for identical-signature storms and success-flaps (#3603)

### DIFF
--- a/lib/features/obd2/data/obd2_link_state.dart
+++ b/lib/features/obd2/data/obd2_link_state.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// The link states one OBD2 adapter can be in, as seen by the ONE
+/// reconnect owner (#3529, Epic #3527).
+enum Obd2LinkState {
+  /// No adapter configured / nothing to supervise.
+  idle,
+
+  /// A user- or policy-initiated dial is in flight.
+  connecting,
+
+  /// A live, initialized service is available via
+  /// [Obd2LinkSupervisor.service].
+  ready,
+
+  /// The link dropped and the supervisor is running its backoff loop.
+  /// It NEVER gives up on its own — the loop runs until success, a user
+  /// disconnect, or an engine-off classification (the #3527 rewrite
+  /// deliberately has no `terminalFailed` dead-end; the old six
+  /// dead-end states are what stranded the 2026-07-08 trip).
+  reconnecting,
+
+  /// The user asked to disconnect. Nothing auto-reconnects until the
+  /// next explicit [Obd2LinkSupervisor.connect] (research rule 7: ONE
+  /// flag distinguishes intent from drop, checked in one place).
+  userDisconnected,
+
+  /// The bus was classified silent (engine off, #3035). The backoff
+  /// loop parks — dialing a sleeping car burns adapter and phone
+  /// battery — until [Obd2LinkSupervisor.wake] (movement, app resume)
+  /// or an explicit connect.
+  engineOff,
+}

--- a/lib/features/obd2/data/obd2_link_supervisor.dart
+++ b/lib/features/obd2/data/obd2_link_supervisor.dart
@@ -9,39 +9,11 @@ import 'package:flutter/foundation.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import 'obd2_link_drop_signal.dart';
+import 'obd2_link_state.dart';
+import 'obd2_reconnect_stand_down.dart';
 import 'obd2_service.dart';
 
-/// The link states one OBD2 adapter can be in, as seen by the ONE
-/// reconnect owner (#3529, Epic #3527).
-enum Obd2LinkState {
-  /// No adapter configured / nothing to supervise.
-  idle,
-
-  /// A user- or policy-initiated dial is in flight.
-  connecting,
-
-  /// A live, initialized service is available via
-  /// [Obd2LinkSupervisor.service].
-  ready,
-
-  /// The link dropped and the supervisor is running its backoff loop.
-  /// It NEVER gives up on its own — the loop runs until success, a user
-  /// disconnect, or an engine-off classification (the #3527 rewrite
-  /// deliberately has no `terminalFailed` dead-end; the old six
-  /// dead-end states are what stranded the 2026-07-08 trip).
-  reconnecting,
-
-  /// The user asked to disconnect. Nothing auto-reconnects until the
-  /// next explicit [Obd2LinkSupervisor.connect] (research rule 7: ONE
-  /// flag distinguishes intent from drop, checked in one place).
-  userDisconnected,
-
-  /// The bus was classified silent (engine off, #3035). The backoff
-  /// loop parks — dialing a sleeping car burns adapter and phone
-  /// battery — until [Obd2LinkSupervisor.wake] (movement, app resume)
-  /// or an explicit connect.
-  engineOff,
-}
+export 'obd2_link_state.dart';
 
 /// How the supervisor obtains a live, initialized [Obd2Service]. The
 /// closure encapsulates *how* to dial (direct-by-MAC, scan fallback,
@@ -79,48 +51,26 @@ class Obd2LinkSupervisor {
   Obd2LinkSupervisor({
     required Obd2LinkDialer dial,
     Stream<Obd2LinkDropEvent>? drops,
-    this.initialBackoff = const Duration(milliseconds: 500),
-    this.maxBackoff = const Duration(seconds: 30),
-    this.stormBackoff = const Duration(minutes: 5),
+    Duration initialBackoff = const Duration(milliseconds: 500),
+    Duration maxBackoff = const Duration(seconds: 30),
+    Duration stormBackoff = const Duration(minutes: 5),
     Random? jitter,
     DateTime Function()? now,
   })  : _dial = dial,
-        _now = now ?? DateTime.now,
-        _jitter = jitter ?? Random() {
+        _standDown = ReconnectStandDown(now: now ?? DateTime.now),
+        _backoff = ReconnectBackoff(
+          initial: initialBackoff,
+          max: maxBackoff,
+          storm: stormBackoff,
+          jitter: jitter ?? Random(),
+        ) {
     _dropSubscription =
         (drops ?? Obd2LinkDropSignal.instance.drops).listen(_onDrop);
   }
 
   final Obd2LinkDialer _dial;
-  final Duration initialBackoff;
-  final Duration maxBackoff;
-
-  /// #3603 — the STAND-DOWN cadence: once [standDownThreshold]
-  /// consecutive identical-signature misses (the field storm: 20
-  /// rfcommOpenFail ladder timeouts at ~70 s each, 21 minutes of burned
-  /// battery) or rapid ready→drop flaps (#3625's blind spot: a success
-  /// that proves nothing) accumulate, the loop widens straight to this
-  /// interval instead of the doubling ladder. The no-dead-end invariant
-  /// holds — the loop still never self-terminates; it just stops
-  /// hammering a link that keeps failing the same way. Any user intent,
-  /// wake, signature change, or ready that SURVIVES [flapWindow]
-  /// restores the fast ladder.
-  final Duration stormBackoff;
-  final DateTime Function() _now;
-  final Random _jitter;
-
-  /// #3603 — consecutive identical failures (or flaps) before the loop
-  /// stands down to [stormBackoff].
-  static const int standDownThreshold = 3;
-
-  /// #3603 — a ready that drops again within this window is a FLAP,
-  /// not a recovery: it must not reset the escalation.
-  static const Duration flapWindow = Duration(seconds: 30);
-
-  String? _lastMissSignature;
-  int _identicalMissStreak = 0;
-  DateTime? _readyAt;
-  int _flapStreak = 0;
+  final ReconnectStandDown _standDown;
+  final ReconnectBackoff _backoff;
 
   final ValueNotifier<Obd2LinkState> _state =
       ValueNotifier<Obd2LinkState>(Obd2LinkState.idle);
@@ -131,7 +81,6 @@ class Obd2LinkSupervisor {
   Obd2Service? _service;
   Future<Obd2Service?>? _attemptInFlight;
   Timer? _backoffTimer;
-  Duration _backoff = Duration.zero;
   bool _userRequestedDisconnect = false;
   bool _disposed = false;
 
@@ -158,17 +107,15 @@ class Obd2LinkSupervisor {
   int get attemptNumber => _attemptCount + 1;
 
   /// Current backoff in milliseconds (telemetry).
-  int get currentBackoffMs => _backoff.inMilliseconds;
+  int get currentBackoffMs => _backoff.currentMs;
 
   /// True once the backoff has grown to its cap — the loop is in its
   /// calm long-wait cadence (#2767's "passive waiting" banner copy).
-  bool get backoffAtCap => _backoff >= maxBackoff;
+  bool get backoffAtCap => _backoff.atCap;
 
-  /// #3603 — true while the loop holds the [stormBackoff] cadence
-  /// (telemetry / banner copy).
-  bool get inStandDown =>
-      _identicalMissStreak >= standDownThreshold ||
-      _flapStreak >= standDownThreshold;
+  /// #3603 — true while the loop holds the storm cadence (telemetry /
+  /// banner copy).
+  bool get inStandDown => _standDown.active;
 
   /// User/policy-initiated connect. Clears the disconnect intent, exits
   /// any parked state, and dials now. Joins the in-flight attempt if
@@ -178,7 +125,7 @@ class Obd2LinkSupervisor {
   Future<Obd2Service?> connect() {
     if (_disposed) return Future<Obd2Service?>.value();
     _userRequestedDisconnect = false;
-    _resetStandDown(); // #3603 — user intent is a positive signal
+    _standDown.reset(); // #3603 — user intent is a positive signal
     _cancelBackoffTimer();
     return _attempt(userInitiated: true);
   }
@@ -193,7 +140,7 @@ class Obd2LinkSupervisor {
   Future<Obd2Service?> connectWith(Obd2LinkDialer dialer) {
     if (_disposed) return Future<Obd2Service?>.value();
     _userRequestedDisconnect = false;
-    _resetStandDown(); // #3603
+    _standDown.reset(); // #3603
     _cancelBackoffTimer();
     return _attempt(userInitiated: true, dialer: dialer);
   }
@@ -204,20 +151,11 @@ class Obd2LinkSupervisor {
     _userRequestedDisconnect = true;
     _cancelBackoffTimer();
     _attemptCount = 0;
-    _resetStandDown(); // #3603
+    _standDown.reset(); // #3603
     final dead = _service;
     _service = null;
     _setState(Obd2LinkState.userDisconnected);
-    if (dead != null) {
-      try {
-        await dead.disconnect();
-      } catch (e, st) {
-        // Best-effort — the intent is recorded either way; a throwing
-        // teardown of a half-dead link must not surface to the user.
-        unawaited(errorLogger.log(ErrorLayer.other, e, st,
-            context: const {'where': 'Obd2LinkSupervisor.disconnect'}));
-      }
-    }
+    await _release(dead, 'disconnect');
   }
 
   /// A drop or session death reported from below (channels via
@@ -232,18 +170,7 @@ class Obd2LinkSupervisor {
           '(${_state.value}) — not dialing');
       return;
     }
-    // #3603 — flap accounting: a ready that died within [flapWindow]
-    // is a flap, not a recovery; one that SURVIVED the window proves
-    // the link works and clears the streak.
-    final readyAt = _readyAt;
-    _readyAt = null;
-    if (readyAt != null) {
-      if (_now().difference(readyAt) < flapWindow) {
-        _flapStreak++;
-      } else {
-        _flapStreak = 0;
-      }
-    }
+    _standDown.noteDrop(); // #3603 — flap accounting
     // #3534 — the per-drop timeline starts here (detect → dial →
     // recovered); the field-validation checklist reads this chain out
     // of the breadcrumb export after an induced-drop drive.
@@ -251,14 +178,14 @@ class Obd2LinkSupervisor {
     _setState(Obd2LinkState.reconnecting);
     // Dial immediately on the first drop; backoff grows only on misses.
     if (_attemptInFlight == null && _backoffTimer == null) {
-      if (_flapStreak >= standDownThreshold) {
+      if (_standDown.active) {
         // #3603 — success-flap stand-down: the instant redial is what
         // burned 20 dial→adopt→drop cycles in the field. Hold the
         // storm cadence until a ready survives or the user acts.
         _armBackoffTimer();
         return;
       }
-      _backoff = Duration.zero;
+      _backoff.reset();
       unawaited(_attempt(userInitiated: false));
     }
   }
@@ -270,7 +197,7 @@ class Obd2LinkSupervisor {
     _cancelBackoffTimer();
     _service = null;
     _attemptCount = 0;
-    _resetStandDown(); // #3603 — the park itself is the stand-down
+    _standDown.reset(); // #3603 — the park itself is the stand-down
     // #3534 — the checklist's "engine-off parks the loop" line item.
     BreadcrumbCollector.add('OBD2 link parked', detail: 'engine off');
     _setState(Obd2LinkState.engineOff);
@@ -281,8 +208,8 @@ class Obd2LinkSupervisor {
   /// already-live link must do nothing.
   void wake() {
     if (_disposed || _state.value != Obd2LinkState.engineOff) return;
-    _resetStandDown(); // #3603 — movement is a positive signal
-    _backoff = Duration.zero;
+    _standDown.reset(); // #3603 — movement is a positive signal
+    _backoff.reset();
     _setState(Obd2LinkState.reconnecting);
     unawaited(_attempt(userInitiated: false));
   }
@@ -329,13 +256,7 @@ class Obd2LinkSupervisor {
     // (research rule 8: recovery = full close + fresh socket).
     final dead = _service;
     _service = null;
-    if (dead != null) {
-      try {
-        await dead.disconnect();
-      } catch (_) {
-        // ignore: silent_catch — releasing a dead link; the fresh dial is the recovery
-      }
-    }
+    await _release(dead, 'recycle');
     _setState(userInitiated
         ? Obd2LinkState.connecting
         : Obd2LinkState.reconnecting);
@@ -352,27 +273,17 @@ class Obd2LinkSupervisor {
       debugPrint('Obd2LinkSupervisor: dial failed: $e\n$st');
       BreadcrumbCollector.add(
         'OBD2 dial failed',
-        detail: '${e.runtimeType} backoff=${_backoff.inMilliseconds}ms',
+        detail: '${e.runtimeType} backoff=${_backoff.currentMs}ms',
       );
     }
     if (_disposed) {
-      if (fresh != null) {
-        try {
-          await fresh.disconnect();
-        } catch (_) {
-          // ignore: silent_catch — supervisor is gone; nothing owns the link anymore
-        }
-      }
+      await _release(fresh, 'disposedDial');
       return null;
     }
     // The user may have hit disconnect while the dial was in flight —
     // intent wins over the race (checked at the ONE gate).
     if (fresh != null && !_mayAutoDial && !userInitiated) {
-      try {
-        await fresh.disconnect();
-      } catch (_) {
-        // ignore: silent_catch — user parked the link mid-dial; releasing the unwanted socket
-      }
+      await _release(fresh, 'parkedMidDial');
       return null;
     }
     if (fresh != null) {
@@ -386,31 +297,14 @@ class Obd2LinkSupervisor {
             : 'recovered after ${_attemptCount + 1} dial(s)',
       );
       _service = fresh;
-      _backoff = Duration.zero;
+      _backoff.reset();
       _attemptCount = 0;
-      // #3603 — a fresh ready clears the miss streak, but NOT the flap
-      // streak: a success that proves nothing (drops again inside
-      // [flapWindow]) must not reset the escalation — the 2026-07-03
-      // detector blind spot. The flap streak clears when a ready
-      // SURVIVES the window (checked at the next drop) or on intent.
-      _lastMissSignature = null;
-      _identicalMissStreak = 0;
-      _readyAt = _now();
+      _standDown.noteReady(); // #3603 — clears misses, arms flap clock
       _setState(Obd2LinkState.ready);
       return fresh;
     }
     _attemptCount++;
-    // #3603 — identical-signature accounting: the field storm was 20
-    // TimeoutExceptions in a row; N of the SAME failure mean the next
-    // attempt will very likely fail the same way too.
-    final signature =
-        failure == null ? 'miss' : failure.runtimeType.toString();
-    if (signature == _lastMissSignature) {
-      _identicalMissStreak++;
-    } else {
-      _lastMissSignature = signature;
-      _identicalMissStreak = 1;
-    }
+    _standDown.noteMiss(failure); // #3603 — identical-signature streak
     // Miss (null or fault): grow the backoff and re-arm — but only when
     // auto-dialing is still allowed. There is deliberately NO attempt
     // cap and NO terminal-failed state.
@@ -425,45 +319,35 @@ class Obd2LinkSupervisor {
     return null;
   }
 
+  /// Best-effort teardown of a dead or unwanted service — a throwing
+  /// disconnect must never derail the loop (research rules 8 + 9); the
+  /// fault is logged, not surfaced.
+  Future<void> _release(Obd2Service? dead, String where) async {
+    if (dead == null) return;
+    try {
+      await dead.disconnect();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: {'where': 'Obd2LinkSupervisor.$where'}));
+    }
+  }
+
   void _armBackoffTimer() {
     _cancelBackoffTimer();
-    if (inStandDown) {
-      // #3603 — stand-down: jump straight to the storm cadence. The
-      // breadcrumb fires once on entry, not every tick.
-      if (_backoff < stormBackoff) {
-        BreadcrumbCollector.add(
-          'OBD2 reconnect stand-down',
-          detail: _flapStreak >= standDownThreshold
-              ? 'flap x$_flapStreak — holding ${stormBackoff.inSeconds}s'
-              : '$_lastMissSignature x$_identicalMissStreak — '
-                  'holding ${stormBackoff.inSeconds}s',
-        );
-      }
-      _backoff = stormBackoff;
-    } else {
-      _backoff = _backoff == Duration.zero
-          ? initialBackoff
-          : _backoff * 2 > maxBackoff
-              ? maxBackoff
-              : _backoff * 2;
+    final wait = _backoff.advance(standDown: inStandDown);
+    if (_backoff.enteredStorm) {
+      // #3603 — the breadcrumb fires once on stand-down entry.
+      BreadcrumbCollector.add(
+        'OBD2 reconnect stand-down',
+        detail: '${_standDown.detail} — '
+            'holding ${_backoff.storm.inSeconds}s',
+      );
     }
-    // 0–12.5% jitter de-syncs the retry cadence from the adapter's own
-    // advertising/settling rhythm (same rationale as #3014's jitter).
-    final jitterMs = _jitter.nextInt(1 + _backoff.inMilliseconds ~/ 8);
-    _backoffTimer = Timer(_backoff + Duration(milliseconds: jitterMs), () {
+    _backoffTimer = Timer(wait, () {
       _backoffTimer = null;
       if (_disposed || !_mayAutoDial) return;
       unawaited(_attempt(userInitiated: false));
     });
-  }
-
-  /// #3603 — positive signal (user intent, wake, park): back to the
-  /// fast ladder.
-  void _resetStandDown() {
-    _lastMissSignature = null;
-    _identicalMissStreak = 0;
-    _flapStreak = 0;
-    _readyAt = null;
   }
 
   void _cancelBackoffTimer() {
@@ -487,13 +371,7 @@ class Obd2LinkSupervisor {
     _dropSubscription = null;
     final dead = _service;
     _service = null;
-    if (dead != null) {
-      try {
-        await dead.disconnect();
-      } catch (_) {
-        // ignore: silent_catch — teardown on dispose; no owner remains to care
-      }
-    }
+    await _release(dead, 'dispose');
     _state.dispose();
     await _states.close();
   }

--- a/lib/features/obd2/data/obd2_link_supervisor.dart
+++ b/lib/features/obd2/data/obd2_link_supervisor.dart
@@ -81,8 +81,11 @@ class Obd2LinkSupervisor {
     Stream<Obd2LinkDropEvent>? drops,
     this.initialBackoff = const Duration(milliseconds: 500),
     this.maxBackoff = const Duration(seconds: 30),
+    this.stormBackoff = const Duration(minutes: 5),
     Random? jitter,
+    DateTime Function()? now,
   })  : _dial = dial,
+        _now = now ?? DateTime.now,
         _jitter = jitter ?? Random() {
     _dropSubscription =
         (drops ?? Obd2LinkDropSignal.instance.drops).listen(_onDrop);
@@ -91,7 +94,33 @@ class Obd2LinkSupervisor {
   final Obd2LinkDialer _dial;
   final Duration initialBackoff;
   final Duration maxBackoff;
+
+  /// #3603 — the STAND-DOWN cadence: once [standDownThreshold]
+  /// consecutive identical-signature misses (the field storm: 20
+  /// rfcommOpenFail ladder timeouts at ~70 s each, 21 minutes of burned
+  /// battery) or rapid ready→drop flaps (#3625's blind spot: a success
+  /// that proves nothing) accumulate, the loop widens straight to this
+  /// interval instead of the doubling ladder. The no-dead-end invariant
+  /// holds — the loop still never self-terminates; it just stops
+  /// hammering a link that keeps failing the same way. Any user intent,
+  /// wake, signature change, or ready that SURVIVES [flapWindow]
+  /// restores the fast ladder.
+  final Duration stormBackoff;
+  final DateTime Function() _now;
   final Random _jitter;
+
+  /// #3603 — consecutive identical failures (or flaps) before the loop
+  /// stands down to [stormBackoff].
+  static const int standDownThreshold = 3;
+
+  /// #3603 — a ready that drops again within this window is a FLAP,
+  /// not a recovery: it must not reset the escalation.
+  static const Duration flapWindow = Duration(seconds: 30);
+
+  String? _lastMissSignature;
+  int _identicalMissStreak = 0;
+  DateTime? _readyAt;
+  int _flapStreak = 0;
 
   final ValueNotifier<Obd2LinkState> _state =
       ValueNotifier<Obd2LinkState>(Obd2LinkState.idle);
@@ -135,6 +164,12 @@ class Obd2LinkSupervisor {
   /// calm long-wait cadence (#2767's "passive waiting" banner copy).
   bool get backoffAtCap => _backoff >= maxBackoff;
 
+  /// #3603 — true while the loop holds the [stormBackoff] cadence
+  /// (telemetry / banner copy).
+  bool get inStandDown =>
+      _identicalMissStreak >= standDownThreshold ||
+      _flapStreak >= standDownThreshold;
+
   /// User/policy-initiated connect. Clears the disconnect intent, exits
   /// any parked state, and dials now. Joins the in-flight attempt if
   /// one exists (single flight). Returns the live service, or null when
@@ -143,6 +178,7 @@ class Obd2LinkSupervisor {
   Future<Obd2Service?> connect() {
     if (_disposed) return Future<Obd2Service?>.value();
     _userRequestedDisconnect = false;
+    _resetStandDown(); // #3603 — user intent is a positive signal
     _cancelBackoffTimer();
     return _attempt(userInitiated: true);
   }
@@ -157,6 +193,7 @@ class Obd2LinkSupervisor {
   Future<Obd2Service?> connectWith(Obd2LinkDialer dialer) {
     if (_disposed) return Future<Obd2Service?>.value();
     _userRequestedDisconnect = false;
+    _resetStandDown(); // #3603
     _cancelBackoffTimer();
     return _attempt(userInitiated: true, dialer: dialer);
   }
@@ -167,6 +204,7 @@ class Obd2LinkSupervisor {
     _userRequestedDisconnect = true;
     _cancelBackoffTimer();
     _attemptCount = 0;
+    _resetStandDown(); // #3603
     final dead = _service;
     _service = null;
     _setState(Obd2LinkState.userDisconnected);
@@ -194,6 +232,18 @@ class Obd2LinkSupervisor {
           '(${_state.value}) — not dialing');
       return;
     }
+    // #3603 — flap accounting: a ready that died within [flapWindow]
+    // is a flap, not a recovery; one that SURVIVED the window proves
+    // the link works and clears the streak.
+    final readyAt = _readyAt;
+    _readyAt = null;
+    if (readyAt != null) {
+      if (_now().difference(readyAt) < flapWindow) {
+        _flapStreak++;
+      } else {
+        _flapStreak = 0;
+      }
+    }
     // #3534 — the per-drop timeline starts here (detect → dial →
     // recovered); the field-validation checklist reads this chain out
     // of the breadcrumb export after an induced-drop drive.
@@ -201,6 +251,13 @@ class Obd2LinkSupervisor {
     _setState(Obd2LinkState.reconnecting);
     // Dial immediately on the first drop; backoff grows only on misses.
     if (_attemptInFlight == null && _backoffTimer == null) {
+      if (_flapStreak >= standDownThreshold) {
+        // #3603 — success-flap stand-down: the instant redial is what
+        // burned 20 dial→adopt→drop cycles in the field. Hold the
+        // storm cadence until a ready survives or the user acts.
+        _armBackoffTimer();
+        return;
+      }
       _backoff = Duration.zero;
       unawaited(_attempt(userInitiated: false));
     }
@@ -213,6 +270,7 @@ class Obd2LinkSupervisor {
     _cancelBackoffTimer();
     _service = null;
     _attemptCount = 0;
+    _resetStandDown(); // #3603 — the park itself is the stand-down
     // #3534 — the checklist's "engine-off parks the loop" line item.
     BreadcrumbCollector.add('OBD2 link parked', detail: 'engine off');
     _setState(Obd2LinkState.engineOff);
@@ -223,6 +281,7 @@ class Obd2LinkSupervisor {
   /// already-live link must do nothing.
   void wake() {
     if (_disposed || _state.value != Obd2LinkState.engineOff) return;
+    _resetStandDown(); // #3603 — movement is a positive signal
     _backoff = Duration.zero;
     _setState(Obd2LinkState.reconnecting);
     unawaited(_attempt(userInitiated: false));
@@ -329,10 +388,29 @@ class Obd2LinkSupervisor {
       _service = fresh;
       _backoff = Duration.zero;
       _attemptCount = 0;
+      // #3603 — a fresh ready clears the miss streak, but NOT the flap
+      // streak: a success that proves nothing (drops again inside
+      // [flapWindow]) must not reset the escalation — the 2026-07-03
+      // detector blind spot. The flap streak clears when a ready
+      // SURVIVES the window (checked at the next drop) or on intent.
+      _lastMissSignature = null;
+      _identicalMissStreak = 0;
+      _readyAt = _now();
       _setState(Obd2LinkState.ready);
       return fresh;
     }
     _attemptCount++;
+    // #3603 — identical-signature accounting: the field storm was 20
+    // TimeoutExceptions in a row; N of the SAME failure mean the next
+    // attempt will very likely fail the same way too.
+    final signature =
+        failure == null ? 'miss' : failure.runtimeType.toString();
+    if (signature == _lastMissSignature) {
+      _identicalMissStreak++;
+    } else {
+      _lastMissSignature = signature;
+      _identicalMissStreak = 1;
+    }
     // Miss (null or fault): grow the backoff and re-arm — but only when
     // auto-dialing is still allowed. There is deliberately NO attempt
     // cap and NO terminal-failed state.
@@ -349,11 +427,26 @@ class Obd2LinkSupervisor {
 
   void _armBackoffTimer() {
     _cancelBackoffTimer();
-    _backoff = _backoff == Duration.zero
-        ? initialBackoff
-        : _backoff * 2 > maxBackoff
-            ? maxBackoff
-            : _backoff * 2;
+    if (inStandDown) {
+      // #3603 — stand-down: jump straight to the storm cadence. The
+      // breadcrumb fires once on entry, not every tick.
+      if (_backoff < stormBackoff) {
+        BreadcrumbCollector.add(
+          'OBD2 reconnect stand-down',
+          detail: _flapStreak >= standDownThreshold
+              ? 'flap x$_flapStreak — holding ${stormBackoff.inSeconds}s'
+              : '$_lastMissSignature x$_identicalMissStreak — '
+                  'holding ${stormBackoff.inSeconds}s',
+        );
+      }
+      _backoff = stormBackoff;
+    } else {
+      _backoff = _backoff == Duration.zero
+          ? initialBackoff
+          : _backoff * 2 > maxBackoff
+              ? maxBackoff
+              : _backoff * 2;
+    }
     // 0–12.5% jitter de-syncs the retry cadence from the adapter's own
     // advertising/settling rhythm (same rationale as #3014's jitter).
     final jitterMs = _jitter.nextInt(1 + _backoff.inMilliseconds ~/ 8);
@@ -362,6 +455,15 @@ class Obd2LinkSupervisor {
       if (_disposed || !_mayAutoDial) return;
       unawaited(_attempt(userInitiated: false));
     });
+  }
+
+  /// #3603 — positive signal (user intent, wake, park): back to the
+  /// fast ladder.
+  void _resetStandDown() {
+    _lastMissSignature = null;
+    _identicalMissStreak = 0;
+    _flapStreak = 0;
+    _readyAt = null;
   }
 
   void _cancelBackoffTimer() {

--- a/lib/features/obd2/data/obd2_reconnect_stand_down.dart
+++ b/lib/features/obd2/data/obd2_reconnect_stand_down.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' show Random;
+
+/// #3603 — stand-down accounting for THE one reconnect owner
+/// ([Obd2LinkSupervisor]).
+///
+/// Two field failure shapes motivated this, both from the 2026-07
+/// connect-trace exports:
+///
+///  * **Identical-signature storms** — 20 consecutive liveReconnect
+///    rfcommOpenFail ladder timeouts over 21 minutes at ~70 s cadence
+///    (2026-07-24). The per-attempt bound (#3421) held, but nothing
+///    above it stood down: N misses that fail the SAME way predict the
+///    next attempt fails the same way too.
+///  * **Success-flaps** (#3625's blind spot) — a dial that "succeeds"
+///    but drops again within seconds proves nothing, yet it reset the
+///    escalation forever; the corpse loop recorded a whole trip with
+///    zero engine data at a ~4.7 s dial→adopt→drop cadence.
+///
+/// Once either streak reaches [threshold], the supervisor holds its
+/// storm cadence instead of the fast ladder. The #3527 no-dead-end
+/// invariant is untouched — the loop never self-terminates; it just
+/// stops hammering a link that keeps failing identically. Positive
+/// signals (user intent, wake, engine-off park, a signature change, a
+/// ready that survives [flapWindow]) restore the fast ladder.
+class ReconnectStandDown {
+  ReconnectStandDown({required DateTime Function() now}) : _now = now;
+
+  /// Consecutive identical failures (or flaps) before the loop stands
+  /// down to the storm cadence.
+  static const int threshold = 3;
+
+  /// A ready that drops again within this window is a FLAP, not a
+  /// recovery: it must not reset the escalation.
+  static const Duration flapWindow = Duration(seconds: 30);
+
+  final DateTime Function() _now;
+  String? _lastMissSignature;
+  int _missStreak = 0;
+  DateTime? _readyAt;
+  int _flapStreak = 0;
+
+  /// True while either streak holds the loop at the storm cadence.
+  bool get active =>
+      _missStreak >= threshold || _flapStreak >= threshold;
+
+  /// Breadcrumb payload naming WHY the loop stood down.
+  String get detail => _flapStreak >= threshold
+      ? 'flap x$_flapStreak'
+      : '$_lastMissSignature x$_missStreak';
+
+  /// A dial miss: `null` result or a fault. Identical signatures
+  /// (failure runtime type; plain misses count as their own kind)
+  /// accumulate; a change of signature restarts the streak at 1.
+  void noteMiss(Object? failure) {
+    final signature =
+        failure == null ? 'miss' : failure.runtimeType.toString();
+    if (signature == _lastMissSignature) {
+      _missStreak++;
+    } else {
+      _lastMissSignature = signature;
+      _missStreak = 1;
+    }
+  }
+
+  /// A fresh ready: clears the miss streak and stamps the flap clock.
+  /// The flap streak is deliberately NOT cleared here — a success that
+  /// proves nothing must not reset the escalation; it clears when a
+  /// ready SURVIVES [flapWindow] (checked at the next drop) or on a
+  /// positive signal ([reset]).
+  void noteReady() {
+    _lastMissSignature = null;
+    _missStreak = 0;
+    _readyAt = _now();
+  }
+
+  /// A drop: flap accounting. A ready that died within [flapWindow] is
+  /// a flap; one that survived the window proves the link works and
+  /// clears the streak. Drops with no prior ready leave the streak
+  /// unchanged (the miss streak owns that shape).
+  void noteDrop() {
+    final readyAt = _readyAt;
+    _readyAt = null;
+    if (readyAt == null) return;
+    if (_now().difference(readyAt) < flapWindow) {
+      _flapStreak++;
+    } else {
+      _flapStreak = 0;
+    }
+  }
+
+  /// Positive signal (user intent, wake, park): back to the fast ladder.
+  void reset() {
+    _lastMissSignature = null;
+    _missStreak = 0;
+    _flapStreak = 0;
+    _readyAt = null;
+  }
+}
+
+/// The supervisor's retry cadence (#3527 ladder + #3603 storm hold):
+/// doubling from [initial] to the [max] cap while healthy; a stand-down
+/// jumps straight to [storm]. Jitter (0-12.5%) de-syncs the cadence
+/// from the adapter's own advertising/settling rhythm (#3014).
+class ReconnectBackoff {
+  ReconnectBackoff({
+    required this.initial,
+    required this.max,
+    required this.storm,
+    required Random jitter,
+  }) : _jitter = jitter;
+
+  final Duration initial;
+  final Duration max;
+  final Duration storm;
+  final Random _jitter;
+  Duration _current = Duration.zero;
+  bool _enteredStorm = false;
+
+  int get currentMs => _current.inMilliseconds;
+  bool get atCap => _current >= max;
+
+  /// True when the LAST [advance] crossed from the ladder into the
+  /// storm hold — the caller breadcrumbs stand-down entry exactly once.
+  bool get enteredStorm => _enteredStorm;
+
+  void reset() => _current = Duration.zero;
+
+  /// Grows the cadence and returns the wait including jitter.
+  Duration advance({required bool standDown}) {
+    _enteredStorm = standDown && _current < storm;
+    _current = standDown
+        ? storm
+        : _current == Duration.zero
+            ? initial
+            : _current * 2 > max
+                ? max
+                : _current * 2;
+    final jitterMs = _jitter.nextInt(1 + _current.inMilliseconds ~/ 8);
+    return _current + Duration(milliseconds: jitterMs);
+  }
+}

--- a/test/features/obd2/data/trip_recording_controller_reconnect_test.dart
+++ b/test/features/obd2/data/trip_recording_controller_reconnect_test.dart
@@ -873,6 +873,11 @@ void main() {
           // (short) grace window and the post-finalise recovery is fast.
           initialBackoff: const Duration(milliseconds: 10),
           maxBackoff: const Duration(milliseconds: 40),
+          // #3603 — the repeated identical misses here rightly trip the
+          // stand-down; a tiny storm interval keeps this real-time test
+          // about ITS invariant (loop survives trip finalise), not the
+          // storm cadence (covered by obd2_link_standdown_test).
+          stormBackoff: const Duration(milliseconds: 80),
         );
 
         final transport = FakeObd2Transport(initResponses());

--- a/test/features/obd2/obd2_link_standdown_test.dart
+++ b/test/features/obd2/obd2_link_standdown_test.dart
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3603 — reconnect stand-down. Field storm: 20 consecutive
+// liveReconnect rfcommOpenFail timeouts over 21 minutes, each burning
+// the full 23 s ladder budget at ~70 s cadence, with no escalation —
+// the per-attempt bound (#3421) held but nothing above it stood down.
+// And the #3625 blind spot: a success that proves nothing (drops again
+// within seconds) reset the escalation forever. After
+// [standDownThreshold] identical-signature misses OR rapid ready→drop
+// flaps, the loop must hold [stormBackoff] instead of the fast ladder —
+// while still never self-terminating (the #3527 no-dead-end invariant).
+import 'dart:async';
+import 'dart:math';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_drop_signal.dart';
+import 'package:tankstellen/features/obd2/data/obd2_link_supervisor.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+
+Obd2Service _liveService() => Obd2Service(FakeObd2Transport());
+
+/// Scripted dialer (same shape as obd2_link_supervisor_test): pops
+/// outcomes off a queue; an empty queue keeps returning the last one.
+class _ScriptedDialer {
+  final List<Object?> _script = [];
+  int calls = 0;
+
+  void enqueue(Object? outcome) => _script.add(outcome);
+
+  /// Drops whatever the queue still holds (incl. the sticky last
+  /// outcome) and scripts [outcome] from the next dial on.
+  void replaceAll(Object? outcome) => _script
+    ..clear()
+    ..add(outcome);
+
+  Future<Obd2Service?> dial() async {
+    calls++;
+    final outcome = _script.length > 1 ? _script.removeAt(0) : _script.first;
+    if (outcome is Obd2Service) return outcome;
+    if (outcome == null) return null;
+    throw outcome;
+  }
+}
+
+void main() {
+  late StreamController<Obd2LinkDropEvent> drops;
+  late _ScriptedDialer dialer;
+
+  // Manual clock advanced in lockstep with fakeAsync elapse — inside
+  // fakeAsync a raw DateTime.now() would not move with the timers.
+  late DateTime nowValue;
+  void elapse(FakeAsync async, Duration d) {
+    nowValue = nowValue.add(d);
+    async.elapse(d);
+  }
+
+  const storm = Duration(minutes: 5);
+
+  Obd2LinkSupervisor build() => Obd2LinkSupervisor(
+        dial: dialer.dial,
+        drops: drops.stream,
+        initialBackoff: const Duration(milliseconds: 500),
+        maxBackoff: const Duration(seconds: 30),
+        stormBackoff: storm,
+        jitter: Random(42),
+        now: () => nowValue,
+      );
+
+  setUp(() {
+    drops = StreamController<Obd2LinkDropEvent>.broadcast();
+    dialer = _ScriptedDialer();
+    nowValue = DateTime(2026, 7, 24, 18, 14);
+  });
+
+  tearDown(() => drops.close());
+
+  void dropNow() => drops.add(const Obd2LinkDropEvent(
+      transportKind: 'classic', reason: 'socket-error'));
+
+  test('three identical-signature faults stand the loop down to the '
+      'storm cadence — the 21-minute field storm shape', () {
+    fakeAsync((async) {
+      dialer.enqueue(TimeoutException('classic connect exceeded the '
+          'whole-ladder budget'));
+      final sup = build();
+
+      dropNow();
+      async.flushMicrotasks();
+      expect(dialer.calls, 1, reason: 'first drop dials immediately');
+      expect(sup.inStandDown, isFalse);
+
+      // Two more misses ride the fast ladder (0.5 s, 1 s + jitter).
+      elapse(async, const Duration(seconds: 3));
+      expect(dialer.calls, 3);
+      expect(sup.inStandDown, isTrue,
+          reason: 'the third identical TimeoutException is the storm '
+              'signature');
+      expect(sup.currentBackoffMs, storm.inMilliseconds,
+          reason: 'stand-down jumps straight to the storm cadence');
+
+      // The fast ladder would have fired ~5 more times in 2 minutes;
+      // the stand-down holds.
+      elapse(async, const Duration(minutes: 2));
+      expect(dialer.calls, 3,
+          reason: 'no dial inside the storm hold');
+
+      // The no-dead-end invariant: the loop still retries eventually.
+      elapse(async, const Duration(minutes: 4));
+      expect(dialer.calls, 4,
+          reason: 'the storm tick still dials — never self-terminates');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('a signature CHANGE resets the streak — alternating failures keep '
+      'the fast ladder', () {
+    fakeAsync((async) {
+      // Alternating timeout / clean-miss: no signature ever repeats
+      // three times.
+      dialer.enqueue(TimeoutException('ladder budget'));
+      dialer.enqueue(null);
+      dialer.enqueue(TimeoutException('ladder budget'));
+      dialer.enqueue(null);
+      final sup = build();
+
+      dropNow();
+      async.flushMicrotasks();
+      // The fast ladder fires attempts 2-4 within ~4 s (0.5/1/2 s +
+      // jitter); attempt 5 would come at ~5.7 s earliest.
+      elapse(async, const Duration(seconds: 4));
+      expect(dialer.calls, 4);
+      expect(sup.inStandDown, isFalse,
+          reason: 'alternating signatures: no streak of three '
+              'identical failures ever formed');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('three rapid ready→drop flaps stand down; the next drop does NOT '
+      'redial instantly (#3625 blind spot)', () {
+    fakeAsync((async) {
+      dialer.enqueue(_liveService());
+      final sup = build();
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+      expect(sup.state.value, Obd2LinkState.ready);
+
+      // Three connect→drop cycles, each dying ~2 s after ready — the
+      // dial itself always "succeeds" (fresh service every time).
+      for (var i = 0; i < 3; i++) {
+        dialer.enqueue(_liveService());
+        elapse(async, const Duration(seconds: 2));
+        dropNow();
+        async.flushMicrotasks();
+      }
+      // Flap 1 and 2 redialed instantly (state is ready again); the
+      // THIRD flap crossed the threshold: the loop is parked on the
+      // storm timer, not ready.
+      expect(sup.inStandDown, isTrue);
+      expect(sup.state.value, Obd2LinkState.reconnecting,
+          reason: 'the instant redial after flap 3 is what burned 20 '
+              'field cycles — the loop must hold instead');
+      final callsAtStandDown = dialer.calls;
+
+      elapse(async, const Duration(minutes: 2));
+      expect(dialer.calls, callsAtStandDown,
+          reason: 'no dial inside the storm hold');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('a ready that SURVIVES the flap window clears the streak', () {
+    fakeAsync((async) {
+      dialer.enqueue(_liveService());
+      final sup = build();
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+
+      // Two flaps…
+      for (var i = 0; i < 2; i++) {
+        dialer.enqueue(_liveService());
+        elapse(async, const Duration(seconds: 2));
+        dropNow();
+        async.flushMicrotasks();
+      }
+      // …then a ready that lives past the 30 s window before dropping.
+      dialer.enqueue(_liveService());
+      elapse(async, const Duration(seconds: 45));
+      dropNow();
+      async.flushMicrotasks();
+
+      expect(sup.inStandDown, isFalse,
+          reason: 'the durable ready proved the link works — streak '
+              'cleared, fast ladder restored');
+      expect(sup.state.value, Obd2LinkState.ready,
+          reason: 'the drop after the durable ready redialed instantly');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('user connect() exits the stand-down and dials immediately', () {
+    fakeAsync((async) {
+      dialer.enqueue(TimeoutException('ladder budget'));
+      final sup = build();
+      dropNow();
+      async.flushMicrotasks();
+      elapse(async, const Duration(seconds: 3));
+      expect(sup.inStandDown, isTrue);
+      final callsBefore = dialer.calls;
+
+      dialer.replaceAll(_liveService());
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+      expect(dialer.calls, callsBefore + 1,
+          reason: 'user intent bypasses the storm hold');
+      expect(sup.inStandDown, isFalse);
+      expect(sup.state.value, Obd2LinkState.ready);
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+}

--- a/test/features/obd2/obd2_link_supervisor_test.dart
+++ b/test/features/obd2/obd2_link_supervisor_test.dart
@@ -82,26 +82,28 @@ void main() {
       async.flushMicrotasks();
       expect(sup.state.value, Obd2LinkState.reconnecting);
 
-      // Far beyond the old maxAttempts=6 horizon: two minutes of misses.
-      async.elapse(const Duration(minutes: 2));
-      final callsAtTwoMinutes = dialer.calls;
-      expect(callsAtTwoMinutes, greaterThan(6),
+      // #3603 — three identical misses now stand the loop down to the
+      // storm cadence (default 5 min), so the horizon is longer; the
+      // INVARIANT under test is unchanged: no dead end, ever.
+      async.elapse(const Duration(minutes: 40));
+      final callsAtForty = dialer.calls;
+      expect(callsAtForty, greaterThan(6),
           reason: 'the loop must outlive the old terminalFailed cap');
       expect(sup.state.value, Obd2LinkState.reconnecting,
           reason: 'no dead end — still trying');
 
-      // Backoff is capped, not runaway: over the NEXT two minutes the
-      // attempt rate settles to ~30 s cadence.
-      async.elapse(const Duration(minutes: 2));
-      final callsInSecondWindow = dialer.calls - callsAtTwoMinutes;
-      expect(callsInSecondWindow, inInclusiveRange(3, 6),
-          reason: 'capped ~30s backoff ⇒ ≈4 attempts per 2 min');
+      // Stand-down cadence is steady, not runaway: over the next
+      // 16 minutes ≈3 storm-interval attempts.
+      async.elapse(const Duration(minutes: 16));
+      final callsInSecondWindow = dialer.calls - callsAtForty;
+      expect(callsInSecondWindow, inInclusiveRange(2, 4),
+          reason: 'storm ~5 min cadence ⇒ ≈3 attempts per 16 min');
 
       // And when the adapter finally reappears, the loop connects. The
-      // queued miss still in front costs one more capped cycle, so give
-      // it two full ~30 s backoff periods (+ jitter).
+      // queued miss still in front costs one more storm cycle, so give
+      // it two full periods (+ jitter).
       dialer.enqueue(_liveService());
-      async.elapse(const Duration(seconds: 80));
+      async.elapse(const Duration(minutes: 12));
       expect(sup.state.value, Obd2LinkState.ready);
       unawaited(sup.dispose());
       async.flushMicrotasks();


### PR DESCRIPTION
## What
Reconnect stand-down: three consecutive identical-signature dial misses — or three rapid ready→drop flaps — switch the supervisor from the fast ladder to a storm cadence (default 5 min) until a positive signal.

## Why
Field storm 2026-07-24: 20 consecutive liveReconnect `rfcommOpenFail` timeouts over 21 minutes at ~70 s cadence — the per-attempt bound (#3421) held, but nothing above it ever stood down. Plus the #3625 leftover: a success that proves nothing (drops again within seconds) reset the escalation forever.

## How
- New `ReconnectStandDown` (obd2_reconnect_stand_down.dart): miss-signature streak (failure runtime type; plain misses are their own kind) + flap streak (a ready that dies inside a 30 s window counts; one that survives clears). Threshold 3.
- New `ReconnectBackoff` (same file): the doubling ladder + jitter extracted from the supervisor; stand-down jumps straight to `stormBackoff`, `enteredStorm` breadcrumbs entry exactly once.
- Supervisor: `notifyDrop` no longer instant-redials while flapped; success clears misses but NOT flaps; user `connect`/`connectWith`, `wake`, `disconnect`, and the engine-off park all reset to the fast ladder. **The #3527 no-dead-end invariant is untouched** — the loop still never self-terminates.
- File-length ratchet forced honest decomposition instead of a new grandfather entry: `Obd2LinkState` → own file (re-exported), stand-down/backoff → own file, 5 duplicated teardown try/catch blocks → one `_release` helper. Supervisor: 398 → 378 effective lines.

## Testing
- [x] New `obd2_link_standdown_test.dart` (5): the 21-min storm shape stands down after miss 3 and STILL retries (no dead end); alternating signatures keep the fast ladder; three rapid flaps park the instant redial; a ready surviving the window clears the streak; user connect() exits the stand-down immediately
- [x] Existing supervisor/breadcrumb/reattach/reconnect suites re-pinned where they asserted the old cadence (growing-backoff test now asserts the storm cadence; the #3531 real-time flatline test gets a tiny `stormBackoff` so it keeps testing ITS invariant)
- [x] Full obd2 + supervisor-consumer suites: 2078 green; analyzer clean; pre-push gates green

## Completeness checklist
- [x] **Pattern audit** — every positive-signal path (connect, connectWith, wake, disconnect, engine-off park) resets; both escalation shapes (miss + flap) covered
- [x] **Producer + consumer** — streak producers and the backoff consumer land together
- [x] **Affordances tested** — n/a, no UI (inStandDown exposed for telemetry/banner copy)
- [x] **Superseded code deleted** — inline ladder/jitter/teardown duplicates removed with the extraction

Closes #3603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g2Ybjri7MwVoFrTSvh98
