### PR TITLE
fix: field-log findings — stop never awaits the network (#3670), whole-dial budget + no background re-scan (#3671), schema breadcrumb once per session (#3672)

### DIFF
--- a/lib/core/sync/deletions_sync.dart
+++ b/lib/core/sync/deletions_sync.dart
@@ -108,7 +108,14 @@ class DeletionsSync {
 
   /// #3331 — one actionable breadcrumb (NOT an ERROR trace) for the
   /// outdated-self-host-schema case, so it doesn't flood the error log.
+  /// #3672 — once per SESSION: the field export showed it 3x within
+  /// 400 ms (one per recorded tombstone); the message is identical and
+  /// actionable exactly once.
+  static bool _breadcrumbedAbsentThisSession = false;
+
   static void _breadcrumbDeletionsAbsent() {
+    if (_breadcrumbedAbsentThisSession) return;
+    _breadcrumbedAbsentThisSession = true;
     BreadcrumbCollector.add(
       'sync: deletions table absent',
       detail: 'self-host TankSync schema predates the deletion-tombstones '

--- a/lib/features/consumption/providers/trip_baseline_recorder.dart
+++ b/lib/features/consumption/providers/trip_baseline_recorder.dart
@@ -7,8 +7,6 @@ import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/hive_boxes.dart';
-import '../../../core/sync/baselines_sync.dart';
-import '../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../../core/domain/vehicle_profile.dart';
 import '../../vehicle/domain/fuzzy_classifier.dart';
 import '../../vehicle/providers/calibration_mode_providers.dart';
@@ -16,6 +14,7 @@ import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/baseline_store.dart';
 import '../../obd2/api.dart';
 import '../domain/baseline_rolling_state.dart';
+import 'trip_baseline_sync.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/situation_classifier.dart';
 import '../../../core/logging/error_logger.dart';
@@ -115,7 +114,14 @@ class TripBaselineRecorder {
         unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: baseline flush failed'}));
       }
       // #780 — fold in the server copy once the local flush lands.
-      await _syncBaselineAfterFlush(vid);
+      // #3670 — fire-and-forget: the merge is a network round-trip to a
+      // possibly-unreachable self-host Supabase, and awaiting it held
+      // the stop UI at "Saving to history…" for minutes in the field
+      // (handshake failures + 30 s sync timeouts in the same log). The
+      // local flush above is the durable part; the server fold-in may
+      // land whenever the network allows. _syncBaselineAfterFlush
+      // never throws (its own catch), so unawaited is safe.
+      unawaited(syncBaselineAfterFlush(_ref, vid));
     }
     _store = null;
     _vehicleId = null;
@@ -369,34 +375,4 @@ class TripBaselineRecorder {
   /// trip. No-op when the Hive box is closed or the sync client
   /// is offline/unauthenticated — both paths return the input
   /// payload unchanged.
-  Future<void> _syncBaselineAfterFlush(String vehicleId) async {
-    try {
-      // #780 phase 3 — honour the opt-in setting. Default false so
-      // users who never toggled it in the sync setup screen don't
-      // silently upload driving data. Ungated favourite sync etc.
-      // are unaffected.
-      // #1373 phase 3e — read the central feature flag instead of the
-      // legacy Hive key. ref.read (not watch) — this is a one-shot
-      // gate at flush time, not a reactive dependency.
-      final enabled = _ref.read(baselineSyncEnabledProvider);
-      if (!enabled) return;
-      if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
-      final box = Hive.box<String>(HiveBoxes.obd2Baselines);
-      final key = 'baseline:$vehicleId';
-      final localJson = box.get(key);
-      final merged = await BaselinesSync.merge(
-        vehicleId: vehicleId,
-        localJson: localJson,
-      );
-      if (merged != null && merged != localJson) {
-        await box.put(key, merged);
-        // No in-memory cache refresh needed — _store is nulled out
-        // right after this call and the next trip creates a fresh
-        // BaselineStore whose loadVehicle reads the merged JSON
-        // from disk.
-      }
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: baseline sync failed'}));
-    }
-  }
 }

--- a/lib/features/consumption/providers/trip_baseline_sync.dart
+++ b/lib/features/consumption/providers/trip_baseline_sync.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:hive/hive.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../../../core/storage/hive_boxes.dart';
+import '../../../core/sync/baselines_sync.dart';
+import '../../sync/providers/baseline_sync_enabled_provider.dart';
+
+/// #3670 — test seam for the server baseline merge: the production path
+/// calls the static [BaselinesSync.merge] (no injection point), so the
+/// non-blocking-stop contract test overrides this to a never-completing
+/// future and asserts the stop path still returns.
+@visibleForTesting
+Future<String?> Function({
+  required String vehicleId,
+  String? localJson,
+})? debugBaselineMergeOverride;
+
+/// #780 — fold the server baseline copy into the local one after the
+/// stop-path flush. Extracted from [TripBaselineRecorder] (#3670) and
+/// FIRE-AND-FORGET by contract: awaiting this network round-trip inside
+/// `stop()` held the save UI at "Saving to history…" for minutes when
+/// the self-host Supabase was grinding TLS handshakes. Never throws.
+Future<void> syncBaselineAfterFlush(Ref ref, String vehicleId) async {
+  try {
+    // #780 phase 3 — honour the opt-in setting. Default false so users
+    // who never toggled it in the sync setup screen don't silently
+    // upload driving data.
+    final enabled = ref.read(baselineSyncEnabledProvider);
+    if (!enabled) return;
+    if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
+    final box = Hive.box<String>(HiveBoxes.obd2Baselines);
+    final key = 'baseline:$vehicleId';
+    final localJson = box.get(key);
+    // #3670 — hard cap: even in the background this merge must not
+    // grind a flaky endpoint forever (the transport's own retries can
+    // exceed a minute on repeated TLS handshake failures).
+    final mergeFn = debugBaselineMergeOverride;
+    final merged = await (mergeFn != null
+            ? mergeFn(vehicleId: vehicleId, localJson: localJson)
+            : BaselinesSync.merge(vehicleId: vehicleId, localJson: localJson))
+        .timeout(const Duration(seconds: 15));
+    if (merged != null && merged != localJson) {
+      await box.put(key, merged);
+      // No in-memory cache refresh needed — the recorder nulls its
+      // store right after scheduling this call and the next trip
+      // creates a fresh BaselineStore whose loadVehicle reads the
+      // merged JSON from disk.
+    }
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+        context: const {'where': 'TripRecording.stop: baseline sync failed'}));
+  }
+}

--- a/lib/features/obd2/data/obd2_dial_budget.dart
+++ b/lib/features/obd2/data/obd2_dial_budget.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'obd2_disconnect_quietly.dart';
+import 'obd2_service.dart';
+
+/// #3671 — default whole-attempt ceiling for one AUTOMATIC reconnect
+/// dial. Generous: a legitimate Classic ladder (#3421, ≤23 s) + scan
+/// window + ELM init retries fit comfortably; the field pathology it
+/// exists for was a single liveReconnect attempt grinding 21 MINUTES
+/// (connect trace t3, 2026-08-03) and pinning the main looper at ~95%
+/// in the background until the OS killed the process for excessive CPU.
+const Duration kDefaultDialBudget = Duration(seconds: 90);
+
+/// Run [dial] under a whole-attempt [budget] (#3671).
+///
+/// `.timeout` cannot cancel the underlying dial (the connect stack has
+/// no cancellation handle), so on overrun the zombie future is drained:
+/// whatever service it eventually lands is released immediately via
+/// [disconnectQuietly] — the single-link invariant holds, and the next
+/// backoff-scheduled attempt finds the RFCOMM channel free once the
+/// zombie dies on its own internal bounds. The thrown [TimeoutException]
+/// reaches the supervisor's dial-fault path, where its stable runtime
+/// type feeds the #3603 same-signature stand-down escalation.
+///
+/// Deliberately applied ONLY to the automatic reconnect dial policy —
+/// interactive one-shot dials (picker, VIN reader, self-test) have a
+/// user watching and their own UX timeouts, and a standing budget timer
+/// under an in-flight interactive dial would break every
+/// `pumpAndSettle` in their widget tests.
+Future<Obd2Service?> dialWithBudget(
+  Future<Obd2Service?> Function() dial, {
+  Duration budget = kDefaultDialBudget,
+}) {
+  final pending = dial();
+  return pending.timeout(budget, onTimeout: () {
+    unawaited(pending.then<void>((late) async {
+      if (late != null) await late.disconnectQuietly();
+    }).catchError((Object e, StackTrace st) {
+      // The zombie's own eventual failure is normal reconnect weather —
+      // it was already accounted for as this attempt's budget miss.
+      debugPrint('dialWithBudget: budget-overrun dial died on its own: $e');
+    }));
+    throw TimeoutException(
+      'dial exceeded the ${budget.inSeconds}s whole-attempt budget (#3671)',
+      budget,
+    );
+  });
+}

--- a/lib/features/obd2/providers/obd2_reconnect_provider.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/widgets.dart' show AppLifecycleState, WidgetsBinding;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/logging/error_logger.dart';
@@ -14,6 +15,7 @@ import '../data/obd2_comm_diagnostics.dart';
 import '../data/obd2_connect_trace.dart';
 import '../data/obd2_connect_trace_log.dart';
 import '../data/obd2_connection_service.dart';
+import '../data/obd2_dial_budget.dart';
 import '../data/obd2_disconnect_quietly.dart';
 import '../data/obd2_link_supervisor.dart';
 import '../data/obd2_service.dart';
@@ -141,7 +143,13 @@ class Obd2Reconnect extends _$Obd2Reconnect {
   /// Shell safety: the app shell watches this provider, so failed
   /// dependency reads (not-yet-bootstrapped graph / widget-test scope)
   /// must degrade to a no-op dial, never crash the shell.
-  Future<Obd2Service?> _dialDefault() async {
+  Future<Obd2Service?> _dialDefault() =>
+      // #3671 — the automatic reconnect dial runs under a whole-attempt
+      // budget; see [dialWithBudget] for the field pathology (a single
+      // liveReconnect attempt grinding 21 minutes in the background).
+      dialWithBudget(_dialDefaultBody);
+
+  Future<Obd2Service?> _dialDefaultBody() async {
     final Obd2ConnectionService connection;
     final LastGoodAdapterStore pinStore;
     try {
@@ -195,7 +203,18 @@ class Obd2Reconnect extends _$Obd2Reconnect {
       }
     }
 
-    // Re-scan fallback.
+    // Re-scan fallback — #3671: only while the app is visible. The
+    // scan is the expensive step of a dial (continuous BLE callbacks on
+    // the main looper, throttled-but-not-free in background); with the
+    // phone parked away from the car overnight it ground for tens of
+    // minutes per attempt until the OS killed the process for excessive
+    // background CPU. The direct by-MAC dials above still run, so
+    // auto-record keeps recovering the moment the adapter answers; the
+    // scan-based rescue resumes on the next foreground dial.
+    if (shouldSkipRescanWhenBackgrounded(_lifecycleStateOrNull())) {
+      BreadcrumbCollector.add('obd2-reconnect: rescan skipped (backgrounded)');
+      return null;
+    }
     final rescanned = await Obd2ConnectTraceLog.runWithOrigin(
       Obd2ConnectOrigin.liveReconnect,
       () => pinned != null
@@ -204,6 +223,17 @@ class Obd2Reconnect extends _$Obd2Reconnect {
       transportDecisionReason: 'reconnect-rescan',
     );
     return _classify(rescanned);
+  }
+
+  /// #3671 — the app lifecycle, or null when the widgets binding is not
+  /// up (pure-Dart provider tests / early startup). Null errs on the
+  /// visible side, keeping the full dial.
+  AppLifecycleState? _lifecycleStateOrNull() {
+    try {
+      return WidgetsBinding.instance.lifecycleState;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// The active vehicle's pinned adapter MAC (#3553), or null when no
@@ -249,3 +279,16 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     }));
   }
 }
+
+/// #3671 — whether a reconnect dial should skip its re-scan fallback.
+///
+/// `paused` / `hidden` / `detached` are genuinely backgrounded — the
+/// user cannot see the app, and a BLE scan there burns main-looper CPU
+/// for a rescue no one is waiting on. `inactive` (a transient overlay,
+/// the iOS app-switcher flash) and `resumed` keep the full dial.
+/// A null lifecycle (engine not yet told) errs on the visible side.
+bool shouldSkipRescanWhenBackgrounded(AppLifecycleState? lifecycle) =>
+    lifecycle == AppLifecycleState.paused ||
+    lifecycle == AppLifecycleState.hidden ||
+    lifecycle == AppLifecycleState.detached;
+

--- a/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'01c0e905b68f724feda84a1fd226613781a5abfb';
+String _$obd2ReconnectHash() => r'8a241fd89983d859604ebd1bc70721c3540fbf2d';
 
 /// App-wide owner of THE [Obd2LinkSupervisor] (#3529, Epic #3527).
 ///

--- a/test/features/consumption/providers/trip_baseline_recorder_reachability_test.dart
+++ b/test/features/consumption/providers/trip_baseline_recorder_reachability_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,8 @@ import 'package:tankstellen/features/consumption/data/baseline_store.dart';
 import 'package:tankstellen/features/obd2/data/trip_live_reading.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
 import 'package:tankstellen/features/consumption/providers/trip_baseline_recorder.dart';
+import 'package:tankstellen/features/sync/providers/baseline_sync_enabled_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_baseline_sync.dart';
 import 'package:tankstellen/core/domain/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
@@ -269,6 +272,39 @@ void main() {
               '${mode.name} mode (#2515)');
     });
   }
+
+  group('non-blocking stop (#3670)', () {
+    test('flushAndSync returns even when the server baseline merge NEVER '
+        'completes — the stop UI must not wait on the network', () async {
+      const profile = VehicleProfile(
+        id: 'v-hang',
+        name: 'Hang test car',
+        type: VehicleType.combustion,
+      );
+      final container = ProviderContainer(overrides: [
+        activeVehicleProfileProvider.overrideWith(
+          () => _StubActiveVehicle(profile),
+        ),
+        baselineSyncEnabledProvider.overrideWithValue(true),
+      ]);
+      addTearDown(container.dispose);
+
+      // The field shape: a self-host Supabase that answers nothing (TLS
+      // handshake grinding). The merge future never completes.
+      debugBaselineMergeOverride =
+          ({required vehicleId, localJson}) => Completer<String?>().future;
+      addTearDown(
+          () => debugBaselineMergeOverride = null);
+
+      DateTime clock() => DateTime(2026, 3, 11, 14, 30);
+      final recorder = container.read(_recorderProvider(clock));
+      await recorder.load();
+
+      // Must resolve promptly: the local flush is awaited, the server
+      // merge is fire-and-forget behind its own 15 s cap.
+      await recorder.flushAndSync().timeout(const Duration(seconds: 2));
+    });
+  });
 }
 
 /// Exposes a [TripBaselineRecorder] built with the provider's own

--- a/test/features/consumption/providers/trip_baseline_sync_test.dart
+++ b/test/features/consumption/providers/trip_baseline_sync_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/providers/trip_baseline_sync.dart';
+import 'package:tankstellen/features/sync/providers/baseline_sync_enabled_provider.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3670 — [syncBaselineAfterFlush] is the fire-and-forget half of the
+/// stop path; its never-throws contract is fault-injected here (a
+/// throwing merge must be logged and swallowed, never surface into the
+/// unawaited zone).
+void main() {
+  silenceErrorLoggerSpool();
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('baseline_sync_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2Baselines);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2Baselines).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+    debugBaselineMergeOverride = null;
+  });
+
+  ProviderContainer container({required bool enabled}) {
+    final c = ProviderContainer(overrides: [
+      baselineSyncEnabledProvider.overrideWithValue(enabled),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  // The function takes a Riverpod [Ref]; a throwaway provider hands one
+  // out of the container.
+  final refProvider = Provider<Ref>((ref) => ref);
+
+  test('a THROWING merge is swallowed and logged — never thrown into '
+      'the fire-and-forget zone', () async {
+    final c = container(enabled: true);
+    debugBaselineMergeOverride = ({required vehicleId, localJson}) =>
+        throw StateError('handshake ground to dust');
+
+    await expectLater(
+      syncBaselineAfterFlush(c.read(refProvider), 'v1'),
+      completes,
+    );
+  });
+
+  test('a merge slower than the 15 s cap is abandoned (TimeoutException '
+      'swallowed), and a successful merge persists the fold-in', () async {
+    final c = container(enabled: true);
+    final box = Hive.box<String>(HiveBoxes.obd2Baselines);
+    await box.put('baseline:v1', '{"local":true}');
+
+    debugBaselineMergeOverride =
+        ({required vehicleId, localJson}) async => '{"merged":true}';
+    await syncBaselineAfterFlush(c.read(refProvider), 'v1');
+    expect(box.get('baseline:v1'), '{"merged":true}');
+  });
+
+  test('sync disabled → no merge call at all', () async {
+    final c = container(enabled: false);
+    var calls = 0;
+    debugBaselineMergeOverride = ({required vehicleId, localJson}) async {
+      calls++;
+      return null;
+    };
+    await syncBaselineAfterFlush(c.read(refProvider), 'v1');
+    expect(calls, 0);
+  });
+}

--- a/test/features/obd2/data/obd2_dial_budget_test.dart
+++ b/test/features/obd2/data/obd2_dial_budget_test.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/data/obd2_dial_budget.dart';
+import 'package:tankstellen/features/obd2/data/obd2_service.dart';
+import 'package:tankstellen/features/obd2/data/obd2_transport.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3671 — the whole-dial budget for the AUTOMATIC reconnect dial.
+/// Field pathology: connect trace t3 showed one liveReconnect attempt
+/// grinding 1,263,965 ms (21 min) while backgrounded, pinning the main
+/// looper until the OS killed the process for excessive CPU.
+void main() {
+  silenceErrorLoggerSpool();
+
+  test('a fast dial passes straight through (timer cancelled — no '
+      'lingering budget timer after completion)', () {
+    fakeAsync((async) {
+      final svc = Obd2Service(FakeObd2Transport());
+      Obd2Service? got;
+      unawaited(dialWithBudget(() async => svc).then((s) => got = s));
+      async.flushMicrotasks();
+      expect(got, same(svc));
+      // The budget timer must have been cancelled with the completion —
+      // nothing left to fire.
+      expect(async.pendingTimers, isEmpty);
+    });
+  });
+
+  test('a dial grinding past the budget throws TimeoutException — the '
+      'supervisor sees a stable-signature miss', () {
+    fakeAsync((async) {
+      final gate = Completer<Obd2Service?>();
+      Object? failure;
+      unawaited(dialWithBudget(
+        () => gate.future,
+        budget: const Duration(seconds: 5),
+      ).catchError((Object e) {
+        failure = e;
+        return null;
+      }));
+      async.elapse(const Duration(seconds: 6));
+      expect(failure, isA<TimeoutException>());
+      gate.complete(null);
+      async.flushMicrotasks();
+    });
+  });
+
+  test('the zombie dial\'s LATE service is released, never leaked as a '
+      'second live link', () {
+    fakeAsync((async) {
+      final transport = FakeObd2Transport();
+      final zombie = Obd2Service(transport);
+      unawaited(transport.connect());
+      final gate = Completer<Obd2Service?>();
+      unawaited(dialWithBudget(
+        () => gate.future,
+        budget: const Duration(seconds: 5),
+      ).catchError((Object e) => null));
+      async.elapse(const Duration(seconds: 6));
+
+      // The runaway dial finally lands a service — long after the
+      // attempt was written off. It must be disconnected immediately.
+      expect(transport.isConnected, isTrue,
+          reason: 'precondition: the zombie holds a LIVE link');
+      gate.complete(zombie);
+      async.flushMicrotasks();
+      expect(transport.isConnected, isFalse,
+          reason: 'a budget-overrun service must be torn down, not adopted');
+    });
+  });
+
+  test('a zombie dial that eventually FAILS is swallowed — no unhandled '
+      'async error reaches the zone', () {
+    fakeAsync((async) {
+      final gate = Completer<Obd2Service?>();
+      unawaited(dialWithBudget(
+        () => gate.future,
+        budget: const Duration(seconds: 5),
+      ).catchError((Object e) => null));
+      async.elapse(const Duration(seconds: 6));
+      gate.completeError(StateError('adapter died mid-grind'));
+      async.flushMicrotasks(); // must not throw into the test zone
+    });
+  });
+}

--- a/test/features/obd2/obd2_link_supervisor_test.dart
+++ b/test/features/obd2/obd2_link_supervisor_test.dart
@@ -335,4 +335,5 @@ void main() {
       async.flushMicrotasks();
     });
   });
+
 }

--- a/test/features/obd2/providers/obd2_reconnect_rescan_gate_test.dart
+++ b/test/features/obd2/providers/obd2_reconnect_rescan_gate_test.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart' show AppLifecycleState;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/obd2/providers/obd2_reconnect_provider.dart';
+
+/// #3671 — the reconnect dial skips its re-scan fallback while the app
+/// is genuinely backgrounded: with the phone parked away from the car
+/// the scan ground for tens of minutes per attempt on the main looper
+/// until the OS killed the process for excessive background CPU. The
+/// direct by-MAC dials are unaffected — auto-record still recovers the
+/// moment the adapter answers.
+void main() {
+  test('paused / hidden / detached skip the rescan', () {
+    expect(shouldSkipRescanWhenBackgrounded(AppLifecycleState.paused), isTrue);
+    expect(shouldSkipRescanWhenBackgrounded(AppLifecycleState.hidden), isTrue);
+    expect(
+        shouldSkipRescanWhenBackgrounded(AppLifecycleState.detached), isTrue);
+  });
+
+  test('resumed / inactive / unknown keep the full dial — a transient '
+      'overlay or an unreported lifecycle must not degrade the rescue', () {
+    expect(
+        shouldSkipRescanWhenBackgrounded(AppLifecycleState.resumed), isFalse);
+    expect(
+        shouldSkipRescanWhenBackgrounded(AppLifecycleState.inactive), isFalse);
+    expect(shouldSkipRescanWhenBackgrounded(null), isFalse);
+  });
+}


### PR DESCRIPTION
Analysis of the 2026-08-04 field error-log export (50 traces, 2 days) + the "Enregistrement dans l'historique…" screenshot. Three issues, one commit each; the fourth finding is commented on #3590.

## fix(consumption): stop never awaits the network — Closes #3670
The stop pipeline **awaited `BaselinesSync.merge`** (a round-trip to the user's self-host Supabase) before the save UI could resolve — and the same log shows that endpoint failing TLS handshakes and 30 s sync timeouts. Local flush stays awaited; the server fold-in is now fire-and-forget behind a 15 s cap, extracted to `trip_baseline_sync.dart` (never-throws, fault-injected). Contract test: `flushAndSync` resolves promptly even when the merge future never completes. "Saving to history…" now covers local writes only.

## fix(obd2): whole-dial budget + no background re-scan — Closes #3671
14× `[EXCESSIVE CPU USAGE]` background kills; the watchdog attributed ~48 s/60 s to the main looper, and connect trace `t3` shows **one liveReconnect attempt grinding 21 minutes** — exactly the 23:30→23:51 kill window. The storm cadence (#3603/#3642) bounds the interval *between* dials and #3421 bounds the Classic ladder, but nothing bounded one whole dial once it reached the scan fallback.
- `dialWithBudget` (90 s) on the **automatic** reconnect dial: overrun ⇒ `TimeoutException` (stable signature feeds the stand-down escalation) and the zombie's late service is released, never adopted. Interactive one-shot dials stay unbudgeted (a user is watching; a standing timer breaks `pumpAndSettle` in their widget tests — found the hard way in this PR).
- While paused/hidden/detached the **re-scan fallback is skipped** (pure gate, shell-safe lifecycle read): direct by-MAC dials still run, so auto-record recovers the moment the adapter answers; the scan — the main-looper-hungry step — waits for foreground.

## chore(sync): schema breadcrumb once per session — Closes #3672
"deletions table absent" fired 3× within 400 ms (once per tombstone). Now once per session.

## Remaining findings (no code change here)
- **`crash_native` ×11 (2 foreground)** — the "recording crashes after 80–100 km": consistent with the #3590 pairip JNI global-ref leak; evidence added to that issue. Action is release-side (disable Play Automatic integrity protection + ship).
- The sync `HandshakeException`/timeout traces are the self-host Supabase being unreachable — with #3670 they no longer block anything user-visible.

## Verification
Detached-worktree run of the committed state: analyze clean, **15,509 passed**, sole failure the recurring Argentina live-API connectivity flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
