### PR TITLE
fix(obd2): uncaught 'Transport closed' — pending completer errored before any listener attaches (#3639)

### DIFF
--- a/lib/features/obd2/data/bluetooth_obd2_transport.dart
+++ b/lib/features/obd2/data/bluetooth_obd2_transport.dart
@@ -332,6 +332,12 @@ class BluetoothObd2Transport
     _frame.clear();
     final completer = Completer<String>();
     _pending = completer;
+    // #3639 — the awaiter only attaches AFTER `_channel.write()` returns;
+    // a stalled write + concurrent disconnect() lets [_failPending] error
+    // this future with NO listener yet (unhandled "Transport closed" at
+    // PlatformDispatcher.onError). ignore() covers that gap; the real
+    // awaiter still receives the error unchanged.
+    completer.future.ignore();
     // Clear `_pending` on EVERY exit — success, timeout *or* a throwing
     // write (#2453). Before, if `_channel.write()` threw (device-not-
     // connected / GATT timeout) with `_pending` still set, every later

--- a/test/features/obd2/data/bluetooth_obd2_transport_test.dart
+++ b/test/features/obd2/data/bluetooth_obd2_transport_test.dart
@@ -152,6 +152,36 @@ void main() {
       expect(() => transport.sendCommand('010D\r'), throwsStateError);
     });
 
+    test(
+        '#3639 disconnect() during a STALLED write does not surface an '
+        'unhandled Transport-closed error', () async {
+      final channel = _ScriptedChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // The platform write on a dying link never returns — `_sendRaw` is
+      // suspended BEFORE the awaiter attaches to the pending completer.
+      channel.scriptWriteHang('010D\r');
+      unawaited(transport.sendCommand('010D\r').then(
+        (_) => fail('a stalled command must not succeed'),
+        // The abandoned command's error (if the caller path ever resumes)
+        // is expected and handled here.
+        onError: (Object _) {},
+      ));
+      // Let `_sendRaw` reach the stalled write.
+      await Future<void>.delayed(Duration.zero);
+
+      // Tearing down mid-write fails the pending completer while its
+      // future has no listener yet — this must NOT escape to the zone as
+      // an unhandled "Bad state: Transport closed" (the test framework
+      // fails the test if it does).
+      await transport.disconnect();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(transport.isConnected, isFalse);
+    });
+
     test('sendCommand handles chunked notifications', () async {
       // BLE notifications often arrive in 20-byte chunks. The transport
       // must accumulate across chunks until the "> " prompt.
@@ -388,6 +418,7 @@ void main() {
 class _ScriptedChannel implements ElmByteChannel {
   final Map<String, List<List<int>>> _chunksByCommand = {};
   final Map<String, Object> _writeThrowsByCommand = {};
+  final Set<String> _writeHangsByCommand = {};
   final StreamController<List<int>> _controller =
       StreamController<List<int>>.broadcast();
   final List<List<int>> _writes = [];
@@ -418,6 +449,13 @@ class _ScriptedChannel implements ElmByteChannel {
   /// still recorded (so order assertions see it) before it throws.
   void scriptWriteThrows(String command, Object error) {
     _writeThrowsByCommand[command] = error;
+  }
+
+  /// #3639 — make `write()` STALL forever for a given command, simulating
+  /// a dying link whose platform write never returns. The write is still
+  /// recorded before stalling.
+  void scriptWriteHang(String command) {
+    _writeHangsByCommand.add(command);
   }
 
   /// #2295 — simulate a forwarded notify-stream error (what the real BLE
@@ -455,6 +493,11 @@ class _ScriptedChannel implements ElmByteChannel {
   Future<void> write(List<int> bytes) async {
     _writes.add(bytes);
     final command = String.fromCharCodes(bytes);
+    if (_writeHangsByCommand.contains(command)) {
+      // #3639 — stall forever: the platform write on a dying link that
+      // never completes.
+      return Completer<void>().future;
+    }
     final throwFor = _writeThrowsByCommand[command];
     if (throwFor != null) {
       // #2453 — the underlying BLE/GATT write rejected. The transport must

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -670,8 +670,10 @@ void main() {
       // #3610 — the two best-effort teardown catches now count a
       // bt.teardown_fail health counter + breadcrumb (+8 over the cap).
       // Decomposition candidate: the #3014 GATT-133 recovery block.
-      lines: 408,
-      bumps: 1,
+      // #3639 — completer.future.ignore() + rationale comment closing the
+      // no-listener window that leaked an unhandled 'Transport closed' (+6).
+      lines: 414,
+      bumps: 2,
       decompositionIssue: 3141,
     ),
     'lib/features/route_search/providers/route_search_provider.dart': (


### PR DESCRIPTION
Closes #3639.

Field trace 2026-07-28T20:44:10: unhandled `Bad state: Transport closed` at `PlatformDispatcher.onError`, empty stack.

`_sendRaw` arms `_pending`, then suspends on `await _channel.write(...)`; the awaiter (`completer.future.timeout(...)`) only attaches after the write returns. On a dying link the write stalls, and a concurrent `disconnect()` / `replaceService` fails the completer through `_failPending` while its future has **no listener** — the error escapes the zone. `completer.future.ignore()` guarantees a handler for that gap; the normal awaiter and the `_enqueue` catch → caller routing receive the error unchanged.

- Regression test: scripted channel whose `write()` stalls forever; `sendCommand` then `disconnect()` mid-write must not surface an unhandled zone error — **RED on the unfixed transport** (fails from `disconnect` at the exact field signature), GREEN with the fix.
- `bluetooth_obd2_transport.dart` grandfather snapshot 408 → 414 (bumps 2, #3141) for the fix + rationale comment.
- Local: `flutter analyze` clean, full `test/features/obd2/data/` suite green (1,892 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G