### PR TITLE
feat(consumption): fill-anchored tank re-evaluation — tank-to-tank truth drives level decay and range

### DIFF
--- a/lib/features/consumption/domain/services/fill_anchored_consumption.dart
+++ b/lib/features/consumption/domain/services/fill_anchored_consumption.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import '../entities/fill_up.dart';
+
+/// Tank-to-tank consumption derived from fill-ups alone (#3645).
+///
+/// ## Why this exists
+///
+/// Every refuel hands us the one physically true consumption measurement
+/// available to the app: between two FULL fills, the litres pumped (the
+/// closing plein plus any partial top-ups in between) are — by
+/// construction — exactly what the car burned, and the odometer delta is
+/// exactly how far it drove. No integrator drift, no GPS-model bias, and
+/// crucially **no dependence on trips being recorded at all**: the pump
+/// and the odometer see the unrecorded commute that the trip aggregate
+/// misses entirely.
+///
+/// Before #3645 the tank-level estimator's decay/range average came
+/// exclusively from recorded-trip aggregates (hard fallback 7.0), so the
+/// gauge and the range drifted whenever recording was incomplete or the
+/// integrator ran hot/cold — and the refuel, the moment of ground truth,
+/// never corrected it. This service is that correction: the fill itself
+/// re-evaluates the tank, "so real und richtig wie möglich".
+@immutable
+class FillAnchoredConsumption {
+  /// km-weighted average across the considered windows:
+  /// `totalLiters / totalKm × 100`.
+  final double avgLPer100Km;
+
+  /// Number of valid plein-to-plein windows folded in.
+  final int windows;
+
+  /// Total odometer kilometres across the considered windows.
+  final double totalKm;
+
+  /// Total pumped litres across the considered windows.
+  final double totalLiters;
+
+  const FillAnchoredConsumption({
+    required this.avgLPer100Km,
+    required this.windows,
+    required this.totalKm,
+    required this.totalLiters,
+  });
+}
+
+/// Per-window plausibility band, in L/100 km. A window outside the band
+/// is an odometer typo, a forgotten fill, or a reset — never a reading.
+/// The band is deliberately generous (a loaded van uphill is real; a
+/// 80 L/100 km "window" is not) so honest outliers survive and data
+/// errors do not.
+const double _minPlausibleLPer100Km = 1.0;
+const double _maxPlausibleLPer100Km = 35.0;
+
+/// Derive the vehicle's true consumption from its fill-up history.
+///
+/// [fillUps] is the vehicle's fill list in ANY order (the provider hands
+/// newest-first; the estimator-history walk uses oldest-first — this
+/// function sorts internally so both callers stay simple).
+///
+/// Window semantics (mirrors the #1361 Reconciler):
+/// * a window is `(fullFillₙ, fullFillₙ₊₁]` over consecutive FULL fills;
+/// * window litres = closing plein + every non-correction fill strictly
+///   inside the window. `isCorrection` entries (#1361) are synthetic
+///   book-keeping, not pumped fuel — the closing plein's litres already
+///   physically include what they model, so counting them would double
+///   the missed consumption;
+/// * window km = odometer delta between the two fulls.
+///
+/// Guards — a window is skipped (never "repaired") when:
+/// * either odometer reading is `<= 0` (unset / not captured), or the
+///   delta is `<= 0` (typo, odometer reset, same-value quick logs);
+/// * the per-window L/100 km falls outside
+///   [_minPlausibleLPer100Km, _maxPlausibleLPer100Km].
+///
+/// Only the most recent [maxWindows] valid windows are averaged, so the
+/// figure tracks the car as it drives TODAY (matching the 3–8 fill-up
+/// convergence the calibration matrix promises) instead of blending in
+/// its whole life. Returns null when no valid window exists — callers
+/// fall back rather than receive a fabricated number.
+///
+/// Related-but-different: [ConsumptionStats] walks closed plein windows
+/// too, with richer semantics (cost, CO₂, correction-litre shares,
+/// fuel-type awareness) for the stats card. This service is deliberately
+/// the minimal, guard-heavy variant the LIVE tank/range math needs —
+/// merging the two walkers is a possible follow-up, not a given.
+///
+/// Known boundary (same as the estimator's level walk): fuel types are
+/// not separated, matching the one-tank-per-vehicle model
+/// (`tankCapacityL` is singular). A bi-fuel LPG+petrol vehicle would
+/// need per-tank modelling everywhere first.
+FillAnchoredConsumption? fillAnchoredAvgLPer100Km(
+  List<FillUp> fillUps, {
+  int maxWindows = 8,
+}) {
+  if (fillUps.length < 2) return null;
+
+  final sorted = [...fillUps]..sort((a, b) => a.date.compareTo(b.date));
+
+  // Walk oldest→newest, collecting valid windows; keep only the most
+  // recent [maxWindows] of them.
+  final windowKm = <double>[];
+  final windowLiters = <double>[];
+
+  FillUp? openingFull;
+  var pumpedSinceOpening = 0.0;
+
+  for (final f in sorted) {
+    if (openingFull == null) {
+      if (f.isFullTank && !f.isCorrection) openingFull = f;
+      continue;
+    }
+    if (f.isCorrection) {
+      // Synthetic entry — ignored for pumped litres. A correction that
+      // is ALSO flagged full-tank must not close a window either: it
+      // was never a physical visit to a pump.
+      continue;
+    }
+    pumpedSinceOpening += f.liters;
+    if (!f.isFullTank) continue;
+
+    // A full fill closes the window opened by [openingFull].
+    final km = f.odometerKm - openingFull.odometerKm;
+    final liters = pumpedSinceOpening;
+    final valid = openingFull.odometerKm > 0 &&
+        f.odometerKm > 0 &&
+        km > 0 &&
+        liters > 0 &&
+        (liters / km * 100) >= _minPlausibleLPer100Km &&
+        (liters / km * 100) <= _maxPlausibleLPer100Km;
+    if (valid) {
+      windowKm.add(km);
+      windowLiters.add(liters);
+    }
+    // Every full fill re-opens the next window regardless of validity —
+    // a skipped window must not merge two windows into one giant span.
+    openingFull = f;
+    pumpedSinceOpening = 0.0;
+  }
+
+  if (windowKm.isEmpty) return null;
+
+  final start = windowKm.length > maxWindows ? windowKm.length - maxWindows : 0;
+  var totalKm = 0.0;
+  var totalLiters = 0.0;
+  for (var i = start; i < windowKm.length; i++) {
+    totalKm += windowKm[i];
+    totalLiters += windowLiters[i];
+  }
+
+  return FillAnchoredConsumption(
+    avgLPer100Km: totalLiters / totalKm * 100.0,
+    windows: windowKm.length - start,
+    totalKm: totalKm,
+    totalLiters: totalLiters,
+  );
+}

--- a/lib/features/consumption/domain/services/tank_level_estimator.dart
+++ b/lib/features/consumption/domain/services/tank_level_estimator.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../core/domain/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
 import '../entities/fill_up.dart';
+import 'fill_anchored_consumption.dart';
 import 'trip_length_aggregator.dart';
 
 /// How a [TankLevelEstimate] was derived (#1195).
@@ -141,15 +142,17 @@ TankLevelEstimate estimateTankLevel({
   final capacityL = vehicle.tankCapacityL;
   final upperBound = capacityL ?? double.infinity;
 
-  // #1191 — ground the estimate in the vehicle's REAL average consumption
-  // from its trip history (measured litres, else the GPS estimate — see
-  // [aggregateByTripLength]), falling back to the fleet default only when
-  // there is no usable trip data for this vehicle yet. This makes the
-  // tank-level and range estimates track how THIS car actually drinks,
-  // instead of a fixed 7.0 L/100 km fleet average.
-  final avgLPer100Km =
+  // #3645 — PREFER the fill-anchored (tank-to-tank) average: pumped
+  // litres ÷ odometer delta between full fills is the one physically
+  // true consumption measurement, captures unrecorded driving by
+  // construction, and carries no integrator/GPS-model bias. Every
+  // refuel thereby re-evaluates the tank ("so real und richtig wie
+  // möglich"). #1191 — the recorded-trip aggregate remains the fallback
+  // when no valid plein-to-plein window exists yet (young history,
+  // unset odometers), and the 7.0 fleet default the last resort.
+  final avgLPer100Km = fillAnchoredAvgLPer100Km(fillUps)?.avgLPer100Km ??
       aggregateByTripLength(trips, vehicleId: vehicle.id).overallAvgLPer100Km ??
-          _defaultAvgLPer100Km;
+      _defaultAvgLPer100Km;
 
   // Compute the starting level right after [lastFillUp] (#1360 partial-
   // fill branch). For full fills this is just capacity; for partials
@@ -246,8 +249,20 @@ double _initialLevelAfterFill({
   if (lastFill.isFullTank) {
     // Capacity wins when known; otherwise fall back to "tank held at
     // least the litres the user just pumped in", which is honest when
-    // capacity isn't configured.
+    // capacity isn't configured. A sensor reading is deliberately NOT
+    // consulted here: "full" is the user's physical statement at the
+    // pump, and the percent-derived 0x2F level habitually under-reads a
+    // brimmed tank.
     return capacityL ?? lastFill.liters;
+  }
+
+  // #3645 — partial fill with an OBD2-measured post-pump level (#1401
+  // phase 7a): the car's own gauge beats our walk-back simulation. The
+  // clamp keeps a glitched sensor honest against the configured
+  // capacity.
+  final measuredAfter = lastFill.fuelLevelAfterL;
+  if (measuredAfter != null) {
+    return measuredAfter.clamp(0.0, upper);
   }
 
   // Build a chronological (oldest→newest) view of every prior fill.

--- a/test/features/consumption/domain/services/fill_anchored_consumption_test.dart
+++ b/test/features/consumption/domain/services/fill_anchored_consumption_test.dart
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/fill_anchored_consumption.dart';
+
+/// Pure unit tests for [fillAnchoredAvgLPer100Km] (#3645).
+///
+/// The service derives the vehicle's TRUE consumption from the only
+/// physical measurement the user hands us at every refuel: pumped
+/// litres ÷ odometer delta between consecutive FULL fills. Synthetic
+/// fixtures only, mirroring the tank_level_estimator_test idiom.
+void main() {
+  var idCounter = 0;
+
+  FillUp fill({
+    required DateTime date,
+    required double liters,
+    required double odometerKm,
+    bool isFullTank = true,
+    bool isCorrection = false,
+  }) {
+    return FillUp(
+      id: 'f${idCounter++}',
+      date: date,
+      liters: liters,
+      totalCost: liters * 1.8,
+      odometerKm: odometerKm,
+      fuelType: FuelType.diesel,
+      vehicleId: 'v1',
+      isFullTank: isFullTank,
+      isCorrection: isCorrection,
+    );
+  }
+
+  group('fillAnchoredAvgLPer100Km — window math', () {
+    test('two full fills form one window: liters of the CLOSING plein '
+        'over the odometer delta', () {
+      // Full at 100000, drive 500 km, refill 30 L to full:
+      // 30 L / 500 km = 6.0 L/100 km — the physically true figure.
+      final result = fillAnchoredAvgLPer100Km([
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+      ]);
+
+      expect(result, isNotNull);
+      expect(result!.avgLPer100Km, closeTo(6.0, 0.001));
+      expect(result.windows, 1);
+      expect(result.totalKm, closeTo(500, 0.001));
+      expect(result.totalLiters, closeTo(30, 0.001));
+    });
+
+    test('a partial fill INSIDE the window adds its litres — the closing '
+        'plein only refills what is still missing', () {
+      // Full → 10 L partial → full 25 L over 500 km: consumed = 35 L.
+      final result = fillAnchoredAvgLPer100Km([
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        fill(
+          date: DateTime(2026, 4, 5),
+          liters: 10,
+          odometerKm: 100200,
+          isFullTank: false,
+        ),
+        fill(date: DateTime(2026, 4, 10), liters: 25, odometerKm: 100500),
+      ]);
+
+      expect(result!.avgLPer100Km, closeTo(7.0, 0.001));
+      expect(result.windows, 1);
+    });
+
+    test('correction entries (#1361) are synthetic, not pumped fuel — '
+        'excluded from the window litres', () {
+      final result = fillAnchoredAvgLPer100Km([
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        fill(
+          date: DateTime(2026, 4, 5),
+          liters: 8,
+          odometerKm: 100200,
+          isFullTank: false,
+          isCorrection: true,
+        ),
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+      ]);
+
+      // 30 L / 500 km — the 8 L correction must NOT inflate the window.
+      expect(result!.avgLPer100Km, closeTo(6.0, 0.001));
+    });
+
+    test('multiple windows: km-weighted average, not a mean of ratios', () {
+      // Window 1: 30 L / 500 km (6.0). Window 2: 45 L / 500 km (9.0).
+      // km-weighted: 75 L / 1000 km = 7.5.
+      final result = fillAnchoredAvgLPer100Km([
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+        fill(date: DateTime(2026, 4, 20), liters: 45, odometerKm: 101000),
+      ]);
+
+      expect(result!.avgLPer100Km, closeTo(7.5, 0.001));
+      expect(result.windows, 2);
+      expect(result.totalKm, closeTo(1000, 0.001));
+    });
+
+    test('input order does not matter — windows derive from dates', () {
+      final a = fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000);
+      final b = fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500);
+
+      expect(
+        fillAnchoredAvgLPer100Km([b, a])!.avgLPer100Km,
+        closeTo(6.0, 0.001),
+      );
+    });
+  });
+
+  group('fillAnchoredAvgLPer100Km — guards (honest numbers only)', () {
+    test('fewer than two full fills → null (no window exists)', () {
+      expect(fillAnchoredAvgLPer100Km(const []), isNull);
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        ]),
+        isNull,
+      );
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+          fill(
+            date: DateTime(2026, 4, 5),
+            liters: 10,
+            odometerKm: 100200,
+            isFullTank: false,
+          ),
+        ]),
+        isNull,
+      );
+    });
+
+    test('zero or negative odometer delta → window skipped (typo, reset, '
+        'or an unset default like the estimator-test fixtures)', () {
+      // Same odometer on both fulls — exactly the shape older fixtures
+      // and quick manual logs produce. Must not fabricate a number.
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+          fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100000),
+        ]),
+        isNull,
+      );
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100500),
+          fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100000),
+        ]),
+        isNull,
+      );
+    });
+
+    test('missing odometer (0 or negative reading) skips the window', () {
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 0),
+          fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+        ]),
+        isNull,
+      );
+    });
+
+    test('implausible per-window consumption is skipped, not averaged in', () {
+      // 40 L over 50 km = 80 L/100 km — an odometer typo, not a reading.
+      // The plausible window must survive alone.
+      final result = fillAnchoredAvgLPer100Km([
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        fill(date: DateTime(2026, 4, 3), liters: 40, odometerKm: 100050),
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100550),
+      ]);
+
+      expect(result, isNotNull);
+      expect(result!.windows, 1);
+      expect(result.avgLPer100Km, closeTo(6.0, 0.001));
+    });
+
+    test('all windows implausible → null, never a fabricated figure', () {
+      expect(
+        fillAnchoredAvgLPer100Km([
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+          fill(date: DateTime(2026, 4, 3), liters: 40, odometerKm: 100050),
+        ]),
+        isNull,
+      );
+    });
+
+    test('only the most recent maxWindows windows count — the average '
+        'tracks the CURRENT car, not its whole life', () {
+      // Ten old 9.0-windows, then two recent 6.0-windows. maxWindows: 2
+      // must yield 6.0, not a lifetime blend.
+      final fills = <FillUp>[
+        for (var i = 0; i <= 9; i++)
+          fill(
+            date: DateTime(2026, 1, 1 + i),
+            liters: 45,
+            odometerKm: 100000 + i * 500,
+          ),
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 105000),
+        fill(date: DateTime(2026, 4, 20), liters: 30, odometerKm: 105500),
+      ];
+
+      final result = fillAnchoredAvgLPer100Km(fills, maxWindows: 2);
+      expect(result!.windows, 2);
+      expect(result.avgLPer100Km, closeTo(6.0, 0.001));
+    });
+  });
+}

--- a/test/features/consumption/domain/services/tank_level_estimator_fill_anchor_test.dart
+++ b/test/features/consumption/domain/services/tank_level_estimator_fill_anchor_test.dart
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/domain/vehicle_profile.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/tank_level_estimator.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #3645 — the estimator prefers the fill-anchored (tank-to-tank)
+/// average over the trip aggregate, and a partial fill anchors on the
+/// OBD2-measured after-level when the sensor captured one.
+///
+/// Fixture idiom mirrors tank_level_estimator_test.dart.
+void main() {
+  const vehicle = VehicleProfile(
+    id: 'v1',
+    name: 'Test Car',
+    type: VehicleType.combustion,
+    tankCapacityL: 50,
+  );
+
+  var idCounter = 0;
+  FillUp fill({
+    required DateTime date,
+    required double liters,
+    required double odometerKm,
+    bool isFullTank = true,
+    double? fuelLevelAfterL,
+  }) {
+    return FillUp(
+      id: 'f${idCounter++}',
+      date: date,
+      liters: liters,
+      totalCost: liters * 1.8,
+      odometerKm: odometerKm,
+      fuelType: FuelType.diesel,
+      vehicleId: 'v1',
+      isFullTank: isFullTank,
+      fuelLevelAfterL: fuelLevelAfterL,
+    );
+  }
+
+  TripHistoryEntry trip({
+    required String id,
+    required DateTime startedAt,
+    required double distanceKm,
+    double? fuelLitersConsumed,
+  }) {
+    return TripHistoryEntry(
+      id: id,
+      vehicleId: 'v1',
+      summary: TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuelLitersConsumed,
+        startedAt: startedAt,
+      ),
+    );
+  }
+
+  group('#3645 — fill-anchored average preferred for decay and range', () {
+    test(
+      'tank-to-tank truth (6.0) beats the recorded-trip aggregate (12.0): '
+      'unmeasured-trip decay and range both use the pump-derived figure',
+      () {
+        // History: two full fills 500 km apart, 30 L pumped → TRUE 6.0.
+        // Trips paint a very different picture (12.0 measured) — e.g. the
+        // adapter only ever recorded the city errands, never the commute.
+        final fillUps = [
+          // newest first, like the provider hands them over
+          fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        ];
+        final trips = [
+          // Before the last fill: feeds ONLY the trip aggregate.
+          trip(
+            id: 't-old',
+            startedAt: DateTime(2026, 4, 5),
+            distanceKm: 50,
+            fuelLitersConsumed: 6, // 12.0 L/100 km recorded average
+          ),
+          // After the last fill: unmeasured → decays via the avg.
+          trip(
+            id: 't-new',
+            startedAt: DateTime(2026, 4, 11),
+            distanceKm: 100,
+          ),
+        ];
+
+        final estimate = estimateTankLevel(
+          vehicle: vehicle,
+          fillUps: fillUps,
+          trips: trips,
+        );
+
+        // Decay for the 100 unmeasured km must use 6.0 (tank-to-tank),
+        // not 12.0 (trip aggregate): 50 - 6 = 44 L.
+        expect(estimate.levelL, closeTo(44.0, 0.01));
+        // Range from the same physically-derived figure.
+        expect(estimate.rangeKm, closeTo(44.0 / 6.0 * 100.0, 0.1));
+      },
+    );
+
+    test(
+      'no valid tank-to-tank window (odometer never moved) → falls back '
+      'to the trip aggregate exactly as before',
+      () {
+        final fillUps = [
+          fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100000),
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        ];
+        final trips = [
+          trip(
+            id: 't-old',
+            startedAt: DateTime(2026, 4, 5),
+            distanceKm: 50,
+            fuelLitersConsumed: 5, // 10.0 recorded average
+          ),
+          trip(id: 't-new', startedAt: DateTime(2026, 4, 11), distanceKm: 100),
+        ];
+
+        final estimate = estimateTankLevel(
+          vehicle: vehicle,
+          fillUps: fillUps,
+          trips: trips,
+        );
+
+        // 50 - (100 km × 10.0/100) = 40 L — unchanged legacy behaviour.
+        expect(estimate.levelL, closeTo(40.0, 0.01));
+      },
+    );
+
+    test('measured OBD2 trip litres still win over ANY average', () {
+      final fillUps = [
+        fill(date: DateTime(2026, 4, 10), liters: 30, odometerKm: 100500),
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+      ];
+      final trips = [
+        trip(
+          id: 't-measured',
+          startedAt: DateTime(2026, 4, 11),
+          distanceKm: 100,
+          fuelLitersConsumed: 9.5, // the integrator's own figure
+        ),
+      ];
+
+      final estimate = estimateTankLevel(
+        vehicle: vehicle,
+        fillUps: fillUps,
+        trips: trips,
+      );
+
+      expect(estimate.levelL, closeTo(50.0 - 9.5, 0.01));
+    });
+  });
+
+  group('#3645 — partial fill anchors on the OBD2-measured after-level', () {
+    test(
+      'partial with a sensor reading: the car\'s own gauge beats the '
+      'walk-back simulation',
+      () {
+        // Walk-back would say: full 50 − 7 L trip + 10 L partial = 53 → 50.
+        // The sensor read 41 L after the pump — trust the car.
+        final fillUps = [
+          fill(
+            date: DateTime(2026, 4, 8),
+            liters: 10,
+            odometerKm: 100300,
+            isFullTank: false,
+            fuelLevelAfterL: 41,
+          ),
+          fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+        ];
+        final trips = [
+          trip(
+            id: 't-between',
+            startedAt: DateTime(2026, 4, 4),
+            distanceKm: 100,
+            fuelLitersConsumed: 7,
+          ),
+        ];
+
+        final estimate = estimateTankLevel(
+          vehicle: vehicle,
+          fillUps: fillUps,
+          trips: trips,
+        );
+
+        expect(estimate.levelL, closeTo(41.0, 0.01));
+      },
+    );
+
+    test('a sensor reading above capacity is clamped, never advertised', () {
+      final fillUps = [
+        fill(
+          date: DateTime(2026, 4, 8),
+          liters: 10,
+          odometerKm: 100300,
+          isFullTank: false,
+          fuelLevelAfterL: 55, // sensor glitch above the 50 L tank
+        ),
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+      ];
+
+      final estimate = estimateTankLevel(
+        vehicle: vehicle,
+        fillUps: fillUps,
+        trips: const [],
+      );
+
+      expect(estimate.levelL, closeTo(50.0, 0.01));
+    });
+
+    test('partial WITHOUT a sensor reading keeps the #1360 walk-back', () {
+      final fillUps = [
+        fill(
+          date: DateTime(2026, 4, 8),
+          liters: 10,
+          odometerKm: 100300,
+          isFullTank: false,
+        ),
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+      ];
+      final trips = [
+        trip(
+          id: 't-between',
+          startedAt: DateTime(2026, 4, 4),
+          distanceKm: 100,
+          fuelLitersConsumed: 7,
+        ),
+      ];
+
+      final estimate = estimateTankLevel(
+        vehicle: vehicle,
+        fillUps: fillUps,
+        trips: trips,
+      );
+
+      // 50 − 7 + 10 clamped to capacity = 50 (legacy behaviour).
+      expect(estimate.levelL, closeTo(50.0, 0.01));
+    });
+
+    test('a FULL fill keeps the capacity convention even with a sensor '
+        'reading present', () {
+      final fillUps = [
+        fill(
+          date: DateTime(2026, 4, 8),
+          liters: 42,
+          odometerKm: 100500,
+          fuelLevelAfterL: 46, // percent-derived sensor under-reads
+        ),
+        fill(date: DateTime(2026, 4, 1), liters: 45, odometerKm: 100000),
+      ];
+
+      final estimate = estimateTankLevel(
+        vehicle: vehicle,
+        fillUps: fillUps,
+        trips: const [],
+      );
+
+      // "Full" is the user's physical statement at the pump — capacity
+      // wins over a percent-derived sensor estimate.
+      expect(estimate.levelL, closeTo(50.0, 0.01));
+    });
+  });
+}


### PR DESCRIPTION
## What
Every refuel re-evaluates the tank against the physically true measurement: pumped litres ÷ odometer delta between full fills now drives the tank-level decay and the range estimate; partial fills anchor on the OBD2-measured post-pump level when captured.

## Why
Closes #3645

The decay/range average came exclusively from recorded-trip aggregates (hard fallback 7.0 L/100 km) — blind to unrecorded driving and carrying integrator/GPS bias. The refuel, the moment of ground truth, never corrected it. Requirement (maintainer, 2026-08-01): *"Die Tankfüllung soll so real und richtig wie möglich bewertet werden, sodass die gefahrenen Kilometer dann auch richtig kalkuliert werden können."*

## How
- **`fill_anchored_consumption.dart`** (new, pure): plein-to-plein window walker — closing plein + partials in the window over the odometer delta, km-weighted across the most recent 8 windows. Guards skip (never repair) unset/reset odometers and implausible windows (>35 L/100 km); synthetic #1361 correction entries are excluded; no valid window → `null`, never a fabricated figure.
- **`tank_level_estimator.dart`**: average preference is now **fill-anchored → trip aggregate → 7.0 default**. Partials anchor on `fuelLevelAfterL` (#1401 7a) clamped to capacity; full fills keep the capacity convention (percent-derived 0x2F under-reads a brimmed tank). Measured per-trip OBD2 litres still win over any average.

## Testing
- [x] 18 new tests, written red-first (window math, correction exclusion, km-weighting, guards, preference order, sensor anchor, clamps)
- [x] All 24 pre-existing estimator tests unchanged and green — the new path activates only on a physically valid window
- [x] Consumption feature suite: 3 210 green; `flutter analyze` clean (lib + test)
- [x] Twin-bug audit: `ConsumptionStats` + calculator prefill already walk closed plein windows; carbon widgets legitimately use the trip aggregate as a comparison reference

## Checklist
- [x] Linked issue (#3645, filed first)
- [x] Under 400 lines excluding tests (193 lib-lines changed)
- [x] No user-facing strings touched (numbers get real, surfaces identical — no ARB)
- [x] No codegen involved (pure Dart service); zero drift
- [x] No secrets, no new dependencies

## Notes for review
Documented boundary: fuel types are not separated, matching the existing one-tank-per-vehicle model (`tankCapacityL` is singular) — bi-fuel needs per-tank modelling everywhere first. Merging this walker with `ConsumptionStats`' richer window walk is a possible follow-up, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
