### PR TITLE
fix: EXCESSIVE-CPU kill triage — background CPU watchdog with per-thread attribution + parked-adapter dial-churn fixes (#3641, #3642)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -423,7 +423,21 @@ object Obd2ClassicPlugin {
                         endedByEof = true
                         break
                     }
-                    if (n == 0) continue
+                    if (n == 0) {
+                        // #3641 — some OEM stacks return 0-byte reads from a
+                        // half-dead socket instead of blocking; a bare
+                        // `continue` then busy-spins this thread at 100% CPU
+                        // (the [EXCESSIVE CPU USAGE] kill class). Yield
+                        // briefly; a live socket blocks in read() anyway, so
+                        // healthy links never pay this.
+                        try {
+                            Thread.sleep(5)
+                        } catch (_: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            break
+                        }
+                        continue
+                    }
                     val slice = buffer.copyOfRange(0, n).toList()
                     postToSink { sink -> sink.success(slice) }
                 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -12,6 +12,7 @@ import '../core/logging/error_logger.dart';
 import '../core/language/language_provider.dart';
 import '../core/notifications/notification_launch_listener.dart';
 import '../core/sync/app_resume_sync.dart';
+import '../core/telemetry/background_cpu_watchdog.dart';
 import '../core/theme/theme_mode_provider.dart';
 import '../features/consumption/presentation/widgets/share_receipt_listener.dart';
 import '../features/consumption/presentation/widgets/trip_recording_banner.dart';
@@ -92,6 +93,8 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
     // periodic Tier-1 already meets the SLA). Never throws; the
     // coordinator's cross-trigger cooldown absorbs rapid resumes.
     if (state == AppLifecycleState.resumed) {
+      // #3641 — foreground CPU is legitimate; disarm the watchdog.
+      BackgroundCpuWatchdog.instance.stop();
       unawaited(BackgroundService.onOpportunisticWake());
       // #3447 — the same free window drives the debounced TankSync pull
       // (≥15 min since the last completed pass, never while a trip is
@@ -107,6 +110,11 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
     // be wasteful. We still listen so a `paused` arriving via the
     // `inactive → paused` path routes through this observer.
     if (state != AppLifecycleState.paused) return;
+    // #3641 — arm the background CPU watchdog: the OS kills us for
+    // burning >25% of a core while paused, and only a live per-thread
+    // sample can name the culprit. Cheap (one proc read/min), no-op off
+    // Android, disarmed again on resume.
+    BackgroundCpuWatchdog.instance.start();
     try {
       final notifier = ref.read(tripRecordingProvider.notifier);
       unawaited(notifier.onAppBackgrounded());

--- a/lib/core/telemetry/background_cpu_watchdog.dart
+++ b/lib/core/telemetry/background_cpu_watchdog.dart
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' show min;
+
+import 'package:flutter/foundation.dart';
+
+import '../logging/error_logger.dart';
+import 'collectors/breadcrumb_collector.dart';
+import 'impl/proc_cpu_support.dart';
+
+/// #3641 — lifecycle-gated CPU watchdog for the `[EXCESSIVE CPU USAGE]`
+/// process kills.
+///
+/// Since 2026-07-27 the OS (Samsung / Android 16) repeatedly kills the
+/// BACKGROUNDED app for burning 33–97% of a core over its 5-minute
+/// observation window. The ApplicationExitInfo record (#3580) names the
+/// process but never the thread, so the culprit stayed invisible across
+/// two field exports. This watchdog catches the burn in the act:
+///
+///  * armed on `paused`, disarmed on `resumed` (foreground CPU is
+///    legitimate — recording, maps);
+///  * once per [tickInterval] it reads `/proc/self/stat` (utime+stime);
+///  * a window above [alertThresholdPct] arms a per-thread snapshot of
+///    `/proc/self/task/*/stat`; if the NEXT window is still hot, the top
+///    threads by CPU delta are reported as an ERROR trace (background
+///    layer — lands in the field export) plus a breadcrumb;
+///  * reports are rate-limited to one per [minReportGap].
+///
+/// Cost while armed: one small proc read per minute; the thread sweep
+/// (~40 tiny files) runs only after a hot window. No-op off Android.
+/// Everything is injectable so tests never touch /proc. Failures are
+/// swallowed to a debugPrint and stop the watchdog — forensics must
+/// never hurt the app it observes.
+class BackgroundCpuWatchdog {
+  BackgroundCpuWatchdog({
+    String? Function(String path)? readFile,
+    List<String> Function()? listThreadStatPaths,
+    DateTime Function()? now,
+    this.tickInterval = const Duration(seconds: 60),
+    this.alertThresholdPct = 25,
+    this.minReportGap = const Duration(minutes: 10),
+    bool? platformSupported,
+    this.onReport,
+  }) : _readFile = readFile ?? _readFileSync,
+       _listThreadStatPaths = listThreadStatPaths ?? _realThreadStatPaths,
+       _now = now ?? DateTime.now,
+       _platformSupported = platformSupported ?? procCpuSupported();
+
+  /// Process-wide instance wired by the app lifecycle observer.
+  static final BackgroundCpuWatchdog instance = BackgroundCpuWatchdog();
+
+  /// Sampling cadence while backgrounded. 60 s mirrors a fifth of the
+  /// OS's own 300 s observation window.
+  final Duration tickInterval;
+
+  /// Report when a window's average CPU exceeds this % of one core —
+  /// matches the `limit=25` the OS kill records carry.
+  final int alertThresholdPct;
+
+  /// Minimum gap between two reports from one process.
+  final Duration minReportGap;
+
+  /// Test seam — invoked with the report summary in addition to the
+  /// production breadcrumb + error trace.
+  final void Function(String summary)? onReport;
+
+  final String? Function(String path) _readFile;
+  final List<String> Function() _listThreadStatPaths;
+  final DateTime Function() _now;
+  final bool _platformSupported;
+
+  Timer? _timer;
+  int? _lastProcessJiffies;
+  DateTime? _lastSampleAt;
+  Map<String, _ThreadSample>? _armedThreadBaseline;
+  DateTime? _lastReportAt;
+
+  /// Whether the watchdog is currently sampling.
+  bool get isRunning => _timer != null;
+
+  /// Arm the watchdog (app went to background). Idempotent; no-op on
+  /// unsupported platforms.
+  void start() {
+    if (!_platformSupported || _timer != null) return;
+    _lastProcessJiffies = _sampleProcessJiffies();
+    _lastSampleAt = _now();
+    _armedThreadBaseline = null;
+    _timer = Timer.periodic(tickInterval, (_) => tick());
+  }
+
+  /// Disarm (app resumed). Idempotent.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _lastProcessJiffies = null;
+    _lastSampleAt = null;
+    _armedThreadBaseline = null;
+  }
+
+  /// One sampling window. Public for tests; production calls arrive from
+  /// the periodic timer.
+  @visibleForTesting
+  void tick() {
+    try {
+      final nowJiffies = _sampleProcessJiffies();
+      final at = _now();
+      final lastJiffies = _lastProcessJiffies;
+      final lastAt = _lastSampleAt;
+      _lastProcessJiffies = nowJiffies;
+      _lastSampleAt = at;
+      if (nowJiffies == null || lastJiffies == null || lastAt == null) {
+        _armedThreadBaseline = null;
+        return;
+      }
+      final wallMs = at.difference(lastAt).inMilliseconds;
+      // Deep sleep / clock weirdness: a degenerate window proves nothing.
+      if (wallMs < tickInterval.inMilliseconds ~/ 2) return;
+      final cpuMs = (nowJiffies - lastJiffies) * _msPerJiffy;
+      final pct = (cpuMs * 100 / wallMs).round();
+      if (pct < alertThresholdPct) {
+        _armedThreadBaseline = null;
+        return;
+      }
+      final baseline = _armedThreadBaseline;
+      if (baseline == null) {
+        // First hot window: arm the per-thread baseline and wait one more
+        // window so the report carries real deltas, not lifetime totals.
+        _armedThreadBaseline = _sampleThreads();
+        return;
+      }
+      _armedThreadBaseline = _sampleThreads();
+      final lastReport = _lastReportAt;
+      if (lastReport != null && at.difference(lastReport) < minReportGap) {
+        return;
+      }
+      _lastReportAt = at;
+      _report(pct: pct, wallMs: wallMs, baseline: baseline);
+    } catch (e, st) {
+      // Forensics must never hurt the app: disarm on any fault.
+      debugPrint('BackgroundCpuWatchdog: tick failed — disarming: $e\n$st');
+      stop();
+    }
+  }
+
+  void _report({
+    required int pct,
+    required int wallMs,
+    required Map<String, _ThreadSample> baseline,
+  }) {
+    final current = _armedThreadBaseline ?? const {};
+    final deltas = <MapEntry<String, int>>[];
+    current.forEach((tid, sample) {
+      final before = baseline[tid];
+      final deltaMs = (sample.jiffies - (before?.jiffies ?? 0)) * _msPerJiffy;
+      if (deltaMs > 0) deltas.add(MapEntry('${sample.name}#$tid', deltaMs));
+    });
+    deltas.sort((a, b) => b.value.compareTo(a.value));
+    final top = deltas.take(8).map((e) => '${e.key}:+${e.value}ms').join(', ');
+    // i18n-ignore: telemetry export text, never rendered in the UI.
+    final threadList = top.isEmpty ? 'no per-thread data' : top;
+    final summary =
+        'background CPU ~$pct% of a core over ${wallMs}ms '
+        '(OS kill limit 25%) — top threads: $threadList';
+    onReport?.call(summary);
+    BreadcrumbCollector.add('bg-cpu-overload', detail: summary);
+    unawaited(
+      errorLogger.log(
+        ErrorLayer.background,
+        StateError('BackgroundCpuWatchdog: $summary'),
+        StackTrace.current,
+        context: const {'where': 'BackgroundCpuWatchdog (#3641)'},
+      ),
+    );
+  }
+
+  int? _sampleProcessJiffies() =>
+      parseProcStatCpuJiffies(_readFile('/proc/self/stat') ?? '');
+
+  Map<String, _ThreadSample> _sampleThreads() {
+    final samples = <String, _ThreadSample>{};
+    for (final path in _listThreadStatPaths()) {
+      final content = _readFile(path);
+      if (content == null) continue;
+      final jiffies = parseProcStatCpuJiffies(content);
+      final name = parseProcStatComm(content);
+      if (jiffies == null || name == null) continue;
+      // /proc/self/task/<tid>/stat — the tid segment keys the map.
+      final segments = path.split('/');
+      final tid = segments.length >= 2 ? segments[segments.length - 2] : path;
+      samples[tid] = _ThreadSample(name: name, jiffies: jiffies);
+    }
+    return samples;
+  }
+
+  static String? _readFileSync(String path) {
+    try {
+      return File(path).readAsStringSync();
+    } catch (_) {
+      // ignore: silent_catch — a vanished tid / unreadable proc entry is normal churn.
+      return null;
+    }
+  }
+
+  static List<String> _realThreadStatPaths() {
+    try {
+      return Directory(
+        '/proc/self/task',
+      ).listSync().map((e) => '${e.path}/stat').toList(growable: false);
+    } catch (_) {
+      // ignore: silent_catch — no task dir (unsupported kernel view) degrades to process-only.
+      return const [];
+    }
+  }
+}
+
+/// Android USER_HZ is 100 on every shipping kernel, so one jiffy is
+/// 10 ms. The reported figures are attribution ratios, not billing —
+/// a non-100 USER_HZ would skew absolutes, never the ranking.
+const int _msPerJiffy = 10;
+
+class _ThreadSample {
+  const _ThreadSample({required this.name, required this.jiffies});
+  final String name;
+  final int jiffies;
+}
+
+/// Parse utime+stime (in jiffies) out of a `/proc/<pid>/stat` line.
+///
+/// The comm field is parenthesised and may itself contain spaces and
+/// parens (`(Signal Catcher)`), so fields are counted from the LAST `)`:
+/// after it, token 0 is the state (field 3), utime is field 14 → token
+/// 11, stime field 15 → token 12. Returns null on any malformed input.
+int? parseProcStatCpuJiffies(String stat) {
+  final close = stat.lastIndexOf(')');
+  if (close < 0 || close + 1 >= stat.length) return null;
+  final fields = stat.substring(close + 1).trim().split(RegExp(r'\s+'));
+  if (fields.length < 13) return null;
+  final utime = int.tryParse(fields[11]);
+  final stime = int.tryParse(fields[12]);
+  if (utime == null || stime == null) return null;
+  return utime + stime;
+}
+
+/// Extract the comm (thread name) from a `/proc/<pid>/stat` line — the
+/// text between the first `(` and the LAST `)`. Null when malformed.
+String? parseProcStatComm(String stat) {
+  final open = stat.indexOf('(');
+  final close = stat.lastIndexOf(')');
+  if (open < 0 || close <= open) return null;
+  return stat.substring(open + 1, min(close, stat.length));
+}

--- a/lib/core/telemetry/impl/proc_cpu_support.dart
+++ b/lib/core/telemetry/impl/proc_cpu_support.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+/// #3641 — whether this platform exposes the `/proc` CPU accounting the
+/// background CPU watchdog samples. Android only: iOS/macOS ship no
+/// readable `/proc`, and only Android kills apps on the background-CPU
+/// limit the watchdog exists to explain. Platform dispatch lives here
+/// (impl/, per #2350/#3163) so the watchdog itself stays shared code.
+bool procCpuSupported() => !kIsWeb && Platform.isAndroid;

--- a/lib/features/obd2/data/auto_trip_coordinator.dart
+++ b/lib/features/obd2/data/auto_trip_coordinator.dart
@@ -477,10 +477,10 @@ class AutoTripCoordinator {
     final sup = linkSupervisor;
     Obd2Service? service;
     try {
-      service = sup?.service ??
-          (sup != null
-              ? await sup.connectWith(() => opener(config.mac))
-              : await opener(config.mac));
+      service = sup == null
+          ? await opener(config.mac)
+          : sup.service ?? // #3642 — automated: respect the stand-down hold
+              await sup.connectWith(() => opener(config.mac), automated: true);
     } catch (e, st) {
       service = null;
       AutoRecordTraceLog.add(

--- a/lib/features/obd2/data/obd2_link_supervisor.dart
+++ b/lib/features/obd2/data/obd2_link_supervisor.dart
@@ -137,10 +137,28 @@ class Obd2LinkSupervisor {
   /// (research rule 2: there is no second dial path). On success the
   /// dialed service becomes the supervised link; the backoff loop keeps
   /// using the DEFAULT dialer afterwards.
-  Future<Obd2Service?> connectWith(Obd2LinkDialer dialer) {
+  /// #3642 — [automated] marks a machine-initiated arm (auto-record's
+  /// proximity/resume dials). Automation is NOT user intent: it respects
+  /// the user's park, never resets the #3603 stand-down, and during an
+  /// active stand-down returns null without dialing (the supervisor's
+  /// own timer keeps the cadence) — the 2026-07-29 field export's 36 ms
+  /// automated redials against a parked car ended in an OS CPU kill.
+  Future<Obd2Service?> connectWith(Obd2LinkDialer dialer,
+      {bool automated = false}) {
     if (_disposed) return Future<Obd2Service?>.value();
+    if (automated) {
+      if (!_mayAutoDial) return Future<Obd2Service?>.value();
+      if (_standDown.active) {
+        // Keep the hold: make sure a timer exists, but never dial now.
+        if (_attemptInFlight == null && _backoffTimer == null) {
+          _armBackoffTimer();
+        }
+        return Future<Obd2Service?>.value();
+      }
+      return _attempt(userInitiated: false, dialer: dialer);
+    }
     _userRequestedDisconnect = false;
-    _standDown.reset(); // #3603
+    _standDown.reset(); // #3603 — user intent is a positive signal
     _cancelBackoffTimer();
     return _attempt(userInitiated: true, dialer: dialer);
   }
@@ -206,12 +224,26 @@ class Obd2LinkSupervisor {
   /// Exit [Obd2LinkState.engineOff] (movement detected / app resumed)
   /// and dial. A no-op in every other state — waking a user-parked or
   /// already-live link must do nothing.
+  /// #3642 — it ALSO breaks an active stand-down hold: the escalated
+  /// holds (5 → 15 → 60 min) exist for a parked car, and this positive
+  /// signal must dial now, not wait out a 60-minute timer.
   void wake() {
-    if (_disposed || _state.value != Obd2LinkState.engineOff) return;
-    _standDown.reset(); // #3603 — movement is a positive signal
-    _backoff.reset();
-    _setState(Obd2LinkState.reconnecting);
-    unawaited(_attempt(userInitiated: false));
+    if (_disposed) return;
+    if (_state.value == Obd2LinkState.engineOff) {
+      _standDown.reset(); // #3603 — movement is a positive signal
+      _backoff.reset();
+      _setState(Obd2LinkState.reconnecting);
+      unawaited(_attempt(userInitiated: false));
+      return;
+    }
+    if (_state.value == Obd2LinkState.reconnecting && _standDown.active) {
+      _standDown.reset(); // #3642 — movement exits the escalated hold
+      _backoff.reset();
+      if (_attemptInFlight == null) {
+        _cancelBackoffTimer();
+        unawaited(_attempt(userInitiated: false));
+      }
+    }
   }
 
   /// The single intent gate (research rule 7): auto-dialing is allowed
@@ -334,13 +366,15 @@ class Obd2LinkSupervisor {
 
   void _armBackoffTimer() {
     _cancelBackoffTimer();
-    final wait = _backoff.advance(standDown: inStandDown);
-    if (_backoff.enteredStorm) {
-      // #3603 — the breadcrumb fires once on stand-down entry.
+    final wasStandDown = inStandDown;
+    final wait = _backoff.advance(standDown: wasStandDown);
+    if (wasStandDown) {
+      // #3603 / #3642 — one breadcrumb per storm-cadence arm, with the
+      // ACTUAL hold (the escalation lengthens it 5 → 15 → 60 min).
       BreadcrumbCollector.add(
         'OBD2 reconnect stand-down',
         detail: '${_standDown.detail} — '
-            'holding ${_backoff.storm.inSeconds}s',
+            'holding ${wait.inSeconds}s',
       );
     }
     _backoffTimer = Timer(wait, () {

--- a/lib/features/obd2/data/obd2_reconnect_stand_down.dart
+++ b/lib/features/obd2/data/obd2_reconnect_stand_down.dart
@@ -118,6 +118,17 @@ class ReconnectBackoff {
   final Random _jitter;
   Duration _current = Duration.zero;
   bool _enteredStorm = false;
+  int _stormAdvances = 0;
+
+  /// #3642 — each consecutive storm-cadence advance means the previous
+  /// held attempt STILL failed identically, so the hold lengthens:
+  /// storm ×1 → ×3 → ×12 (5 → 15 → 60 min at the default). A parked car
+  /// (adapter powered, ignition off, permanently in range) otherwise
+  /// keeps a ~18% duty cycle of doomed ~67 s Bluetooth ladders running
+  /// all day — the field shape behind the 2026-07-29 `[EXCESSIVE CPU
+  /// USAGE]` process kill. Any positive signal ([reset], or a healthy
+  /// ladder advance) restores the fast cadence.
+  static const List<int> stormEscalation = [1, 3, 12];
 
   int get currentMs => _current.inMilliseconds;
   bool get atCap => _current >= max;
@@ -126,18 +137,28 @@ class ReconnectBackoff {
   /// storm hold — the caller breadcrumbs stand-down entry exactly once.
   bool get enteredStorm => _enteredStorm;
 
-  void reset() => _current = Duration.zero;
+  void reset() {
+    _current = Duration.zero;
+    _stormAdvances = 0;
+  }
 
   /// Grows the cadence and returns the wait including jitter.
   Duration advance({required bool standDown}) {
-    _enteredStorm = standDown && _current < storm;
-    _current = standDown
-        ? storm
-        : _current == Duration.zero
-            ? initial
-            : _current * 2 > max
-                ? max
-                : _current * 2;
+    _enteredStorm = standDown && _stormAdvances == 0;
+    if (standDown) {
+      final step = _stormAdvances >= stormEscalation.length
+          ? stormEscalation.last
+          : stormEscalation[_stormAdvances];
+      _stormAdvances++;
+      _current = storm * step;
+    } else {
+      _stormAdvances = 0;
+      _current = _current == Duration.zero
+          ? initial
+          : _current * 2 > max
+              ? max
+              : _current * 2;
+    }
     final jitterMs = _jitter.nextInt(1 + _current.inMilliseconds ~/ 8);
     return _current + Duration(milliseconds: jitterMs);
   }

--- a/test/core/telemetry/background_cpu_watchdog_test.dart
+++ b/test/core/telemetry/background_cpu_watchdog_test.dart
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #3641 — the background CPU watchdog: /proc stat parsing, the
+// two-hot-windows report flow with per-thread attribution, the report
+// rate limit, and the fail-open (disarm, never throw) contract.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/telemetry/background_cpu_watchdog.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+/// A minimal but realistic `/proc/<pid>/stat` line. [comm] deliberately
+/// exercises the parens-and-spaces trap ("(Signal Catcher)").
+String _statLine({required String comm, required int utime, int stime = 0}) =>
+    '12345 ($comm) S 1 12345 0 0 -1 1077936448 2500 0 1 0 '
+    '$utime $stime 33 44 20 0 42 0 12345678 999424 12345 '
+    '18446744073709551615 1 1 0 0 0 0 0 4096 0 0 0 0 17 3 0 0 0 0 0';
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('proc stat parsing', () {
+    test('utime+stime extracted; comm with spaces and parens survives', () {
+      final line = _statLine(comm: 'Signal (Catcher)', utime: 120, stime: 30);
+      expect(parseProcStatCpuJiffies(line), 150);
+      expect(parseProcStatComm(line), 'Signal (Catcher)');
+    });
+
+    test('malformed input → null, never a throw', () {
+      expect(parseProcStatCpuJiffies(''), isNull);
+      expect(parseProcStatCpuJiffies('no parens at all'), isNull);
+      expect(parseProcStatCpuJiffies('1 (x) S 2'), isNull);
+      expect(parseProcStatComm(''), isNull);
+    });
+  });
+
+  group('watchdog windows', () {
+    late DateTime now;
+    late Map<String, String> files;
+    late List<String> reports;
+
+    BackgroundCpuWatchdog build({Duration gap = const Duration(minutes: 10)}) =>
+        BackgroundCpuWatchdog(
+          readFile: (path) => files[path],
+          listThreadStatPaths: () => files.keys
+              .where((p) => p.startsWith('/proc/self/task/'))
+              .toList(),
+          now: () => now,
+          minReportGap: gap,
+          platformSupported: true,
+          onReport: reports.add,
+        );
+
+    setUp(() {
+      now = DateTime(2026, 7, 29, 23, 0);
+      reports = [];
+      files = {
+        '/proc/self/stat': _statLine(comm: 'main', utime: 1000),
+        '/proc/self/task/101/stat': _statLine(comm: 'main', utime: 500),
+        '/proc/self/task/202/stat': _statLine(comm: 'spinner', utime: 500),
+      };
+    });
+
+    void tickAfter(BackgroundCpuWatchdog dog, Duration wall,
+        {required int processJiffies, int spinnerJiffies = 500}) {
+      now = now.add(wall);
+      files['/proc/self/stat'] =
+          _statLine(comm: 'main', utime: processJiffies);
+      files['/proc/self/task/202/stat'] =
+          _statLine(comm: 'spinner', utime: spinnerJiffies);
+      dog.tick();
+    }
+
+    test('a cool window reports nothing', () {
+      final dog = build()..start();
+      // 60 s window, 600 ms CPU = 1%.
+      tickAfter(dog, const Duration(seconds: 60), processJiffies: 1060);
+      expect(reports, isEmpty);
+      dog.stop();
+    });
+
+    test('two hot windows → one report naming the burning thread', () {
+      final dog = build()..start();
+      // Window 1: 3000 jiffies = 30 s CPU over 60 s = 50% — arms the
+      // per-thread baseline, no report yet.
+      tickAfter(dog, const Duration(seconds: 60), processJiffies: 4000);
+      expect(reports, isEmpty, reason: 'first hot window only arms');
+      // Window 2: still hot; the spinner thread ate the delta.
+      tickAfter(dog, const Duration(seconds: 60),
+          processJiffies: 7000, spinnerJiffies: 3400);
+      expect(reports, hasLength(1));
+      expect(reports.single, contains('50%'));
+      expect(reports.single, contains('spinner#202:+29000ms'),
+          reason: 'the per-thread delta names the culprit');
+    });
+
+    test('reports are rate-limited; a cool window disarms the baseline', () {
+      final dog = build()..start();
+      tickAfter(dog, const Duration(seconds: 60), processJiffies: 4000);
+      tickAfter(dog, const Duration(seconds: 60),
+          processJiffies: 7000, spinnerJiffies: 3400);
+      expect(reports, hasLength(1));
+      // Still hot immediately after: inside the gap — no second report.
+      tickAfter(dog, const Duration(seconds: 60),
+          processJiffies: 10000, spinnerJiffies: 6400);
+      expect(reports, hasLength(1));
+      // Cool window: baseline disarmed…
+      tickAfter(dog, const Duration(seconds: 60), processJiffies: 10060);
+      // …so a single hot window after the gap still only ARMS. (The
+      // silent 10-min jump stretches the wall window to 11 min, so the
+      // CPU delta must be ≥25% of 660 s to read hot.)
+      now = now.add(const Duration(minutes: 10));
+      tickAfter(dog, const Duration(seconds: 60), processJiffies: 27100);
+      expect(reports, hasLength(1),
+          reason: 're-armed, not yet re-reported');
+    });
+
+    test('a degenerate wall window (deep sleep) proves nothing', () {
+      final dog = build()..start();
+      tickAfter(dog, const Duration(seconds: 5), processJiffies: 4000);
+      expect(reports, isEmpty,
+          reason: 'a 5 s wall window under a 60 s cadence is discarded');
+    });
+
+    test('fault injection: a throwing proc read disarms without throwing',
+        () {
+      var boom = false;
+      final dog = BackgroundCpuWatchdog(
+        readFile: (path) {
+          if (boom) throw StateError('proc read failed');
+          return files[path];
+        },
+        listThreadStatPaths: () => const [],
+        now: () => now,
+        platformSupported: true,
+        onReport: reports.add,
+      )..start();
+      expect(dog.isRunning, isTrue);
+      boom = true;
+      now = now.add(const Duration(seconds: 60));
+      expect(dog.tick, returnsNormally);
+      expect(dog.isRunning, isFalse,
+          reason: 'forensics must never hurt the app: fail open, disarm');
+    });
+
+    test('unsupported platform: start is a no-op', () {
+      final dog = BackgroundCpuWatchdog(
+        readFile: (path) => files[path],
+        listThreadStatPaths: () => const [],
+        now: () => now,
+        platformSupported: false,
+      )..start();
+      expect(dog.isRunning, isFalse);
+    });
+  });
+}

--- a/test/features/obd2/obd2_link_standdown_test.dart
+++ b/test/features/obd2/obd2_link_standdown_test.dart
@@ -209,6 +209,133 @@ void main() {
     });
   });
 
+  test('#3642 consecutive storm holds ESCALATE 5 → 15 → 60 min — a parked '
+      'car stops costing an all-day dial duty cycle', () {
+    fakeAsync((async) {
+      dialer.enqueue(TimeoutException('ladder budget'));
+      final sup = build();
+      dropNow();
+      async.flushMicrotasks();
+      elapse(async, const Duration(seconds: 3));
+      expect(sup.inStandDown, isTrue);
+      expect(dialer.calls, 3);
+
+      // Hold 1: storm ×1 (5 min + ≤37 s jitter).
+      elapse(async, const Duration(minutes: 6));
+      expect(dialer.calls, 4, reason: 'first storm hold is 5 min');
+
+      // Hold 2: storm ×3 (15 min + ≤112 s jitter) — a 5-min cadence
+      // would have dialed twice more by 13 min.
+      elapse(async, const Duration(minutes: 13));
+      expect(dialer.calls, 4, reason: 'second hold escalated past 13 min');
+      elapse(async, const Duration(minutes: 4));
+      expect(dialer.calls, 5, reason: 'second storm hold is 15 min');
+
+      // Hold 3: storm ×12 (60 min + ≤7.5 min jitter), the cap.
+      elapse(async, const Duration(minutes: 55));
+      expect(dialer.calls, 5, reason: 'third hold escalated past 55 min');
+      elapse(async, const Duration(minutes: 13));
+      expect(dialer.calls, 6,
+          reason: 'the no-dead-end invariant survives the escalation — '
+              'the loop still dials, hourly');
+
+      // A user connect resets the escalation back to the fast ladder.
+      dialer.replaceAll(_liveService());
+      unawaited(sup.connect());
+      async.flushMicrotasks();
+      expect(sup.inStandDown, isFalse);
+      expect(sup.state.value, Obd2LinkState.ready);
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('#3642 an AUTOMATED connectWith during a stand-down neither dials '
+      'nor resets the hold — automation is not user intent', () {
+    fakeAsync((async) {
+      dialer.enqueue(TimeoutException('ladder budget'));
+      final sup = build();
+      dropNow();
+      async.flushMicrotasks();
+      elapse(async, const Duration(seconds: 3));
+      expect(sup.inStandDown, isTrue);
+      final callsBefore = dialer.calls;
+
+      var overrideCalls = 0;
+      Obd2Service? got = _liveService(); // sentinel — must become null
+      unawaited(sup.connectWith(() async {
+        overrideCalls++;
+        return _liveService();
+      }, automated: true).then((s) => got = s));
+      async.flushMicrotasks();
+
+      expect(overrideCalls, 0,
+          reason: 'the 36 ms instant redial from the 2026-07-29 field '
+              'export — an automated arm must not dial into the hold');
+      expect(dialer.calls, callsBefore);
+      expect(got, isNull, reason: 'the caller sees a plain miss');
+      expect(sup.inStandDown, isTrue,
+          reason: 'the stand-down accounting survives the automated arm');
+
+      // The supervisor's own storm timer keeps ownership of the cadence.
+      elapse(async, const Duration(minutes: 6));
+      expect(dialer.calls, callsBefore + 1,
+          reason: 'the held dial still fires, with the DEFAULT dialer');
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('#3642 an automated connectWith OUTSIDE a stand-down dials through '
+      'the normal single-flight machinery', () {
+    fakeAsync((async) {
+      dialer.enqueue(null);
+      final sup = build();
+
+      var overrideCalls = 0;
+      Obd2Service? got;
+      unawaited(sup.connectWith(() async {
+        overrideCalls++;
+        return _liveService();
+      }, automated: true).then((s) => got = s));
+      async.flushMicrotasks();
+
+      expect(overrideCalls, 1);
+      expect(got, isNotNull);
+      expect(sup.state.value, Obd2LinkState.ready);
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
+  test('#3642 wake() breaks an active stand-down hold — sustained movement '
+      'must not wait out an escalated timer', () {
+    fakeAsync((async) {
+      dialer.enqueue(TimeoutException('ladder budget'));
+      final sup = build();
+      dropNow();
+      async.flushMicrotasks();
+      elapse(async, const Duration(seconds: 3));
+      expect(sup.inStandDown, isTrue);
+      final callsBefore = dialer.calls;
+
+      // The car drives off: the GPS movement nudge fires wake().
+      dialer.replaceAll(_liveService());
+      sup.wake();
+      async.flushMicrotasks();
+      expect(dialer.calls, callsBefore + 1,
+          reason: 'movement dials immediately instead of holding');
+      expect(sup.inStandDown, isFalse);
+      expect(sup.state.value, Obd2LinkState.ready);
+
+      unawaited(sup.dispose());
+      async.flushMicrotasks();
+    });
+  });
+
   test('user connect() exits the stand-down and dials immediately', () {
     fakeAsync((async) {
       dialer.enqueue(TimeoutException('ladder budget'));

--- a/test/features/obd2/obd2_link_supervisor_test.dart
+++ b/test/features/obd2/obd2_link_supervisor_test.dart
@@ -82,28 +82,27 @@ void main() {
       async.flushMicrotasks();
       expect(sup.state.value, Obd2LinkState.reconnecting);
 
-      // #3603 — three identical misses now stand the loop down to the
-      // storm cadence (default 5 min), so the horizon is longer; the
-      // INVARIANT under test is unchanged: no dead end, ever.
+      // #3603 / #3642 — three identical misses stand the loop down, and
+      // consecutive holds ESCALATE (5 → 15 → 60 min, capped), so the
+      // horizon is much longer; the INVARIANT under test is unchanged:
+      // no dead end, ever.
       async.elapse(const Duration(minutes: 40));
-      final callsAtForty = dialer.calls;
-      expect(callsAtForty, greaterThan(6),
-          reason: 'the loop must outlive the old terminalFailed cap');
+      expect(dialer.calls, 5,
+          reason: 'fast ladder ×3, then the 5 min and 15 min holds');
       expect(sup.state.value, Obd2LinkState.reconnecting,
           reason: 'no dead end — still trying');
 
-      // Stand-down cadence is steady, not runaway: over the next
-      // 16 minutes ≈3 storm-interval attempts.
-      async.elapse(const Duration(minutes: 16));
-      final callsInSecondWindow = dialer.calls - callsAtForty;
-      expect(callsInSecondWindow, inInclusiveRange(2, 4),
-          reason: 'storm ~5 min cadence ⇒ ≈3 attempts per 16 min');
+      // The escalated cadence parks at hourly — steady, never terminal.
+      async.elapse(const Duration(minutes: 55));
+      expect(dialer.calls, 6,
+          reason: 'the capped 60-min hold still dials — the loop must '
+              'outlive the old terminalFailed cap');
 
       // And when the adapter finally reappears, the loop connects. The
-      // queued miss still in front costs one more storm cycle, so give
-      // it two full periods (+ jitter).
+      // queued miss still in front costs one more capped hold, so two
+      // full 60-min periods (+ jitter) must pass.
       dialer.enqueue(_liveService());
-      async.elapse(const Duration(minutes: 12));
+      async.elapse(const Duration(minutes: 140));
       expect(sup.state.value, Obd2LinkState.ready);
       unawaited(sup.dispose());
       async.flushMicrotasks();

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -676,6 +676,14 @@ void main() {
       bumps: 2,
       decompositionIssue: 3141,
     ),
+    'lib/features/obd2/data/obd2_link_supervisor.dart': (
+      // #3642 — automated-arm gating (connectWith(automated:)) +
+      // stand-down escalation wiring + wake() hold-break (+15 over the
+      // cap). Decomposition candidate: the park/wake state block.
+      lines: 415,
+      bumps: 1,
+      decompositionIssue: 3141,
+    ),
     'lib/features/route_search/providers/route_search_provider.dart': (
       // #3610 — kDebugMode gates around the per-search debugPrints
       // (+6 over the cap). Decomposition candidate: the strategy-run


### PR DESCRIPTION
Closes #3641, closes #3642.

Field evidence (error-log exports 2026-07-28/29): five `[EXCESSIVE CPU USAGE]` background process kills in one day (33–97% of a core over the OS's 5-minute window), the worst directly bracketing an all-day OBD2 dial loop against the parked car.

**#3641 — background CPU watchdog (`lib/core/telemetry/background_cpu_watchdog.dart`)**
- Arms on `paused`, disarms on `resumed`; one `/proc/self/stat` read per minute.
- Two consecutive windows above the 25% OS kill limit → ERROR trace + breadcrumb naming the top threads by CPU delta from `/proc/self/task/*/stat`. Rate-limited (10 min); fail-open (any fault disarms); platform dispatch in `impl/proc_cpu_support.dart`.
- The next field export names the burning thread instead of leaving pairip (#3590) and app code indistinguishable.
- Folds in a defensive fix: the Kotlin Classic reader's `n == 0 → continue` could busy-spin on OEM stacks that return 0-byte reads from a half-dead socket — now yields 5 ms.

**#3642 — parked-adapter dial churn (the supervisor stays THE one reconnect owner; all #3527/#3603 invariants preserved)**
- Storm holds escalate 5 → 15 → 60 min (capped) on consecutive identical stand-down cycles; any positive signal restores the fast ladder.
- `connectWith(automated: true)` for auto-record: respects the user's park, never resets the stand-down, never dials into an active hold (the 36 ms instant redials in the field breadcrumbs). User-initiated overrides unchanged (#3553 preserved).
- `wake()` also breaks an active hold — sustained movement / app resume dials immediately, so driving off never waits out a 60-min timer.

Tests: watchdog windows/rate-limit/fail-open + proc-stat parsing (11 new); stand-down escalation, automated-arm gating, wake-breaks-hold (4 new); the no-dead-end supervisor test updated to the escalated cadence. `flutter analyze` clean; 2,900 tests green across obd2 + telemetry + app + consumption-provider suites; all lint gates green (supervisor grandfathered 415 vs #3141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Stfu8NZvRfSKFP6ETavR4G