### PR TITLE
feat(search): direction-aware road distances — OSRM bearings pin the origin to the driver's carriageway (#3637)

### DIFF
--- a/lib/features/route_search/data/services/routing_service.dart
+++ b/lib/features/route_search/data/services/routing_service.dart
@@ -169,27 +169,40 @@ class RoutingService {
   /// unreachable or omits the distances matrix (some servers disable the
   /// annotation) — callers keep the crow-flies figure then. Never maps
   /// durations onto distances.
+  /// #3637 — with [originBearingDegrees] the origin snaps only onto road
+  /// segments matching the travel direction (±[kOsrmBearingToleranceDeg]),
+  /// so a driver on the northbound carriageway gets northbound-departure
+  /// distances — the opposite carriageway and backwards departures cost
+  /// their real turn-around km. If the constrained call answers all-null
+  /// (no segment matched a noisy heading), ONE unconstrained retry keeps
+  /// the feature alive — direction-awareness must never cost the figures.
   Future<List<double?>> roadDistancesKm({
     required double originLat,
     required double originLng,
     required List<({double lat, double lng})> destinations,
+    double? originBearingDegrees,
   }) async {
     if (destinations.isEmpty) return const [];
-    final coords = StringBuffer('$originLng,$originLat');
-    for (final d in destinations) {
-      coords.write(';${d.lng},${d.lat}');
+    Future<List<double?>> call(double? bearing) async {
+      final response = await _dio.get<dynamic>(
+        '$_baseUrl/table/v1/driving/'
+        '${osrmTableCoords(originLat, originLng, destinations)}',
+        queryParameters: osrmTableParams(
+          destinationCount: destinations.length,
+          originBearingDegrees: bearing,
+        ),
+      );
+      return parseOsrmTableDistancesKm(
+        response.data as Map<String, dynamic>,
+        destinationCount: destinations.length,
+      );
     }
-    final response = await _dio.get<dynamic>(
-      '$_baseUrl/table/v1/driving/$coords',
-      queryParameters: {
-        'sources': '0',
-        'annotations': 'distance',
-      },
-    );
-    return parseOsrmTableDistancesKm(
-      response.data as Map<String, dynamic>,
-      destinationCount: destinations.length,
-    );
+
+    final first = await call(originBearingDegrees);
+    if (originBearingDegrees == null || first.any((d) => d != null)) {
+      return first;
+    }
+    return call(null);
   }
 }
 
@@ -215,4 +228,43 @@ List<double?> parseOsrmTableDistancesKm(
       else
         null,
   ];
+}
+
+/// Bearing snap tolerance (°) for the direction-aware origin (#3637) —
+/// wide enough for GPS course noise on a straight carriageway, narrow
+/// enough to exclude the opposite direction.
+const double kOsrmBearingToleranceDeg = 25;
+
+/// OSRM `lon,lat;lon,lat…` coordinate path segment (#3637, extracted so
+/// the query shape is unit-testable without Dio).
+String osrmTableCoords(
+  double originLat,
+  double originLng,
+  List<({double lat, double lng})> destinations,
+) {
+  final coords = StringBuffer('$originLng,$originLat');
+  for (final d in destinations) {
+    coords.write(';${d.lng},${d.lat}');
+  }
+  return coords.toString();
+}
+
+/// OSRM `/table` query parameters (#3637). The `bearings` list MUST
+/// carry one entry per coordinate — the origin's `deg,tolerance`
+/// followed by one empty (unconstrained) entry per destination.
+Map<String, String> osrmTableParams({
+  required int destinationCount,
+  double? originBearingDegrees,
+}) {
+  final params = <String, String>{
+    'sources': '0',
+    'annotations': 'distance',
+  };
+  final b = originBearingDegrees;
+  if (b != null && b.isFinite) {
+    params['bearings'] =
+        '${b.round() % 360},${kOsrmBearingToleranceDeg.round()}'
+        '${';' * destinationCount}';
+  }
+  return params;
 }

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -336,9 +336,12 @@ class RadarSearch extends _$RadarSearch {
       // with real road km (display enrichment; fire-and-forget, the
       // notifier owns the movement/time gate and silent degrade).
       try {
-        unawaited(ref
-            .read(roadDistancesProvider.notifier)
-            .refresh(lat: lat, lng: lng, ranked: ranked));
+        unawaited(ref.read(roadDistancesProvider.notifier).refresh(
+            lat: lat,
+            lng: lng,
+            ranked: ranked,
+            // #3637 — direction-aware origin snap (null at standstill).
+            headingDegrees: geo.sanitizedHeading(_lastFix?.heading)));
       } catch (_) {
         // ignore: silent_catch — shell safety: a not-up graph must not break the scan
       }

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'f7a079da00736be4bcbdb3002d32a9cd23d1057d';
+String _$radarSearchHash() => r'b94ae83b35ba3d3c09e6ee27c641b8cf4c2342e5';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/lib/features/search/providers/road_distance_provider.dart
+++ b/lib/features/search/providers/road_distance_provider.dart
@@ -27,12 +27,15 @@ const Duration kRoadDistanceRefetchInterval = Duration(seconds: 60);
 Future<List<double?>> Function(
   double lat,
   double lng,
+  double? bearingDegrees,
   List<({double lat, double lng})> destinations,
 ) roadDistanceFetcher(Ref ref) {
   final service = RoutingService();
-  return (lat, lng, destinations) => service.roadDistancesKm(
+  return (lat, lng, bearingDegrees, destinations) =>
+      service.roadDistancesKm(
         originLat: lat,
         originLng: lng,
+        originBearingDegrees: bearingDegrees,
         destinations: destinations,
       );
 }
@@ -62,6 +65,10 @@ class RoadDistances extends _$RoadDistances {
     required double lat,
     required double lng,
     required List<Station> ranked,
+    // #3637 — the sanitized GPS course: constrains the OSRM origin snap
+    // to the driver's carriageway/direction. Null (standstill, no fix)
+    // keeps the unconstrained behavior.
+    double? headingDegrees,
   }) async {
     if (ranked.isEmpty || _inFlight) return;
     final now = DateTime.now();
@@ -80,6 +87,7 @@ class RoadDistances extends _$RoadDistances {
       final kms = await fetch(
         lat,
         lng,
+        headingDegrees,
         [for (final s in top) (lat: s.lat, lng: s.lng)],
       );
       _lastLat = lat;

--- a/lib/features/search/providers/road_distance_provider.g.dart
+++ b/lib/features/search/providers/road_distance_provider.g.dart
@@ -23,16 +23,19 @@ final class RoadDistanceFetcherProvider
           Future<List<double?>> Function(
             double lat,
             double lng,
+            double? bearingDegrees,
             List<({double lat, double lng})> destinations,
           ),
           Future<List<double?>> Function(
             double lat,
             double lng,
+            double? bearingDegrees,
             List<({double lat, double lng})> destinations,
           ),
           Future<List<double?>> Function(
             double lat,
             double lng,
+            double? bearingDegrees,
             List<({double lat, double lng})> destinations,
           )
         >
@@ -41,6 +44,7 @@ final class RoadDistanceFetcherProvider
           Future<List<double?>> Function(
             double lat,
             double lng,
+            double? bearingDegrees,
             List<({double lat, double lng})> destinations,
           )
         > {
@@ -66,6 +70,7 @@ final class RoadDistanceFetcherProvider
     Future<List<double?>> Function(
       double lat,
       double lng,
+      double? bearingDegrees,
       List<({double lat, double lng})> destinations,
     )
   >
@@ -75,6 +80,7 @@ final class RoadDistanceFetcherProvider
   Future<List<double?>> Function(
     double lat,
     double lng,
+    double? bearingDegrees,
     List<({double lat, double lng})> destinations,
   )
   create(Ref ref) {
@@ -86,6 +92,7 @@ final class RoadDistanceFetcherProvider
     Future<List<double?>> Function(
       double lat,
       double lng,
+      double? bearingDegrees,
       List<({double lat, double lng})> destinations,
     )
     value,
@@ -97,6 +104,7 @@ final class RoadDistanceFetcherProvider
             Future<List<double?>> Function(
               double lat,
               double lng,
+              double? bearingDegrees,
               List<({double lat, double lng})> destinations,
             )
           >(value),
@@ -105,7 +113,7 @@ final class RoadDistanceFetcherProvider
 }
 
 String _$roadDistanceFetcherHash() =>
-    r'e51a006f17661a15390f83f9c984d2d157b9cafe';
+    r'd0ec27cea4cc1fc08a152f30fcc16703d958fa52';
 
 /// Station-id → real road distance (km) for the radar surface (#3634).
 ///
@@ -161,7 +169,7 @@ final class RoadDistancesProvider
   }
 }
 
-String _$roadDistancesHash() => r'3f3e1638dd24f72f372f75b27a96c12b4b53f08a';
+String _$roadDistancesHash() => r'347c27d9a15f9375b5bc94de349335e2bd32cc05';
 
 /// Station-id → real road distance (km) for the radar surface (#3634).
 ///

--- a/test/features/search/providers/road_distance_provider_test.dart
+++ b/test/features/search/providers/road_distance_provider_test.dart
@@ -78,7 +78,7 @@ void main() {
       var calls = 0;
       final container = ProviderContainer(overrides: [
         roadDistanceFetcherProvider.overrideWithValue(
-          (lat, lng, dests) async {
+          (lat, lng, bearing, dests) async {
             calls++;
             return [for (var i = 0; i < dests.length; i++) 10.0 + i];
           },
@@ -110,7 +110,7 @@ void main() {
       var fail = false;
       final container = ProviderContainer(overrides: [
         roadDistanceFetcherProvider.overrideWithValue(
-          (lat, lng, dests) async {
+          (lat, lng, bearing, dests) async {
             if (fail) throw Exception('osrm down');
             return [7.7];
           },
@@ -127,6 +127,56 @@ void main() {
       await notifier.refresh(lat: 43.1, lng: 3.0, ranked: ranked);
       expect(container.read(roadDistancesProvider), {'a': 7.7},
           reason: 'routing is garnish — a failure must change nothing');
+    });
+  });
+
+  group('#3637 direction-aware bearings', () {
+    test('osrmTableParams: origin bearing + one empty entry per '
+        'destination; absent when no bearing', () {
+      final constrained = osrmTableParams(
+          destinationCount: 3, originBearingDegrees: 271.6);
+      expect(constrained['bearings'], '272,25;;;',
+          reason: 'rounded heading, tolerance, 3 unconstrained slots');
+      final free = osrmTableParams(destinationCount: 3);
+      expect(free.containsKey('bearings'), isFalse);
+      // Wrap-around + non-finite safety.
+      expect(
+          osrmTableParams(destinationCount: 1, originBearingDegrees: 365.0)[
+              'bearings'],
+          '5,25;');
+      expect(
+          osrmTableParams(
+                  destinationCount: 1,
+                  originBearingDegrees: double.nan)
+              .containsKey('bearings'),
+          isFalse);
+    });
+
+    test('osrmTableCoords is lon,lat ordered', () {
+      expect(
+        osrmTableCoords(43.0, 3.0, [(lat: 43.1, lng: 3.1)]),
+        '3.0,43.0;3.1,43.1',
+      );
+    });
+
+    test('the provider threads the heading to the fetch seam', () async {
+      double? seenBearing;
+      final container = ProviderContainer(overrides: [
+        roadDistanceFetcherProvider.overrideWithValue(
+          (lat, lng, bearing, dests) async {
+            seenBearing = bearing;
+            return [1.0];
+          },
+        ),
+      ]);
+      addTearDown(container.dispose);
+      await container.read(roadDistancesProvider.notifier).refresh(
+        lat: 43.0,
+        lng: 3.0,
+        ranked: [_station('a', 43.01, 3.0)],
+        headingDegrees: 88.0,
+      );
+      expect(seenBearing, 88.0);
     });
   });
 }


### PR DESCRIPTION
Live-probed: same origin/station = 5.86 km departing 45° vs 7.26 km at 225° — the bearings constraint makes road distances respect the carriageway/direction, including real turn-around costs. Pure query builder (unit-tested), sanitized-course threading (null at standstill = unconstrained), one unconstrained retry when a noisy heading matches no segment. F-Droid-clean: keyless HTTPS param on the existing open-source OSRM; fdroid's LocationManager heading works without GMS. Closes #3637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G