### PR TITLE
feat(obd2): connection reset on the recording page — reachable while connecting and during a recording (#3678)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -768,6 +768,8 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
                 onEnterPip: () => _pip.enterPip(),
                 onTogglePause: _togglePause,
                 onStop: _onStop,
+                // #3678 — shared reset run (guarded, honest snackbar).
+                onResetConnection: () => runObd2ConnectionReset(context, ref),
               ),
             ],
       bodyPadding: EdgeInsets.zero,

--- a/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
@@ -8,7 +8,7 @@ import '../../../../l10n/app_localizations.dart';
 /// Overflow targets the recording kebab dispatches via its single
 /// `onSelected` path (#2764). Each item maps to a callback the host
 /// [TripRecordingScreen] already owns (pin / help / PiP).
-enum _RecordingOverflowAction { pin, help, pip }
+enum _RecordingOverflowAction { pin, help, pip, resetLink }
 
 /// Trailing app-bar actions for the active trip-recording screen (#2764).
 ///
@@ -36,6 +36,7 @@ class RecordingAppBarActions extends StatelessWidget {
     required this.onEnterPip,
     required this.onTogglePause,
     required this.onStop,
+    required this.onResetConnection,
   });
 
   /// Whether the recording form is currently pinned (wake lock held).
@@ -60,6 +61,12 @@ class RecordingAppBarActions extends StatelessWidget {
   final VoidCallback onTogglePause;
   final VoidCallback onStop;
 
+  /// #3678 — hard reset of the OBD2 link (ATZ + recycle + fresh dial),
+  /// reachable from the connecting phase (a hung start) through the
+  /// whole recording. Mid-trip this is the same drop→ready→re-bind
+  /// path the trip layer's LinkState subscription already survives.
+  final VoidCallback onResetConnection;
+
   void _onSelected(_RecordingOverflowAction action) {
     switch (action) {
       case _RecordingOverflowAction.pin:
@@ -68,6 +75,8 @@ class RecordingAppBarActions extends StatelessWidget {
         onShowPinHelp();
       case _RecordingOverflowAction.pip:
         onEnterPip();
+      case _RecordingOverflowAction.resetLink:
+        onResetConnection();
     }
   }
 
@@ -129,6 +138,16 @@ class RecordingAppBarActions extends StatelessWidget {
               child: _MenuRow(
                 icon: Icons.help_outline,
                 label: l.tripRecordingPinHelpTooltip,
+              ),
+            ),
+            // #3678 — hard reset of the OBD2 link. Lives in the kebab
+            // (not primary) — reached deliberately, not mid-glance.
+            PopupMenuItem<_RecordingOverflowAction>(
+              key: const Key('tripResetConnectionButton'),
+              value: _RecordingOverflowAction.resetLink,
+              child: _MenuRow(
+                icon: Icons.restart_alt,
+                label: l.obd2ResetConnection,
               ),
             ),
             // #1884 — minimise to PiP; Android-only.

--- a/lib/features/consumption/presentation/widgets/vehicle_adapter_section.dart
+++ b/lib/features/consumption/presentation/widgets/vehicle_adapter_section.dart
@@ -4,8 +4,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/error/guarded.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../obd2/api.dart';
 
@@ -136,21 +134,12 @@ class _ResetConnectionButtonState
   bool _busy = false;
 
   Future<void> _reset() async {
-    final l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.maybeOf(context);
     setState(() => _busy = true);
-    // Shell-safe (#2163): an unwired provider graph (isolated widget
-    // tests) degrades to "no link", never a crash.
-    final linked = await guardAsync(
-      () => ref.read(obd2ReconnectProvider.notifier).resetConnection(),
-      where: 'VehicleAdapterSection: OBD2 reset failed',
-      fallback: false,
-    );
+    // #3678 — the shared reset run (guarded + honest snackbar; the
+    // messenger is captured inside, before the await).
+    await runObd2ConnectionReset(context, ref);
     if (!mounted) return;
     setState(() => _busy = false);
-    messenger?.showSnackBar(SnackBarHelper.infoSnackBar(
-      linked ? l.obd2ResetConnectionDone : l.obd2ResetConnectionNoLink,
-    ));
   }
 
   @override

--- a/lib/features/obd2/api.dart
+++ b/lib/features/obd2/api.dart
@@ -56,6 +56,7 @@ export 'data/trip_distance_source.dart';
 export 'data/trip_live_reading.dart';
 export 'data/trip_recording_controller.dart';
 export 'domain/services/obd2_analytics_signals.dart';
+export 'presentation/obd2_connection_reset_action.dart';
 export 'presentation/obd2_connect_telemetry.dart';
 export 'presentation/obd2_connection_error_l10n.dart';
 export 'presentation/widgets/obd2_adapter_picker.dart';

--- a/lib/features/obd2/presentation/obd2_connection_reset_action.dart
+++ b/lib/features/obd2/presentation/obd2_connection_reset_action.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/error/guarded.dart';
+import '../../../core/widgets/snackbar_helper.dart';
+import '../../../l10n/app_localizations.dart';
+import '../providers/obd2_reconnect_provider.dart';
+
+/// #3676/#3678 — the ONE user-facing "reset the OBD2 connection" run,
+/// shared by the vehicle screen's adapter card and the recording
+/// screen's overflow kebab: ATZ chip reset on the dongle (best effort),
+/// full link recycle, fresh dial — then an honest outcome snackbar
+/// ("re-established" vs "reconnecting in the background").
+///
+/// Shell-safe (#2163): an unwired provider graph (isolated widget
+/// tests) degrades to "no link", never a crash. The messenger and the
+/// localized strings are captured BEFORE the await (SnackBarHelper
+/// contract) so the feedback survives the caller's context dying
+/// mid-reset (e.g. the user navigates off the recording screen while
+/// the redial runs).
+Future<void> runObd2ConnectionReset(BuildContext context, WidgetRef ref) async {
+  final l = AppLocalizations.of(context);
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  final linked = await guardAsync(
+    () => ref.read(obd2ReconnectProvider.notifier).resetConnection(),
+    where: 'runObd2ConnectionReset failed',
+    fallback: false,
+  );
+  messenger?.showSnackBar(SnackBarHelper.infoSnackBar(
+    linked ? l.obd2ResetConnectionDone : l.obd2ResetConnectionNoLink,
+  ));
+}

--- a/test/features/consumption/presentation/widgets/recording_app_bar_actions_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_app_bar_actions_test.dart
@@ -48,6 +48,7 @@ void main() {
               onEnterPip: () => fired.add('pip'),
               onTogglePause: () => fired.add('pause'),
               onStop: () => fired.add('stop'),
+              onResetConnection: () => fired.add('reset'),
             ),
           ],
         ),
@@ -174,5 +175,19 @@ void main() {
       expect(find.bySemanticsLabel('Unpin recording form'), findsOneWidget);
       handle.dispose();
     });
+    testWidgets('Reset-connection item (#3678) lives in the kebab and '
+        'fires — including while CONNECTING (isActive false), the hung '
+        'start it exists for', (tester) async {
+      await tester.pumpWidget(harness(isActive: false));
+      await openKebab(tester);
+
+      final reset = find.byKey(const Key('tripResetConnectionButton'));
+      expect(reset, findsOneWidget);
+      expect(find.text('Reset connection'), findsOneWidget);
+      await tester.tap(reset);
+      await tester.pumpAndSettle();
+      expect(fired, contains('reset'));
+    });
+
   });
 }


### PR DESCRIPTION
Follow-up to #3676: the "Reset connection" action lived only on the vehicle screen's adapter card — the place a user actually needs it is the **recording page**: a hung start in the connecting phase (before the recording), or a misbehaving live link mid-trip.

- **`runObd2ConnectionReset`** (obd2/presentation, barrel-exported): the ONE guarded reset run — ATZ chip reset (best effort) → full link recycle → fresh dial → honest outcome snackbar. Messenger + strings are captured *before* the await, so the feedback survives the caller's context dying mid-reset. The vehicle-section button is refactored onto it (no behavior change; its shell-safety test still passes).
- **Recording kebab item** (`tripResetConnectionButton`): the overflow menu renders through the **connecting, recording and paused** phases, so the reset is reachable exactly when needed — including before the first live sample. Mid-trip, the reset recycles through the supervisor's single-flight dial: the same drop→ready→re-bind path the trip layer's LinkState subscription already survives (#3527/#3531, pinned by `trip_recording_controller_reconnect_test`).
- Reuses the #3676 ARB keys — no new strings, all 24 locales already covered.

Tests: the kebab item renders and fires with `isActive: false` (the connecting phase it exists for). Detached-worktree verification: analyze clean, **15,515 passed**, sole failure the recurring Argentina live-API flake.

Closes #3678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
