### PR TITLE
feat(ux): 10-second undo for every destructive delete — fill-ups, recordings, favorites, ignored stations (#3664)

### DIFF
--- a/lib/core/widgets/snackbar_helper.dart
+++ b/lib/core/widgets/snackbar_helper.dart
@@ -43,7 +43,13 @@ class SnackBarHelper {
 
   static const Duration _infoDuration = Duration(seconds: 3);
   static const Duration _errorDuration = Duration(seconds: 5);
-  static const Duration _undoDuration = Duration(seconds: 4);
+
+  /// #3664 — the undo window for destructive actions (delete a fill-up,
+  /// a recording, a favorite, ignore a station). 10 seconds by
+  /// maintainer directive: an accidental delete must be recoverable
+  /// "without problems", and 4 s was gone before the user's eyes came
+  /// back from the swipe. Public so tests pin the contract.
+  static const Duration undoDuration = Duration(seconds: 10);
 
   // ---- Builders -------------------------------------------------------
   // Pure: take only already-resolved values, so they stay safe to call
@@ -142,6 +148,20 @@ class SnackBarHelper {
     );
   }
 
+  /// An undo [SnackBar] builder for call sites past an async gap or a
+  /// `Navigator.pop` (#3664): capture the [ScaffoldMessengerState] and
+  /// the localized [undoLabel] BEFORE the gap, then show this. Same
+  /// [undoDuration] window as [showWithUndo].
+  static SnackBar undoSnackBar(
+    String message, {
+    required VoidCallback onUndo,
+    required String undoLabel,
+  }) => infoSnackBar(
+    message,
+    duration: undoDuration,
+    action: SnackBarAction(label: undoLabel, onPressed: onUndo),
+  );
+
   /// Show a snackbar with an undo action. [undoLabel] defaults to the
   /// localized "Undo" string — never a hard-coded literal.
   static void showWithUndo(
@@ -153,11 +173,7 @@ class SnackBarHelper {
     if (!context.mounted) return;
     final label = undoLabel ?? AppLocalizations.of(context).undo;
     ScaffoldMessenger.of(context).showSnackBar(
-      infoSnackBar(
-        message,
-        duration: _undoDuration,
-        action: SnackBarAction(label: label, onPressed: onUndo),
-      ),
+      undoSnackBar(message, onUndo: onUndo, undoLabel: label),
     );
   }
 

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -346,8 +346,29 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       ),
     );
     if (confirmed != true || !context.mounted) return;
-    await ref.read(tripHistoryListProvider.notifier).delete(widget.tripId);
+    // #3664 — capture-and-restore undo. The whole entry (summary +
+    // embedded detail) lives in one Hive row; hold it in this closure
+    // and Undo re-saves it losslessly. Messenger + strings are captured
+    // BEFORE the pop (SnackBarHelper contract) because this screen's
+    // context dies with it.
+    final notifier = ref.read(tripHistoryListProvider.notifier);
+    final deleted = ref
+        .read(tripHistoryListProvider)
+        .where((t) => t.id == widget.tripId)
+        .firstOrNull;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final undoLabel = l.undo;
+    final message = l.trajetDeletedUndoSnackbar;
+    await notifier.delete(widget.tripId);
     if (!context.mounted) return;
     context.pop();
+    if (deleted == null || messenger == null) return;
+    messenger.showSnackBar(
+      SnackBarHelper.undoSnackBar(
+        message,
+        undoLabel: undoLabel,
+        onUndo: () => unawaited(notifier.save(deleted)),
+      ),
+    );
   }
 }

--- a/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/utils/time_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/add_fill_up_validators.dart';
@@ -125,9 +128,23 @@ class _EditCorrectionFillUpSheetState
   }
 
   Future<void> _delete() async {
-    await ref.read(fillUpListProvider.notifier).remove(widget.fillUp.id);
+    // #3664 — capture the messenger + localized strings BEFORE the
+    // await/pop (SnackBarHelper contract): the sheet's own context dies
+    // with the pop, but the undo snackbar must outlive it.
+    final messenger = ScaffoldMessenger.of(context);
+    final l = AppLocalizations.of(context);
+    final notifier = ref.read(fillUpListProvider.notifier);
+    final deleted = widget.fillUp;
+    await notifier.remove(deleted.id);
     if (!mounted) return;
     Navigator.of(context).pop();
+    messenger.showSnackBar(
+      SnackBarHelper.undoSnackBar(
+        l.fillUpDeletedUndoSnackbar,
+        undoLabel: l.undo,
+        onUndo: () => unawaited(notifier.update(deleted)),
+      ),
+    );
   }
 
   @override

--- a/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/trip_history_repository.dart';
 import '../../domain/add_fill_up_validators.dart';
@@ -77,9 +80,25 @@ class _EditVirtualTrajetSheetState
   }
 
   Future<void> _delete() async {
-    await ref.read(tripHistoryListProvider.notifier).delete(widget.entry.id);
+    // #3664 — capture the messenger + localized strings BEFORE the
+    // await/pop: the sheet's context dies with the pop, but the undo
+    // snackbar must outlive it. The whole entry (summary + embedded
+    // detail) lives in one Hive row, so re-saving it restores the
+    // recording losslessly.
+    final messenger = ScaffoldMessenger.of(context);
+    final l = AppLocalizations.of(context);
+    final notifier = ref.read(tripHistoryListProvider.notifier);
+    final deleted = widget.entry;
+    await notifier.delete(deleted.id);
     if (!mounted) return;
     Navigator.of(context).pop();
+    messenger.showSnackBar(
+      SnackBarHelper.undoSnackBar(
+        l.trajetDeletedUndoSnackbar,
+        undoLabel: l.undo,
+        onUndo: () => unawaited(notifier.save(deleted)),
+      ),
+    );
   }
 
   @override

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -14,6 +14,7 @@ import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../achievements/presentation/widgets/badge_shelf.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
@@ -94,7 +95,16 @@ class FuelTab extends ConsumerWidget {
           child: const Icon(Icons.delete, color: Colors.white),
         ),
         onDismissed: (_) {
-          unawaited(ref.read(fillUpListProvider.notifier).remove(fillUp.id));
+          final notifier = ref.read(fillUpListProvider.notifier);
+          unawaited(notifier.remove(fillUp.id));
+          // #3664 — capture-and-restore undo: the swiped entity is held
+          // in this closure; Undo re-saves it (same id, fresh updatedAt
+          // so the LWW sync merge propagates the resurrection too).
+          SnackBarHelper.showWithUndo(
+            context,
+            AppLocalizations.of(context).fillUpDeletedUndoSnackbar,
+            onUndo: () => unawaited(notifier.update(fillUp)),
+          );
         },
         child: FillUpCard(
           fillUp: fillUp,

--- a/lib/l10n/_fragments/undo_delete_de.arb
+++ b/lib/l10n/_fragments/undo_delete_de.arb
@@ -1,0 +1,4 @@
+{
+  "fillUpDeletedUndoSnackbar": "Tankfüllung gelöscht",
+  "trajetDeletedUndoSnackbar": "Aufzeichnung gelöscht"
+}

--- a/lib/l10n/_fragments/undo_delete_en.arb
+++ b/lib/l10n/_fragments/undo_delete_en.arb
@@ -1,0 +1,10 @@
+{
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "description": "Undo snackbar shown after a fill-up is deleted (swipe on the Carburant list or the correction sheet's delete button, #3664). The trailing Undo action restores it within the 10 s window."
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "description": "Undo snackbar shown after a trip recording is deleted (trip detail screen or the virtual-trajet sheet, #3664). The trailing Undo action restores it within the 10 s window."
+  }
+}

--- a/lib/l10n/_fragments/undo_delete_fr.arb
+++ b/lib/l10n/_fragments/undo_delete_fr.arb
@@ -1,0 +1,4 @@
+{
+  "fillUpDeletedUndoSnackbar": "Plein supprimé",
+  "trajetDeletedUndoSnackbar": "Enregistrement supprimé"
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3936,6 +3936,8 @@
   "tripVerdictAggressive": "Aggressiv",
   "tripVerdictDismiss": "Jetzt nicht",
   "tripVerdictThanks": "Danke — das hilft, deine Fahranalyse zu kalibrieren.",
+  "fillUpDeletedUndoSnackbar": "Tankfüllung gelöscht",
+  "trajetDeletedUndoSnackbar": "Aufzeichnung gelöscht",
   "unifiedFilterFuel": "Kraftstoff",
   "unifiedFilterEv": "EV",
   "unifiedFilterBoth": "Beide",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7867,6 +7867,14 @@
   "@tripVerdictThanks": {
     "description": "Confirmation line shown in place of the verdict prompt right after the driver answers (#3501)."
   },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "description": "Undo snackbar shown after a fill-up is deleted (swipe on the Carburant list or the correction sheet's delete button, #3664). The trailing Undo action restores it within the 10 s window."
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "description": "Undo snackbar shown after a trip recording is deleted (trip detail screen or the virtual-trajet sheet, #3664). The trailing Undo action restores it within the 10 s window."
+  },
   "unifiedFilterFuel": "Fuel",
   "@unifiedFilterFuel": {
     "description": "Filter chip label that narrows the unified search list to fuel pumps only (#1116 phase 3c)."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -2300,6 +2300,8 @@
   "tripVerdictAggressive": "⟦Áǧǧřéššîṽé ·····⟧",
   "tripVerdictDismiss": "⟦Ñóŧ ñóŵ ···⟧",
   "tripVerdictThanks": "⟦Ŧĥáñķš — ŧĥîš ĥéłƥš çáłîƀřáŧé ýóúř đřîṽîñǧ áñáłýšîš. ···················⟧",
+  "fillUpDeletedUndoSnackbar": "⟦Ƒîłł-úƥ đéłéŧéđ ······⟧",
+  "trajetDeletedUndoSnackbar": "⟦Řéçóřđîñǧ đéłéŧéđ ·······⟧",
   "unifiedFilterFuel": "⟦Ƒúéł ··⟧",
   "unifiedFilterEv": "⟦ÉṼ ·⟧",
   "unifiedFilterBoth": "⟦Ɓóŧĥ ··⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5548,5 +5548,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14030,6 +14030,18 @@ abstract class AppLocalizations {
   /// **'Thanks — this helps calibrate your driving analysis.'**
   String get tripVerdictThanks;
 
+  /// Undo snackbar shown after a fill-up is deleted (swipe on the Carburant list or the correction sheet's delete button, #3664). The trailing Undo action restores it within the 10 s window.
+  ///
+  /// In en, this message translates to:
+  /// **'Fill-up deleted'**
+  String get fillUpDeletedUndoSnackbar;
+
+  /// Undo snackbar shown after a trip recording is deleted (trip detail screen or the virtual-trajet sheet, #3664). The trailing Undo action restores it within the 10 s window.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording deleted'**
+  String get trajetDeletedUndoSnackbar;
+
   /// Filter chip label that narrows the unified search list to fuel pumps only (#1116 phase 3c).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8161,6 +8161,12 @@ class AppLocalizationsBg extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Гориво';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8111,6 +8111,12 @@ class AppLocalizationsCs extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Palivo';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8098,6 +8098,12 @@ class AppLocalizationsDa extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Brændstof';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8148,6 +8148,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Danke — das hilft, deine Fahranalyse zu kalibrieren.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Tankfüllung gelöscht';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Aufzeichnung gelöscht';
+
+  @override
   String get unifiedFilterFuel => 'Kraftstoff';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8165,6 +8165,12 @@ class AppLocalizationsEl extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Καύσιμο';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8061,6 +8061,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override
@@ -16590,6 +16596,12 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get tripVerdictThanks =>
       '⟦Ŧĥáñķš — ŧĥîš ĥéłƥš çáłîƀřáŧé ýóúř đřîṽîñǧ áñáłýšîš. ···················⟧';
+
+  @override
+  String get fillUpDeletedUndoSnackbar => '⟦Ƒîłł-úƥ đéłéŧéđ ······⟧';
+
+  @override
+  String get trajetDeletedUndoSnackbar => '⟦Řéçóřđîñǧ đéłéŧéđ ·······⟧';
 
   @override
   String get unifiedFilterFuel => '⟦Ƒúéł ··⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8153,6 +8153,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Combustible';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8092,6 +8092,12 @@ class AppLocalizationsEt extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Kütus';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8098,6 +8098,12 @@ class AppLocalizationsFi extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Polttoaine';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8180,6 +8180,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Carburant';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8125,6 +8125,12 @@ class AppLocalizationsHr extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Gorivo';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8146,6 +8146,12 @@ class AppLocalizationsHu extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Üzemanyag';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8141,6 +8141,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Carburante';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8137,6 +8137,12 @@ class AppLocalizationsLt extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Kuras';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8142,6 +8142,12 @@ class AppLocalizationsLv extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Degviela';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8093,6 +8093,12 @@ class AppLocalizationsNb extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Drivstoff';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8124,6 +8124,12 @@ class AppLocalizationsNl extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Brandstof';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8131,6 +8131,12 @@ class AppLocalizationsPl extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Paliwo';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8156,6 +8156,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Combustível';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8154,6 +8154,12 @@ class AppLocalizationsRo extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Combustibil';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8128,6 +8128,12 @@ class AppLocalizationsSk extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Palivo';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8105,6 +8105,12 @@ class AppLocalizationsSl extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Gorivo';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8094,6 +8094,12 @@ class AppLocalizationsSv extends AppLocalizations {
       'Thanks — this helps calibrate your driving analysis.';
 
   @override
+  String get fillUpDeletedUndoSnackbar => 'Fill-up deleted';
+
+  @override
+  String get trajetDeletedUndoSnackbar => 'Recording deleted';
+
+  @override
   String get unifiedFilterFuel => 'Bränsle';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5675,5 +5675,15 @@
         "type": "String"
       }
     }
+  },
+  "fillUpDeletedUndoSnackbar": "Fill-up deleted",
+  "@fillUpDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "trajetDeletedUndoSnackbar": "Recording deleted",
+  "@trajetDeletedUndoSnackbar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/widgets/snackbar_helper_test.dart
+++ b/test/core/widgets/snackbar_helper_test.dart
@@ -122,7 +122,8 @@ void main() {
       expect(snackBar.action!.label, 'Undo');
     });
 
-    testWidgets('showWithUndo() has 4-second duration', (tester) async {
+    testWidgets('showWithUndo() has the 10-second undo window (#3664)',
+        (tester) async {
       await pumpApp(tester, Builder(
         builder: (context) => ElevatedButton(
           onPressed: () => SnackBarHelper.showWithUndo(
@@ -137,8 +138,35 @@ void main() {
       await tester.tap(find.text('Tap'));
       await tester.pump();
 
+      // 10 s by maintainer directive — an accidental delete (fill-up,
+      // recording, favorite, ignored station) must stay recoverable
+      // long enough for the user's eyes to come back from the swipe.
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-      expect(snackBar.duration, const Duration(seconds: 4));
+      expect(snackBar.duration, const Duration(seconds: 10));
+      expect(snackBar.duration, SnackBarHelper.undoDuration);
+    });
+
+    testWidgets('tapping Undo fires the callback (#3664)', (tester) async {
+      var undone = 0;
+      await pumpApp(tester, Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => SnackBarHelper.showWithUndo(
+            context,
+            'Removed',
+            onUndo: () => undone++,
+          ),
+          child: const Text('Tap'),
+        ),
+      ));
+
+      await tester.tap(find.text('Tap'));
+      // Let the snackbar's entrance animation finish so the action
+      // button is actually hit-testable.
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Undo'));
+      await tester.pump();
+
+      expect(undone, 1);
     });
 
     testWidgets('showWithUndo() supports custom undo label', (tester) async {

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -678,6 +678,33 @@ void main() {
       expect(find.byKey(const Key('trip_detail_delete_button')), findsNothing);
     });
 
+    testWidgets('after delete, Undo restores the recording within the '
+        '10 s window (#3664)', (tester) async {
+      final handles = await _pumpDetail(
+        tester,
+        entry: _seedEntry(),
+        activeVehicle: vehicle,
+        vehicles: const [vehicle],
+        samples: _seedSamples(),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('trip_detail_delete_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('trip_detail_delete_confirm')));
+      await tester.pumpAndSettle();
+
+      // The undo snackbar outlives the popped detail screen (the
+      // messenger was captured before the pop).
+      expect(find.text('Recording deleted'), findsOneWidget);
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+
+      // Undo re-saves the captured entry losslessly — same id.
+      expect(handles.tripsNotifier.saveCalls, hasLength(1));
+      expect(handles.tripsNotifier.saveCalls.single.id, 'trip-1');
+    });
+
     testWidgets('cancel → delete NOT called', (tester) async {
       final handles = await _pumpDetail(
         tester,

--- a/test/features/consumption/presentation/widgets/fuel_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/fuel_tab_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/achievements/domain/achievement.dart';
 import 'package:tankstellen/features/achievements/presentation/widgets/badge_shelf.dart';
@@ -174,6 +175,43 @@ void main() {
       expect(flexes, containsAllInOrder(<int>[2, 3]));
     });
   });
+
+  group('swipe-to-delete undo (#3664)', () {
+    testWidgets('dismissing a fill-up shows the undo snackbar and Undo '
+        'restores it in the provider state', (tester) async {
+      await pumpApp(
+        tester,
+        FuelTab(fillUps: fillUps, stats: stats, l: l10nEn),
+        overrides: [
+          achievementsProvider.overrideWithValue(earned),
+          gamificationEnabledProvider.overrideWithValue(false),
+          activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
+          fillUpListProvider.overrideWith(() => _MutableFillUpList(fillUps)),
+        ],
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(FuelTab)),
+      );
+      expect(container.read(fillUpListProvider), hasLength(1));
+
+      await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+
+      // Deleted from the provider; the undo affordance is up.
+      expect(container.read(fillUpListProvider), isEmpty);
+      expect(find.text(l10nEn.fillUpDeletedUndoSnackbar), findsOneWidget);
+
+      await tester.tap(find.text(l10nEn.undo));
+      await tester.pumpAndSettle();
+
+      // Restored: the captured fill-up is back, same id.
+      expect(
+        container.read(fillUpListProvider).map((f) => f.id),
+        contains('f1'),
+      );
+    });
+  });
 }
 
 /// Returns null for the active vehicle so [TankLevelCard] short-circuits
@@ -190,4 +228,26 @@ class _FixedFillUpList extends FillUpList {
 
   @override
   List<FillUp> build() => _value;
+}
+
+/// In-memory FillUpList whose remove/update mutate state directly —
+/// no repository, so the swipe-to-delete + undo flow (#3664) can be
+/// exercised without Hive.
+class _MutableFillUpList extends FillUpList {
+  _MutableFillUpList(this._value);
+  final List<FillUp> _value;
+
+  @override
+  List<FillUp> build() => List.of(_value);
+
+  @override
+  Future<void> remove(String id) async {
+    state = state.where((f) => f.id != id).toList();
+  }
+
+  @override
+  Future<void> update(FillUp fillUp) async {
+    state = [...state.where((f) => f.id != fillUp.id), fillUp];
+  }
+
 }


### PR DESCRIPTION
## Problem

A fill-up was deleted by accident and there was no way back. Favorites, ignored stations and alerts already showed an undo snackbar — but only for 4 seconds — while fill-ups and trip recordings had **no undo at all**: a swipe or a sheet delete was instantly permanent.

## What this PR does (#3664)

Per the maintainer directive: every accidental delete (recording, fill-up, favorite, ignoring a station) is undoable **within 10 seconds**.

- **Shared window 4 s → 10 s** — `SnackBarHelper.undoDuration`, now public and pinned by test; the existing favorite / ignore / alert surfaces get the longer window for free.
- **Fill-up deletes** (the reported accident): the Carburant list swipe and the correction sheet's delete now capture the entity and offer Undo — the restore re-saves with a fresh `updatedAt`, so the LWW sync merge propagates the resurrection to other devices too.
- **Recording deletes**: the trip-detail delete and the virtual-trajet sheet's delete gain the same. The whole entry (summary + embedded detail) lives in one Hive row, so the captured object restores losslessly.
- Post-await/post-pop call sites capture the `ScaffoldMessenger` + localized strings **before** the gap per the helper's contract (the sheet/screen context dies with the pop, the snackbar must outlive it) — served by the new `undoSnackBar` builder.
- i18n: 2 new keys as an en/de/fr fragment triple, fanned out to all 24 locales + the pseudo-locale.

## Tests

The 10 s window + undo-callback contract on the helper; the fuel-tab swipe → snackbar → provider-state restore flow; trip-detail delete → pop → Undo → lossless re-save of the same id.

Verified in a detached worktree of the committed state: `flutter analyze` clean; full suite 15,488 passed, only failure the recurring Argentina live-API connectivity flake.

Closes #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
