### PR TITLE
feat(cache): per-shape schema stamps replace the blanket appBuild bust (#3619)

### DIFF
--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -12,11 +12,13 @@ import '../logging/error_logger.dart';
 import '../services/service_result.dart';
 import '../storage/storage_providers.dart';
 import 'cache_eviction_policy.dart';
+import 'cache_schema.dart';
 
 export 'cache_eviction_policy.dart' show CacheEvictionPolicy;
 // CacheTtl / CacheKey moved out under the 400-line cap (#3155); the
 // re-export keeps every existing `cache_manager.dart` import working.
 export 'cache_keys.dart';
+export 'cache_schema.dart' show CacheSchema;
 
 part 'cache_manager.g.dart';
 
@@ -34,12 +36,17 @@ class CacheEntry {
 
   /// The app build that wrote this entry (`AppConstants.appVersion` at
   /// `put()` time), or `null` for an entry persisted by a build that
-  /// predates the stamp (#3219 follow-up). Cached payloads are PARSED
-  /// output, so an entry written by a different build may embed the very
-  /// parser bug an update just fixed — [CacheManager.getFresh] therefore
-  /// refuses to serve a cross-build entry as fresh (it stays available to
-  /// the stale/offline fallback via [CacheManager.get]).
+  /// predates the stamp (#3219 follow-up). Since #3619 this is
+  /// DIAGNOSTIC only — freshness gating moved to [schemaVersion], so an
+  /// app update no longer cold-boots every cache.
   final String? appBuild;
+
+  /// The [CacheSchema] version of this entry's key prefix at `put()`
+  /// time (#3619), or `null` for a pre-stamp entry. [CacheManager.getFresh]
+  /// requires an exact match with the CURRENT registered version: a
+  /// codec shape change bumps the registry, the stale envelope reads as
+  /// a fresh-miss (one refetch), and everything else survives updates.
+  final int? schemaVersion;
 
   /// JSON-encoded size of [payload], stamped once at `put()` time
   /// (#3613), or `null` for an entry persisted by a build that predates
@@ -56,6 +63,7 @@ class CacheEntry {
     required this.originalSource,
     required this.ttl,
     this.appBuild,
+    this.schemaVersion,
     this.approxBytes,
   });
 
@@ -130,9 +138,11 @@ class CacheManager implements CacheStrategy {
         // #3150 — the enum NAME, not the reorder-fragile index.
         'source': source.name,
         'ttlMs': ttl.inMilliseconds,
-        // #3219 follow-up — stamp the writing build so [getFresh] can
-        // refuse to serve another build's PARSED payload as fresh.
+        // #3219 follow-up — the writing build, diagnostic since #3619.
         'appBuild': AppConstants.appVersion,
+        // #3619 — the key prefix's schema version; [getFresh] requires
+        // an exact match with the current registry.
+        'schema': CacheSchema.forKey(key),
         // #3613 — stamp the payload's encoded byte length once here so
         // the eviction byte sweep never has to re-encode it. `dataset:`
         // entries are exempt from the byte sweep (#3155), so encoding
@@ -174,6 +184,8 @@ class CacheManager implements CacheStrategy {
       originalSource: _sourceFrom(raw['source']),
       ttl: Duration(milliseconds: raw['ttlMs'] as int? ?? 300000),
       appBuild: raw['appBuild'] as String?,
+      // #3619 — absent on pre-stamp entries → null (fresh-miss).
+      schemaVersion: raw['schema'] as int?,
       // #3613 — absent on pre-stamp entries → null (sweep re-encodes).
       approxBytes: raw['bytes'] as int?,
     );
@@ -191,25 +203,24 @@ class CacheManager implements CacheStrategy {
     return ServiceSource.cache;
   }
 
-  /// Get data only if the cache entry is still valid (not expired) AND was
-  /// written by THIS app build.
+  /// Get data only if the cache entry is still valid (not expired) AND
+  /// carries the CURRENT [CacheSchema] version for its key prefix.
   ///
-  /// #3219 follow-up — cached payloads are PARSED output (e.g. the
-  /// `serializeStationList` Station JSON), so an entry persisted by an older
-  /// build embeds that build's parser bugs. With FR's 6-hour
-  /// `searchResultTtl`, the #3224 hours fix was invisible after updating:
-  /// the freshly installed build kept serving the PRE-fix build's hour-less
-  /// stations for the same search key until the TTL lapsed — "the fix
-  /// shipped but the phone still shows the bug". A cross-build (or
-  /// unstamped pre-stamp) entry is therefore treated as a fresh-miss —
-  /// forcing one re-fetch + re-parse with the current code — while [get]
-  /// still serves it to the chain's stale/offline fallback, so an update
-  /// never costs the offline backbone.
+  /// #3219 established WHY parsed payloads need a freshness gate (an
+  /// older build's parser bugs sit embedded in its cached output); the
+  /// original gate was the blunt appBuild stamp, which cold-booted EVERY
+  /// cache — including multi-MB `dataset:` country payloads — on EVERY
+  /// update. #3619 narrows it: only a SHAPE change (a [CacheSchema]
+  /// bump, enforced by the shape-pinning test) busts, and only for the
+  /// affected entry type. Unstamped pre-#3619 entries read as a
+  /// fresh-miss once, exactly like the old cross-build path; [get]
+  /// still serves everything to the stale/offline fallback, so an
+  /// update never costs the offline backbone.
   @override
   CacheEntry? getFresh(String key) {
     final entry = get(key);
     if (entry == null || entry.isExpired) return null;
-    if (entry.appBuild != AppConstants.appVersion) return null;
+    if (entry.schemaVersion != CacheSchema.forKey(key)) return null;
     return entry;
   }
 

--- a/lib/core/cache/cache_schema.dart
+++ b/lib/core/cache/cache_schema.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// #3619 — per-shape cache schema versions.
+///
+/// Cached payloads are PARSED output, so a payload whose serialized
+/// SHAPE changed between builds can embed exactly the parser bug an
+/// update just fixed (#3219: the FR per-day-hours fix was invisible
+/// because the pre-fix build's hour-less parse sat fresh under the same
+/// key). The original guard was the blunt appBuild stamp: EVERY cache
+/// entry — including the multi-MB `dataset:` country payloads — busted
+/// on EVERY app update, refetching the world after each of our frequent
+/// releases.
+///
+/// This registry replaces the sledgehammer with discipline + enforcement
+/// (the DesKilo cacheSchemaVersion pattern, ported back):
+///
+///  * every envelope is stamped with its key-prefix's schema version;
+///  * `CacheManager.getFresh` requires an exact schema match — the
+///    appBuild mismatch alone no longer busts;
+///  * **bumping the matching constant below is part of ANY change to
+///    that entry type's serialized shape** — enforced by
+///    `test/core/cache/cache_schema_shape_test.dart`, which pins each
+///    codec's structural signature against the registered version:
+///    shape drift without a bump is a red test, not a field bug.
+///
+/// A missing stamp (entry written before this registry, or by a future
+/// build with a HIGHER version) reads as a fresh-miss, exactly like the
+/// old cross-build gate — `CacheManager.get` still serves it to the
+/// stale/offline fallback, so an update never costs the offline
+/// backbone.
+class CacheSchema {
+  CacheSchema._();
+
+  /// Schema version per cache-key `type:` prefix (see [CacheKey] /
+  /// [PersistentDataset.keyPrefix]). Bump the matching entry whenever
+  /// the SERIALIZED SHAPE of that type changes; unknown prefixes get
+  /// [fallback].
+  static const Map<String, int> byPrefix = {
+    // serializeStationList — {'stations': [Station.toJson()]}
+    'search': 1,
+    'station': 1,
+    'dataset': 1,
+    // serializeStationDetail — station + hours + overrides envelope
+    'detail': 1,
+    // serializePrices — {'prices': {id: StationPrices.toJson()}}
+    'prices': 1,
+    // geocoding_chain inline shapes: {'lat','lng'} / {'address'} /
+    // {'countryCode'}
+    'geo': 1,
+    // serializeLocations — {'locations': [ResolvedLocation fields]}
+    'city': 1,
+  };
+
+  /// Version for prefixes not (yet) in [byPrefix].
+  static const int fallback = 1;
+
+  /// The registered schema version for [key] (`type:` = everything
+  /// before the first `:`; keys without a colon use the whole key).
+  static int forKey(String key) {
+    final colon = key.indexOf(':');
+    final prefix = colon < 0 ? key : key.substring(0, colon);
+    return byPrefix[prefix] ?? fallback;
+  }
+}

--- a/lib/core/services/location_search_service.dart
+++ b/lib/core/services/location_search_service.dart
@@ -151,7 +151,7 @@ class LocationSearchService {
       // Cache the deduped results so cached reads dedup-stably too.
       await _cache.put(
         cacheKey,
-        _serializeLocations(results),
+        serializeLocations(results),
         ttl: CacheTtl.citySearch,
         source: ServiceSource.nominatimGeocoding,
       );
@@ -162,21 +162,6 @@ class LocationSearchService {
     }
   }
 
-  Map<String, dynamic> _serializeLocations(List<ResolvedLocation> locs) => {
-        'locations': locs
-            .map((l) => {
-                  'name': l.name,
-                  'lat': l.lat,
-                  'lng': l.lng,
-                  'postcode': l.postcode,
-                  'osmId': l.osmId,
-                  'importance': l.importance,
-                  'placeRank': l.placeRank,
-                  'addressType': l.addressType,
-                  'country': l.country,
-                })
-            .toList(),
-      };
 
   List<ResolvedLocation> _deserializeLocations(Map<String, dynamic> data) {
     final list = data['locations'] as List<dynamic>?;
@@ -290,3 +275,22 @@ class LocationSearchService {
   }
 
 }
+
+/// The `city:` cache envelope codec. Top-level (not private to the
+/// service) so the #3619 shape-pinning test can hash its structural
+/// signature against [CacheSchema.byPrefix]'s `city` version.
+Map<String, dynamic> serializeLocations(List<ResolvedLocation> locs) => {
+      'locations': locs
+          .map((l) => {
+                'name': l.name,
+                'lat': l.lat,
+                'lng': l.lng,
+                'postcode': l.postcode,
+                'osmId': l.osmId,
+                'importance': l.importance,
+                'placeRank': l.placeRank,
+                'addressType': l.addressType,
+                'country': l.country,
+              })
+          .toList(),
+    };

--- a/test/core/cache/cache_build_stamp_test.dart
+++ b/test/core/cache/cache_build_stamp_test.dart
@@ -7,17 +7,18 @@ import 'package:tankstellen/core/constants/app_constants.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 
-/// #3219 follow-up — the cross-build cache-freshness gate.
+/// #3219 → #3619 — the cache-freshness gate, schema edition.
 ///
-/// Cached payloads are PARSED output, so an entry written by an older app
-/// build embeds that build's parser bugs. The field shape: the #3224 FR
-/// per-day-hours fix shipped, the maintainer updated, and the phone STILL
-/// showed only 24/7 hours — because the pre-fix build's hour-less parse
-/// output sat fresh (FR `searchResultTtl` = 6 h) under the same search key
-/// and `getFresh` happily served it. The gate: `getFresh` refuses an entry
-/// stamped by a different build (or carrying no stamp at all — every
-/// pre-stamp build), forcing one re-fetch + re-parse with the current code,
-/// while `get` keeps serving it to the stale/offline fallback.
+/// Cached payloads are PARSED output, so a payload whose serialized shape
+/// changed can embed the parser bug an update just fixed (#3219's field
+/// shape: the #3224 FR hours fix invisible behind a fresh pre-fix entry).
+/// The original gate busted on ANY appBuild mismatch — cold-booting every
+/// cache, multi-MB country datasets included, on every release. #3619
+/// narrows it: `getFresh` requires the entry's stamped [CacheSchema]
+/// version to match the CURRENT registry — a cross-build entry with the
+/// same schema serves fresh; only a schema bump (enforced by the
+/// shape-pinning test) or a pre-stamp legacy envelope forces the one
+/// re-fetch. `get` keeps serving everything to the stale/offline fallback.
 class _FakeCacheStorage implements CacheStorage {
   final Map<String, dynamic> store = {};
 
@@ -59,70 +60,93 @@ void main() {
     cache = CacheManager(storage);
   });
 
-  group('CacheManager cross-build freshness gate (#3219 follow-up)', () {
+  group('CacheManager schema freshness gate (#3619)', () {
     test('an entry written by THIS build is served fresh (no regression)',
         () async {
       AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_A');
-      await cache.put('k', {'v': 1},
+      await cache.put('search:k', {'v': 1},
           ttl: const Duration(hours: 6),
           source: ServiceSource.prixCarburantsApi);
 
-      final entry = cache.getFresh('k');
+      final entry = cache.getFresh('search:k');
       expect(entry, isNotNull);
       expect(entry!.payload['v'], 1);
       expect(entry.appBuild, '6.0.0+TEST_BUILD_A');
+      expect(entry.schemaVersion, CacheSchema.forKey('search:k'));
     });
 
     test(
-        'an unexpired entry written by a DIFFERENT build is a fresh-miss '
-        'but still serves the stale/offline fallback', () async {
+        'an unexpired CROSS-BUILD entry with the CURRENT schema stays '
+        'fresh — the #3619 point: updates no longer cold-boot the cache',
+        () async {
       AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_A');
-      await cache.put('k', {'v': 1},
-          ttl: const Duration(hours: 6),
+      await cache.put('dataset:AR:stations', {'v': 1},
+          ttl: const Duration(days: 30),
           source: ServiceSource.prixCarburantsApi);
 
-      // The app updates: same cache file, new build.
+      // The app updates: same cache file, new build, SAME schema.
       AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_B');
 
-      expect(cache.getFresh('k'), isNull,
-          reason: 'a cross-build entry may embed the parser bug the update '
-              'just fixed — it must force a re-fetch');
-      final stale = cache.get('k');
+      final entry = cache.getFresh('dataset:AR:stations');
+      expect(entry, isNotNull,
+          reason: 'same shape ⇒ the multi-MB dataset must survive the '
+              'update instead of refetching on first launch');
+      expect(entry!.appBuild, '6.0.0+TEST_BUILD_A');
+    });
+
+    test(
+        'a STALE-SCHEMA entry is a fresh-miss but still serves the '
+        'stale/offline fallback', () async {
+      // Byte-shape of an envelope stamped by a build whose codec shape
+      // predates a registry bump.
+      storage.store['search:k'] = {
+        'payload': {'v': 1},
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': ServiceSource.prixCarburantsApi.name,
+        'ttlMs': const Duration(hours: 6).inMilliseconds,
+        'appBuild': '6.0.0+TEST_BUILD_A',
+        'schema': CacheSchema.forKey('search:k') + 1,
+      };
+
+      expect(cache.getFresh('search:k'), isNull,
+          reason: 'a different schema version may embed the parser bug '
+              'the bump documented — it must force a re-fetch');
+      final stale = cache.get('search:k');
       expect(stale, isNotNull,
           reason: 'the stale/offline fallback must keep working across '
-              'an update');
+              'a schema bump');
       expect(stale!.payload['v'], 1);
     });
 
     test(
-        'a legacy UNSTAMPED envelope (written by a pre-stamp build) is a '
-        'fresh-miss but keeps its stale fallback', () async {
+        'a legacy UNSTAMPED envelope (pre-#3619 build) is a fresh-miss '
+        'but keeps its stale fallback', () async {
       AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_B');
-      // Byte-shape of what every pre-#3219-follow-up build persisted: no
-      // `appBuild` key at all — exactly the envelopes on a field device the
-      // moment it updates onto this code.
+      // What every pre-schema build persisted: no `schema` key at all —
+      // exactly the envelopes on a field device the moment it updates
+      // onto this code.
       storage.store['legacy'] = {
         'payload': {'v': 42},
         'storedAt': DateTime.now().millisecondsSinceEpoch,
         'source': ServiceSource.prixCarburantsApi.name,
         'ttlMs': const Duration(hours: 6).inMilliseconds,
+        'appBuild': '6.0.0+TEST_BUILD_A',
       };
 
       expect(cache.getFresh('legacy'), isNull);
       final stale = cache.get('legacy');
       expect(stale, isNotNull);
       expect(stale!.payload['v'], 42);
-      expect(stale.appBuild, isNull);
+      expect(stale.schemaVersion, isNull);
     });
 
-    test('the stamp round-trips through the persisted envelope', () async {
+    test('both stamps round-trip through the persisted envelope', () async {
       AppConstants.setRuntimeVersion('6.0.0+TEST_BUILD_C');
-      await cache.put('k', {'v': 1},
+      await cache.put('city:berlin:de', {'v': 1},
           ttl: const Duration(minutes: 5), source: ServiceSource.cache);
-      expect(
-        (storage.store['k'] as Map)['appBuild'],
-        '6.0.0+TEST_BUILD_C',
-      );
+      final raw = storage.store['city:berlin:de'] as Map;
+      expect(raw['appBuild'], '6.0.0+TEST_BUILD_C');
+      expect(raw['schema'], CacheSchema.forKey('city:berlin:de'));
     });
   });
 }

--- a/test/core/cache/cache_schema_shape_test.dart
+++ b/test/core/cache/cache_schema_shape_test.dart
@@ -42,15 +42,15 @@ void main() {
   // Deterministic fixtures; fields they leave null pin as `null` — the
   // signature tracks keys and populated types, which is where parser
   // shape drift lives.
-  final detail = StationDetail(
+  const detail = StationDetail(
     station: testStation,
-    openingTimes: const [
+    openingTimes: [
       OpeningTime(text: 'Mo-Fr', start: '06:00', end: '22:00'),
     ],
-    overrides: const ['override'],
+    overrides: ['override'],
     wholeDay: false,
     state: 'open',
-    openingHours: const WeeklyOpeningHours(),
+    openingHours: WeeklyOpeningHours(),
   );
   const prices = StationPrices(
     e5: 1.85,

--- a/test/core/cache/cache_schema_shape_test.dart
+++ b/test/core/cache/cache_schema_shape_test.dart
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3619 — THE enforcement behind CacheSchema: every cache codec's
+// structural signature (recursive keys + value types, values erased) is
+// pinned here TOGETHER with its registered schema version. Changing a
+// codec's serialized shape without bumping the matching
+// CacheSchema.byPrefix entry fails this test — the discipline that lets
+// getFresh stop cold-booting every cache on every app update.
+//
+// When this test fails after an intentional shape change:
+//  1. bump the prefix's version in lib/core/cache/cache_schema.dart;
+//  2. update the pinned signature below to the printed actual.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_schema.dart';
+import 'package:tankstellen/core/domain/opening_hours.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/domain/station_prices.dart';
+import 'package:tankstellen/core/services/location_search_service.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+
+import '../../fixtures/stations.dart';
+
+/// Canonical structural signature: keys sorted, value types erased,
+/// lists described by their first element. Deterministic for a fixed
+/// fixture, insensitive to VALUES — only shape drift changes it.
+String shapeOf(dynamic v) {
+  if (v == null) return 'null';
+  if (v is Map) {
+    final keys = v.keys.map((k) => k.toString()).toList()..sort();
+    return '{${keys.map((k) => '$k:${shapeOf(v[k])}').join(',')}}';
+  }
+  if (v is List) return '[${v.isEmpty ? '' : shapeOf(v.first)}]';
+  if (v is String) return 'str';
+  if (v is bool) return 'bool';
+  if (v is int) return 'int';
+  if (v is double) return 'double';
+  return v.runtimeType.toString();
+}
+
+void main() {
+  // Deterministic fixtures; fields they leave null pin as `null` — the
+  // signature tracks keys and populated types, which is where parser
+  // shape drift lives.
+  final detail = StationDetail(
+    station: testStation,
+    openingTimes: const [
+      OpeningTime(text: 'Mo-Fr', start: '06:00', end: '22:00'),
+    ],
+    overrides: const ['override'],
+    wholeDay: false,
+    state: 'open',
+    openingHours: const WeeklyOpeningHours(),
+  );
+  const prices = StationPrices(
+    e5: 1.85,
+    e10: 1.79,
+    e98: 1.99,
+    diesel: 1.65,
+    dieselPremium: 1.75,
+    e85: 1.10,
+    lpg: 0.99,
+    cng: 1.09,
+    status: 'open',
+  );
+  const location = ResolvedLocation(
+    name: 'Berlin',
+    lat: 52.52,
+    lng: 13.405,
+    postcode: '10115',
+    osmId: 240109189,
+    importance: 0.9,
+    placeRank: 15,
+    addressType: 'city',
+    country: 'DE',
+  );
+
+  // prefix → (version, codec sample). The geo shapes are inline literals
+  // in geocoding_chain.dart (three sub-shapes under one prefix) — pinned
+  // here as literals; keep them in sync with that file.
+  final codecs = <String, ({int version, Map<String, dynamic> sample})>{
+    'search': (
+      version: CacheSchema.byPrefix['search']!,
+      sample: serializeStationList([testStation]),
+    ),
+    'station': (
+      version: CacheSchema.byPrefix['station']!,
+      sample: serializeStationList([testStation]),
+    ),
+    'dataset': (
+      version: CacheSchema.byPrefix['dataset']!,
+      sample: serializeStationList([testStation]),
+    ),
+    'detail': (
+      version: CacheSchema.byPrefix['detail']!,
+      sample: serializeStationDetail(detail),
+    ),
+    'prices': (
+      version: CacheSchema.byPrefix['prices']!,
+      sample: serializePrices({'id-1': prices}),
+    ),
+    'geo': (
+      version: CacheSchema.byPrefix['geo']!,
+      sample: {
+        'zip': {'lat': 52.52, 'lng': 13.405},
+        'revAddress': {'address': 'Hauptstr. 12'},
+        'revCountry': {'countryCode': 'DE'},
+      },
+    ),
+    'city': (
+      version: CacheSchema.byPrefix['city']!,
+      sample: serializeLocations(const [location]),
+    ),
+  };
+
+  /// The pinned (version, signature) pairs. A mismatch means the codec's
+  /// shape drifted: bump CacheSchema.byPrefix AND update the pin here.
+  const pins = <String, ({int version, String shape})>{
+    'search': (version: 1, shape: _stationListShape),
+    'station': (version: 1, shape: _stationListShape),
+    'dataset': (version: 1, shape: _stationListShape),
+    'detail': (version: 1, shape: _detailShape),
+    'prices': (version: 1, shape: _pricesShape),
+    'geo': (version: 1, shape: _geoShape),
+    'city': (version: 1, shape: _cityShape),
+  };
+
+  test('every CacheSchema prefix is pinned and vice versa', () {
+    expect(codecs.keys.toSet(), CacheSchema.byPrefix.keys.toSet());
+    expect(pins.keys.toSet(), CacheSchema.byPrefix.keys.toSet());
+  });
+
+  for (final entry in codecs.entries) {
+    test('${entry.key}: codec shape matches its registered schema version',
+        () {
+      final pin = pins[entry.key]!;
+      expect(entry.value.version, pin.version,
+          reason: 'CacheSchema.byPrefix["${entry.key}"] drifted from the '
+              'pinned version without updating this test');
+      final actual = shapeOf(entry.value.sample);
+      expect(actual, pin.shape,
+          reason: 'The ${entry.key} codec\'s serialized SHAPE changed. If '
+              'intentional: bump CacheSchema.byPrefix["${entry.key}"] and '
+              're-pin. Actual signature:\n$actual');
+    });
+  }
+}
+
+// Pinned structural signatures (see shapeOf). Nullable fields the
+// fixture leaves unset print as `null` — key ADDS/REMOVES/RENAMES are
+// the drift this pin exists to catch.
+const _stationListShape = '{stations:[{amenities:[],availableFuels:[],brand:str,cng:null,department:null,diesel:double,dieselPremium:null,dist:double,e10:double,e5:double,e85:null,e98:null,houseNumber:str,id:str,is24h:bool,isOpen:bool,lat:double,lng:double,lpg:null,name:str,openingHours:null,openingHoursText:null,place:str,postCode:str,region:null,services:[],stationType:null,street:str,unavailableFuels:[],updatedAt:str}]}';
+const _detailShape =
+    '{openingHours:{automate24h:bool,availability:str,days:[],'
+    'rawSource:null},openingTimes:[{end:str,start:str,text:str}],'
+    'overrides:[str],state:str,station:{amenities:[],availableFuels:[],brand:str,cng:null,department:null,diesel:double,dieselPremium:null,dist:double,e10:double,e5:double,e85:null,e98:null,houseNumber:str,id:str,is24h:bool,isOpen:bool,lat:double,lng:double,lpg:null,name:str,openingHours:null,openingHoursText:null,place:str,postCode:str,region:null,services:[],stationType:null,street:str,unavailableFuels:[],updatedAt:str},wholeDay:bool}';
+const _pricesShape =
+    '{prices:{id-1:{cng:double,diesel:double,dieselPremium:double,'
+    'e10:double,e5:double,e85:double,e98:double,lpg:double,'
+    'status:str}}}';
+const _geoShape = '{revAddress:{address:str},'
+    'revCountry:{countryCode:str},zip:{lat:double,lng:double}}';
+const _cityShape = '{locations:[{addressType:str,country:str,'
+    'importance:double,lat:double,lng:double,name:str,osmId:int,'
+    'placeRank:int,postcode:str}]}';

--- a/test/features/station_services/france/prix_carburants_cross_build_cache_test.dart
+++ b/test/features/station_services/france/prix_carburants_cross_build_cache_test.dart
@@ -132,7 +132,8 @@ void main() {
 
     final storage = _FakeCacheStorage();
     // Seed the EXACT envelope a pre-stamp build wrote: fresh (stored now,
-    // 6 h TTL like FR's searchResultTtl), parsed payload, NO appBuild key.
+    // 6 h TTL like FR's searchResultTtl), parsed payload, no stamp keys —
+    // under #3619 the missing `schema` stamp is what makes it a fresh-miss.
     storage.store[CacheKey.stationSearch(
       params.lat, params.lng, params.radiusKm, FuelType.all.apiValue,
       countryCode: 'FR',


### PR DESCRIPTION
## What
Cache entries are stamped with a per-key-prefix schema version (new `CacheSchema` registry); `getFresh` gates on schema match instead of the blanket appBuild bust, so app updates no longer cold-boot every cache.

## Why
`entry.appBuild != AppConstants.appVersion → null` busted EVERY entry on EVERY release — including the multi-MB `dataset:` country payloads (Argentina CSV, Greece asset), which refetched on first launch after each update. The #3219 protection (parsed payloads embed the writing build's parser bugs) is real, but the shape only changes when a codec changes — not on every version bump. (Round-trip lesson from the DesKilo port of this cache.)

## How
- `lib/core/cache/cache_schema.dart` — `CacheSchema.byPrefix` (search/station/dataset/detail/prices/geo/city, all v1) + `forKey`; re-exported from cache_manager.
- `CacheManager.put` stamps `schema`; `CacheEntry.schemaVersion`; `getFresh` requires an exact match with the CURRENT registry. `appBuild` stays as a diagnostic stamp. Legacy unstamped envelopes = one-time fresh-miss (same as the old cross-build path); `get` serves everything to the stale/offline fallback.
- **Enforcement** (the #3219 guarantee, moved from sledgehammer to discipline): `test/core/cache/cache_schema_shape_test.dart` pins each codec's structural signature (recursive keys+types, values erased) against its registered version — shape drift without a bump is a red test with the actual signature in the failure message. `serializeLocations` (city) became top-level so the pin can reach it.

## Testing
- [x] Rewritten `cache_build_stamp_test.dart`: same-build fresh; **cross-build same-schema stays fresh (the point)**; stale-schema envelope = fresh-miss + stale-servable; legacy unstamped = fresh-miss + stale-servable; both stamps round-trip
- [x] New shape-pinning suite (8 tests) incl. registry↔pin parity
- [x] FR #3219 field-regression test passes unchanged (its seed has no stamps — still a fresh-miss)
- [x] `test/core/cache/` + `test/core/services/` green (one pre-existing live-network Argentina connectivity timeout, unrelated); analyzer clean; pre-push gates green

## Completeness checklist
- [x] **Pattern audit** — all 7 envelope prefixes registered and pinned; parity test fails if a new prefix appears unregistered
- [x] **Producer + consumer** — stamp writer and getFresh gate land together
- [x] **Affordances tested** — n/a, no UI
- [x] **Superseded code deleted** — the appBuild freshness check removed from getFresh (stamp kept as diagnostics)

Closes #3619 (epic #3609)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g2Ybjri7MwVoFrTSvh98
