### PR TITLE
feat(search): stale-while-revalidate — cached stations paint instantly, refresh behind (#3618)

### DIFF
--- a/lib/core/services/station_search_peek.dart
+++ b/lib/core/services/station_search_peek.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/search_params.dart';
+import '../domain/station.dart';
+import '../cache/cache_manager.dart';
+import 'country_service_registry.dart';
+import 'mixins/station_service_helpers.dart';
+import 'service_result.dart';
+import 'station_service_chain_codec.dart';
+
+/// #3618 — stale-while-revalidate PEEK for the search surface.
+///
+/// The chain's `getWithFallback` BLOCKS on the network whenever the
+/// fresh tier misses; stale only answers after a network FAILURE. On a
+/// warm start with an expired cache the user watched the shimmer for
+/// the whole round-trip even though yesterday's stations sat on disk
+/// (the DesKilo floor-plan port paints instantly from disk — this is
+/// that insight, round-tripped back).
+///
+/// This helper answers a search from the cache tier — ANY age, no
+/// network, synchronous — mirroring [StationServiceChain.searchStations]
+/// exactly: same [CacheKey.stationSearch] construction, same
+/// [deserializeStationList] codec, same #2926 hard fuel filter. The
+/// key-construction twin-ship is pinned by
+/// `test/core/services/station_search_peek_test.dart`, which seeds the
+/// cache THROUGH a real chain search and requires the peek to find it.
+///
+/// Bulk-file countries return null: their searches local-filter the
+/// persisted national dataset (#2264) and never write per-key search
+/// entries. Live surfaces (radar) deliberately do not call this — they
+/// keep the blocking mode.
+ServiceResult<List<Station>>? peekCachedStationSearch({
+  required CacheStrategy cache,
+  required String countryCode,
+  required SearchParams params,
+}) {
+  if (CountryServiceRegistry.policyFor(countryCode)?.isBulkFile ?? false) {
+    return null;
+  }
+  final entry = cache.get(CacheKey.stationSearch(
+    params.lat,
+    params.lng,
+    params.radiusKm,
+    params.fuelType.apiValue,
+    countryCode: countryCode,
+    postalCode: params.postalCode,
+    locationName: params.locationName,
+  ));
+  if (entry == null) return null;
+  final stations = deserializeStationList(entry.payload);
+  if (stations == null || stations.isEmpty) return null;
+  final filtered = params.applyFuelFilter
+      ? StationServiceHelpers.filterByFuel(stations, params.fuelType)
+      : stations;
+  if (filtered.isEmpty) return null;
+  return ServiceResult(
+    data: filtered,
+    source: ServiceSource.cache,
+    fetchedAt: entry.storedAt,
+    // Honest staleness: a still-fresh entry peeked before the network
+    // answer is not stale — the banner then shows nothing to retract.
+    isStale: entry.isExpired,
+  );
+}

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -237,9 +237,15 @@ class SearchState extends _$SearchState {
         sortBy: sortBy ?? SortBy.price,
         postalCode: resolvedPostalCode,
       );
-      final result = await ref
-          .read(stationServiceProvider)
-          .searchStations(params, cancelToken: cancelToken);
+      // #3618 — SWR: the last stations for this cell paint immediately;
+      // the network result then replaces them in place.
+      final result = await searchWithSwrPreview(
+        ref,
+        params,
+        isFuelSearch: evFuture == null,
+        cancelToken: cancelToken,
+        publishPreview: (preview) => state = preview,
+      );
       if (!ref.mounted) return;
       _publishCarSearch(result.data, resolved.fuelType);
       final finalState = await finalizeUnifiedResult(ref, result, evFuture);

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -95,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'81aed7f3015e87c17cbab28a1e75531149085d39';
+String _$searchStateHash() => r'8b9429d999dacfebc9215d4ef823c98edea0d498';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -9,11 +9,16 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/logging/error_logger.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/services/geocoding_chain.dart';
+import '../../../core/services/service_providers.dart';
 import '../../../core/services/service_result.dart';
+import '../../../core/services/station_search_peek.dart';
 import '../../../core/domain/fuel_type.dart';
 import '../../../core/domain/search_result_item.dart';
 import '../../../core/domain/station.dart';
+import '../../../core/country/country_provider.dart';
+import '../../../core/domain/search_params.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
 import 'ev_search_provider.dart';
@@ -195,3 +200,35 @@ ServiceResult<List<SearchResultItem>> _emptyEvSearchResult({Object? evError}) =>
               ),
             ],
     );
+
+/// #3618 — the fuel search with a stale-while-revalidate PREVIEW: if
+/// the cache holds ANY-age stations for this exact search cell, they
+/// are published through [publishPreview] IMMEDIATELY (prices are
+/// hours-stable; the freshness banner's "updated X ago" communicates
+/// the age), then the normal blocking chain runs and its result
+/// replaces the preview in place. EV searches skip the preview — their
+/// feed comes from a different service — and live surfaces (radar)
+/// don't come through here at all, keeping their blocking mode.
+Future<ServiceResult<List<Station>>> searchWithSwrPreview(
+  Ref ref,
+  SearchParams params, {
+  required bool isFuelSearch,
+  required CancelToken cancelToken,
+  required void Function(
+          AsyncValue<ServiceResult<List<SearchResultItem>>> preview)
+      publishPreview,
+}) async {
+  if (isFuelSearch) {
+    final cached = peekCachedStationSearch(
+      cache: ref.read(cacheManagerProvider),
+      countryCode: ref.read(activeCountryProvider).code,
+      params: params,
+    );
+    if (cached != null) {
+      publishPreview(AsyncValue.data(wrapFuelResultAsSearchItems(cached)));
+    }
+  }
+  return ref
+      .read(stationServiceProvider)
+      .searchStations(params, cancelToken: cancelToken);
+}

--- a/test/core/services/station_search_peek_test.dart
+++ b/test/core/services/station_search_peek_test.dart
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3618 — the SWR peek must be a faithful, network-free TWIN of the
+// chain's search read: same key construction, same codec, same #2926
+// hard fuel filter. The round-trip test seeds the cache THROUGH a real
+// chain search — if the peek's key construction ever drifts from the
+// chain's, it stops finding what the chain just wrote and this fails.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/domain/search_params.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_search_peek.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+class MockStationService extends Mock implements StationService {}
+
+class FakeSearchParams extends Fake implements SearchParams {}
+
+/// Real envelope semantics over a plain map — enough for the chain to
+/// write and the peek to read the SAME entry.
+class _MemoryCache implements CacheStrategy {
+  final map = <String, CacheEntry>{};
+
+  @override
+  Future<void> put(
+    String key,
+    Map<String, dynamic> data, {
+    required Duration ttl,
+    required ServiceSource source,
+  }) async {
+    map[key] = CacheEntry(
+      payload: data,
+      storedAt: DateTime.now(),
+      originalSource: source,
+      ttl: ttl,
+    );
+  }
+
+  @override
+  CacheEntry? get(String key) => map[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final entry = map[key];
+    return entry == null || entry.isExpired ? null : entry;
+  }
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  const params = SearchParams(
+    lat: 52.52,
+    lng: 13.41,
+    radiusKm: 10,
+    fuelType: FuelType.e10,
+  );
+
+  const e10Station = Station(
+    id: 'e10-1',
+    name: 'E10 Station',
+    brand: 'TEST',
+    street: 'Teststr.',
+    postCode: '10115',
+    place: 'Berlin',
+    lat: 52.52,
+    lng: 13.41,
+    isOpen: true,
+    e10: 1.459,
+  );
+  const dieselOnlyStation = Station(
+    id: 'diesel-1',
+    name: 'Diesel Only',
+    brand: 'TEST',
+    street: 'Teststr.',
+    postCode: '10115',
+    place: 'Berlin',
+    lat: 52.53,
+    lng: 13.42,
+    isOpen: true,
+    diesel: 1.659,
+  );
+
+  setUpAll(() => registerFallbackValue(FakeSearchParams()));
+
+  test(
+      'ROUND-TRIP: what a real chain search cached, the peek finds — '
+      'same key, same codec, same fuel filter', () async {
+    final cache = _MemoryCache();
+    final primary = MockStationService();
+    when(() => primary.searchStations(any(),
+        cancelToken: any(named: 'cancelToken'))).thenAnswer(
+      (_) async => ServiceResult(
+        data: const [e10Station, dieselOnlyStation],
+        source: ServiceSource.tankerkoenigApi,
+        fetchedAt: DateTime.now(),
+      ),
+    );
+    final chain = StationServiceChain(primary, cache);
+
+    final chainResult = await chain.searchStations(params);
+
+    final peeked = peekCachedStationSearch(
+      cache: cache,
+      countryCode: '',
+      params: params,
+    );
+    expect(peeked, isNotNull,
+        reason: 'the peek must construct the exact key the chain wrote');
+    expect(
+      peeked!.data.map((s) => s.id),
+      chainResult.data.map((s) => s.id),
+      reason: 'peek output must equal the chain output — the full '
+          'cached set re-passed through the #2926 fuel filter',
+    );
+    expect(peeked.data.map((s) => s.id), ['e10-1'],
+        reason: 'the diesel-only station must not survive an e10 search');
+    expect(peeked.isStale, isFalse,
+        reason: 'a still-fresh entry peeks as not stale');
+    expect(peeked.source, ServiceSource.cache);
+  });
+
+  test('an EXPIRED entry still peeks — flagged stale', () async {
+    final cache = _MemoryCache();
+    final primary = MockStationService();
+    when(() => primary.searchStations(any(),
+        cancelToken: any(named: 'cancelToken'))).thenAnswer(
+      (_) async => ServiceResult(
+        data: const [e10Station],
+        source: ServiceSource.tankerkoenigApi,
+        fetchedAt: DateTime.now(),
+      ),
+    );
+    await StationServiceChain(primary, cache).searchStations(params);
+    // Age the entry past its TTL.
+    final key = cache.map.keys.single;
+    final old = cache.map[key]!;
+    cache.map[key] = CacheEntry(
+      payload: old.payload,
+      storedAt: DateTime.now().subtract(const Duration(hours: 7)),
+      originalSource: old.originalSource,
+      ttl: old.ttl,
+    );
+
+    final peeked = peekCachedStationSearch(
+      cache: cache,
+      countryCode: '',
+      params: params,
+    );
+    expect(peeked, isNotNull,
+        reason: 'ANY-age peek — hours-stale prices are the SWR premise');
+    expect(peeked!.isStale, isTrue);
+  });
+
+  test('no cached entry → null (the caller keeps the shimmer)', () {
+    expect(
+      peekCachedStationSearch(
+        cache: _MemoryCache(),
+        countryCode: '',
+        params: params,
+      ),
+      isNull,
+    );
+  });
+
+  test('a BULK-file country → null: its searches local-filter the '
+      'persisted dataset and never write per-key entries', () {
+    final cache = _MemoryCache();
+    expect(
+      peekCachedStationSearch(
+        cache: cache,
+        countryCode: 'ES',
+        params: params,
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -13,8 +13,12 @@ import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/location/location_service.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/services/geocoding_chain.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/domain/ev/charging_station.dart';
@@ -1228,4 +1232,191 @@ void main() {
       expect(stations, isEmpty);
     });
   });
+
+  group('#3618 stale-while-revalidate preview (searchByGps)', () {
+    const cachedStation = Station(
+      id: 'swr-cached-1',
+      name: 'Yesterday Station',
+      brand: 'JET',
+      street: 'Alte Str.',
+      postCode: '10115',
+      place: 'Berlin',
+      lat: 52.52,
+      lng: 13.405,
+      isOpen: true,
+      e10: 1.799,
+    );
+    const freshStation = Station(
+      id: 'swr-fresh-1',
+      name: 'Fresh Station',
+      brand: 'ARAL',
+      street: 'Neue Str.',
+      postCode: '10115',
+      place: 'Berlin',
+      lat: 52.52,
+      lng: 13.405,
+      isOpen: true,
+      e10: 1.749,
+    );
+
+    Position gpsFix() => Position(
+          latitude: 52.52,
+          longitude: 13.405,
+          timestamp: DateTime(2026, 7, 26),
+          accuracy: 5,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          headingAccuracy: 0,
+          speed: 0,
+          speedAccuracy: 0,
+        );
+
+    test(
+        'the last cached stations for the cell paint BEFORE the network '
+        'answers, then the fresh result replaces them in place', () async {
+      final mockLocation = MockLocationService();
+      when(() => mockLocation.getCurrentPosition())
+          .thenAnswer((_) async => gpsFix());
+      // No geocoder → no postal code in the cache key (the peek builds
+      // the identical key).
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenThrow(Exception('no geocoder in this test'));
+
+      final networkGate = Completer<ServiceResult<List<Station>>>();
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) => networkGate.future);
+
+      final cache = CacheManager(_SwrFakeCacheStorage());
+      final container = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        stationServiceProvider.overrideWithValue(mockStationService),
+        geocodingChainProvider.overrideWithValue(mockGeocoding),
+        locationServiceProvider.overrideWithValue(mockLocation),
+        userPositionProvider.overrideWith(() => _NullUserPosition()),
+        cacheManagerProvider.overrideWithValue(cache),
+      ]);
+      addTearDown(container.dispose);
+      // Keep the autoDispose provider alive across the async gaps.
+      container.listen(searchStateProvider, (_, _) {});
+
+      // Seed what "yesterday's" search wrote for this exact cell.
+      final countryCode = container.read(activeCountryProvider).code;
+      await cache.put(
+        CacheKey.stationSearch(52.52, 13.405, 10, FuelType.e10.apiValue,
+            countryCode: countryCode),
+        serializeStationList(const [cachedStation]),
+        ttl: CacheTtl.stationSearch,
+        source: ServiceSource.tankerkoenigApi,
+      );
+
+      final searchFuture = container
+          .read(searchStateProvider.notifier)
+          .searchByGps(fuelType: FuelType.e10, radiusKm: 10);
+
+      // Let GPS + geocode + the peek run; the network stays gated.
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final preview = container.read(searchStateProvider);
+      expect(preview.hasValue, isTrue,
+          reason: 'the SWR preview must have replaced the shimmer while '
+              'the network is still in flight');
+      final previewItems = preview.value!.data;
+      expect(previewItems.map((i) => i.id), ['swr-cached-1'],
+          reason: 'the preview is yesterday\'s cached station');
+
+      // The network lands: the fresh result replaces the preview.
+      networkGate.complete(ServiceResult(
+        data: const [freshStation],
+        source: ServiceSource.tankerkoenigApi,
+        fetchedAt: DateTime.now(),
+      ));
+      await searchFuture;
+      final finalState = container.read(searchStateProvider);
+      expect(finalState.value!.data.map((i) => i.id), ['swr-fresh-1']);
+    });
+
+    test('no cached cell → the shimmer stays until the network answers '
+        '(blocking mode unchanged)', () async {
+      final mockLocation = MockLocationService();
+      when(() => mockLocation.getCurrentPosition())
+          .thenAnswer((_) async => gpsFix());
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenThrow(Exception('no geocoder in this test'));
+      final networkGate = Completer<ServiceResult<List<Station>>>();
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) => networkGate.future);
+
+      final container = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        stationServiceProvider.overrideWithValue(mockStationService),
+        geocodingChainProvider.overrideWithValue(mockGeocoding),
+        locationServiceProvider.overrideWithValue(mockLocation),
+        userPositionProvider.overrideWith(() => _NullUserPosition()),
+        cacheManagerProvider
+            .overrideWithValue(CacheManager(_SwrFakeCacheStorage())),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(searchStateProvider, (_, _) {});
+
+      final searchFuture = container
+          .read(searchStateProvider.notifier)
+          .searchByGps(fuelType: FuelType.e10, radiusKm: 10);
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(container.read(searchStateProvider).isLoading, isTrue,
+          reason: 'no preview without a cached cell — no invented data');
+
+      networkGate.complete(ServiceResult(
+        data: const [freshStation],
+        source: ServiceSource.tankerkoenigApi,
+        fetchedAt: DateTime.now(),
+      ));
+      await searchFuture;
+      expect(
+        container.read(searchStateProvider).value!.data.map((i) => i.id),
+        ['swr-fresh-1'],
+      );
+    });
+  });
+}
+
+/// Minimal in-memory [CacheStorage] for the SWR tests — the real
+/// [CacheManager] envelope semantics over a plain map.
+class _SwrFakeCacheStorage implements CacheStorage {
+  final Map<String, dynamic> store = {};
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async {
+    if (data == null) {
+      store.remove(key);
+    } else {
+      store[key] = data;
+    }
+  }
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
+    final raw = store[key];
+    if (raw is! Map) return null;
+    return Map<String, dynamic>.from(raw);
+  }
+
+  @override
+  Future<void> clearCache() async => store.clear();
+
+  @override
+  int get cacheEntryCount => store.length;
+
+  @override
+  Iterable<dynamic> get cacheKeys => store.keys;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => store.remove(key);
 }


### PR DESCRIPTION
## What
Stale-while-revalidate for the search surface: on `searchByGps`, the last cached stations for the exact search cell paint IMMEDIATELY (any age), and the normal blocking chain result replaces them in place when the network lands.

## Why
`getWithFallback` blocks on the network whenever the fresh tier misses — stale only answered after a network FAILURE. Warm start with an expired cache = the user watches the shimmer for the whole round-trip while yesterday's stations sit on disk. Prices are hours-stable, so a seconds-stale first paint is honest; the existing "updated X ago" affordance communicates it. Synergy with #3607: StartupReveal settles on real content instead of a shimmer.

## How
- `lib/core/services/station_search_peek.dart` — `peekCachedStationSearch`: cache-tier answer, any age, no network, synchronous; a faithful twin of the chain's read (same `CacheKey.stationSearch` construction, same `deserializeStationList`, same #2926 hard fuel filter). Bulk-file countries → null (no per-key tier, #2264). `isStale` honest: only when actually expired.
- `searchWithSwrPreview` (orchestration) — publishes the peek as a preview `AsyncValue.data`, then runs the unchanged blocking `searchStations`. Fuel searches only; EV feeds come from their own service; radar and every other surface keep the blocking mode untouched.
- `searchByGps` swaps its direct service call for the wrapper — 3 lines net; zip/city searches unchanged (user-initiated with fresh intent; candidates for a follow-up if wanted).

## Testing
- [x] Peek unit tests (4): **round-trip pin** — the cache is seeded THROUGH a real chain search and the peek must find it (key-construction drift = red), fuel filter parity, expired→isStale, miss→null, bulk country→null
- [x] Provider tests (2): cached cell paints before the gated network completes, then the fresh result replaces it in place; no cached cell → shimmer stays (blocking unchanged)
- [x] `test/features/search/` + chain suites: 901 green; analyzer clean; pre-push gates green

## Completeness checklist
- [x] **Pattern audit** — every other searchStations caller (radar, widget, cross-border, zip/city) deliberately left blocking; documented in the peek's doc comment
- [x] **Producer + consumer** — peek producer + preview consumer + replacement path in one PR
- [x] **Affordances tested** — the staleness affordance is the existing freshness banner (fed by `isStale`/`fetchedAt`, both set)
- [x] **Superseded code deleted** — n/a (additive mode; blocking path unchanged)

Closes #3618 (epic #3609)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g2Ybjri7MwVoFrTSvh98
