### PR TITLE
feat(ui): polish wave — animated chrome, skeletons, detail transitions, pull-to-refresh, empty states (#3615)

### DIFF
--- a/lib/app/routes/detail_transition_page.dart
+++ b/lib/app/routes/detail_transition_page.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// #3615 — the shared detail-push transition: a short fade with a
+/// subtle upward settle, replacing the platform default so the
+/// list → detail moment reads as one motion language across fuel and
+/// EV stations. Honors the OS reduced-motion setting by collapsing to
+/// a plain fade.
+CustomTransitionPage<void> detailTransitionPage({
+  required LocalKey key,
+  required Widget child,
+}) {
+  return CustomTransitionPage<void>(
+    key: key,
+    child: child,
+    transitionDuration: const Duration(milliseconds: 250),
+    reverseTransitionDuration: const Duration(milliseconds: 200),
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      final curved = CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      );
+      final fade = FadeTransition(opacity: curved, child: child);
+      if (MediaQuery.disableAnimationsOf(context)) return fade;
+      return FadeTransition(
+        opacity: curved,
+        child: SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(0, 0.04),
+            end: Offset.zero,
+          ).animate(curved),
+          child: child,
+        ),
+      );
+    },
+  );
+}

--- a/lib/app/routes/station_routes.dart
+++ b/lib/app/routes/station_routes.dart
@@ -14,6 +14,7 @@ import '../../features/report/presentation/screens/report_screen.dart';
 import '../../features/search/presentation/screens/ev_station_detail_screen.dart';
 import '../../features/station_detail/presentation/screens/station_detail_screen.dart';
 import '../station_id_validator.dart';
+import 'detail_transition_page.dart';
 import 'invalid_id_screen.dart';
 
 /// Detail-level routes anchored on a single station id: fuel and EV
@@ -34,19 +35,26 @@ List<RouteBase> stationRoutes(Ref ref) => [
       ),
       GoRoute(
         path: RoutePaths.stationPattern,
-        builder: (context, state) {
+        // #3615 — shared detail transition (fade + settle).
+        pageBuilder: (context, state) {
           final id = state.pathParameters['id'];
-          if (!isValidStationId(id)) {
-            return invalidIdScreen(context, state.matchedLocation);
-          }
-          return StationDetailScreen(stationId: id!);
+          return detailTransitionPage(
+            key: state.pageKey,
+            child: !isValidStationId(id)
+                ? invalidIdScreen(context, state.matchedLocation)
+                : StationDetailScreen(stationId: id!),
+          );
         },
       ),
       GoRoute(
         path: RoutePaths.evStation,
-        builder: (context, state) {
+        // #3615 — same detail transition as the fuel screen.
+        pageBuilder: (context, state) {
           final station = state.extra as ChargingStation;
-          return EVStationDetailScreen(station: station);
+          return detailTransitionPage(
+            key: state.pageKey,
+            child: EVStationDetailScreen(station: station),
+          );
         },
       ),
       // Deep-link friendly EV detail: takes the station id in the

--- a/lib/core/widgets/shimmer_placeholder.dart
+++ b/lib/core/widgets/shimmer_placeholder.dart
@@ -118,3 +118,30 @@ class ShimmerStationDetail extends StatelessWidget {
     );
   }
 }
+
+/// A generic shimmering pane for surfaces that are not lists — map
+/// panes, embedded previews (#3615: replaces the bare centred spinners
+/// so every loading surface speaks the one skeleton language the
+/// search list established).
+class ShimmerPane extends StatelessWidget {
+  const ShimmerPane({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      highlightColor: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Container(
+          width: double.infinity,
+          height: double.infinity,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: AppRadius.lg,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/alert_statistics_card.dart';
 import '../widgets/alerts_best_effort_note.dart';
 import '../widgets/alerts_last_checked_footer.dart';
 import '../widgets/radius_alert_create_sheet.dart';
+import '../../../../core/widgets/shimmer_placeholder.dart';
 
 class AlertsScreen extends ConsumerWidget {
   const AlertsScreen({super.key});
@@ -43,7 +44,7 @@ class AlertsScreen extends ConsumerWidget {
       ),
       body: alertsAsync.when(
         data: (alerts) => _AlertsBody(alerts: alerts),
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const ShimmerStationList(),
         error: (error, stackTrace) => ServiceChainErrorWidget(
           error: error,
           stackTrace: stackTrace,
@@ -79,77 +80,82 @@ class _AlertsBody extends ConsumerWidget {
     // dense rows. Replaces the old layout where per-station alerts floated
     // unlabelled above a big divider (asymmetric with the labelled radius
     // section) and the screen wasted most of its vertical space.
-    return ListView(
-      padding: const EdgeInsets.only(top: 8, bottom: 24),
-      children: [
-        const AlertStatisticsCard(),
-        const SizedBox(height: 4),
-        // ── Station alerts ──────────────────────────────────────────
-        _SectionHeader(
-          title: l10n.alertsStationSectionTitle,
-          count: alerts.length,
-          addTooltip: l10n.alertsStationAdd,
-          // #2857 — the "+" used to be a dead-end that only re-showed the
-          // "create from a station's detail page" hint. It now opens the
-          // favorite-station picker and, on selection, the same
-          // [CreateAlertDialog] the station-detail app bar uses.
-          onAdd: () => AlertStationPickerSheet.addStationAlert(context, ref),
-        ),
-        if (alerts.isEmpty)
-          _SectionEmpty(
-            icon: Icons.notifications_off_outlined,
-            text: l10n.noPriceAlertsHint,
-          )
-        else
-          _GroupedAlertsCard(
-            children: [
-              for (final a in alerts)
-                _AlertListTile(key: ValueKey(a.id), alert: a),
-            ],
+    // #3615 — pull-to-refresh re-evaluates both alert sections.
+    return RefreshIndicator(
+      onRefresh: () async {
+        ref.invalidate(alertsAsyncProvider);
+        ref.invalidate(radiusAlertsProvider);
+      },
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(top: 8, bottom: 24),
+        children: [
+          const AlertStatisticsCard(),
+          const SizedBox(height: 4),
+          // ── Station alerts ──────────────────────────────────────────
+          _SectionHeader(
+            title: l10n.alertsStationSectionTitle,
+            count: alerts.length,
+            addTooltip: l10n.alertsStationAdd,
+            // #2857 — the "+" used to be a dead-end that only re-showed the
+            // "create from a station's detail page" hint. It now opens the
+            // favorite-station picker and, on selection, the same
+            // [CreateAlertDialog] the station-detail app bar uses.
+            onAdd: () => AlertStationPickerSheet.addStationAlert(context, ref),
           ),
-        const SizedBox(height: 12),
-        // ── Zone / radius alerts (#578 phase 2) ─────────────────────
-        _SectionHeader(
-          title: l10n.alertsRadiusSectionTitle,
-          count: radiusAsync.asData?.value.length ?? 0,
-          addTooltip: l10n.alertsRadiusAdd,
-          onAdd: () => RadiusAlertCreateSheet.show(context),
-        ),
-        radiusAsync.when(
-          data: (radiusAlerts) {
-            if (radiusAlerts.isEmpty) {
-              return _RadiusEmptyState();
-            }
-            return _GroupedAlertsCard(
+          if (alerts.isEmpty)
+            _SectionEmpty(
+              icon: Icons.notifications_off_outlined,
+              text: l10n.noPriceAlertsHint,
+            )
+          else
+            _GroupedAlertsCard(
               children: [
-                for (final a in radiusAlerts)
-                  _RadiusAlertListTile(
-                    key: ValueKey('radius-${a.id}'),
-                    alert: a,
-                  ),
+                for (final a in alerts)
+                  _AlertListTile(key: ValueKey(a.id), alert: a),
               ],
-            );
-          },
-          loading: () => const Padding(
-            padding: EdgeInsets.all(16),
-            child: Center(child: CircularProgressIndicator()),
+            ),
+          const SizedBox(height: 12),
+          // ── Zone / radius alerts (#578 phase 2) ─────────────────────
+          _SectionHeader(
+            title: l10n.alertsRadiusSectionTitle,
+            count: radiusAsync.asData?.value.length ?? 0,
+            addTooltip: l10n.alertsRadiusAdd,
+            onAdd: () => RadiusAlertCreateSheet.show(context),
           ),
-          error: (error, stackTrace) => ServiceChainErrorWidget(
-            error: error,
-            stackTrace: stackTrace,
-            searchContext: l10n.alertsLoadErrorTitle,
-            onRetry: () => ref.invalidate(radiusAlertsProvider),
+          radiusAsync.when(
+            data: (radiusAlerts) {
+              if (radiusAlerts.isEmpty) {
+                return _RadiusEmptyState();
+              }
+              return _GroupedAlertsCard(
+                children: [
+                  for (final a in radiusAlerts)
+                    _RadiusAlertListTile(
+                      key: ValueKey('radius-${a.id}'),
+                      alert: a,
+                    ),
+                ],
+              );
+            },
+            loading: () => const ShimmerStationList(count: 2),
+            error: (error, stackTrace) => ServiceChainErrorWidget(
+              error: error,
+              stackTrace: stackTrace,
+              searchContext: l10n.alertsLoadErrorTitle,
+              onRetry: () => ref.invalidate(radiusAlertsProvider),
+            ),
           ),
-        ),
-        // #3147 — "last checked" footer: surfaces the dedup store's
-        // last-completed-scan stamp so a user can verify the background
-        // scan actually runs (the alert-SLA field check).
-        const AlertsLastCheckedFooter(),
-        // #3169 — iOS-only honest disclosure: background alert delivery
-        // on iPhone is best-effort (OS-budgeted), never Android-grade.
-        // Renders nothing on other platforms.
-        const AlertsBestEffortNote(),
-      ],
+          // #3147 — "last checked" footer: surfaces the dedup store's
+          // last-completed-scan stamp so a user can verify the background
+          // scan actually runs (the alert-SLA field check).
+          const AlertsLastCheckedFooter(),
+          // #3169 — iOS-only honest disclosure: background alert delivery
+          // on iPhone is best-effort (OS-budgeted), never Android-grade.
+          // Renders nothing on other platforms.
+          const AlertsBestEffortNote(),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/consumption/presentation/widgets/charging_tab.dart
+++ b/lib/features/consumption/presentation/widgets/charging_tab.dart
@@ -15,6 +15,7 @@ import '../../providers/charging_logs_provider.dart';
 import 'charging_cost_trend_chart.dart';
 import 'charging_efficiency_chart.dart';
 import 'charging_log_card.dart';
+import '../../../../core/widgets/shimmer_placeholder.dart';
 
 /// Body of the Charging tab on the Consumption screen.
 ///
@@ -33,7 +34,7 @@ class ChargingTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return async.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const ShimmerStationList(),
       error: (e, _) => Center(child: Text('Failed to load charging logs: $e')),
       data: (logs) {
         if (logs.isEmpty) {
@@ -45,37 +46,42 @@ class ChargingTab extends ConsumerWidget {
           );
         }
         final ordered = logs.reversed.toList(growable: false);
-        return ListView.builder(
-          padding: EdgeInsets.only(
-            top: 8,
-            bottom: 96 + MediaQuery.of(context).viewPadding.bottom,
+        // #3615 — pull-to-refresh re-reads the charging-log store.
+        return RefreshIndicator(
+          onRefresh: () async => ref.invalidate(chargingLogsProvider),
+          child: ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: EdgeInsets.only(
+              top: 8,
+              bottom: 96 + MediaQuery.of(context).viewPadding.bottom,
+            ),
+            itemCount: ordered.length + 1,
+            itemBuilder: (context, index) {
+              if (index == 0) {
+                // Charts header — read the derived rollup providers so
+                // they react to the same chargingLogsProvider we already
+                // watched upstream.
+                return const _ChargingChartsSection();
+              }
+              final log = ordered[index - 1];
+              return Dismissible(
+                key: ValueKey('charging-${log.id}'),
+                direction: DismissDirection.endToStart,
+                background: Container(
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 24),
+                  color: DarkModeColors.error(context),
+                  child: const Icon(Icons.delete, color: Colors.white),
+                ),
+                onDismissed: (_) {
+                  unawaited(
+                    ref.read(chargingLogsProvider.notifier).remove(log.id),
+                  );
+                },
+                child: ChargingLogCard(log: log),
+              );
+            },
           ),
-          itemCount: ordered.length + 1,
-          itemBuilder: (context, index) {
-            if (index == 0) {
-              // Charts header — read the derived rollup providers so
-              // they react to the same chargingLogsProvider we already
-              // watched upstream.
-              return const _ChargingChartsSection();
-            }
-            final log = ordered[index - 1];
-            return Dismissible(
-              key: ValueKey('charging-${log.id}'),
-              direction: DismissDirection.endToStart,
-              background: Container(
-                alignment: Alignment.centerRight,
-                padding: const EdgeInsets.only(right: 24),
-                color: DarkModeColors.error(context),
-                child: const Icon(Icons.delete, color: Colors.white),
-              ),
-              onDismissed: (_) {
-                unawaited(
-                  ref.read(chargingLogsProvider.notifier).remove(log.id),
-                );
-              },
-              child: ChargingLogCard(log: log),
-            );
-          },
         );
       },
     );

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -132,18 +132,23 @@ class FuelTab extends ConsumerWidget {
       );
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
-      itemCount: fillUps.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: headerChildren,
-          );
-        }
-        return buildFillUpRow(index - 1);
-      },
+    // #3615 — pull-to-refresh re-reads the fill-up store + stats.
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(fillUpListProvider),
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
+        itemCount: fillUps.length + 1,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: headerChildren,
+            );
+          }
+          return buildFillUpRow(index - 1);
+        },
+      ),
     );
   }
 

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -22,6 +22,7 @@ import '../../../search/providers/search_screen_ui_provider.dart';
 import '../../../search/providers/selected_station_provider.dart';
 import 'station_map_geometry.dart';
 import 'station_map_layers.dart';
+import '../../../../core/widgets/shimmer_placeholder.dart';
 
 /// A reusable map widget that displays station markers in the split-screen
 /// landscape pane.
@@ -91,7 +92,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
           }
           return _buildRouteMap(context, result, stations, selectedFuel);
         },
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const ShimmerPane(),
         error: (_, _) => _mapUnavailable(context),
       );
     }
@@ -105,7 +106,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
       return radar.stations.when(
         data: (stations) =>
             _buildMap(context, stations, selectedFuel, searchRadius, sortMode),
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const ShimmerPane(),
         error: (_, _) => _mapUnavailable(context),
       );
     }
@@ -125,7 +126,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
           sortMode,
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const ShimmerPane(),
       error: (_, _) => _mapUnavailable(context),
     );
   }

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -19,6 +19,7 @@ import '../../../../core/domain/search_result_item.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
 import 'station_map_geometry.dart';
 import 'station_map_layers.dart';
+import '../../../../core/widgets/shimmer_placeholder.dart';
 
 /// Displays a map of nearby stations from the current search results.
 ///
@@ -180,7 +181,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
           ],
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const ShimmerPane(),
       error: (error, _) => ServiceChainErrorWidget(
         error: error,
         onRetry: () => context.go(RoutePaths.search),

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -334,56 +334,75 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
         isWideScreen(context) && ref.watch(radarSearchProvider).active;
     return Column(
       children: [
-        if (!hideChromeForLandscapeRadar) ...[
-          DemoModeBanner(country: country, corridorCountryCodes: corridorCodes),
-          // #3361 — honest "no coverage for your country" notice (replaces the
-          // silent fall-back to Germany that read as a geo-restriction).
-          const UnsupportedRegionNotice(),
-          // Compact summary bar — top-level entry point for editing criteria.
-          const SearchSummaryBar(),
-          UserPositionBar(
-            onUpdatePosition: () async {
-              final settings = ref.read(settingsStorageProvider);
-              // #3159 — capture before the consent/GPS awaits; ref.read on an
-              // unmounted element throws a StateError under Riverpod 3.
-              final positionNotifier = ref.read(userPositionProvider.notifier);
-              if (!LocationConsentDialog.hasConsent(settings)) {
-                if (!mounted) return;
-                final consented = await LocationConsentDialog.show(context);
-                if (!consented) return;
-                await LocationConsentDialog.recordConsent(settings);
-              }
-              try {
-                await positionNotifier.updateFromGps();
-                if (!mounted) return;
-                final state = ref.read(searchStateProvider);
-                if (state.hasValue && state.value!.data.isNotEmpty) {
-                  unawaited(_performGpsSearch());
-                }
-              } catch (e, st) {
-                // #1692 — never surface a raw exception toString() to the
-                // user; show a localized, actionable message instead.
-                // #2146 — route to the exportable log so the cause is
-                // recoverable from a bug report.
-                unawaited(
-                  errorLogger.log(
-                    ErrorLayer.ui,
-                    e,
-                    st,
-                    context: const {
-                      'where': 'SearchScreen: userPosition.updateFromGps',
-                    },
-                  ),
-                );
-                if (!context.mounted) return;
-                SnackBarHelper.showError(
-                  context,
-                  AppLocalizations.of(context).searchFailedSnackbar,
-                );
-              }
-            },
-          ),
-        ],
+        // #3615 — the chrome banners appear/disappear with a size
+        // animation instead of a post-frame layout jump.
+        AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          alignment: Alignment.topCenter,
+          child: hideChromeForLandscapeRadar
+              ? const SizedBox(width: double.infinity)
+              : Column(
+                  children: [
+                    DemoModeBanner(
+                      country: country,
+                      corridorCountryCodes: corridorCodes,
+                    ),
+                    // #3361 — honest "no coverage for your country" notice (replaces the
+                    // silent fall-back to Germany that read as a geo-restriction).
+                    const UnsupportedRegionNotice(),
+                    // Compact summary bar — top-level entry point for editing criteria.
+                    const SearchSummaryBar(),
+                    UserPositionBar(
+                      onUpdatePosition: () async {
+                        final settings = ref.read(settingsStorageProvider);
+                        // #3159 — capture before the consent/GPS awaits; ref.read on an
+                        // unmounted element throws a StateError under Riverpod 3.
+                        final positionNotifier = ref.read(
+                          userPositionProvider.notifier,
+                        );
+                        if (!LocationConsentDialog.hasConsent(settings)) {
+                          if (!mounted) return;
+                          final consented = await LocationConsentDialog.show(
+                            context,
+                          );
+                          if (!consented) return;
+                          await LocationConsentDialog.recordConsent(settings);
+                        }
+                        try {
+                          await positionNotifier.updateFromGps();
+                          if (!mounted) return;
+                          final state = ref.read(searchStateProvider);
+                          if (state.hasValue && state.value!.data.isNotEmpty) {
+                            unawaited(_performGpsSearch());
+                          }
+                        } catch (e, st) {
+                          // #1692 — never surface a raw exception toString() to the
+                          // user; show a localized, actionable message instead.
+                          // #2146 — route to the exportable log so the cause is
+                          // recoverable from a bug report.
+                          unawaited(
+                            errorLogger.log(
+                              ErrorLayer.ui,
+                              e,
+                              st,
+                              context: const {
+                                'where':
+                                    'SearchScreen: userPosition.updateFromGps',
+                              },
+                            ),
+                          );
+                          if (!context.mounted) return;
+                          SnackBarHelper.showError(
+                            context,
+                            AppLocalizations.of(context).searchFailedSnackbar,
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                ),
+        ),
         // Results dominate the remaining vertical space.
         Expanded(
           child: Semantics(

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -9,8 +9,6 @@ import '../../../../core/widgets/responsive_layout.dart';
 import '../../../../core/widgets/settings_app_bar_action.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/location_consent.dart';
-import '../../../../core/location/user_position_provider.dart';
-import '../../../../core/logging/error_logger.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -30,14 +28,12 @@ import '../../providers/radar_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/selected_station_provider.dart';
-import '../widgets/demo_mode_banner.dart';
-import '../widgets/unsupported_region_notice.dart';
 import '../widgets/radar_pin_help_sheet.dart';
 import '../widgets/radar_screen_pin_mixin.dart';
 import '../widgets/radar_search_fab.dart';
 import '../widgets/search_results_content.dart';
+import '../widgets/search_chrome_banners.dart';
 import '../widgets/search_summary_bar.dart';
-import '../widgets/user_position_bar.dart';
 
 /// Main search screen — results-first layout.
 ///
@@ -334,74 +330,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
         isWideScreen(context) && ref.watch(radarSearchProvider).active;
     return Column(
       children: [
-        // #3615 — the chrome banners appear/disappear with a size
-        // animation instead of a post-frame layout jump.
-        AnimatedSize(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          alignment: Alignment.topCenter,
-          child: hideChromeForLandscapeRadar
-              ? const SizedBox(width: double.infinity)
-              : Column(
-                  children: [
-                    DemoModeBanner(
-                      country: country,
-                      corridorCountryCodes: corridorCodes,
-                    ),
-                    // #3361 — honest "no coverage for your country" notice (replaces the
-                    // silent fall-back to Germany that read as a geo-restriction).
-                    const UnsupportedRegionNotice(),
-                    // Compact summary bar — top-level entry point for editing criteria.
-                    const SearchSummaryBar(),
-                    UserPositionBar(
-                      onUpdatePosition: () async {
-                        final settings = ref.read(settingsStorageProvider);
-                        // #3159 — capture before the consent/GPS awaits; ref.read on an
-                        // unmounted element throws a StateError under Riverpod 3.
-                        final positionNotifier = ref.read(
-                          userPositionProvider.notifier,
-                        );
-                        if (!LocationConsentDialog.hasConsent(settings)) {
-                          if (!mounted) return;
-                          final consented = await LocationConsentDialog.show(
-                            context,
-                          );
-                          if (!consented) return;
-                          await LocationConsentDialog.recordConsent(settings);
-                        }
-                        try {
-                          await positionNotifier.updateFromGps();
-                          if (!mounted) return;
-                          final state = ref.read(searchStateProvider);
-                          if (state.hasValue && state.value!.data.isNotEmpty) {
-                            unawaited(_performGpsSearch());
-                          }
-                        } catch (e, st) {
-                          // #1692 — never surface a raw exception toString() to the
-                          // user; show a localized, actionable message instead.
-                          // #2146 — route to the exportable log so the cause is
-                          // recoverable from a bug report.
-                          unawaited(
-                            errorLogger.log(
-                              ErrorLayer.ui,
-                              e,
-                              st,
-                              context: const {
-                                'where':
-                                    'SearchScreen: userPosition.updateFromGps',
-                              },
-                            ),
-                          );
-                          if (!context.mounted) return;
-                          SnackBarHelper.showError(
-                            context,
-                            AppLocalizations.of(context).searchFailedSnackbar,
-                          );
-                        }
-                      },
-                    ),
-                  ],
-                ),
+        SearchChromeBanners(
+          hidden: hideChromeForLandscapeRadar,
+          country: country,
+          corridorCountryCodes: corridorCodes,
+          onSearchAgain: _performGpsSearch,
         ),
         // Results dominate the remaining vertical space.
         Expanded(

--- a/lib/features/search/presentation/widgets/search_chrome_banners.dart
+++ b/lib/features/search/presentation/widgets/search_chrome_banners.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/country/country_config.dart';
+import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/logging/error_logger.dart';
+import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../providers/search_provider.dart';
+import '../../../../core/location/location_consent.dart';
+import 'demo_mode_banner.dart';
+import 'search_summary_bar.dart';
+import 'unsupported_region_notice.dart';
+import 'user_position_bar.dart';
+
+/// The search screen's chrome column — demo banner, unsupported-region
+/// notice, summary bar, user-position bar. Extracted from
+/// `search_screen.dart` under the 400-line norm (#3615), which also
+/// wrapped the whole group in [AnimatedSize] so banners appear and
+/// disappear as a motion instead of a post-frame layout jump.
+class SearchChromeBanners extends ConsumerWidget {
+  const SearchChromeBanners({
+    super.key,
+    required this.hidden,
+    required this.country,
+    required this.corridorCountryCodes,
+    required this.onSearchAgain,
+  });
+
+  /// #3372 — landscape radar owns the pane: collapse the chrome.
+  final bool hidden;
+  final CountryConfig country;
+  final Set<String> corridorCountryCodes;
+
+  /// Re-runs the GPS search after a successful position update while
+  /// results are showing.
+  final Future<void> Function() onSearchAgain;
+
+  Future<void> _updatePosition(BuildContext context, WidgetRef ref) async {
+    final settings = ref.read(settingsStorageProvider);
+    // #3159 — capture before the consent/GPS awaits; ref.read on an
+    // unmounted element throws a StateError under Riverpod 3.
+    final positionNotifier = ref.read(userPositionProvider.notifier);
+    if (!LocationConsentDialog.hasConsent(settings)) {
+      if (!context.mounted) return;
+      final consented = await LocationConsentDialog.show(context);
+      if (!consented) return;
+      await LocationConsentDialog.recordConsent(settings);
+    }
+    try {
+      await positionNotifier.updateFromGps();
+      if (!context.mounted) return;
+      final state = ref.read(searchStateProvider);
+      if (state.hasValue && state.value!.data.isNotEmpty) {
+        unawaited(onSearchAgain());
+      }
+    } catch (e, st) {
+      // #1692 — never surface a raw exception toString() to the user;
+      // show a localized, actionable message instead. #2146 — route to
+      // the exportable log so the cause is recoverable from a report.
+      unawaited(
+        errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: const {
+            'where': 'SearchScreen: userPosition.updateFromGps',
+          },
+        ),
+      );
+      if (!context.mounted) return;
+      SnackBarHelper.showError(
+        context,
+        AppLocalizations.of(context).searchFailedSnackbar,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: hidden
+          ? const SizedBox(width: double.infinity)
+          : Column(
+              children: [
+                DemoModeBanner(
+                  country: country,
+                  corridorCountryCodes: corridorCountryCodes,
+                ),
+                // #3361 — honest "no coverage for your country" notice
+                // (replaces the silent fall-back to Germany that read
+                // as a geo-restriction).
+                const UnsupportedRegionNotice(),
+                // Compact summary bar — entry point for editing criteria.
+                const SearchSummaryBar(),
+                UserPositionBar(
+                  onUpdatePosition: () => _updatePosition(context, ref),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -23,6 +23,7 @@ import '../../providers/search_provider.dart';
 import 'radar_scope_view.dart';
 import 'route_results_view.dart';
 import 'search_results_list.dart';
+import '../../../../core/widgets/empty_state.dart';
 
 /// Renders the result panel of `SearchScreen` based on the current
 /// [SearchMode] and [FuelType]:
@@ -161,8 +162,17 @@ class SearchResultsContent extends ConsumerWidget {
           // lands and the list re-ranks.
           return Column(
             children: [
-              if (radar.locating)
-                _RadarUpdatingBanner(message: l10n.radarUpdatingLocation),
+              // #3615 — the refresh banner slides in/out instead of
+              // snapping the list down a row.
+              AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: radar.locating
+                    ? _RadarUpdatingBanner(
+                        message: l10n.radarUpdatingLocation)
+                    : const SizedBox(width: double.infinity),
+              ),
               Expanded(child: body),
             ],
           );
@@ -183,27 +193,15 @@ class SearchResultsContent extends ConsumerWidget {
     return searchState.when(
       data: (result) {
         if (result.data.isEmpty) {
-          return Center(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // #2743 — the redundant "Stations les plus proches" CTA
-                  // card was removed; it duplicated the always-visible
-                  // central search FAB and the Fuel Station Radar button.
-                  // #2131 — the empty-state inline "Search" CTA moved to
-                  // the central FAB. The shell's FAB is always visible
-                  // on this screen, so the empty state is no longer a
-                  // dead-end even without an inline button.
-                  Text(
-                    l10n.startSearch,
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+          // #2743/#2131 — no inline CTA: the central search FAB is the
+          // always-visible affordance. #3615 — same icon+title visual
+          // language as the radar empty state (shared EmptyState), so
+          // the screen's two "nothing here" moments no longer look like
+          // two different apps.
+          return SingleChildScrollView(
+            child: EmptyState(
+              icon: Icons.search,
+              title: l10n.startSearch,
             ),
           );
         }

--- a/test/app/routes/station_routes_test.dart
+++ b/test/app/routes/station_routes_test.dart
@@ -83,14 +83,15 @@ void main() {
       }
     });
 
-    test('every GoRoute has a non-null builder', () {
+    test('every GoRoute has a builder or a pageBuilder (#3615: the two '
+        'detail routes moved to the shared transition pageBuilder)', () {
       final routes = _routesUnderTest();
       for (var i = 0; i < routes.length; i++) {
         final route = routes[i] as GoRoute;
         expect(
-          route.builder,
+          route.builder ?? route.pageBuilder,
           isNotNull,
-          reason: 'route $i (${route.path}) should have a non-null builder',
+          reason: 'route $i (${route.path}) should build something',
         );
       }
     });

--- a/test/features/alerts/presentation/screens/alerts_screen_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/core/domain/fuel_type.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/core/widgets/shimmer_placeholder.dart';
 
 void main() {
   group('AlertsScreen', () {
@@ -240,11 +241,57 @@ void main() {
       );
     });
   });
+  group('#3615 polish', () {
+    testWidgets('loading shows the shared skeleton, not a bare spinner',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertsAsyncProvider
+              .overrideWithValue(const AsyncValue<List<PriceAlert>>.loading()),
+        ],
+        settle: false,
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byType(ShimmerStationList), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('the alerts list is pull-to-refreshable', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _FixedAlerts(const [])),
+        ],
+      );
+
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+      // The gesture completes without touching the network: local
+      // providers just re-read their stores.
+      await tester.fling(
+          find.byType(ListView).first, const Offset(0, 300), 1000);
+      await tester.pumpAndSettle();
+    });
+  });
 }
 
 class _EmptyAlerts extends AlertNotifier {
   @override
   List<PriceAlert> build() => [];
+
 }
 
 class _FixedAlerts extends AlertNotifier {

--- a/test/features/map/presentation/widgets/inline_map_test.dart
+++ b/test/features/map/presentation/widgets/inline_map_test.dart
@@ -17,6 +17,7 @@ import 'package:tankstellen/features/search/providers/search_provider.dart';
 import '../../../../fixtures/stations.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import 'package:tankstellen/core/widgets/shimmer_placeholder.dart';
 
 /// Widget tests for [InlineMap] — the embeddable map widget that drives
 /// the split-screen layout from `searchStateProvider` + the active fuel
@@ -34,7 +35,7 @@ void main() {
       );
 
   group('InlineMap loading branch', () {
-    testWidgets('renders a CircularProgressIndicator while AsyncLoading',
+    testWidgets('renders the shimmer pane while AsyncLoading (#3615)',
         (tester) async {
       final test = standardTestOverrides();
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -59,7 +60,10 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // #3615 — the map pane speaks the shared skeleton language, not
+      // a bare centred spinner.
+      expect(find.byType(ShimmerPane), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
       // Loading branch must not render the data widgets.
       expect(find.byType(StationMapLayers), findsNothing);
       expect(find.byType(EmptyState), findsNothing);


### PR DESCRIPTION
## What
The audit's UI polish wave (epic #3609, child 6): animated chrome banners, one skeleton language for every loading surface, a shared detail-push transition, pull-to-refresh on the local-data tabs, and aligned empty states on the search screen.

## Why
The 2026-07-26 audit flagged the post-frame layout jumps when banners appear, six bare centred spinners inconsistent with the search list's shimmer, platform-default pushes to station detail, no pull-to-refresh on consumption/alerts, and two different "nothing here" visual languages on one screen.

## How
- **AnimatedSize** around the search chrome (demo / unsupported-region / summary / position bars — extracted to `SearchChromeBanners`, which also brings `search_screen.dart` back under the 400-line norm) and around the radar "updating location" banner.
- **Skeletons**: new `ShimmerPane` (rounded shimmer block) for map panes (`inline_map` ×3, `nearby_map_view`); `ShimmerStationList` for `charging_tab` and both `alerts_screen` loading branches. Zero `Center(child: CircularProgressIndicator())` left on these surfaces.
- **Detail transition**: `detailTransitionPage` (fade + subtle upward settle, 250 ms) on the fuel and EV station-detail routes; collapses to a plain fade under the OS reduced-motion setting.
- **Pull-to-refresh**: consumption fuel tab (`fillUpListProvider`), charging tab (`chargingLogsProvider`), alerts screen (`alertsAsyncProvider` + `radiusAlertsProvider`).
- **Empty states**: the idle "start a search" state now uses the shared `EmptyState` (icon + title), matching the radar's empty state.

Deferred from the issue (tracked by epic #3609): the mechanical spacing-token sweep (481 hardcoded EdgeInsets — per-feature chunks) and the optional determinate splash progress.

## Testing
- [x] New pins: inline-map loading renders `ShimmerPane` (spinner asserted ABSENT); alerts loading renders `ShimmerStationList`; alerts list is pull-to-refreshable (gesture completes)
- [x] Full affected suites green: search presentation, alerts, consumption presentation, map, station_detail — 2096 tests; analyzer clean; pre-push gates green

## Completeness checklist
- [x] **Pattern audit** — all six audit-listed spinner sites converted; remaining `CircularProgressIndicator`s are inline button/pill progress (intentional, not loading surfaces)
- [x] **Producer + consumer** — n/a (UI only)
- [x] **Affordances tested** — skeleton + refresh affordances pinned; transition exercised by every routing test that pushes detail
- [x] **Superseded code deleted** — the ad-hoc bare-text empty state and the six spinner branches are gone

Closes #3615

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141g2Ybjri7MwVoFrTSvh98
