### PR TITLE
feat(search): real road distances via one OSRM /table call per gated refresh (#3634)

### DIFF
--- a/lib/features/route_search/api.dart
+++ b/lib/features/route_search/api.dart
@@ -21,3 +21,4 @@ export 'presentation/widgets/route_input.dart';
 export 'providers/route_input_provider.dart';
 export 'providers/route_search_params_provider.dart';
 export 'providers/route_search_provider.dart';
+export 'data/services/routing_service.dart';

--- a/lib/features/route_search/data/services/routing_service.dart
+++ b/lib/features/route_search/data/services/routing_service.dart
@@ -161,4 +161,58 @@ class RoutingService {
 
     return samples;
   }
+
+  /// #3634 — real road distances from ONE origin to [destinations] in a
+  /// single OSRM `/table` request (`sources=0`, distance annotation).
+  ///
+  /// Returns km per destination, `null` where OSRM reports the point
+  /// unreachable or omits the distances matrix (some servers disable the
+  /// annotation) — callers keep the crow-flies figure then. Never maps
+  /// durations onto distances.
+  Future<List<double?>> roadDistancesKm({
+    required double originLat,
+    required double originLng,
+    required List<({double lat, double lng})> destinations,
+  }) async {
+    if (destinations.isEmpty) return const [];
+    final coords = StringBuffer('$originLng,$originLat');
+    for (final d in destinations) {
+      coords.write(';${d.lng},${d.lat}');
+    }
+    final response = await _dio.get<dynamic>(
+      '$_baseUrl/table/v1/driving/$coords',
+      queryParameters: {
+        'sources': '0',
+        'annotations': 'distance',
+      },
+    );
+    return parseOsrmTableDistancesKm(
+      response.data as Map<String, dynamic>,
+      destinationCount: destinations.length,
+    );
+  }
+}
+
+/// Pure parser for the OSRM `/table` response (#3634): the first (only)
+/// row of `distances` holds metres from the origin, index 0 being the
+/// origin-to-origin zero which is skipped. Null-safe against servers
+/// that omit the matrix, rows shorter than expected, and per-cell nulls
+/// (unreachable snap).
+List<double?> parseOsrmTableDistancesKm(
+  Map<String, dynamic> json, {
+  required int destinationCount,
+}) {
+  final none = List<double?>.filled(destinationCount, null);
+  if (json['code'] != 'Ok') return none;
+  final distances = json['distances'];
+  if (distances is! List || distances.isEmpty) return none;
+  final row = distances.first;
+  if (row is! List) return none;
+  return [
+    for (var i = 1; i <= destinationCount; i++)
+      if (i < row.length && row[i] is num)
+        (row[i] as num).toDouble() / 1000.0
+      else
+        null,
+  ];
 }

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -23,6 +23,8 @@ import '../../domain/entities/brand_registry.dart';
 import '../../../../core/domain/fuel_type.dart';
 import '../../../../core/domain/station.dart';
 import 'amenity_chips.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../providers/road_distance_provider.dart';
 
 part 'station_card_price_column.dart';
 part 'station_card_price_row.dart';

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -117,10 +117,33 @@ class _StationDetails extends StatelessWidget {
           children: [
             // #2622 — distance gets priority in this cramped row; the
             // timestamp (Flexible) is what wraps/ellipsises first.
-            Text(
-              PriceFormatter.formatDistance(station.dist),
-              style: theme.textTheme.bodySmall,
-            ),
+            // #3634 — when the OSRM table has answered for this station,
+            // the REAL road distance replaces the crow-flies figure (the
+            // route icon marks the difference); otherwise the haversine
+            // value stands as always.
+            Consumer(builder: (context, ref, _) {
+              final roadKm = ref.watch(
+                  roadDistancesProvider.select((m) => m[station.id]));
+              if (roadKm == null) {
+                return Text(
+                  PriceFormatter.formatDistance(station.dist),
+                  style: theme.textTheme.bodySmall,
+                );
+              }
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.route,
+                      size: 12,
+                      color: theme.colorScheme.onSurfaceVariant),
+                  const SizedBox(width: 2),
+                  Text(
+                    PriceFormatter.formatDistance(roadKm),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              );
+            }),
             if (station.updatedAt != null) ...[
               const SizedBox(width: 8),
               Icon(

--- a/lib/features/search/providers/radar_highway_args.dart
+++ b/lib/features/search/providers/radar_highway_args.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../../../core/country/country_provider.dart';
+import '../../../core/services/radar/highway_mode.dart';
+import '../../../core/services/radar/highway_mode_provider.dart';
+import '../../../core/utils/geo_utils.dart' as geo;
+
+/// #3631 — the highway ahead-filter arguments for the shared ranking:
+/// active verdict + the freshest sanitized course + the active country's
+/// driving side. Falls back to inactive on any read fault (shell safety
+/// — ranking must never fail because a provider isn't up). Extracted
+/// from `radar_search_provider.dart` for the 400-line guard (#3634).
+({bool active, double? heading, bool leftHand}) highwayRankArgs(
+  Ref ref,
+  Position? lastFix,
+) {
+  try {
+    final active = ref.read(highwayModeProvider);
+    final heading = geo.sanitizedHeading(lastFix?.heading);
+    final leftHand = kLeftHandTrafficCountries
+        .contains(ref.read(activeCountryProvider).code.toUpperCase());
+    return (active: active, heading: heading, leftHand: leftHand);
+  } catch (_) {
+    // ignore: silent_catch — shell safety: rank args degrade to mode-off
+    return (active: false, heading: null, leftHand: false);
+  }
+}

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -20,9 +20,9 @@ import '../../approach/providers/fuel_station_radar_provider.dart';
 import '../../../core/services/radar/radar_in_radius_cache_provider.dart';
 import '../../widget/data/car_station_writer.dart';
 import 'search_filters_provider.dart';
-import '../../../core/services/radar/highway_mode.dart';
 import '../../../core/services/radar/highway_mode_provider.dart';
-import '../../../core/country/country_provider.dart';
+import 'road_distance_provider.dart';
+import 'radar_highway_args.dart';
 
 part 'radar_search_provider.g.dart';
 
@@ -318,7 +318,7 @@ class RadarSearch extends _$RadarSearch {
           : const <Station>[];
 
       _lastRaw = [...corridor, ...nearby];
-      final hw = _highwayArgs();
+      final hw = highwayRankArgs(ref, _lastFix);
       final ranked = RadarRanking.rank(_lastRaw,
           lat: lat,
           lng: lng,
@@ -331,6 +331,17 @@ class RadarSearch extends _$RadarSearch {
       unawaited(carWriter.writeRadar(ranked, fuel));
 
       state = state.copyWith(stations: AsyncData<List<Station>>(ranked));
+
+      // #3634 — one gated OSRM /table call annotates the visible top-N
+      // with real road km (display enrichment; fire-and-forget, the
+      // notifier owns the movement/time gate and silent degrade).
+      try {
+        unawaited(ref
+            .read(roadDistancesProvider.notifier)
+            .refresh(lat: lat, lng: lng, ranked: ranked));
+      } catch (_) {
+        // ignore: silent_catch — shell safety: a not-up graph must not break the scan
+      }
     } catch (e, st) {
       // On a background (live) refresh, keep the last good results; only an
       // explicit (initial / retry) scan surfaces the error.
@@ -341,27 +352,12 @@ class RadarSearch extends _$RadarSearch {
   }
 
 
-  /// #3631 — the highway ahead-filter arguments for the shared ranking:
-  /// active verdict + the freshest sanitized course + the active
-  /// country's driving side. Falls back to inactive on any read fault
-  /// (shell safety — ranking must never fail because a provider isn't up).
-  ({bool active, double? heading, bool leftHand}) _highwayArgs() {
-    try {
-      final active = ref.read(highwayModeProvider);
-      final heading = geo.sanitizedHeading(_lastFix?.heading);
-      final leftHand = kLeftHandTrafficCountries
-          .contains(ref.read(activeCountryProvider).code.toUpperCase());
-      return (active: active, heading: heading, leftHand: leftHand);
-    } catch (_) {
-      return (active: false, heading: null, leftHand: false);
-    }
-  }
 
   /// Re-rank the cached raw set against ([lat], [lng]) and publish — no network.
   void _republish(double lat, double lng) {
     if (_lastRaw.isEmpty) return;
     final fuel = ref.read(selectedFuelTypeProvider);
-    final hw = _highwayArgs();
+    final hw = highwayRankArgs(ref, _lastFix);
     final ranked = RadarRanking.rank(_lastRaw,
         lat: lat,
         lng: lng,

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'dbeba4fc9751f87a1645eb5d4c8e72c6315ccb6b';
+String _$radarSearchHash() => r'f7a079da00736be4bcbdb3002d32a9cd23d1057d';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/lib/features/search/providers/road_distance_provider.dart
+++ b/lib/features/search/providers/road_distance_provider.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/domain/station.dart';
+import '../../../core/logging/error_logger.dart';
+import '../../../core/utils/geo_utils.dart' as geo;
+import '../../route_search/api.dart';
+
+part 'road_distance_provider.g.dart';
+
+/// How many top-ranked stations get a real road distance per refresh —
+/// one OSRM `/table` request covers all of them (#3634).
+const int kRoadDistanceTopN = 8;
+
+/// Movement/time gate mirroring the #3254 in-radius merge: don't re-ask
+/// OSRM until the origin moved this far or this long has passed.
+const double kRoadDistanceRefetchMeters = 500;
+const Duration kRoadDistanceRefetchInterval = Duration(seconds: 60);
+
+/// The single road-distance fetch seam, injectable so tests never touch
+/// the network. Defaults to the shared [RoutingService] table call.
+@Riverpod(keepAlive: true)
+Future<List<double?>> Function(
+  double lat,
+  double lng,
+  List<({double lat, double lng})> destinations,
+) roadDistanceFetcher(Ref ref) {
+  final service = RoutingService();
+  return (lat, lng, destinations) => service.roadDistancesKm(
+        originLat: lat,
+        originLng: lng,
+        destinations: destinations,
+      );
+}
+
+/// Station-id → real road distance (km) for the radar surface (#3634).
+///
+/// Display-only enrichment: the crow-flies figure always remains the
+/// baseline, sorting stays with the ranking authority, and any failure
+/// leaves the map as-is (silent degrade — the list must never suffer for
+/// a routing hiccup). Session-lived; `keepAlive` so paging around the
+/// app doesn't refetch.
+@Riverpod(keepAlive: true)
+class RoadDistances extends _$RoadDistances {
+  double? _lastLat;
+  double? _lastLng;
+  DateTime? _lastAt;
+  bool _inFlight = false;
+
+  @override
+  Map<String, double> build() => const {};
+
+  /// Refresh road distances for the [kRoadDistanceTopN] nearest of
+  /// [ranked] from ([lat], [lng]). Gated on movement + time; silent on
+  /// failure; merges into the existing map so older entries keep
+  /// answering while a refresh is in flight.
+  Future<void> refresh({
+    required double lat,
+    required double lng,
+    required List<Station> ranked,
+  }) async {
+    if (ranked.isEmpty || _inFlight) return;
+    final now = DateTime.now();
+    final lastLat = _lastLat, lastLng = _lastLng, lastAt = _lastAt;
+    if (lastLat != null && lastLng != null && lastAt != null) {
+      final movedM = geo.distanceMeters(lastLat, lastLng, lat, lng);
+      if (movedM < kRoadDistanceRefetchMeters &&
+          now.difference(lastAt) < kRoadDistanceRefetchInterval) {
+        return;
+      }
+    }
+    final top = ranked.take(kRoadDistanceTopN).toList(growable: false);
+    _inFlight = true;
+    try {
+      final fetch = ref.read(roadDistanceFetcherProvider);
+      final kms = await fetch(
+        lat,
+        lng,
+        [for (final s in top) (lat: s.lat, lng: s.lng)],
+      );
+      _lastLat = lat;
+      _lastLng = lng;
+      _lastAt = now;
+      final next = Map<String, double>.from(state);
+      for (var i = 0; i < top.length && i < kms.length; i++) {
+        final km = kms[i];
+        if (km != null) next[top[i].id] = km;
+      }
+      state = next;
+    } catch (e, st) {
+      // Routing is best-effort garnish — log for the field export, keep
+      // whatever distances we already had.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st,
+          context: const {'where': 'RoadDistances refresh'}));
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/search/providers/road_distance_provider.g.dart
+++ b/lib/features/search/providers/road_distance_provider.g.dart
@@ -1,0 +1,190 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'road_distance_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The single road-distance fetch seam, injectable so tests never touch
+/// the network. Defaults to the shared [RoutingService] table call.
+
+@ProviderFor(roadDistanceFetcher)
+final roadDistanceFetcherProvider = RoadDistanceFetcherProvider._();
+
+/// The single road-distance fetch seam, injectable so tests never touch
+/// the network. Defaults to the shared [RoutingService] table call.
+
+final class RoadDistanceFetcherProvider
+    extends
+        $FunctionalProvider<
+          Future<List<double?>> Function(
+            double lat,
+            double lng,
+            List<({double lat, double lng})> destinations,
+          ),
+          Future<List<double?>> Function(
+            double lat,
+            double lng,
+            List<({double lat, double lng})> destinations,
+          ),
+          Future<List<double?>> Function(
+            double lat,
+            double lng,
+            List<({double lat, double lng})> destinations,
+          )
+        >
+    with
+        $Provider<
+          Future<List<double?>> Function(
+            double lat,
+            double lng,
+            List<({double lat, double lng})> destinations,
+          )
+        > {
+  /// The single road-distance fetch seam, injectable so tests never touch
+  /// the network. Defaults to the shared [RoutingService] table call.
+  RoadDistanceFetcherProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'roadDistanceFetcherProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$roadDistanceFetcherHash();
+
+  @$internal
+  @override
+  $ProviderElement<
+    Future<List<double?>> Function(
+      double lat,
+      double lng,
+      List<({double lat, double lng})> destinations,
+    )
+  >
+  $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+
+  @override
+  Future<List<double?>> Function(
+    double lat,
+    double lng,
+    List<({double lat, double lng})> destinations,
+  )
+  create(Ref ref) {
+    return roadDistanceFetcher(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(
+    Future<List<double?>> Function(
+      double lat,
+      double lng,
+      List<({double lat, double lng})> destinations,
+    )
+    value,
+  ) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<
+            Future<List<double?>> Function(
+              double lat,
+              double lng,
+              List<({double lat, double lng})> destinations,
+            )
+          >(value),
+    );
+  }
+}
+
+String _$roadDistanceFetcherHash() =>
+    r'e51a006f17661a15390f83f9c984d2d157b9cafe';
+
+/// Station-id → real road distance (km) for the radar surface (#3634).
+///
+/// Display-only enrichment: the crow-flies figure always remains the
+/// baseline, sorting stays with the ranking authority, and any failure
+/// leaves the map as-is (silent degrade — the list must never suffer for
+/// a routing hiccup). Session-lived; `keepAlive` so paging around the
+/// app doesn't refetch.
+
+@ProviderFor(RoadDistances)
+final roadDistancesProvider = RoadDistancesProvider._();
+
+/// Station-id → real road distance (km) for the radar surface (#3634).
+///
+/// Display-only enrichment: the crow-flies figure always remains the
+/// baseline, sorting stays with the ranking authority, and any failure
+/// leaves the map as-is (silent degrade — the list must never suffer for
+/// a routing hiccup). Session-lived; `keepAlive` so paging around the
+/// app doesn't refetch.
+final class RoadDistancesProvider
+    extends $NotifierProvider<RoadDistances, Map<String, double>> {
+  /// Station-id → real road distance (km) for the radar surface (#3634).
+  ///
+  /// Display-only enrichment: the crow-flies figure always remains the
+  /// baseline, sorting stays with the ranking authority, and any failure
+  /// leaves the map as-is (silent degrade — the list must never suffer for
+  /// a routing hiccup). Session-lived; `keepAlive` so paging around the
+  /// app doesn't refetch.
+  RoadDistancesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'roadDistancesProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$roadDistancesHash();
+
+  @$internal
+  @override
+  RoadDistances create() => RoadDistances();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Map<String, double> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Map<String, double>>(value),
+    );
+  }
+}
+
+String _$roadDistancesHash() => r'3f3e1638dd24f72f372f75b27a96c12b4b53f08a';
+
+/// Station-id → real road distance (km) for the radar surface (#3634).
+///
+/// Display-only enrichment: the crow-flies figure always remains the
+/// baseline, sorting stays with the ranking authority, and any failure
+/// leaves the map as-is (silent degrade — the list must never suffer for
+/// a routing hiccup). Session-lived; `keepAlive` so paging around the
+/// app doesn't refetch.
+
+abstract class _$RoadDistances extends $Notifier<Map<String, double>> {
+  Map<String, double> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<Map<String, double>, Map<String, double>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Map<String, double>, Map<String, double>>,
+              Map<String, double>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
@@ -1147,14 +1148,17 @@ void main() {
 
       testWidgets('card uses elevation 1 in dark mode', (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            theme: ThemeData.dark(),
-            home: const Scaffold(
-              body: StationCard(
-                station: testStation,
-                selectedFuelType: FuelType.e10,
+          // #3634 — the card's road-distance Consumer needs a scope.
+          ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: ThemeData.dark(),
+              home: const Scaffold(
+                body: StationCard(
+                  station: testStation,
+                  selectedFuelType: FuelType.e10,
+                ),
               ),
             ),
           ),

--- a/test/features/search/providers/road_distance_provider_test.dart
+++ b/test/features/search/providers/road_distance_provider_test.dart
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3634 — real road distances: the OSRM /table parser, and the
+// enrichment notifier's movement/time gate + merge + silent degrade.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/features/route_search/data/services/routing_service.dart';
+import 'package:tankstellen/features/search/providers/road_distance_provider.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+Station _station(String id, double lat, double lng) => Station(
+      id: id,
+      name: id,
+      brand: '',
+      street: '',
+      place: '',
+      postCode: '',
+      lat: lat,
+      lng: lng,
+      dist: 0,
+      isOpen: true,
+    );
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('parseOsrmTableDistancesKm', () {
+    test('happy matrix: metres → km, origin cell skipped', () {
+      final r = parseOsrmTableDistancesKm({
+        'code': 'Ok',
+        'distances': [
+          [0, 12300.0, 4500.0],
+        ],
+      }, destinationCount: 2);
+      expect(r, [12.3, 4.5]);
+    });
+
+    test('unreachable destination is null, others survive', () {
+      final r = parseOsrmTableDistancesKm({
+        'code': 'Ok',
+        'distances': [
+          [0, null, 800.0],
+        ],
+      }, destinationCount: 2);
+      expect(r, [null, 0.8]);
+    });
+
+    test('missing matrix / bad code / short row → all null (never '
+        'durations-as-distance)', () {
+      expect(
+        parseOsrmTableDistancesKm({'code': 'Ok'}, destinationCount: 2),
+        [null, null],
+      );
+      expect(
+        parseOsrmTableDistancesKm(
+            {'code': 'NoTable', 'distances': <List<num?>>[]},
+            destinationCount: 1),
+        [null],
+      );
+      expect(
+        parseOsrmTableDistancesKm({
+          'code': 'Ok',
+          'distances': [
+            [0, 500.0],
+          ],
+        }, destinationCount: 3),
+        [0.5, null, null],
+      );
+    });
+  });
+
+  group('RoadDistances notifier', () {
+    test('fetches the top-N, merges by id, and gates the next refresh '
+        'until moved/aged', () async {
+      var calls = 0;
+      final container = ProviderContainer(overrides: [
+        roadDistanceFetcherProvider.overrideWithValue(
+          (lat, lng, dests) async {
+            calls++;
+            return [for (var i = 0; i < dests.length; i++) 10.0 + i];
+          },
+        ),
+      ]);
+      addTearDown(container.dispose);
+      final notifier = container.read(roadDistancesProvider.notifier);
+      final ranked = [
+        _station('a', 43.01, 3.0),
+        _station('b', 43.02, 3.0),
+      ];
+
+      await notifier.refresh(lat: 43.0, lng: 3.0, ranked: ranked);
+      expect(calls, 1);
+      expect(container.read(roadDistancesProvider),
+          {'a': 10.0, 'b': 11.0});
+
+      // Same spot, immediately: gated.
+      await notifier.refresh(lat: 43.0001, lng: 3.0, ranked: ranked);
+      expect(calls, 1, reason: '<500 m and <60 s — no refetch');
+
+      // Moved 1 km: refetches and merges.
+      await notifier.refresh(lat: 43.009, lng: 3.0, ranked: ranked);
+      expect(calls, 2);
+    });
+
+    test('a fetch failure is silent — existing distances survive',
+        () async {
+      var fail = false;
+      final container = ProviderContainer(overrides: [
+        roadDistanceFetcherProvider.overrideWithValue(
+          (lat, lng, dests) async {
+            if (fail) throw Exception('osrm down');
+            return [7.7];
+          },
+        ),
+      ]);
+      addTearDown(container.dispose);
+      final notifier = container.read(roadDistancesProvider.notifier);
+      final ranked = [_station('a', 43.01, 3.0)];
+
+      await notifier.refresh(lat: 43.0, lng: 3.0, ranked: ranked);
+      expect(container.read(roadDistancesProvider), {'a': 7.7});
+
+      fail = true;
+      await notifier.refresh(lat: 43.1, lng: 3.0, ranked: ranked);
+      expect(container.read(roadDistancesProvider), {'a': 7.7},
+          reason: 'routing is garnish — a failure must change nothing');
+    });
+  });
+}


### PR DESCRIPTION
The station list's distance line now shows the real road km (route icon) once a single gated OSRM /table request answers for the visible top-8 — crow-flies stays as baseline and on any failure. Movement/time-gated, id-merged, injectable fetch seam, display-only. Closes #3634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G