### PR TITLE
feat(radar): highway mode — sustained-speed detection + ahead-only filter across all radar surfaces (#3631)

### DIFF
--- a/lib/core/services/radar/highway_mode.dart
+++ b/lib/core/services/radar/highway_mode.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import '../../domain/station.dart';
+import '../../utils/geo_utils.dart' as geo;
+
+/// Speed at/above which sustained driving reads as motorway (#3631).
+const double kHighwayEnterSpeedKmh = 95.0;
+
+/// Sustained time above [kHighwayEnterSpeedKmh] before the mode engages.
+const Duration kHighwayEnterSustain = Duration(seconds: 60);
+
+/// Below this speed the exit clock runs.
+const double kHighwayExitSpeedKmh = 70.0;
+
+/// Sustained time below [kHighwayExitSpeedKmh] before the mode releases —
+/// long enough that a traffic jam or a brief exit-ramp slowdown doesn't
+/// flap the filter off mid-highway.
+const Duration kHighwayExitSustain = Duration(seconds: 180);
+
+/// Relative bearing (°) beyond which a station counts as behind/beside —
+/// outside the "ahead" cone.
+const double kHighwayAheadConeDeg = 75.0;
+
+/// Lateral distance (km) within which a station is "essentially ON the
+/// road" — the band where an opposite-carriageway service area lives.
+const double kHighwayOnRoadLateralKm = 0.15;
+
+/// Countries the app serves that drive on the left — the
+/// opposite-carriageway side inverts there.
+const Set<String> kLeftHandTrafficCountries = {'UK', 'IE', 'MT', 'CY'};
+
+/// Sustained-speed highway detection with hysteresis (#3631).
+///
+/// Fed the GPS speed the approach detector already polls with — no new
+/// location subscription. Pure and clock-injected: `onFix` folds one fix,
+/// [active] is the current verdict.
+///
+/// Deliberately a speed heuristic, not a map lookup: it needs no network,
+/// no new dependency, and the failure modes are benign (a fast rural
+/// N-road gains the ahead-filter too — which is still correct behavior
+/// for a driver passing stations they cannot reach).
+class HighwayModeDetector {
+  DateTime? _fastSince;
+  DateTime? _slowSince;
+  bool _active = false;
+
+  bool get active => _active;
+
+  /// Fold one GPS fix. [speedKmh] non-finite/negative reads as 0.
+  void onFix({required double speedKmh, required DateTime at}) {
+    final v = speedKmh.isFinite && speedKmh > 0 ? speedKmh : 0.0;
+    if (!_active) {
+      if (v >= kHighwayEnterSpeedKmh) {
+        _fastSince ??= at;
+        if (at.difference(_fastSince!) >= kHighwayEnterSustain) {
+          _active = true;
+          _slowSince = null;
+        }
+      } else {
+        _fastSince = null;
+      }
+      return;
+    }
+    if (v < kHighwayExitSpeedKmh) {
+      _slowSince ??= at;
+      if (at.difference(_slowSince!) >= kHighwayExitSustain) {
+        _active = false;
+        _fastSince = null;
+        _slowSince = null;
+      }
+    } else {
+      _slowSince = null;
+    }
+  }
+
+  /// Drop this detector's history (fresh trip).
+  void reset() {
+    _fastSince = null;
+    _slowSince = null;
+    _active = false;
+  }
+}
+
+/// The #3631 ahead-filter: keep only stations a highway driver can still
+/// reach — ahead within the [kHighwayAheadConeDeg] cone, minus the
+/// opposite-carriageway trap (essentially on the road but on the wrong
+/// side). Stations further off-axis ahead (a town off the next exit)
+/// stay.
+///
+/// SAFETY FALLBACK: when the filter would return an empty list, the
+/// UNFILTERED input is returned — a driver low on fuel must never see
+/// zero stations because of a heuristic. Callers can distinguish via
+/// [HighwayAheadResult.filtered].
+class HighwayAheadResult {
+  const HighwayAheadResult({required this.stations, required this.filtered});
+
+  final List<Station> stations;
+
+  /// False when the safety fallback engaged (nothing survived the cone).
+  final bool filtered;
+}
+
+HighwayAheadResult filterStationsAhead({
+  required List<Station> stations,
+  required double lat,
+  required double lng,
+  required double headingDegrees,
+  required bool leftHandTraffic,
+}) {
+  if (!headingDegrees.isFinite || stations.isEmpty) {
+    return HighwayAheadResult(stations: stations, filtered: false);
+  }
+  final kept = <Station>[];
+  for (final s in stations) {
+    final distKm = geo.distanceMeters(lat, lng, s.lat, s.lng) / 1000.0;
+    final bearing = geo.bearingDegrees(lat, lng, s.lat, s.lng);
+    // Signed relative bearing in (-180, 180]: positive = right of travel.
+    var rel = bearing - headingDegrees;
+    while (rel > 180) {
+      rel -= 360;
+    }
+    while (rel <= -180) {
+      rel += 360;
+    }
+    if (rel.abs() > kHighwayAheadConeDeg) continue; // behind / beside
+    final lateralKm = distKm * math.sin(rel * math.pi / 180.0);
+    final onRoad = lateralKm.abs() < kHighwayOnRoadLateralKm;
+    // On the road but on the oncoming side = the opposite carriageway.
+    final oncomingSide = leftHandTraffic ? lateralKm > 0 : lateralKm < 0;
+    if (onRoad && oncomingSide && distKm > kHighwayOnRoadLateralKm) {
+      continue;
+    }
+    kept.add(s);
+  }
+  if (kept.isEmpty) {
+    return HighwayAheadResult(stations: stations, filtered: false);
+  }
+  return HighwayAheadResult(stations: kept, filtered: true);
+}

--- a/lib/core/services/radar/highway_mode_provider.dart
+++ b/lib/core/services/radar/highway_mode_provider.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'highway_mode.dart';
+
+part 'highway_mode_provider.g.dart';
+
+/// App-wide highway-mode verdict (#3631).
+///
+/// Fed by whichever surface currently owns a live GPS stream (the radar
+/// search provider on the search screen) — one detector, one truth, so
+/// the ahead-filter and the UI chip always agree. `keepAlive` because
+/// the sustained-speed history must survive screen churn: driving 10
+/// minutes on the motorway then opening the search screen should land
+/// directly in highway mode.
+@Riverpod(keepAlive: true)
+class HighwayMode extends _$HighwayMode {
+  final HighwayModeDetector _detector = HighwayModeDetector();
+
+  @override
+  bool build() => false;
+
+  /// Fold one GPS fix ([speedMps] as geolocator reports it).
+  void onFix(double speedMps) {
+    final speedKmh =
+        speedMps.isFinite && speedMps > 0 ? speedMps * 3.6 : 0.0;
+    _detector.onFix(speedKmh: speedKmh, at: DateTime.now());
+    if (_detector.active != state) state = _detector.active;
+  }
+
+  /// Forget the speed history (used by tests and a country/session reset).
+  void reset() {
+    _detector.reset();
+    if (state) state = false;
+  }
+}

--- a/lib/core/services/radar/highway_mode_provider.g.dart
+++ b/lib/core/services/radar/highway_mode_provider.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'highway_mode_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// App-wide highway-mode verdict (#3631).
+///
+/// Fed by whichever surface currently owns a live GPS stream (the radar
+/// search provider on the search screen) — one detector, one truth, so
+/// the ahead-filter and the UI chip always agree. `keepAlive` because
+/// the sustained-speed history must survive screen churn: driving 10
+/// minutes on the motorway then opening the search screen should land
+/// directly in highway mode.
+
+@ProviderFor(HighwayMode)
+final highwayModeProvider = HighwayModeProvider._();
+
+/// App-wide highway-mode verdict (#3631).
+///
+/// Fed by whichever surface currently owns a live GPS stream (the radar
+/// search provider on the search screen) — one detector, one truth, so
+/// the ahead-filter and the UI chip always agree. `keepAlive` because
+/// the sustained-speed history must survive screen churn: driving 10
+/// minutes on the motorway then opening the search screen should land
+/// directly in highway mode.
+final class HighwayModeProvider extends $NotifierProvider<HighwayMode, bool> {
+  /// App-wide highway-mode verdict (#3631).
+  ///
+  /// Fed by whichever surface currently owns a live GPS stream (the radar
+  /// search provider on the search screen) — one detector, one truth, so
+  /// the ahead-filter and the UI chip always agree. `keepAlive` because
+  /// the sustained-speed history must survive screen churn: driving 10
+  /// minutes on the motorway then opening the search screen should land
+  /// directly in highway mode.
+  HighwayModeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'highwayModeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$highwayModeHash();
+
+  @$internal
+  @override
+  HighwayMode create() => HighwayMode();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$highwayModeHash() => r'e5eae2512e1ea3d21847fb8c75a1a2f5eb9a41ce';
+
+/// App-wide highway-mode verdict (#3631).
+///
+/// Fed by whichever surface currently owns a live GPS stream (the radar
+/// search provider on the search screen) — one detector, one truth, so
+/// the ahead-filter and the UI chip always agree. `keepAlive` because
+/// the sustained-speed history must survive screen churn: driving 10
+/// minutes on the motorway then opening the search screen should land
+/// directly in highway mode.
+
+abstract class _$HighwayMode extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/services/radar/radar_ranking.dart
+++ b/lib/core/services/radar/radar_ranking.dart
@@ -6,6 +6,7 @@ import '../../domain/station.dart';
 import '../mixins/station_service_helpers.dart';
 import '../../utils/geo_utils.dart' as geo;
 import '../../utils/station_extensions.dart';
+import 'highway_mode.dart';
 
 /// The single distance-ranking authority shared by every radar surface (#3267).
 ///
@@ -54,6 +55,15 @@ class RadarRanking {
     required double lng,
     required FuelType fuel,
     bool requirePrice = false,
+    // #3631 — highway mode: with a finite [headingDegrees] and
+    // [highwayAheadOnly], only stations actually reachable ahead survive
+    // (same-carriageway services + next-exit candidates); the
+    // opposite-carriageway trap is dropped. Falls back to the unfiltered
+    // set rather than ever returning empty (a low-fuel driver must never
+    // see nothing because of a heuristic).
+    double? headingDegrees,
+    bool highwayAheadOnly = false,
+    bool leftHandTraffic = false,
   }) {
     // 1. Dedup by id — last write wins (the in-radius merge row beats the
     // corridor row it follows).
@@ -73,9 +83,23 @@ class RadarRanking {
             fuel,
           );
 
+    // 2b. #3631 — the highway ahead-filter (see highway_mode.dart).
+    final Iterable<Station> directional;
+    if (highwayAheadOnly && headingDegrees != null) {
+      directional = filterStationsAhead(
+        stations: filtered.toList(growable: false),
+        lat: lat,
+        lng: lng,
+        headingDegrees: headingDegrees,
+        leftHandTraffic: leftHandTraffic,
+      ).stations;
+    } else {
+      directional = filtered;
+    }
+
     // 3. Live distance stamp + 4. distance sort.
     return [
-      for (final s in filtered)
+      for (final s in directional)
         s.copyWith(dist: geo.distanceMeters(lat, lng, s.lat, s.lng) / 1000.0),
     ]..sort((a, b) => a.dist.compareTo(b.dist));
   }
@@ -88,12 +112,18 @@ class RadarRanking {
     required double lat,
     required double lng,
     required FuelType fuel,
+    double? headingDegrees,
+    bool highwayAheadOnly = false,
+    bool leftHandTraffic = false,
   }) {
     final ranked = rank(
       stations,
       lat: lat,
       lng: lng,
       fuel: fuel,
+      headingDegrees: headingDegrees,
+      highwayAheadOnly: highwayAheadOnly,
+      leftHandTraffic: leftHandTraffic,
       requirePrice: true,
     );
     return ranked.isEmpty ? null : ranked.first;

--- a/lib/features/approach/providers/nearest_station_radar_provider.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.dart
@@ -11,6 +11,9 @@ import '../../profile/providers/profile_provider.dart';
 import '../../../core/services/radar/radar_ranking.dart';
 import 'effective_approach_state_provider.dart';
 import 'fuel_station_radar_provider.dart';
+import '../../../core/services/radar/highway_mode.dart';
+import '../../../core/services/radar/highway_mode_provider.dart';
+import '../../../core/country/country_provider.dart';
 
 part 'nearest_station_radar_provider.g.dart';
 
@@ -83,15 +86,36 @@ Future<Station?> nearestStationRadar(Ref ref) async {
     // the current fix (#2808 — the corridor `dist` is frozen at fetch time so
     // without this the PiP bar + caption never move) and return the nearest.
     // `null` when nothing in range is priced.
+    // #3631 — the PiP's single target must never be an opposite-carriageway
+    // station the driver cannot reach.
+    final hw = _highwaySafe(ref);
     return RadarRanking.nearestPriced(
       stations,
       lat: gps.latitude,
       lng: gps.longitude,
       fuel: fuel,
+      headingDegrees: geo.sanitizedHeading(gps.heading),
+      highwayAheadOnly: hw.active,
+      leftHandTraffic: hw.leftHand,
     );
   } on Object {
     // Radar / chain failure — treat as "no station nearby". The provider
     // re-runs on the next approach-state tick.
     return null;
+  }
+}
+
+/// #3631 — highway args resolved defensively: any not-up provider reads
+/// as "mode off" (these fall inside catch-all providers whose tests run
+/// minimal containers; ranking must never fail because of the filter).
+({bool active, bool leftHand}) _highwaySafe(Ref ref) {
+  try {
+    return (
+      active: ref.read(highwayModeProvider),
+      leftHand: kLeftHandTrafficCountries
+          .contains(ref.read(activeCountryProvider).code.toUpperCase()),
+    );
+  } catch (_) {
+    return (active: false, leftHand: false);
   }
 }

--- a/lib/features/approach/providers/nearest_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.g.dart
@@ -151,4 +151,4 @@ final class NearestStationRadarProvider
 }
 
 String _$nearestStationRadarHash() =>
-    r'bbae8635d6a1623b5895d1d964503f35fcf96023';
+    r'354f82d6e08c57e08ff3540a1f3a873a9313c6b4';

--- a/lib/features/approach/providers/radar_candidate_list_provider.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.dart
@@ -12,6 +12,9 @@ import '../../../core/services/radar/radar_ranking.dart';
 import 'effective_approach_state_provider.dart';
 import 'fuel_station_radar_provider.dart';
 import '../../../core/services/radar/radar_in_radius_cache_provider.dart';
+import '../../../core/services/radar/highway_mode.dart';
+import '../../../core/services/radar/highway_mode_provider.dart';
+import '../../../core/country/country_provider.dart';
 
 part 'radar_candidate_list_provider.g.dart';
 
@@ -116,16 +119,36 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
     // the effective fuel so a swipe never lands on a `--` row (#2583), live-
     // stamp each row's distance off the current fix (#2808 — the corridor
     // `dist` is frozen at fetch time) and distance-sort nearest-first.
+    // #3631 — on the highway only stations actually ahead can be paged to.
+    final hw = _highwaySafe(ref);
     return RadarRanking.rank(
       [...corridor, ...inRadius],
       lat: gps.latitude,
       lng: gps.longitude,
       fuel: fuel,
       requirePrice: true,
+      headingDegrees: geo.sanitizedHeading(gps.heading),
+      highwayAheadOnly: hw.active,
+      leftHandTraffic: hw.leftHand,
     );
   } on Object {
     // Radar / chain failure — treat as "no stations nearby". The provider
     // re-runs on the next approach-state tick.
     return const [];
+  }
+}
+
+/// #3631 — highway args resolved defensively: any not-up provider reads
+/// as "mode off" (these fall inside catch-all providers whose tests run
+/// minimal containers; ranking must never fail because of the filter).
+({bool active, bool leftHand}) _highwaySafe(Ref ref) {
+  try {
+    return (
+      active: ref.read(highwayModeProvider),
+      leftHand: kLeftHandTrafficCountries
+          .contains(ref.read(activeCountryProvider).code.toUpperCase()),
+    );
+  } catch (_) {
+    return (active: false, leftHand: false);
   }
 }

--- a/lib/features/approach/providers/radar_candidate_list_provider.g.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.g.dart
@@ -210,4 +210,4 @@ final class RadarCandidateListProvider
 }
 
 String _$radarCandidateListHash() =>
-    r'319e230c75f4669b9c98ef2a7e935f1361a44d46';
+    r'c7995161c343c4dfe5054bb76c3bcaa7ae4626e2';

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -24,6 +24,7 @@ import 'radar_scope_view.dart';
 import 'route_results_view.dart';
 import 'search_results_list.dart';
 import '../../../../core/widgets/empty_state.dart';
+import '../../../../core/services/radar/highway_mode_provider.dart';
 
 /// Renders the result panel of `SearchScreen` based on the current
 /// [SearchMode] and [FuelType]:
@@ -160,6 +161,9 @@ class SearchResultsContent extends ConsumerWidget {
           // tells the user the spot is being refreshed (instead of silently
           // showing stale-position distances), and clears once the live fix
           // lands and the list re-ranks.
+          // #3631 — while highway mode is on, the list only carries
+          // stations actually reachable ahead; the chip says so.
+          final highway = ref.watch(highwayModeProvider);
           return Column(
             children: [
               // #3615 — the refresh banner slides in/out instead of
@@ -171,6 +175,16 @@ class SearchResultsContent extends ConsumerWidget {
                 child: radar.locating
                     ? _RadarUpdatingBanner(
                         message: l10n.radarUpdatingLocation)
+                    : const SizedBox(width: double.infinity),
+              ),
+              AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: highway
+                    ? _RadarUpdatingBanner(
+                        message: l10n.highwayModeChip,
+                        icon: Icons.fork_right)
                     : const SizedBox(width: double.infinity),
               ),
               Expanded(child: body),
@@ -275,9 +289,13 @@ class _RadarEmptyState extends StatelessWidget {
 /// user sees results instantly), and this strip signals the spot is being
 /// refreshed; it clears once the live fix lands and the list re-ranks.
 class _RadarUpdatingBanner extends StatelessWidget {
-  const _RadarUpdatingBanner({required this.message});
+  const _RadarUpdatingBanner({required this.message, this.icon});
 
   final String message;
+
+  /// #3631 — a static icon replaces the progress spinner for
+  /// state-chips (highway mode) that aren't "working on something".
+  final IconData? icon;
 
   @override
   Widget build(BuildContext context) {
@@ -290,11 +308,14 @@ class _RadarUpdatingBanner extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const SizedBox(
-            width: 14,
-            height: 14,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
+          if (icon != null)
+            Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant)
+          else
+            const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
           const SizedBox(width: 10),
           Flexible(
             child: Text(

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -20,6 +20,9 @@ import '../../approach/providers/fuel_station_radar_provider.dart';
 import '../../../core/services/radar/radar_in_radius_cache_provider.dart';
 import '../../widget/data/car_station_writer.dart';
 import 'search_filters_provider.dart';
+import '../../../core/services/radar/highway_mode.dart';
+import '../../../core/services/radar/highway_mode_provider.dart';
+import '../../../core/country/country_provider.dart';
 
 part 'radar_search_provider.g.dart';
 
@@ -255,6 +258,14 @@ class RadarSearch extends _$RadarSearch {
   /// down, then trigger a gated re-fetch in the background.
   void _onFix(Position p) {
     _lastFix = p;
+    // #3631 — feed the app-wide highway detector from the ONE live GPS
+    // stream this surface owns; the rank calls below read its verdict.
+    try {
+      ref.read(highwayModeProvider.notifier).onFix(p.speed);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+          context: const {'where': 'radar highwayMode onFix'}));
+    }
     if (!state.active) return;
     // 1. Immediate, network-free re-rank off the cached raw set so the distance
     //    captions + closeness bars move on every fix.
@@ -307,7 +318,14 @@ class RadarSearch extends _$RadarSearch {
           : const <Station>[];
 
       _lastRaw = [...corridor, ...nearby];
-      final ranked = RadarRanking.rank(_lastRaw, lat: lat, lng: lng, fuel: fuel);
+      final hw = _highwayArgs();
+      final ranked = RadarRanking.rank(_lastRaw,
+          lat: lat,
+          lng: lng,
+          fuel: fuel,
+          headingDegrees: hw.heading,
+          highwayAheadOnly: hw.active,
+          leftHandTraffic: hw.leftHand);
 
       // #2948 — publish to the Android Auto Radar screen (swallows write faults).
       unawaited(carWriter.writeRadar(ranked, fuel));
@@ -322,11 +340,35 @@ class RadarSearch extends _$RadarSearch {
     }
   }
 
+
+  /// #3631 — the highway ahead-filter arguments for the shared ranking:
+  /// active verdict + the freshest sanitized course + the active
+  /// country's driving side. Falls back to inactive on any read fault
+  /// (shell safety — ranking must never fail because a provider isn't up).
+  ({bool active, double? heading, bool leftHand}) _highwayArgs() {
+    try {
+      final active = ref.read(highwayModeProvider);
+      final heading = geo.sanitizedHeading(_lastFix?.heading);
+      final leftHand = kLeftHandTrafficCountries
+          .contains(ref.read(activeCountryProvider).code.toUpperCase());
+      return (active: active, heading: heading, leftHand: leftHand);
+    } catch (_) {
+      return (active: false, heading: null, leftHand: false);
+    }
+  }
+
   /// Re-rank the cached raw set against ([lat], [lng]) and publish — no network.
   void _republish(double lat, double lng) {
     if (_lastRaw.isEmpty) return;
     final fuel = ref.read(selectedFuelTypeProvider);
-    final ranked = RadarRanking.rank(_lastRaw, lat: lat, lng: lng, fuel: fuel);
+    final hw = _highwayArgs();
+    final ranked = RadarRanking.rank(_lastRaw,
+        lat: lat,
+        lng: lng,
+        fuel: fuel,
+        headingDegrees: hw.heading,
+        highwayAheadOnly: hw.active,
+        leftHandTraffic: hw.leftHand);
     unawaited(carWriter.writeRadar(ranked, fuel));
     // #3354 — stamp the live course so the scope can orient heading-up.
     state = state.copyWith(

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'1aebbdcc66b59606cd957d916336782ba663c648';
+String _$radarSearchHash() => r'dbeba4fc9751f87a1645eb5d4c8e72c6315ccb6b';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -42,5 +42,9 @@
   "radarSearching": "Suche läuft…",
   "@radarSearching": {
     "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
+  },
+  "highwayModeChip": "Autobahn-Modus — nur Tankstellen voraus auf deiner Strecke",
+  "@highwayModeChip": {
+    "description": "#3631"
   }
 }

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -42,5 +42,9 @@
   "radarSearching": "Searching…",
   "@radarSearching": {
     "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "description": "#3631 chip over the radar list while sustained motorway driving is detected; the list drops opposite-direction stations"
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3794,6 +3794,10 @@
   "@radarSearching": {
     "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
   },
+  "highwayModeChip": "Autobahn-Modus — nur Tankstellen voraus auf deiner Strecke",
+  "@highwayModeChip": {
+    "description": "#3631"
+  },
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7611,6 +7611,10 @@
   "@radarSearching": {
     "description": "Label on the Fuel Station Radar launch button while a scan is initialising — the GPS fix is being acquired and/or the first station list is loading — so the user sees the radar is working rather than a button that silently flipped to 'Stop' (#3290)."
   },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "description": "#3631 chip over the radar list while sustained motorway driving is detected; the list drops opposite-direction stations"
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -2241,6 +2241,7 @@
   "radarAcquiringLocation": "⟦Ƒîñđîñǧ ýóúř łóçáŧîóñ… ·········⟧",
   "radarUpdatingLocation": "⟦Úƥđáŧîñǧ ýóúř łóçáŧîóñ… ·········⟧",
   "radarSearching": "⟦Šéářçĥîñǧ… ····⟧",
+  "highwayModeChip": "⟦Ĥîǧĥŵáý ɱóđé — šĥóŵîñǧ šŧáŧîóñš áĥéáđ óñ ýóúř řóúŧé ···················⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",
   "tripRecordingPinSemanticOff": "⟦Ƥîñ řéçóřđîñǧ ƒóřɱ ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5465,5 +5465,6 @@
     }
   },
   "qrLaunchConfirmOpen": "Ouvrir le lien",
-  "qrLaunchConfirmCancel": "Annuler"
+  "qrLaunchConfirmCancel": "Annuler",
+  "highwayModeChip": "Mode autoroute — seules les stations devant vous sur votre trajet"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13676,6 +13676,12 @@ abstract class AppLocalizations {
   /// **'Searching…'**
   String get radarSearching;
 
+  /// #3631 chip over the radar list while sustained motorway driving is detected; the list drops opposite-direction stations
+  ///
+  /// In en, this message translates to:
+  /// **'Highway mode — showing stations ahead on your route'**
+  String get highwayModeChip;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7954,6 +7954,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Закачането задържа екрана включен — изразходва повече батерия';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7903,6 +7903,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Připnutí udržuje obrazovku zapnutou — spotřebuje více baterie';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7891,6 +7891,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fastgørelse holder skærmen tændt — bruger mere batteri';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7940,6 +7940,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get radarSearching => 'Suche läuft…';
 
   @override
+  String get highwayModeChip =>
+      'Autobahn-Modus — nur Tankstellen voraus auf deiner Strecke';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7956,6 +7956,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Η καρφίτσωση κρατά την οθόνη αναμμένη — χρησιμοποιεί περισσότερη μπαταρία';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7855,6 +7855,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 
@@ -16310,6 +16314,10 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get radarSearching => '⟦Šéářçĥîñǧ… ····⟧';
+
+  @override
+  String get highwayModeChip =>
+      '⟦Ĥîǧĥŵáý ɱóđé — šĥóŵîñǧ šŧáŧîóñš áĥéáđ óñ ýóúř řóúŧé ···················⟧';
 
   @override
   String get tripRecordingPinTooltip =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7944,6 +7944,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fijar mantiene la pantalla encendida: consume más batería';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7885,6 +7885,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kinnitamine hoiab ekraani peal — kasutab rohkem akut';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7892,6 +7892,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kiinnittäminen pitää näytön päällä — kuluttaa enemmän akkua';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7970,6 +7970,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Mode autoroute — seules les stations devant vous sur votre trajet';
+
+  @override
   String get tripRecordingPinTooltip =>
       'L\'épinglage garde l\'écran allumé — consomme plus de batterie';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7917,6 +7917,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prikačivanje drži ekran uključenim — troši više baterije';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7937,6 +7937,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'A rögzítés bekapcsolva tartja a képernyőt — több akkumulátort használ';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7933,6 +7933,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fissare mantiene lo schermo acceso — consuma più batteria';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7930,6 +7930,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prisegimas palaiko ekraną įjungtą — naudoja daugiau baterijos';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7936,6 +7936,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Piespraušana patur ekrānu ieslēgtu — patērē vairāk akumulatora';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7887,6 +7887,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Festing holder skjermen på – bruker mer batteri';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7916,6 +7916,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Vastpinnen houdt het scherm aan — verbruikt meer batterij';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7922,6 +7922,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Przypięcie utrzymuje ekran włączony — zużywa więcej baterii';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7948,6 +7948,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixar mantém o ecrã ligado — usa mais bateria';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7944,6 +7944,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixarea menține ecranul aprins — consumă mai multă baterie';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7920,6 +7920,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pripnutie udržuje obrazovku zapnutú — vyčerpáva viac batérie';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7899,6 +7899,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Priklepanje ohranja zaslon vklopljen — porablja več baterije';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7887,6 +7887,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get radarSearching => 'Searching…';
 
   @override
+  String get highwayModeChip =>
+      'Highway mode — showing stations ahead on your route';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Nålning håller skärmen på – förbrukar mer batteri';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5570,5 +5570,10 @@
   "@qrLaunchConfirmCancel": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayModeChip": "Highway mode — showing stations ahead on your route",
+  "@highwayModeChip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/services/radar/highway_mode_test.dart
+++ b/test/core/services/radar/highway_mode_test.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3631 — highway mode: hysteresis on sustained speed, and the ahead
+// filter that drops opposite-direction stations (the low-fuel-on-the-
+// highway field report) while keeping same-carriageway services and
+// next-exit candidates — with the never-empty safety fallback.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/radar/highway_mode.dart';
+
+Station _station(String id, double lat, double lng) => Station(
+      id: id,
+      name: id,
+      brand: '',
+      street: '',
+      place: '',
+      postCode: '',
+      lat: lat,
+      lng: lng,
+      dist: 0,
+      isOpen: true,
+    );
+
+void main() {
+  group('HighwayModeDetector hysteresis', () {
+    final t0 = DateTime(2026, 7, 26, 10);
+
+    test('engages only after sustained enter-speed, not a burst', () {
+      final d = HighwayModeDetector();
+      d.onFix(speedKmh: 120, at: t0);
+      d.onFix(speedKmh: 120, at: t0.add(const Duration(seconds: 30)));
+      expect(d.active, isFalse, reason: '30 s is not sustained');
+      d.onFix(speedKmh: 120, at: t0.add(const Duration(seconds: 61)));
+      expect(d.active, isTrue);
+    });
+
+    test('a slowdown burst (traffic, exit ramp) does not release it', () {
+      final d = HighwayModeDetector();
+      d.onFix(speedKmh: 120, at: t0);
+      d.onFix(speedKmh: 120, at: t0.add(const Duration(seconds: 61)));
+      d.onFix(speedKmh: 30, at: t0.add(const Duration(seconds: 100)));
+      d.onFix(speedKmh: 30, at: t0.add(const Duration(seconds: 200)));
+      expect(d.active, isTrue, reason: '100 s slow < the 180 s release');
+      d.onFix(speedKmh: 110, at: t0.add(const Duration(seconds: 210)));
+      d.onFix(speedKmh: 30, at: t0.add(const Duration(seconds: 300)));
+      d.onFix(speedKmh: 30, at: t0.add(const Duration(seconds: 490)));
+      expect(d.active, isFalse, reason: '190 s sustained slow releases');
+    });
+
+    test('a speed dip resets the ENTER clock', () {
+      final d = HighwayModeDetector();
+      d.onFix(speedKmh: 120, at: t0);
+      d.onFix(speedKmh: 60, at: t0.add(const Duration(seconds: 40)));
+      d.onFix(speedKmh: 120, at: t0.add(const Duration(seconds: 50)));
+      d.onFix(speedKmh: 120, at: t0.add(const Duration(seconds: 100)));
+      expect(d.active, isFalse,
+          reason: 'the sustain window restarted at the dip');
+    });
+  });
+
+  group('filterStationsAhead', () {
+    // Heading due north from (43.0, 3.0). 1° lat ≈ 111 km;
+    // 1° lng ≈ 111·cos(43°) ≈ 81 km.
+    const lat = 43.0, lng = 3.0;
+
+    test('keeps ahead + next-exit, drops behind and the opposite '
+        'carriageway (right-hand traffic)', () {
+      final ahead = _station('ahead', 43.09, 3.0); // 10 km due north
+      final behind = _station('behind', 42.91, 3.0); // 10 km due south
+      // ~5 km ahead, ~80 m LEFT of the carriageway — the opposite-
+      // direction service area of the field report.
+      final opposite = _station('opposite', 43.045, 2.999);
+      // ~5 km ahead, ~80 m RIGHT — my side's service area.
+      final myside = _station('myside', 43.045, 3.001);
+      // ~6 km ahead, ~2.4 km left — a town off the next exit: reachable.
+      final exitTown = _station('exit', 43.055, 2.97);
+
+      final r = filterStationsAhead(
+        stations: [ahead, behind, opposite, myside, exitTown],
+        lat: lat,
+        lng: lng,
+        headingDegrees: 0,
+        leftHandTraffic: false,
+      );
+      final ids = r.stations.map((s) => s.id).toList();
+      expect(r.filtered, isTrue);
+      expect(ids, containsAll(['ahead', 'myside', 'exit']));
+      expect(ids, isNot(contains('behind')));
+      expect(ids, isNot(contains('opposite')),
+          reason: 'on-road + oncoming side = unreachable on a highway');
+    });
+
+    test('left-hand traffic inverts the oncoming side', () {
+      final leftOfRoad = _station('left', 43.045, 2.999);
+      final rightOfRoad = _station('right', 43.045, 3.001);
+      final r = filterStationsAhead(
+        stations: [leftOfRoad, rightOfRoad],
+        lat: lat,
+        lng: lng,
+        headingDegrees: 0,
+        leftHandTraffic: true,
+      );
+      final ids = r.stations.map((s) => s.id).toList();
+      expect(ids, contains('left'));
+      expect(ids, isNot(contains('right')));
+    });
+
+    test('SAFETY: a cone that would empty the list falls back to the '
+        'unfiltered input', () {
+      final behindOnly = _station('b', 42.9, 3.0);
+      final r = filterStationsAhead(
+        stations: [behindOnly],
+        lat: lat,
+        lng: lng,
+        headingDegrees: 0,
+        leftHandTraffic: false,
+      );
+      expect(r.filtered, isFalse);
+      expect(r.stations, hasLength(1),
+          reason: 'a low-fuel driver must never see zero stations '
+              'because of a heuristic');
+    });
+
+    test('non-finite heading is a no-op', () {
+      final s1 = _station('x', 42.9, 3.0);
+      final r = filterStationsAhead(
+        stations: [s1],
+        lat: lat,
+        lng: lng,
+        headingDegrees: double.nan,
+        leftHandTraffic: false,
+      );
+      expect(r.filtered, isFalse);
+      expect(r.stations, hasLength(1));
+    });
+  });
+}

--- a/test/l10n/french_required_prefixes.dart
+++ b/test/l10n/french_required_prefixes.dart
@@ -65,6 +65,7 @@ const List<String> kFrenchRequiredPrefixes = <String>[
   'lessonCombustionHealth',
   'lessonTransport',
   'tankReport',
+  'highwayMode',
   'insightUpshiftCruise',
   'fuelBreakdownHighRpmCruise',
 


### PR DESCRIPTION
Low-fuel-on-the-highway field report: the radar list was full of opposite-direction stations. Speed-hysteresis highway detection + along/lateral geometry filter at the #3267 ranking chokepoint (behind dropped, opposite-carriageway trap dropped with UK/IE/MT/CY side inversion, next-exit candidates kept, never-empty safety fallback), chip on the radar list, shell-safe provider reads. 7 new geometry/hysteresis tests; search/approach/core suites green. Closes #3631

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G