### PR TITLE
perf(search): first paint never waits on the network — stale-first deadline race, SWR bulk loaders, last-known results survive eviction (#3668)

### DIFF
--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -247,7 +247,10 @@ class CacheManager implements CacheStrategy {
       if (key is! String) continue;
       final entry = get(key);
       if (entry == null) continue;
-      // Evict if age exceeds 3x TTL
+      // Evict if age exceeds 3x TTL. #3668 — `search:` entries are exempt:
+      // they are the last-known results the stale-first paint serves at
+      // startup (the per-prefix budget and byte ceiling still bound them).
+      if (key.startsWith('search:')) continue;
       if (entry.age > entry.ttl * 3) {
         await _storage.deleteCacheEntry(key);
         evicted++;
@@ -277,10 +280,14 @@ class CacheManager implements CacheStrategy {
       entries.add(MapEntry(raw, entry));
     }
 
-    // Pass 1 — expiry (> 3x TTL).
+    // Pass 1 — expiry (> 3x TTL). #3668 — `search:` entries are exempt
+    // from the expiry sweep: they are the last-known results the
+    // stale-first paint serves at startup (a week-old price list with the
+    // stale banner beats a skeleton). Pass 2's per-prefix budget and
+    // pass 3's byte ceiling still bound them.
     final survivors = <MapEntry<String, CacheEntry>>[];
     for (final e in entries) {
-      if (e.value.age > e.value.ttl * 3) {
+      if (!e.key.startsWith('search:') && e.value.age > e.value.ttl * 3) {
         await _storage.deleteCacheEntry(e.key);
         evicted++;
       } else {

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -3,7 +3,18 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show debugPrint;
+
 import '../persistent_dataset.dart';
+
+export 'keyed_cached_dataset_mixin.dart';
+
+/// #3668 — how long a cold-path dataset fetch may run before an existing
+/// (even hard-stale) disk copy is served and the fetch continues in the
+/// background. First paint must never wait on a whole-country download
+/// when ANY previous copy exists. Mutable top-level (the
+/// `stationTransientRetryDelay` pattern) so tests can shrink it.
+Duration datasetStaleServeDeadline = const Duration(seconds: 2);
 
 /// Mixin for services that download a full national dataset and cache it
 /// in memory (MITECO, MISE, Argentina, Denmark).
@@ -102,21 +113,7 @@ mixin CachedDatasetMixin {
   }) async {
     if (cached != null && isDatasetFresh(softTtl)) return cached;
 
-    // Disk read-through — survives cold start + offline. #3154 — the
-    // deserialize runs through compute() inside [PersistentDataset.readAsync]
-    // so the ~11k-fromJson rehydrate stays off the UI isolate.
-    if (cached == null || !isDatasetFresh(hardTtl)) {
-      final disk = await persistent.readAsync();
-      if (disk != null && disk.age <= hardTtl) {
-        store(disk.value);
-        markDatasetRefreshedAt(disk.age);
-        if (disk.age <= softTtl) return disk.value;
-        // Soft-stale: fall through to refresh, but keep the disk copy as a
-        // fallback if the network is unavailable.
-      }
-    }
-
-    try {
+    Future<T> refresh() async {
       // #2313 — dedupe concurrent downloads (one fetch for N simultaneous
       // cold/soft-stale searches). The disk write below runs only for the
       // caller that actually performed the fetch; piggy-backing callers skip
@@ -127,16 +124,73 @@ mixin CachedDatasetMixin {
       markDatasetRefreshed();
       await persistent.write(value, hardTtl: hardTtl);
       return value;
-    } on Object {
-      // Network failed — serve any persisted copy rather than throw.
-      final disk = await persistent.readAsync();
-      if (disk != null) {
-        store(disk.value);
-        markDatasetRefreshedAt(disk.age);
-        return disk.value;
-      }
-      rethrow;
     }
+
+    // #3668 — in-memory soft-stale (still within the hard TTL): serve NOW,
+    // refresh in the background. Blocking a search on the whole-country
+    // re-download while holding a servable copy was the startup-skeleton
+    // bug this fixes.
+    if (cached != null && isDatasetFresh(hardTtl)) {
+      _refreshInBackground(refresh);
+      return cached;
+    }
+
+    // Disk read-through — survives cold start + offline. #3154 — the
+    // deserialize runs through compute() inside [PersistentDataset.readAsync]
+    // so the ~11k-fromJson rehydrate stays off the UI isolate.
+    final disk = await persistent.readAsync();
+    if (disk != null && disk.age <= hardTtl) {
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      if (disk.age <= softTtl) return disk.value;
+      // #3668 — soft-stale disk copy: serve NOW, refresh in the background
+      // (was: fall through and BLOCK on the refresh).
+      _refreshInBackground(refresh);
+      return disk.value;
+    }
+
+    // Past the hard TTL (or nothing persisted): the fetch must run — but a
+    // hard-stale disk copy still caps the wait at [datasetStaleServeDeadline]
+    // (#3668): fresh data is preferred, a blank screen is not.
+    final pending = refresh();
+    if (disk == null) {
+      try {
+        return await pending;
+      } on Object {
+        // Network failed — serve any persisted copy rather than throw.
+        final lateDisk = await persistent.readAsync();
+        if (lateDisk != null) {
+          store(lateDisk.value);
+          markDatasetRefreshedAt(lateDisk.age);
+          return lateDisk.value;
+        }
+        rethrow;
+      }
+    }
+    try {
+      return await pending.timeout(datasetStaleServeDeadline);
+    } on TimeoutException {
+      _swallowBackground(pending);
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      return disk.value;
+    } on Object {
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      return disk.value;
+    }
+  }
+
+  /// Fire-and-forget a refresh future, logging (never throwing) its
+  /// eventual failure — an unhandled async error would crash the zone
+  /// (#3668).
+  void _refreshInBackground(Future<Object?> Function() refresh) =>
+      _swallowBackground(refresh());
+
+  void _swallowBackground(Future<Object?> pending) {
+    unawaited(pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
+      debugPrint('CachedDatasetMixin: background dataset refresh failed: $e');
+    }));
   }
 
   /// Completeness-gated variant of [loadPersistentDataset] (#2249).
@@ -170,16 +224,7 @@ mixin CachedDatasetMixin {
   }) async {
     if (cached != null && isDatasetFresh(softTtl)) return cached;
 
-    if (cached == null || !isDatasetFresh(hardTtl)) {
-      final disk = await persistent.readAsync(); // #3154 — off-isolate
-      if (disk != null && disk.age <= hardTtl) {
-        store(disk.value);
-        markDatasetRefreshedAt(disk.age);
-        if (disk.age <= softTtl) return disk.value;
-      }
-    }
-
-    try {
+    Future<T> refresh() async {
       final value = await _dedupedFetch<T>(fetch);
       store(value);
       if (isComplete(value)) {
@@ -193,125 +238,50 @@ mixin CachedDatasetMixin {
         await persistent.write(value, hardTtl: shortTtl);
       }
       return value;
-    } on Object {
-      final disk = await persistent.readAsync(); // #3154 — off-isolate
-      if (disk != null) {
-        store(disk.value);
-        markDatasetRefreshedAt(disk.age);
-        return disk.value;
-      }
-      rethrow;
-    }
-  }
-}
-
-/// Keyed variant of [CachedDatasetMixin] (#3156).
-///
-/// Some bulk feeds are not ONE national dataset but a *family* of datasets
-/// keyed by a sub-national identifier (ES MITECO: one row set per province).
-/// [CachedDatasetMixin] is single-dataset — one freshness clock, one in-flight
-/// fetch slot — which forced MITECO to hand-roll the very same TTL /
-/// read-through / offline-fallback state machine, a fork where mixin fixes
-/// (the #2313 fetch dedupe, the #3154 off-isolate disk deserialize) never
-/// reached Spain. This mixin is that state machine with per-[key] clocks and
-/// in-flight slots.
-mixin KeyedCachedDatasetMixin {
-  final Map<String, DateTime> _keyedCachedAt = {};
-
-  /// Per-key in-flight fetch slots — same #2313 dedupe contract as
-  /// [CachedDatasetMixin]: concurrent callers for the SAME key share one
-  /// download (the first caller's closure, so a later caller's `CancelToken`
-  /// only awaits, never cancels); different keys fetch independently.
-  final Map<String, Future<dynamic>> _keyedPendingLoads = {};
-
-  /// Whether the in-memory dataset for [key] is still fresh.
-  bool isKeyedDatasetFresh(String key, Duration ttl) {
-    final cachedAt = _keyedCachedAt[key];
-    return cachedAt != null && DateTime.now().difference(cachedAt) < ttl;
-  }
-
-  /// Mark [key]'s in-memory dataset as just refreshed.
-  void markKeyedDatasetRefreshed(String key) =>
-      _keyedCachedAt[key] = DateTime.now();
-
-  /// Stamp [key]'s freshness clock to [age] ago — used when a dataset is
-  /// rehydrated from disk so its remaining freshness reflects the persisted
-  /// copy's age, not the moment of rehydration (#2264).
-  void markKeyedDatasetRefreshedAt(String key, Duration age) =>
-      _keyedCachedAt[key] = DateTime.now().subtract(age);
-
-  /// Per-key [CachedDatasetMixin.loadPersistentDataset] — identical
-  /// soft/hard-TTL, read-through, dedupe and offline-fallback semantics, with
-  /// two host-shaped differences:
-  ///
-  ///  - [persistent] is nullable, so hosts whose disk cache is optional (the
-  ///    pure in-memory parser tests pass no [CacheStrategy]) run the same code
-  ///    path minus the disk steps, and
-  ///  - when [fetch] fails and no disk copy exists, a stale in-memory [cached]
-  ///    copy is served as the last resort before rethrowing (the pre-#3156
-  ///    MITECO offline behaviour: hours-stale province rows beat failing the
-  ///    whole search).
-  Future<T> loadKeyedPersistentDataset<T>({
-    required String key,
-    required T? cached,
-    required Duration softTtl,
-    required Duration hardTtl,
-    required PersistentDataset<T>? persistent,
-    required Future<T> Function() fetch,
-    required void Function(T value) store,
-  }) async {
-    if (cached != null && isKeyedDatasetFresh(key, softTtl)) return cached;
-
-    // Disk read-through — survives cold start + offline; deserialize runs
-    // through compute() inside [PersistentDataset.readAsync] (#3154).
-    if (persistent != null &&
-        (cached == null || !isKeyedDatasetFresh(key, hardTtl))) {
-      final disk = await persistent.readAsync();
-      if (disk != null && disk.age <= hardTtl) {
-        store(disk.value);
-        markKeyedDatasetRefreshedAt(key, disk.age);
-        if (disk.age <= softTtl) return disk.value;
-        // Soft-stale: fall through to refresh, keeping the disk copy as the
-        // fallback if the network is unavailable.
-      }
     }
 
-    try {
-      final value = await _dedupedKeyedFetch<T>(key, fetch);
-      store(value);
-      markKeyedDatasetRefreshed(key);
-      await persistent?.write(value, hardTtl: hardTtl);
-      return value;
-    } on Object {
-      // Network failed — serve any persisted copy rather than throw.
-      if (persistent != null) {
-        final disk = await persistent.readAsync(); // #3154 — off-isolate
-        if (disk != null) {
-          store(disk.value);
-          markKeyedDatasetRefreshedAt(key, disk.age);
-          return disk.value;
+    // #3668 — soft-stale (memory or disk) serves immediately with a
+    // background refresh; a hard-stale disk copy caps the cold fetch at
+    // [datasetStaleServeDeadline]. Same shape as [loadPersistentDataset].
+    if (cached != null && isDatasetFresh(hardTtl)) {
+      _refreshInBackground(refresh);
+      return cached;
+    }
+
+    final disk = await persistent.readAsync(); // #3154 — off-isolate
+    if (disk != null && disk.age <= hardTtl) {
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      if (disk.age <= softTtl) return disk.value;
+      _refreshInBackground(refresh);
+      return disk.value;
+    }
+
+    final pending = refresh();
+    if (disk == null) {
+      try {
+        return await pending;
+      } on Object {
+        final lateDisk = await persistent.readAsync(); // #3154 — off-isolate
+        if (lateDisk != null) {
+          store(lateDisk.value);
+          markDatasetRefreshedAt(lateDisk.age);
+          return lateDisk.value;
         }
+        rethrow;
       }
-      // Last resort: a stale in-memory copy beats failing the search.
-      if (cached != null) return cached;
-      rethrow;
     }
-  }
-
-  /// Per-key twin of the unkeyed mixin's deduped fetch (#2313): collapses
-  /// concurrent calls for the same [key] onto a single in-flight future,
-  /// clearing the slot once it settles so a later call refetches.
-  Future<T> _dedupedKeyedFetch<T>(String key, Future<T> Function() fetch) {
-    final inFlight = _keyedPendingLoads[key];
-    if (inFlight != null) return inFlight.then((v) => v as T);
-    final started = fetch();
-    _keyedPendingLoads[key] = started;
-    return started.whenComplete(() {
-      // Only clear if it's still our future (a later refetch may have
-      // replaced it).
-      if (identical(_keyedPendingLoads[key], started)) {
-        unawaited(_keyedPendingLoads.remove(key));
-      }
-    });
+    try {
+      return await pending.timeout(datasetStaleServeDeadline);
+    } on TimeoutException {
+      _swallowBackground(pending);
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      return disk.value;
+    } on Object {
+      store(disk.value);
+      markDatasetRefreshedAt(disk.age);
+      return disk.value;
+    }
   }
 }

--- a/lib/core/services/mixins/keyed_cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/keyed_cached_dataset_mixin.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import '../persistent_dataset.dart';
+import 'cached_dataset_mixin.dart' show datasetStaleServeDeadline;
+
+/// Keyed variant of [CachedDatasetMixin] (#3156).
+///
+/// Some bulk feeds are not ONE national dataset but a *family* of datasets
+/// keyed by a sub-national identifier (ES MITECO: one row set per province).
+/// [CachedDatasetMixin] is single-dataset — one freshness clock, one in-flight
+/// fetch slot — which forced MITECO to hand-roll the very same TTL /
+/// read-through / offline-fallback state machine, a fork where mixin fixes
+/// (the #2313 fetch dedupe, the #3154 off-isolate disk deserialize) never
+/// reached Spain. This mixin is that state machine with per-[key] clocks and
+/// in-flight slots.
+mixin KeyedCachedDatasetMixin {
+  final Map<String, DateTime> _keyedCachedAt = {};
+
+  /// Per-key in-flight fetch slots — same #2313 dedupe contract as
+  /// [CachedDatasetMixin]: concurrent callers for the SAME key share one
+  /// download (the first caller's closure, so a later caller's `CancelToken`
+  /// only awaits, never cancels); different keys fetch independently.
+  final Map<String, Future<dynamic>> _keyedPendingLoads = {};
+
+  /// Whether the in-memory dataset for [key] is still fresh.
+  bool isKeyedDatasetFresh(String key, Duration ttl) {
+    final cachedAt = _keyedCachedAt[key];
+    return cachedAt != null && DateTime.now().difference(cachedAt) < ttl;
+  }
+
+  /// Mark [key]'s in-memory dataset as just refreshed.
+  void markKeyedDatasetRefreshed(String key) =>
+      _keyedCachedAt[key] = DateTime.now();
+
+  /// Stamp [key]'s freshness clock to [age] ago — used when a dataset is
+  /// rehydrated from disk so its remaining freshness reflects the persisted
+  /// copy's age, not the moment of rehydration (#2264).
+  void markKeyedDatasetRefreshedAt(String key, Duration age) =>
+      _keyedCachedAt[key] = DateTime.now().subtract(age);
+
+  /// Per-key [CachedDatasetMixin.loadPersistentDataset] — identical
+  /// soft/hard-TTL, read-through, dedupe and offline-fallback semantics, with
+  /// two host-shaped differences:
+  ///
+  ///  - [persistent] is nullable, so hosts whose disk cache is optional (the
+  ///    pure in-memory parser tests pass no [CacheStrategy]) run the same code
+  ///    path minus the disk steps, and
+  ///  - when [fetch] fails and no disk copy exists, a stale in-memory [cached]
+  ///    copy is served as the last resort before rethrowing (the pre-#3156
+  ///    MITECO offline behaviour: hours-stale province rows beat failing the
+  ///    whole search).
+  Future<T> loadKeyedPersistentDataset<T>({
+    required String key,
+    required T? cached,
+    required Duration softTtl,
+    required Duration hardTtl,
+    required PersistentDataset<T>? persistent,
+    required Future<T> Function() fetch,
+    required void Function(T value) store,
+  }) async {
+    if (cached != null && isKeyedDatasetFresh(key, softTtl)) return cached;
+
+    Future<T> refresh() async {
+      final value = await _dedupedKeyedFetch<T>(key, fetch);
+      store(value);
+      markKeyedDatasetRefreshed(key);
+      await persistent?.write(value, hardTtl: hardTtl);
+      return value;
+    }
+
+    // #3668 — soft-stale (memory or disk) serves immediately with a
+    // background refresh; a hard-stale disk copy caps the cold fetch at
+    // [datasetStaleServeDeadline]. Same shape as the unkeyed mixin.
+    if (cached != null && isKeyedDatasetFresh(key, hardTtl)) {
+      _swallowKeyedBackground(refresh());
+      return cached;
+    }
+
+    // Disk read-through — survives cold start + offline; deserialize runs
+    // through compute() inside [PersistentDataset.readAsync] (#3154).
+    ({T value, Duration age})? disk;
+    if (persistent != null) {
+      disk = await persistent.readAsync();
+      if (disk != null && disk.age <= hardTtl) {
+        store(disk.value);
+        markKeyedDatasetRefreshedAt(key, disk.age);
+        if (disk.age <= softTtl) return disk.value;
+        _swallowKeyedBackground(refresh());
+        return disk.value;
+      }
+    }
+
+    final pending = refresh();
+    if (disk != null) {
+      try {
+        return await pending.timeout(datasetStaleServeDeadline);
+      } on TimeoutException {
+        _swallowKeyedBackground(pending);
+        store(disk.value);
+        markKeyedDatasetRefreshedAt(key, disk.age);
+        return disk.value;
+      } on Object {
+        store(disk.value);
+        markKeyedDatasetRefreshedAt(key, disk.age);
+        return disk.value;
+      }
+    }
+    try {
+      return await pending;
+    } on Object {
+      // Network failed — serve any persisted copy rather than throw.
+      if (persistent != null) {
+        final lateDisk = await persistent.readAsync(); // #3154 — off-isolate
+        if (lateDisk != null) {
+          store(lateDisk.value);
+          markKeyedDatasetRefreshedAt(key, lateDisk.age);
+          return lateDisk.value;
+        }
+      }
+      // Last resort: a stale in-memory copy beats failing the search.
+      if (cached != null) return cached;
+      rethrow;
+    }
+  }
+
+  /// Keyed twin of the unkeyed mixin's background-swallow (#3668).
+  void _swallowKeyedBackground(Future<Object?> pending) {
+    unawaited(pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
+      debugPrint(
+          'KeyedCachedDatasetMixin: background dataset refresh failed: $e');
+    }));
+  }
+
+  /// Per-key twin of the unkeyed mixin's deduped fetch (#2313): collapses
+  /// concurrent calls for the same [key] onto a single in-flight future,
+  /// clearing the slot once it settles so a later call refetches.
+  Future<T> _dedupedKeyedFetch<T>(String key, Future<T> Function() fetch) {
+    final inFlight = _keyedPendingLoads[key];
+    if (inFlight != null) return inFlight.then((v) => v as T);
+    final started = fetch();
+    _keyedPendingLoads[key] = started;
+    return started.whenComplete(() {
+      // Only clear if it's still our future (a later refetch may have
+      // replaced it).
+      if (identical(_keyedPendingLoads[key], started)) {
+        unawaited(_keyedPendingLoads.remove(key));
+      }
+    });
+  }
+}

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -23,6 +23,8 @@ import 'station_service.dart';
 import 'station_service_chain_codec.dart';
 import 'station_transient_retry.dart';
 
+part 'station_service_chain_coalescing.dart';
+
 /// Orchestrates station data retrieval with fallback:
 ///
 ///   1. Fresh cache (< TTL) → return immediately (skip API)
@@ -50,10 +52,12 @@ import 'station_transient_retry.dart';
 /// When no policy is supplied (legacy call sites + most chain unit tests) the
 /// chain defaults to the polled path with [CacheTtl.stationSearch], so its
 /// observable behaviour is unchanged.
-class StationServiceChain implements StationService {
+class StationServiceChain with _ChainCoalescing implements StationService {
+  @override
   final StationService _primary;
   final CacheStrategy _cache;
   final ServiceSource _errorSource;
+  @override
   final String countryCode;
 
   /// Data-source policy (#2264). Controls whether [searchStations] uses the
@@ -67,6 +71,7 @@ class StationServiceChain implements StationService {
   /// `Feature.debugMode` the registry hands a live recorder here and the
   /// network-vs-cache outcome of each access is recorded for the rate-limit
   /// compliance + cache-hit-ratio export.
+  @override
   final DataAccessRecorder? _recorder;
 
   /// Shared foreground+background per-provider request budget (#2866). When
@@ -75,17 +80,8 @@ class StationServiceChain implements StationService {
   /// next background scan can see that the foreground just hit this provider
   /// and skip it within its `minInterval`. Null for the legacy call sites /
   /// unit tests that don't wire a budget — then no stamp is written.
+  @override
   final ProviderRequestBudget? _budget;
-
-  /// In-flight request deduplication: concurrent calls for the same cache key
-  /// share a single Future instead of hitting the API multiple times.
-  /// Entries are removed in the finally block of [_throughChain] and also
-  /// evicted if older than [_inFlightMaxAge] to prevent leaks.
-  final _inFlight = <String, Future<ServiceResult<dynamic>>>{};
-  final _inFlightTimestamps = <String, DateTime>{};
-
-  /// Max time an entry can stay in _inFlight before forced eviction.
-  static const _inFlightMaxAge = Duration(minutes: 2);
 
   StationServiceChain(this._primary, this._cache, {
     ServiceSource errorSource = ServiceSource.tankerkoenigApi,
@@ -187,8 +183,23 @@ class StationServiceChain implements StationService {
     // under load) and the Argentina CKAN bulk-download (#1955 — slow
     // first-byte triggering Dio's connect timeout). Both recover on a
     // second attempt within a second.
-    final apiClock = Stopwatch()..start();
-    try {
+    //
+    // #3668 — the stale tier is a LATENCY fallback too, not only a
+    // failure fallback. When a servable stale entry exists, the fetch
+    // races a short first-paint deadline: past it, the stale entry is
+    // served (`isStale: true` — the ServiceStatusBanner renders the
+    // "updating" state) while the fetch keeps running in the background
+    // and caches its result, so the NEXT read is fresh. Field case: FR
+    // legacy polling on weak 4G held the search skeleton >10 s (worst
+    // case ~90 s: 15 s connect + 30 s receive + one retry) with
+    // yesterday's results sitting in Hive the whole time.
+    final staleForRace = _staleResult<T>(
+      cacheKey, endpoint, deserialize, check, errors,
+      recordHit: false,
+    );
+
+    Future<ServiceResult<T>> fetchAndCache() async {
+      final apiClock = Stopwatch()..start();
       final result = await callWithTransientRetry(apiCall);
       apiClock.stop();
       await _cache.put(
@@ -206,6 +217,27 @@ class StationServiceChain implements StationService {
       // minInterval. Fire-and-forget; null in legacy/test call sites.
       _budget?.recordRequest(countryCode);
       return result;
+    }
+
+    final pending = fetchAndCache();
+    try {
+      if (staleForRace != null) {
+        return await pending.timeout(stalePaintDeadline);
+      }
+      return await pending;
+    } on TimeoutException {
+      // Deadline hit with a stale fallback in hand: serve it now, let the
+      // fetch finish (and cache) in the background. Its eventual failure
+      // is logged, never thrown into the void.
+      unawaited(pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
+        recordDataAccessFailure(countryCode);
+        logStationApiFailure(e is Exception ? e : Exception(e.toString()), st,
+            countryCode: countryCode, cacheKey: cacheKey);
+      }));
+      recordDataAccess(_recorder, countryCode, endpoint,
+          DataAccessHit.hiveStale, ServiceSource.cache,
+          count: dataAccessResultCount(staleForRace!.data), isStale: true);
+      return staleForRace;
     } on Exception catch (e, st) {
       recordDataAccessFailure(countryCode); // #3146 — always-on tally
       // #3370/#2296 — breadcrumb an EXPECTED `unsupported` gap (e.g. Luxembourg
@@ -221,27 +253,56 @@ class StationServiceChain implements StationService {
       ));
     }
 
-    // Step 3: Stale cache
-    final stale = _cache.get(cacheKey);
-    if (stale != null) {
-      final data = deserialize(stale.payload);
-      if (data != null && check(data)) {
-        recordDataAccess(_recorder, countryCode, endpoint,
-            DataAccessHit.hiveStale, ServiceSource.cache,
-            count: dataAccessResultCount(data), isStale: true);
-        return ServiceResult(
-          data: data,
-          source: ServiceSource.cache,
-          fetchedAt: stale.storedAt,
-          isStale: true,
-          errors: errors,
-        );
-      }
-    }
+    // Step 3: Stale cache (fetch failed — re-read so the hit is recorded
+    // and the accumulated errors ride along on the result).
+    final stale = _staleResult<T>(
+      cacheKey, endpoint, deserialize, check, errors,
+      recordHit: true,
+    );
+    if (stale != null) return stale;
 
     // Step 4: Nothing worked
     throw ServiceChainExhaustedException(errors: errors);
   }
+
+  /// Deserialize the stale cache entry for [cacheKey] into a servable
+  /// [ServiceResult], or null when absent/invalid (#3668). [recordHit]
+  /// controls whether the diagnostics recorder is stamped — the race
+  /// pre-read must not record a hit it may never serve.
+  ServiceResult<T>? _staleResult<T>(
+    String cacheKey,
+    DataAccessEndpoint endpoint,
+    T? Function(Map<String, dynamic> data) deserialize,
+    bool Function(T data) check,
+    List<ServiceError> errors, {
+    required bool recordHit,
+  }) {
+    final stale = _cache.get(cacheKey);
+    if (stale == null) return null;
+    final data = deserialize(stale.payload);
+    if (data == null || !check(data)) return null;
+    if (recordHit) {
+      recordDataAccess(_recorder, countryCode, endpoint,
+          DataAccessHit.hiveStale, ServiceSource.cache,
+          count: dataAccessResultCount(data), isStale: true);
+    }
+    return ServiceResult(
+      data: data,
+      source: ServiceSource.cache,
+      fetchedAt: stale.storedAt,
+      isStale: true,
+      errors: List.of(errors),
+    );
+  }
+
+  /// #3668 — first-paint deadline for the stale race: when a servable
+  /// stale entry exists, the API call gets this long to answer before
+  /// the stale entry is served and the fetch continues in the
+  /// background. 2 s keeps a fast network fresh-first while capping the
+  /// startup skeleton; mutable for tests (pattern of
+  /// [transientRetryDelay]).
+  @visibleForTesting
+  static Duration stalePaintDeadline = const Duration(seconds: 2);
 
   /// Delay between the first and second attempt of the in-chain transient
   /// retry. Re-exports the single source of truth in
@@ -301,59 +362,6 @@ class StationServiceChain implements StationService {
     return identical(filtered, result.data) ? result : result.withData(filtered);
   }
 
-  /// Bulk-dataset search path (#2264): no per-key Hive cache. Adds only the
-  /// resilience layers that matter — in-flight coalescing + the single
-  /// transient retry — then returns the primary's result verbatim, so search
-  /// results are byte-identical to calling the primary directly.
-  Future<ServiceResult<List<Station>>> _bulkSearch(
-    SearchParams params, {
-    CancelToken? cancelToken,
-  }) async {
-    _evictStaleInFlight();
-    final key = 'bulk:${CacheKey.stationSearch(
-      params.lat, params.lng, params.radiusKm, params.fuelType.apiValue,
-      countryCode: countryCode,
-      postalCode: params.postalCode,
-      locationName: params.locationName,
-    )}';
-
-    if (_inFlight.containsKey(key)) {
-      final result = await _inFlight[key]!;
-      if (result.data is List<Station>) {
-        recordDataAccess(_recorder, countryCode,
-            DataAccessEndpoint.bulkDataset, DataAccessHit.coalesced,
-            result.source,
-            count: dataAccessResultCount(result.data),
-            isStale: result.isStale);
-        return result.withData<List<Station>>(result.data as List<Station>);
-      }
-    }
-
-    final future = callWithTransientRetry(
-      () => _primary.searchStations(params, cancelToken: cancelToken),
-    );
-    _inFlight[key] = future;
-    _inFlightTimestamps[key] = DateTime.now();
-    final bulkClock = Stopwatch()..start();
-    try {
-      final result = await future;
-      bulkClock.stop();
-      recordDataAccess(_recorder, countryCode, DataAccessEndpoint.bulkDataset,
-          DataAccessHit.networkApi, result.source,
-          count: dataAccessResultCount(result.data),
-          latencyMicros: bulkClock.elapsedMicroseconds,
-          isStale: result.isStale);
-      // #2866 — stamp the shared per-provider (here: per-dataset) budget so a
-      // background scan won't re-download the whole-country dataset within the
-      // policy's minInterval after a foreground search just fetched it.
-      _budget?.recordRequest(countryCode);
-      return result;
-    } finally {
-      unawaited(_inFlight.remove(key) ?? Future<void>.value());
-      _inFlightTimestamps.remove(key);
-    }
-  }
-
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,
@@ -381,20 +389,4 @@ class StationServiceChain implements StationService {
         deserialize: deserializePrices,
         ttl: CacheTtl.prices,
       );
-
-  /// Remove in-flight entries older than [_inFlightMaxAge].
-  /// Guards against orphaned futures from unhandled exceptions or timeouts.
-  void _evictStaleInFlight() {
-    final now = DateTime.now();
-    final staleKeys = _inFlightTimestamps.entries
-        .where((e) => now.difference(e.value) > _inFlightMaxAge)
-        .map((e) => e.key)
-        .toList();
-    for (final key in staleKeys) {
-      unawaited(_inFlight.remove(key));
-      _inFlightTimestamps.remove(key);
-      debugPrint('StationServiceChain: evicted stale in-flight entry: $key');
-    }
-  }
-
 }

--- a/lib/core/services/station_service_chain_coalescing.dart
+++ b/lib/core/services/station_service_chain_coalescing.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+part of 'station_service_chain.dart';
+
+/// #3668 — the chain's in-flight coalescing state + the bulk-dataset
+/// search path, split out of `station_service_chain.dart` as a `part`
+/// mixin to keep the chain file under the #1680 length ratchet after
+/// the stale-first deadline race landed. Same library, so the private
+/// fields on [StationServiceChain] satisfy the abstract members below.
+mixin _ChainCoalescing {
+  // Satisfied by the fields/getters on [StationServiceChain].
+  StationService get _primary;
+  DataAccessRecorder? get _recorder;
+  ProviderRequestBudget? get _budget;
+  String get countryCode;
+
+  /// In-flight request deduplication: concurrent calls for the same cache key
+  /// share a single Future instead of hitting the API multiple times.
+  /// Entries are removed in the finally block of `_throughChain` and also
+  /// evicted if older than [_inFlightMaxAge] to prevent leaks.
+  final _inFlight = <String, Future<ServiceResult<dynamic>>>{};
+  final _inFlightTimestamps = <String, DateTime>{};
+
+  /// Max time an entry can stay in _inFlight before forced eviction.
+  static const _inFlightMaxAge = Duration(minutes: 2);
+
+  /// Bulk-dataset search path (#2264): no per-key Hive cache. Adds only the
+  /// resilience layers that matter — in-flight coalescing + the single
+  /// transient retry — then returns the primary's result verbatim, so search
+  /// results are byte-identical to calling the primary directly.
+  Future<ServiceResult<List<Station>>> _bulkSearch(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    _evictStaleInFlight();
+    final key = 'bulk:${CacheKey.stationSearch(
+      params.lat, params.lng, params.radiusKm, params.fuelType.apiValue,
+      countryCode: countryCode,
+      postalCode: params.postalCode,
+      locationName: params.locationName,
+    )}';
+
+    if (_inFlight.containsKey(key)) {
+      final result = await _inFlight[key]!;
+      if (result.data is List<Station>) {
+        recordDataAccess(_recorder, countryCode,
+            DataAccessEndpoint.bulkDataset, DataAccessHit.coalesced,
+            result.source,
+            count: dataAccessResultCount(result.data),
+            isStale: result.isStale);
+        return result.withData<List<Station>>(result.data as List<Station>);
+      }
+    }
+
+    final future = callWithTransientRetry(
+      () => _primary.searchStations(params, cancelToken: cancelToken),
+    );
+    _inFlight[key] = future;
+    _inFlightTimestamps[key] = DateTime.now();
+    final bulkClock = Stopwatch()..start();
+    try {
+      final result = await future;
+      bulkClock.stop();
+      recordDataAccess(_recorder, countryCode, DataAccessEndpoint.bulkDataset,
+          DataAccessHit.networkApi, result.source,
+          count: dataAccessResultCount(result.data),
+          latencyMicros: bulkClock.elapsedMicroseconds,
+          isStale: result.isStale);
+      // #2866 — stamp the shared per-provider (here: per-dataset) budget so a
+      // background scan won't re-download the whole-country dataset within the
+      // policy's minInterval after a foreground search just fetched it.
+      _budget?.recordRequest(countryCode);
+      return result;
+    } finally {
+      unawaited(_inFlight.remove(key) ?? Future<void>.value());
+      _inFlightTimestamps.remove(key);
+    }
+  }
+
+  /// Remove in-flight entries older than [_inFlightMaxAge].
+  /// Guards against orphaned futures from unhandled exceptions or timeouts.
+  void _evictStaleInFlight() {
+    final now = DateTime.now();
+    final staleKeys = _inFlightTimestamps.entries
+        .where((e) => now.difference(e.value) > _inFlightMaxAge)
+        .map((e) => e.key)
+        .toList();
+    for (final key in staleKeys) {
+      unawaited(_inFlight.remove(key));
+      _inFlightTimestamps.remove(key);
+      debugPrint('StationServiceChain: evicted stale in-flight entry: $key');
+    }
+  }
+}

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -403,6 +403,36 @@ void main() {
       expect(cache.get('still-fresh'), isNotNull);
     });
 
+    test('search:-prefixed entries are EXEMPT from the 3x-TTL sweep — '
+        'they are the stale-first paint\'s startup fallback (#3668)',
+        () async {
+      // storedAt epoch 0 → decades past any TTL.
+      await fakeStorage.cacheData('search:FR:48.85:2.35:10.0:e85', {
+        'payload': {'stations': <Object>[]},
+        'storedAt': 0,
+        'source': ServiceSource.cache.index,
+        'ttlMs': 1,
+      });
+      await fakeStorage.cacheData('detail:ancient', {
+        'payload': {'x': 1},
+        'storedAt': 0,
+        'source': ServiceSource.cache.index,
+        'ttlMs': 1,
+      });
+
+      final evicted = await cache.evictExpired();
+      expect(evicted, 1, reason: 'only the non-search entry goes');
+      expect(cache.get('search:FR:48.85:2.35:10.0:e85'), isNotNull,
+          reason: 'last-known search results must survive — a week-old '
+              'price list with the stale banner beats a startup skeleton');
+      expect(cache.get('detail:ancient'), isNull);
+
+      // The bounded sweep honours the same exemption in its pass 1.
+      final evicted2 = await cache.evictBounded();
+      expect(evicted2, 0);
+      expect(cache.get('search:FR:48.85:2.35:10.0:e85'), isNotNull);
+    });
+
     test('evictExpired returns 0 when nothing to evict', () async {
       await cache.put('fresh', {'v': 1},
           ttl: const Duration(hours: 1), source: ServiceSource.cache);

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -11,6 +11,8 @@ import 'package:tankstellen/core/services/service_result.dart';
 
 class _TestCached with CachedDatasetMixin {}
 
+class _TestKeyedCached with KeyedCachedDatasetMixin {}
+
 /// Tiny in-memory CacheStrategy for the persistence tests.
 class _MemCache implements CacheStrategy {
   final Map<String, CacheEntry> _store = {};
@@ -422,4 +424,160 @@ void main() {
       expect(persistent.read()?.value, [5, 5]);
     });
   });
+  group('stale-first serve + background refresh (#3668)', () {
+    setUp(() => datasetStaleServeDeadline = const Duration(milliseconds: 50));
+    tearDown(() => datasetStaleServeDeadline = const Duration(seconds: 2));
+
+    test('a soft-stale DISK copy is served immediately; the refresh runs '
+        'in the background and persists', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([1, 2], hardTtl: const Duration(days: 1));
+
+      final gate = Completer<void>();
+      var fetchCalls = 0;
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: Duration.zero, // just-written copy is already soft-stale
+        hardTtl: const Duration(days: 1),
+        persistent: persistent,
+        fetch: () async {
+          fetchCalls++;
+          await gate.future;
+          return [9];
+        },
+        store: (_) {},
+      );
+
+      expect(result, [1, 2],
+          reason: 'the servable copy must paint first — the whole-country '
+              'refresh may not block the search');
+      expect(fetchCalls, 1, reason: 'the background refresh must start');
+
+      gate.complete();
+      await pumpEventQueue();
+      expect(persistent.read()?.value, [9],
+          reason: 'the background refresh must persist its result');
+      expect(cached.isDatasetFresh(const Duration(minutes: 5)), isTrue,
+          reason: 'the background refresh must stamp the freshness clock');
+    });
+
+    test('an in-memory soft-stale copy is served immediately with a '
+        'background refresh', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      cached.markDatasetRefreshed(); // in-memory copy exists…
+      final gate = Completer<void>();
+
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: const [5],
+        softTtl: Duration.zero, // …but is already soft-stale
+        hardTtl: const Duration(days: 1),
+        persistent: persistent,
+        fetch: () async {
+          await gate.future;
+          return [9];
+        },
+        store: (_) {},
+      );
+
+      expect(result, const [5]);
+      gate.complete();
+      await pumpEventQueue();
+      expect(persistent.read()?.value, [9]);
+    });
+
+    test('a HARD-stale disk copy still caps the cold fetch at the '
+        'deadline instead of blanking the screen', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      // hardTtl zero → the persisted copy is immediately past the hard TTL.
+      await persistent.write([1, 2], hardTtl: const Duration(days: 1));
+
+      final gate = Completer<void>();
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: Duration.zero,
+        hardTtl: Duration.zero,
+        persistent: persistent,
+        fetch: () async {
+          await gate.future;
+          return [9];
+        },
+        store: (_) {},
+      );
+
+      expect(result, [1, 2],
+          reason: 'past the deadline, an ancient copy beats a skeleton');
+      gate.complete();
+      await pumpEventQueue();
+      expect(persistent.read()?.value, [9]);
+    });
+
+    test('with NOTHING persisted the cold fetch still blocks (true first '
+        'run — there is nothing to serve instead)', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: Duration.zero,
+        hardTtl: Duration.zero,
+        persistent: persistent,
+        fetch: () async => [9],
+        store: (_) {},
+      );
+      expect(result, [9]);
+    });
+
+    test('a FAILING background refresh completes normally — the swallow '
+        'is the never-throws boundary, fault-injected (#3668)', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([1, 2], hardTtl: const Duration(days: 1));
+
+      // Soft-stale copy → serve-then-refresh; the refresh THROWS.
+      await expectLater(
+        cached.loadPersistentDataset<List<int>>(
+          cached: null,
+          softTtl: Duration.zero,
+          hardTtl: const Duration(days: 1),
+          persistent: persistent,
+          fetch: () async => throw StateError('upstream down'),
+          store: (_) {},
+        ),
+        completes,
+      );
+      // Let the background failure settle — it must be swallowed (logged),
+      // never thrown into the zone.
+      await pumpEventQueue();
+    });
+
+    test('keyed variant: soft-stale disk copy serves immediately with a '
+        'background refresh', () async {
+      final keyed = _TestKeyedCached();
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([1, 2], hardTtl: const Duration(days: 1));
+
+      final gate = Completer<void>();
+      final result = await keyed.loadKeyedPersistentDataset<List<int>>(
+        key: 'p1',
+        cached: null,
+        softTtl: Duration.zero,
+        hardTtl: const Duration(days: 1),
+        persistent: persistent,
+        fetch: () async {
+          await gate.future;
+          return [9];
+        },
+        store: (_) {},
+      );
+
+      expect(result, [1, 2]);
+      gate.complete();
+      await pumpEventQueue();
+      expect(persistent.read()?.value, [9]);
+    });
+  });
+
 }

--- a/test/core/services/station_service_chain_stale_race_test.dart
+++ b/test/core/services/station_service_chain_stale_race_test.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/domain/fuel_type.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/domain/search_params.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+/// #3668 — the stale tier is a LATENCY fallback, not only a failure
+/// fallback. When a servable stale entry exists, a fetch slower than
+/// [StationServiceChain.stalePaintDeadline] must NOT hold the first
+/// paint: the stale entry is served (`isStale: true`) and the fetch
+/// finishes in the background, caching its result for the next read.
+///
+/// Field case this pins: FR legacy polling on weak 4G held the search
+/// skeleton >10 s (worst case ~90 s) with yesterday's results sitting
+/// in Hive the whole time.
+///
+/// No wall-clock reads here (wall-clock ratchet #3660): staleness is
+/// driven by the fake cache's `freshEnabled` switch, not by entry age.
+class _GatedService implements StationService {
+  _GatedService(this.stations);
+
+  final List<Station> stations;
+
+  /// When non-null, [searchStations] parks on this until completed.
+  Completer<void>? gate;
+
+  /// When non-null, thrown instead of returning.
+  Object? failure;
+
+  int callCount = 0;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    callCount++;
+    final g = gate;
+    if (g != null) await g.future;
+    final f = failure;
+    if (f != null) throw f;
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String id, {
+    CancelToken? cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids, {
+    CancelToken? cancelToken,
+  }) =>
+      throw UnimplementedError();
+}
+
+/// In-memory cache whose FRESH tier can be switched off, so a stored
+/// entry is visible only to the stale tier — exactly the state a
+/// past-TTL startup finds on disk.
+class _StaleCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+  bool freshEnabled = true;
+  int putCount = 0;
+
+  @override
+  Future<void> put(
+    String key,
+    Map<String, dynamic> data, {
+    required Duration ttl,
+    required ServiceSource source,
+  }) async {
+    putCount++;
+    _store[key] = CacheEntry(
+      payload: data,
+      storedAt: DateTime.fromMillisecondsSinceEpoch(0),
+      originalSource: source,
+      ttl: ttl,
+    );
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) => freshEnabled ? _store[key] : null;
+}
+
+SearchParams _params() => const SearchParams(
+      lat: 48.85,
+      lng: 2.35,
+      radiusKm: 5,
+      fuelType: FuelType.all,
+    );
+
+Station _station(String id) => Station(
+      id: id,
+      name: 'S$id',
+      brand: 'B',
+      street: '',
+      place: '',
+      postCode: '',
+      lat: 48.85,
+      lng: 2.35,
+      dist: 0.1,
+      isOpen: true,
+    );
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late _GatedService service;
+  late _StaleCache cache;
+  late StationServiceChain chain;
+
+  setUp(() {
+    StationServiceChain.stalePaintDeadline = const Duration(milliseconds: 80);
+    StationServiceChain.transientRetryDelay = const Duration(milliseconds: 1);
+    service = _GatedService([_station('fresh-1')]);
+    cache = _StaleCache();
+    chain = StationServiceChain(service, cache, countryCode: 'FR');
+  });
+
+  tearDown(() {
+    StationServiceChain.stalePaintDeadline = const Duration(seconds: 2);
+    StationServiceChain.transientRetryDelay =
+        const Duration(milliseconds: 500);
+  });
+
+  /// Seed the cache through the chain itself so the stale payload uses
+  /// the real codec, then flip the fresh tier off.
+  Future<void> seedStale() async {
+    final seeded = await chain.searchStations(_params());
+    expect(seeded.isStale, isFalse);
+    cache.freshEnabled = false;
+  }
+
+  group('stale-first paint deadline race (#3668)', () {
+    test('a fetch slower than the deadline serves the stale entry — and '
+        'the background fetch still lands in the cache', () async {
+      await seedStale();
+      final putsAfterSeed = cache.putCount;
+
+      // Second search: fetch parks on the gate — slower than the 80 ms
+      // deadline.
+      service.gate = Completer<void>();
+      final result = await chain.searchStations(_params());
+
+      expect(result.isStale, isTrue,
+          reason: 'the stale entry must be served at the deadline');
+      expect(result.source, ServiceSource.cache);
+      expect(result.data.map((s) => s.id), contains('fresh-1'));
+
+      // Release the fetch: its result must still be cached so the NEXT
+      // read is fresh.
+      service.gate!.complete();
+      await pumpEventQueue();
+      expect(cache.putCount, greaterThan(putsAfterSeed),
+          reason: 'the background fetch must cache its result');
+    });
+
+    test('a fetch faster than the deadline returns FRESH data', () async {
+      await seedStale();
+      final result = await chain.searchStations(_params());
+      expect(result.isStale, isFalse);
+      expect(result.source, ServiceSource.tankerkoenigApi);
+    });
+
+    test('with NO stale entry the chain waits out a slow fetch', () async {
+      service.gate = Completer<void>();
+      final pending = chain.searchStations(_params());
+      var done = false;
+      unawaited(pending.then((_) => done = true));
+
+      // Well past the deadline: still waiting — nothing to serve instead.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      expect(done, isFalse,
+          reason: 'with no fallback there is nothing to race against');
+
+      service.gate!.complete();
+      final result = await pending;
+      expect(result.isStale, isFalse);
+    });
+
+    test('a fetch that FAILS fast falls through to stale with the error '
+        'attached (pre-#3668 contract preserved)', () async {
+      await seedStale();
+      service.failure =
+          const ApiException(message: 'boom', statusCode: 500);
+
+      final result = await chain.searchStations(_params());
+      expect(result.isStale, isTrue);
+      expect(result.errors, isNotEmpty);
+    });
+  });
+}

--- a/test/lint/wall_clock_test.dart
+++ b/test/lint/wall_clock_test.dart
@@ -57,12 +57,17 @@ void main() {
     'lib/core/services/diagnostics/data_access_recorder.dart': 2,
     'lib/core/services/geocoding_chain.dart': 6,
     'lib/core/services/impl/demo_station_service.dart': 4,
-    'lib/core/services/mixins/cached_dataset_mixin.dart': 6,
+    // #3668 decomposition: 6 reads split 3/3 with the keyed mixin —
+    // a move, not a widening (total unchanged).
+    'lib/core/services/mixins/cached_dataset_mixin.dart': 3,
+    'lib/core/services/mixins/keyed_cached_dataset_mixin.dart': 3,
     'lib/core/services/mixins/station_service_helpers.dart': 2,
     'lib/core/services/radar/highway_mode_provider.dart': 1,
     'lib/core/services/rate_limit_interceptor.dart': 1,
     'lib/core/services/service_result.dart': 1,
-    'lib/core/services/station_service_chain.dart': 4,
+    // #3668 decomposition: 4 reads split 2/2 with the coalescing part.
+    'lib/core/services/station_service_chain.dart': 2,
+    'lib/core/services/station_service_chain_coalescing.dart': 2,
     'lib/core/services/widgets/freshness_badge.dart': 1,
     'lib/core/storage/stores/cache_hive_store.dart': 2,
     'lib/core/sync/baselines_sync.dart': 1,


### PR DESCRIPTION
## Field report

FR / E85 / 10 km, weak 4G: **>10 s of skeletons at every app start** despite a <1 min GPS fix — and yesterday's results sitting in Hive the whole time.

## Why it was possible (three compounding causes)

1. **The stale tier was a *failure* fallback, not a *latency* fallback.** The chain runs fresh → API → stale strictly in sequence: a slow-but-alive fetch (FR legacy = up to two sequential `data.economie.gouv.fr` GETs; 15 s connect + 30 s receive + one transient retry ⇒ worst case ~90 s) held the skeleton with servable data on disk.
2. **FR legacy TTL is 6 h ⇒ every morning start is a fresh-miss**, so the blocking fetch was the *common* path.
3. **The 3×TTL eviction sweep deleted search entries after 18 h** — after a day away, even the failure fallback was gone.

Bulk sources (`CachedDatasetMixin`) had the same bug in a second form: a soft-stale persisted whole-country dataset "fell through to refresh" (blocked on the download it could have backgrounded), and past the hard TTL the disk copy wasn't served at all until the fetch *failed*.

## The fix — first paint never waits on the network

- **Chain (all polled countries):** with a valid stale entry in hand, the fetch races a **2 s first-paint deadline** (`stalePaintDeadline`, test-mutable). Past it, the stale result is served (`isStale: true` — the existing ServiceStatusBanner shows "updating") and the fetch completes in the background, caching for the next read. No fallback → waits exactly as before.
- **Bulk loaders (unkeyed/guarded/keyed):** serve-then-refresh — a soft-stale copy returns immediately with a deduped background refresh; a hard-stale disk copy caps the cold fetch at the same deadline; a true first run still blocks (nothing to serve). Background failures are swallowed-and-logged (fault-injection test per the never-throws contract).
- **Eviction:** `search:` entries are exempt from the 3×TTL expiry pass (still bounded by the per-prefix budget + byte ceiling) — a week-old price list with the stale banner beats a skeleton.

Expected effect: startup shows last-known stations within ~2 s worst-case whenever the app has EVER searched here; fresh prices swap in on the next interaction or refresh.

## Tests

New chain race suite (stale-served-at-deadline + background cache landing, fresh-when-fast, waits-when-no-fallback, fail-fast contract preserved); mixin SWR suite (soft-stale memory/disk serve-immediately, hard-stale deadline cap, first-run blocks, keyed variant, failing-background-refresh fault injection); eviction exemption. File-length ratchet honoured by decomposition (keyed mixin → own file re-exported; chain coalescing/bulk → `part` mixin); wall-clock baseline entries moved with the code, totals unchanged.

Detached-worktree verification: analyze clean, full suite 15,499 passed (sole failure: the recurring Argentina live-API connectivity flake).

Closes #3668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
