### PR TITLE
feat(search): highway mode v2 — exit-aware suggestions from OSM motorway_junction data via a per-country prebuilt asset (#3633)

### DIFF
--- a/.github/workflows/motorway-exits-publish.yml
+++ b/.github/workflows/motorway-exits-publish.yml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: Motorway Exits Publish
+
+# #3633 — per-country motorway-exit datasets for highway mode v2, via
+# the proven fuel-gr rolling-release pattern (#3549): extract every OSM
+# `highway=motorway_junction` node per supported country through
+# Overpass and publish one compact JSON per country as assets of the
+# rolling `motorway-exits` release:
+#   https://github.com/fdittgen-png/tankstellen/releases/download/motorway-exits/exits_fr.json
+#
+# Exits change on the timescale of YEARS, so monthly is generous; the
+# app caches each country's asset for a year (soft-refresh monthly) and
+# degrades to exit-less v1 highway mode when the asset was never
+# fetched. A partially-failed run publishes the countries that
+# succeeded (each is its own asset; the app keeps its cached copy for
+# the rest) and goes red so the gap is retried.
+#
+# Data: © OpenStreetMap contributors, ODbL — attribution ships with the
+# app's existing OSM attribution surface.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 3 * *' # monthly, the 3rd at 03:00 UTC (Overpass off-peak)
+
+permissions:
+  contents: write # release asset upload
+
+concurrency:
+  group: motorway-exits-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90 # 17 countries × (query + retries + courtesy gaps)
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Extract motorway exits per country (Overpass)
+        id: extract
+        # continue-on-error so a partial run still PUBLISHES the
+        # successful countries below; the final step re-fails the job.
+        continue-on-error: true
+        run: python3 tool/motorway_exits/publish_motorway_exits.py "$RUNNER_TEMP/exits"
+
+      - name: Publish to the rolling motorway-exits release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          files=("$RUNNER_TEMP"/exits/exits_*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no exit datasets produced — nothing to publish"
+            exit 1
+          fi
+          gh release view motorway-exits --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create motorway-exits --repo "$GITHUB_REPOSITORY" \
+              --title "Motorway exits (rolling data release)" \
+              --notes "Machine-updated monthly by motorway-exits-publish.yml (#3633): per-country OSM highway=motorway_junction nodes for highway mode v2. Data © OpenStreetMap contributors, ODbL. Not an app release." \
+              --prerelease
+          gh release upload motorway-exits "${files[@]}" \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Summary + propagate extract failure
+        env:
+          EXTRACT_OUTCOME: ${{ steps.extract.outcome }}
+        run: |
+          {
+            echo "## Motorway exits publish"
+            echo ""
+            for f in "$RUNNER_TEMP"/exits/exits_*.json; do
+              [ -f "$f" ] || continue
+              echo "- \`$(basename "$f")\`: $(wc -c < "$f") bytes"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$EXTRACT_OUTCOME" != "success" ]; then
+            echo "::error::one or more countries failed to extract (published the rest)"
+            exit 1
+          fi

--- a/lib/core/services/radar/motorway_exits.dart
+++ b/lib/core/services/radar/motorway_exits.dart
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import '../../domain/station.dart';
+import '../../utils/geo_utils.dart' as geo;
+import 'highway_mode.dart';
+
+/// One OSM `highway=motorway_junction` node (#3633) — an exit's
+/// position plus its signposted number (`ref`, e.g. "36") and optional
+/// name. Parsed from the compact per-country asset the
+/// `motorway-exits-publish.yml` pipeline publishes.
+@immutable
+class MotorwayExit {
+  final double lat;
+  final double lng;
+
+  /// The signposted exit number ("36", "34a"), or null when OSM has no
+  /// `ref` for the node — the annotation then falls back to [name].
+  final String? ref;
+
+  /// The exit's destination name ("Saint-Thibéry"), when tagged.
+  final String? name;
+
+  const MotorwayExit({
+    required this.lat,
+    required this.lng,
+    this.ref,
+    this.name,
+  });
+
+  /// Parse the pipeline's compact shape `{"la":…,"lo":…,"r":…,"n":…}`.
+  /// Returns null on a malformed entry (skip, never throw — the asset
+  /// is machine-written but the cache layer's contract is lenient).
+  static MotorwayExit? fromCompactJson(Map<String, dynamic> json) {
+    final la = json['la'];
+    final lo = json['lo'];
+    if (la is! num || lo is! num) return null;
+    return MotorwayExit(
+      lat: la.toDouble(),
+      lng: lo.toDouble(),
+      ref: json['r'] as String?,
+      name: json['n'] as String?,
+    );
+  }
+
+  /// A display label for the annotation: the signposted number when
+  /// tagged, else the exit name, else null (no annotation).
+  String? get label => ref ?? name;
+}
+
+/// Parse a whole per-country asset (`{"v":1,"exits":[…]}`) into exits.
+/// Lenient: unknown versions and malformed entries yield what parses.
+List<MotorwayExit> parseMotorwayExits(Map<String, dynamic> json) {
+  final raw = json['exits'];
+  if (raw is! List) return const [];
+  return [
+    for (final e in raw)
+      if (e is Map)
+        ?MotorwayExit.fromCompactJson(Map<String, dynamic>.from(e)),
+  ];
+}
+
+/// Per-station exit annotation (#3633): which exit serves the station
+/// and what the straight-line detour from that exit is.
+@immutable
+class HighwayExitInfo {
+  /// The exit's display label ([MotorwayExit.label]) — never null here;
+  /// unlabeled exits produce no annotation.
+  final String exitLabel;
+
+  /// Straight-line km from the exit to the station (the issue's scope:
+  /// no routing — an honest lower bound the UI prefixes with "+").
+  final double detourKm;
+
+  /// Along-track km from the driver to the STATION's projection on the
+  /// travel bearing — the v2 sort key ("what can I reach next").
+  final double alongKm;
+
+  const HighwayExitInfo({
+    required this.exitLabel,
+    required this.detourKm,
+    required this.alongKm,
+  });
+}
+
+/// Result of [annotateStationsViaExits]: the input stations re-sorted
+/// by along-track distance, plus per-station exit annotations.
+@immutable
+class HighwayExitAnnotation {
+  final List<Station> stations;
+  final Map<String, HighwayExitInfo> infoByStationId;
+
+  const HighwayExitAnnotation({
+    required this.stations,
+    required this.infoByStationId,
+  });
+}
+
+/// #3633 v2 — make the ahead-filtered station list exit-aware.
+///
+/// Projects [exits] and [stations] onto the travel bearing (the same
+/// along/lateral math as the #3631 cone):
+///
+///  * exits behind the driver or outside the ahead cone are ignored;
+///  * a station essentially ON the road (|lateral| <
+///    [kHighwayOnRoadLateralKm]) is a service area — no exit needed,
+///    no annotation, but its along-track distance still drives the
+///    sort;
+///  * an off-axis station is associated with the nearest exit AHEAD of
+///    the driver at-or-before the station's along-track position (the
+///    exit you would take), annotated "via exit {label} · +{detour} km"
+///    with the straight-line exit→station distance;
+///  * the returned list is sorted by along-track distance — "what can
+///    I reach next" — replacing the crow-flies order (a station 2 km
+///    away laterally across fields sorts after the services 5 km
+///    straight ahead).
+///
+/// Pure and total: with no usable exits or a non-finite heading the
+/// input order is preserved and the annotation map is empty, so the
+/// caller degrades to exit-less v1 behaviour with zero branching.
+HighwayExitAnnotation annotateStationsViaExits({
+  required List<Station> stations,
+  required List<MotorwayExit> exits,
+  required double lat,
+  required double lng,
+  required double headingDegrees,
+}) {
+  if (stations.isEmpty || exits.isEmpty || !headingDegrees.isFinite) {
+    return HighwayExitAnnotation(stations: stations, infoByStationId: const {});
+  }
+
+  double relOf(double toLat, double toLng) {
+    var rel = geo.bearingDegrees(lat, lng, toLat, toLng) - headingDegrees;
+    while (rel > 180) {
+      rel -= 360;
+    }
+    while (rel <= -180) {
+      rel += 360;
+    }
+    return rel;
+  }
+
+  // Exits ahead, projected onto the bearing, sorted by along-track km.
+  final aheadExits = <({MotorwayExit exit, double alongKm})>[];
+  for (final e in exits) {
+    final rel = relOf(e.lat, e.lng);
+    if (rel.abs() > kHighwayAheadConeDeg) continue;
+    final distKm = geo.distanceMeters(lat, lng, e.lat, e.lng) / 1000.0;
+    final alongKm = distKm * math.cos(rel * math.pi / 180.0);
+    if (alongKm <= 0) continue;
+    aheadExits.add((exit: e, alongKm: alongKm));
+  }
+  aheadExits.sort((a, b) => a.alongKm.compareTo(b.alongKm));
+
+  final info = <String, HighwayExitInfo>{};
+  final alongByStationId = <String, double>{};
+  for (final s in stations) {
+    final rel = relOf(s.lat, s.lng);
+    final distKm = geo.distanceMeters(lat, lng, s.lat, s.lng) / 1000.0;
+    final alongKm = distKm * math.cos(rel * math.pi / 180.0);
+    final lateralKm = distKm * math.sin(rel * math.pi / 180.0);
+    alongByStationId[s.id] = alongKm;
+    // On-road service area: reachable without exiting — no annotation.
+    if (lateralKm.abs() < kHighwayOnRoadLateralKm) continue;
+    // The exit you would take: the LAST exit at-or-before the station's
+    // along-track position (small tolerance — an exit level with the
+    // station still serves it). Ignore unlabeled exits.
+    ({MotorwayExit exit, double alongKm})? via;
+    for (final e in aheadExits) {
+      if (e.alongKm > alongKm + 0.5) break;
+      if (e.exit.label == null) continue;
+      via = e;
+    }
+    if (via == null) continue;
+    info[s.id] = HighwayExitInfo(
+      exitLabel: via.exit.label!,
+      detourKm:
+          geo.distanceMeters(via.exit.lat, via.exit.lng, s.lat, s.lng) /
+              1000.0,
+      alongKm: alongKm,
+    );
+  }
+
+  final sorted = [...stations]..sort((a, b) =>
+      (alongByStationId[a.id] ?? a.dist)
+          .compareTo(alongByStationId[b.id] ?? b.dist));
+  return HighwayExitAnnotation(stations: sorted, infoByStationId: info);
+}

--- a/lib/core/services/radar/motorway_exits_provider.dart
+++ b/lib/core/services/radar/motorway_exits_provider.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../cache/cache_manager.dart';
+import 'motorway_exits.dart';
+import 'motorway_exits_service.dart';
+
+part 'motorway_exits_provider.g.dart';
+
+/// The one [MotorwayExitsService] (#3633). keepAlive — it owns the
+/// per-country in-memory datasets and their freshness clocks.
+@Riverpod(keepAlive: true)
+MotorwayExitsService motorwayExitsService(Ref ref) =>
+    MotorwayExitsService(cache: ref.watch(cacheManagerProvider));
+
+/// The active-country motorway exits currently in memory (#3633).
+///
+/// Synchronous by design: the radar ranking runs synchronously per GPS
+/// poll, so it reads whatever is loaded NOW. [ensureLoaded] kicks the
+/// async fetch/rehydrate (called by the radar when highway mode is
+/// active); until it lands the state is empty and highway mode behaves
+/// exactly like exit-less v1.
+@Riverpod(keepAlive: true)
+class MotorwayExits extends _$MotorwayExits {
+  String? _loadedFor;
+  bool _loading = false;
+
+  @override
+  List<MotorwayExit> build() => const [];
+
+  /// Fire-and-forget load of [countryCode]'s exits. Idempotent per
+  /// country; a country switch reloads. Never throws (the service's
+  /// contract) — a failed load leaves the empty v1 state.
+  void ensureLoaded(String countryCode) {
+    final cc = countryCode.toUpperCase();
+    if (_loading || _loadedFor == cc) return;
+    _loading = true;
+    unawaited(() async {
+      try {
+        final exits = await ref.read(motorwayExitsServiceProvider).exitsFor(cc);
+        // The provider is keepAlive, but a torn-down test container (or
+        // a future lifecycle change) must not take a post-dispose write.
+        if (!ref.mounted) return;
+        _loadedFor = cc;
+        state = exits;
+      } finally {
+        _loading = false;
+      }
+    }());
+  }
+}
+
+/// Per-station exit annotations for the CURRENT radar list (#3633),
+/// written by the radar search provider after each ranked poll and
+/// consumed by the station card ("via exit {ref} · +{km} km") — the
+/// same map-shaped side-channel pattern as `roadDistancesProvider`
+/// (#3634), so the card wiring stays identical.
+@Riverpod(keepAlive: true)
+class HighwayExitInfoMap extends _$HighwayExitInfoMap {
+  @override
+  Map<String, HighwayExitInfo> build() => const {};
+
+  void publish(Map<String, HighwayExitInfo> info) => state = info;
+
+  void clear() {
+    if (state.isNotEmpty) state = const {};
+  }
+}

--- a/lib/core/services/radar/motorway_exits_provider.g.dart
+++ b/lib/core/services/radar/motorway_exits_provider.g.dart
@@ -1,0 +1,229 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'motorway_exits_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The one [MotorwayExitsService] (#3633). keepAlive — it owns the
+/// per-country in-memory datasets and their freshness clocks.
+
+@ProviderFor(motorwayExitsService)
+final motorwayExitsServiceProvider = MotorwayExitsServiceProvider._();
+
+/// The one [MotorwayExitsService] (#3633). keepAlive — it owns the
+/// per-country in-memory datasets and their freshness clocks.
+
+final class MotorwayExitsServiceProvider
+    extends
+        $FunctionalProvider<
+          MotorwayExitsService,
+          MotorwayExitsService,
+          MotorwayExitsService
+        >
+    with $Provider<MotorwayExitsService> {
+  /// The one [MotorwayExitsService] (#3633). keepAlive — it owns the
+  /// per-country in-memory datasets and their freshness clocks.
+  MotorwayExitsServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'motorwayExitsServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$motorwayExitsServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<MotorwayExitsService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  MotorwayExitsService create(Ref ref) {
+    return motorwayExitsService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(MotorwayExitsService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<MotorwayExitsService>(value),
+    );
+  }
+}
+
+String _$motorwayExitsServiceHash() =>
+    r'8b26b65dc6201b6e77764c49d25fbd5f3a517f4c';
+
+/// The active-country motorway exits currently in memory (#3633).
+///
+/// Synchronous by design: the radar ranking runs synchronously per GPS
+/// poll, so it reads whatever is loaded NOW. [ensureLoaded] kicks the
+/// async fetch/rehydrate (called by the radar when highway mode is
+/// active); until it lands the state is empty and highway mode behaves
+/// exactly like exit-less v1.
+
+@ProviderFor(MotorwayExits)
+final motorwayExitsProvider = MotorwayExitsProvider._();
+
+/// The active-country motorway exits currently in memory (#3633).
+///
+/// Synchronous by design: the radar ranking runs synchronously per GPS
+/// poll, so it reads whatever is loaded NOW. [ensureLoaded] kicks the
+/// async fetch/rehydrate (called by the radar when highway mode is
+/// active); until it lands the state is empty and highway mode behaves
+/// exactly like exit-less v1.
+final class MotorwayExitsProvider
+    extends $NotifierProvider<MotorwayExits, List<MotorwayExit>> {
+  /// The active-country motorway exits currently in memory (#3633).
+  ///
+  /// Synchronous by design: the radar ranking runs synchronously per GPS
+  /// poll, so it reads whatever is loaded NOW. [ensureLoaded] kicks the
+  /// async fetch/rehydrate (called by the radar when highway mode is
+  /// active); until it lands the state is empty and highway mode behaves
+  /// exactly like exit-less v1.
+  MotorwayExitsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'motorwayExitsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$motorwayExitsHash();
+
+  @$internal
+  @override
+  MotorwayExits create() => MotorwayExits();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<MotorwayExit> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<MotorwayExit>>(value),
+    );
+  }
+}
+
+String _$motorwayExitsHash() => r'4cd4988dcaee0bbc21effc0ea5edbe42f4d49541';
+
+/// The active-country motorway exits currently in memory (#3633).
+///
+/// Synchronous by design: the radar ranking runs synchronously per GPS
+/// poll, so it reads whatever is loaded NOW. [ensureLoaded] kicks the
+/// async fetch/rehydrate (called by the radar when highway mode is
+/// active); until it lands the state is empty and highway mode behaves
+/// exactly like exit-less v1.
+
+abstract class _$MotorwayExits extends $Notifier<List<MotorwayExit>> {
+  List<MotorwayExit> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<List<MotorwayExit>, List<MotorwayExit>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<List<MotorwayExit>, List<MotorwayExit>>,
+              List<MotorwayExit>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Per-station exit annotations for the CURRENT radar list (#3633),
+/// written by the radar search provider after each ranked poll and
+/// consumed by the station card ("via exit {ref} · +{km} km") — the
+/// same map-shaped side-channel pattern as `roadDistancesProvider`
+/// (#3634), so the card wiring stays identical.
+
+@ProviderFor(HighwayExitInfoMap)
+final highwayExitInfoMapProvider = HighwayExitInfoMapProvider._();
+
+/// Per-station exit annotations for the CURRENT radar list (#3633),
+/// written by the radar search provider after each ranked poll and
+/// consumed by the station card ("via exit {ref} · +{km} km") — the
+/// same map-shaped side-channel pattern as `roadDistancesProvider`
+/// (#3634), so the card wiring stays identical.
+final class HighwayExitInfoMapProvider
+    extends
+        $NotifierProvider<HighwayExitInfoMap, Map<String, HighwayExitInfo>> {
+  /// Per-station exit annotations for the CURRENT radar list (#3633),
+  /// written by the radar search provider after each ranked poll and
+  /// consumed by the station card ("via exit {ref} · +{km} km") — the
+  /// same map-shaped side-channel pattern as `roadDistancesProvider`
+  /// (#3634), so the card wiring stays identical.
+  HighwayExitInfoMapProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'highwayExitInfoMapProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$highwayExitInfoMapHash();
+
+  @$internal
+  @override
+  HighwayExitInfoMap create() => HighwayExitInfoMap();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Map<String, HighwayExitInfo> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Map<String, HighwayExitInfo>>(value),
+    );
+  }
+}
+
+String _$highwayExitInfoMapHash() =>
+    r'2d7d7329a06b049ced636fd4d9defc41d9696733';
+
+/// Per-station exit annotations for the CURRENT radar list (#3633),
+/// written by the radar search provider after each ranked poll and
+/// consumed by the station card ("via exit {ref} · +{km} km") — the
+/// same map-shaped side-channel pattern as `roadDistancesProvider`
+/// (#3634), so the card wiring stays identical.
+
+abstract class _$HighwayExitInfoMap
+    extends $Notifier<Map<String, HighwayExitInfo>> {
+  Map<String, HighwayExitInfo> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<Map<String, HighwayExitInfo>, Map<String, HighwayExitInfo>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                Map<String, HighwayExitInfo>,
+                Map<String, HighwayExitInfo>
+              >,
+              Map<String, HighwayExitInfo>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/core/services/radar/motorway_exits_service.dart
+++ b/lib/core/services/radar/motorway_exits_service.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+
+import '../../cache/cache_manager.dart';
+import '../dio_factory.dart';
+import '../mixins/cached_dataset_mixin.dart';
+import '../persistent_dataset.dart';
+import '../service_result.dart';
+import 'motorway_exits.dart';
+
+/// Per-country motorway-exit datasets (#3633), consumed from the
+/// rolling `motorway-exits` release the pipeline publishes — a URL
+/// fully under the project's control (the fuel-gr pattern, #3549).
+///
+/// Keyed per country through [KeyedCachedDatasetMixin] +
+/// [PersistentDataset]: soft TTL 30 days (exits change on the timescale
+/// of years; the pipeline republishes monthly), hard TTL 365 days as
+/// offline grace. A never-fetched country simply yields an empty list —
+/// highway mode degrades to its exit-less v1 behaviour.
+class MotorwayExitsService with KeyedCachedDatasetMixin {
+  MotorwayExitsService({Dio? dio, CacheStrategy? cache, String? baseUrl})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 20),
+            ),
+        _cache = cache,
+        _baseUrl = baseUrl ?? defaultBaseUrl;
+
+  /// Rolling release the `motorway-exits-publish.yml` pipeline feeds.
+  // i18n-ignore: release-asset URL, not user-facing text
+  static const String defaultBaseUrl =
+      'https://github.com/fdittgen-png/tankstellen/releases/download/'
+      'motorway-exits';
+
+  static const Duration _softTtl = Duration(days: 30);
+  static const Duration _hardTtl = Duration(days: 365);
+
+  final Dio _dio;
+  final CacheStrategy? _cache;
+  final String _baseUrl;
+
+  final Map<String, List<MotorwayExit>> _byCountry = {};
+
+  PersistentDataset<List<MotorwayExit>>? _datasetFor(String cc) {
+    final cache = _cache;
+    if (cache == null) return null;
+    return PersistentDataset<List<MotorwayExit>>(
+      cache: cache,
+      countryCode: cc,
+      datasetName: 'motorway_exits',
+      source: ServiceSource.cache,
+      serialize: _serializeExits,
+      deserialize: _deserializeExits,
+    );
+  }
+
+  /// The exits for [countryCode] (upper- or lower-case). Serves the
+  /// in-memory/persisted copy per the keyed mixin's SWR semantics and
+  /// refreshes from the release asset when soft-stale. NEVER throws:
+  /// any failure yields the last-known copy or an empty list (v1
+  /// degradation).
+  Future<List<MotorwayExit>> exitsFor(String countryCode) async {
+    final cc = countryCode.toUpperCase();
+    try {
+      return await loadKeyedPersistentDataset<List<MotorwayExit>>(
+        key: cc,
+        cached: _byCountry[cc],
+        softTtl: _softTtl,
+        hardTtl: _hardTtl,
+        persistent: _datasetFor(cc),
+        fetch: () => _fetch(cc),
+        store: (v) => _byCountry[cc] = v,
+      );
+    } on Object {
+      // ignore: silent_catch — degrade to exit-less v1; the mixin already
+      // exhausted the persisted fallbacks before rethrowing.
+      return _byCountry[cc] ?? const [];
+    }
+  }
+
+  Future<List<MotorwayExit>> _fetch(String cc) async {
+    final url = '$_baseUrl/exits_${cc.toLowerCase()}.json';
+    final resp = await _dio.get<Map<String, dynamic>>(url);
+    final body = resp.data;
+    if (body == null) return const [];
+    return parseMotorwayExits(body);
+  }
+}
+
+// Top-level (isolate-sendable, #3154) codec pair for [PersistentDataset].
+Map<String, dynamic> _serializeExits(List<MotorwayExit> exits) => {
+      'exits': [
+        for (final e in exits)
+          {
+            'la': e.lat,
+            'lo': e.lng,
+            if (e.ref != null) 'r': e.ref,
+            if (e.name != null) 'n': e.name,
+          },
+      ],
+    };
+
+List<MotorwayExit>? _deserializeExits(Map<String, dynamic> json) =>
+    parseMotorwayExits(json);

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -25,6 +25,7 @@ import '../../../../core/domain/station.dart';
 import 'amenity_chips.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/road_distance_provider.dart';
+import '../../../../core/services/radar/motorway_exits_provider.dart';
 
 part 'station_card_price_column.dart';
 part 'station_card_price_row.dart';

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -192,6 +192,46 @@ class _StationDetails extends StatelessWidget {
             ],
           ],
         ),
+        // #3633 — highway mode v2: "via exit {ref} · +{km} km" under the
+        // distance row when the radar's exit layer annotated this
+        // station (same side-channel pattern as roadDistancesProvider).
+        // Absent off-highway / for on-road service areas / when the
+        // exits asset hasn't loaded — the row simply doesn't render.
+        Consumer(
+          builder: (context, ref, _) {
+            final info = ref.watch(
+              highwayExitInfoMapProvider.select((m) => m[station.id]),
+            );
+            if (info == null) return const SizedBox.shrink();
+            return Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.fork_right,
+                    size: 12,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 2),
+                  Flexible(
+                    child: Text(
+                      l10n.highwayViaExit(
+                        info.exitLabel,
+                        info.detourKm.toStringAsFixed(1),
+                      ),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
         // #2899/#2984 — Fuel Station Radar closeness bar: the SAME green→accent
         // [ProximityFillBar] the trip radar card + PiP overlay use, so all
         // three radar surfaces fill identically as the driver nears a station.

--- a/lib/features/search/providers/radar_exit_layer.dart
+++ b/lib/features/search/providers/radar_exit_layer.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/country/country_provider.dart';
+import '../../../core/domain/station.dart';
+import '../../../core/services/radar/motorway_exits.dart';
+import '../../../core/services/radar/motorway_exits_provider.dart';
+import '../../../core/services/radar/radar_ranking.dart';
+import '../../../core/domain/fuel_type.dart';
+
+/// #3633 v2 — exit-aware layer over the ranked list: when highway mode
+/// is active and the active country's motorway exits are loaded,
+/// re-sort by along-track distance and publish per-station "via exit"
+/// annotations to [highwayExitInfoMapProvider] (the #3634-style
+/// side-channel the station card watches). Off-highway (or before the
+/// exits asset lands) this is v1 behaviour verbatim: ranked order
+/// unchanged, annotation map empty. Shell-safe.
+List<Station> applyHighwayExitLayer(
+  Ref ref,
+  List<Station> ranked,
+  double lat,
+  double lng,
+  ({bool active, double? heading, bool leftHand}) hw,
+) {
+  try {
+    final heading = hw.heading;
+    if (!hw.active || heading == null) {
+      ref.read(highwayExitInfoMapProvider.notifier).clear();
+      return ranked;
+    }
+    // Lazy per-country load — a no-op once loaded; until it lands the
+    // exits list is empty and the annotation degrades to v1.
+    ref
+        .read(motorwayExitsProvider.notifier)
+        .ensureLoaded(ref.read(activeCountryProvider).code);
+    final annotated = annotateStationsViaExits(
+      stations: ranked,
+      exits: ref.read(motorwayExitsProvider),
+      lat: lat,
+      lng: lng,
+      headingDegrees: heading,
+    );
+    ref
+        .read(highwayExitInfoMapProvider.notifier)
+        .publish(annotated.infoByStationId);
+    return annotated.stations;
+  } catch (_) {
+    // ignore: silent_catch — shell safety: an unwired graph keeps v1 order
+    return ranked;
+  }
+}
+
+/// #3633 — the radar's shared "rank, then exit-layer" step: the #3267
+/// [RadarRanking] authority followed by [applyHighwayExitLayer], so
+/// both radar publish paths (poll + republish) stay one call.
+List<Station> rankWithExitLayer(
+  Ref ref,
+  Iterable<Station> raw, {
+  required double lat,
+  required double lng,
+  required FuelType fuel,
+  required ({bool active, double? heading, bool leftHand}) hw,
+}) =>
+    applyHighwayExitLayer(
+      ref,
+      RadarRanking.rank(raw,
+          lat: lat,
+          lng: lng,
+          fuel: fuel,
+          headingDegrees: hw.heading,
+          highwayAheadOnly: hw.active,
+          leftHandTraffic: hw.leftHand),
+      lat,
+      lng,
+      hw,
+    );
+

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -22,6 +22,7 @@ import '../../widget/data/car_station_writer.dart';
 import 'search_filters_provider.dart';
 import '../../../core/services/radar/highway_mode_provider.dart';
 import 'road_distance_provider.dart';
+import 'radar_exit_layer.dart';
 import 'radar_highway_args.dart';
 
 part 'radar_search_provider.g.dart';
@@ -319,13 +320,10 @@ class RadarSearch extends _$RadarSearch {
 
       _lastRaw = [...corridor, ...nearby];
       final hw = highwayRankArgs(ref, _lastFix);
-      final ranked = RadarRanking.rank(_lastRaw,
-          lat: lat,
-          lng: lng,
-          fuel: fuel,
-          headingDegrees: hw.heading,
-          highwayAheadOnly: hw.active,
-          leftHandTraffic: hw.leftHand);
+      // #3633 — shared rank + v2 exit layer (along-track sort + "via
+      // exit" annotations; a no-op off-highway).
+      final ranked =
+          rankWithExitLayer(ref, _lastRaw, lat: lat, lng: lng, fuel: fuel, hw: hw);
 
       // #2948 — publish to the Android Auto Radar screen (swallows write faults).
       unawaited(carWriter.writeRadar(ranked, fuel));
@@ -361,13 +359,8 @@ class RadarSearch extends _$RadarSearch {
     if (_lastRaw.isEmpty) return;
     final fuel = ref.read(selectedFuelTypeProvider);
     final hw = highwayRankArgs(ref, _lastFix);
-    final ranked = RadarRanking.rank(_lastRaw,
-        lat: lat,
-        lng: lng,
-        fuel: fuel,
-        headingDegrees: hw.heading,
-        highwayAheadOnly: hw.active,
-        leftHandTraffic: hw.leftHand);
+    final ranked =
+        rankWithExitLayer(ref, _lastRaw, lat: lat, lng: lng, fuel: fuel, hw: hw);
     unawaited(carWriter.writeRadar(ranked, fuel));
     // #3354 — stamp the live course so the scope can orient heading-up.
     state = state.copyWith(

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -122,7 +122,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'b94ae83b35ba3d3c09e6ee27c641b8cf4c2342e5';
+String _$radarSearchHash() => r'1a4cb7bd93351d29e249db2e00b1df0b899f8396';
 
 /// The on-search Fuel Station Radar (#2659 / #3267).
 ///

--- a/lib/l10n/_fragments/highway_exits_de.arb
+++ b/lib/l10n/_fragments/highway_exits_de.arb
@@ -1,0 +1,9 @@
+{
+  "highwayViaExit": "über Ausfahrt {ref} · +{km} km",
+  "@highwayViaExit": {
+    "placeholders": {
+      "ref": {"type": "String"},
+      "km": {"type": "String"}
+    }
+  }
+}

--- a/lib/l10n/_fragments/highway_exits_en.arb
+++ b/lib/l10n/_fragments/highway_exits_en.arb
@@ -1,0 +1,10 @@
+{
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "description": "Highway mode v2 (#3633): sub-line on a radar station card naming the motorway exit that serves an off-highway station and the straight-line detour from that exit. {ref} is the signposted exit number/name from OSM, {km} the detour with one decimal.",
+    "placeholders": {
+      "ref": {"type": "String"},
+      "km": {"type": "String"}
+    }
+  }
+}

--- a/lib/l10n/_fragments/highway_exits_fr.arb
+++ b/lib/l10n/_fragments/highway_exits_fr.arb
@@ -1,0 +1,9 @@
+{
+  "highwayViaExit": "via sortie {ref} · +{km} km",
+  "@highwayViaExit": {
+    "placeholders": {
+      "ref": {"type": "String"},
+      "km": {"type": "String"}
+    }
+  }
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2870,6 +2870,17 @@
   "hapticEcoCoachSettingTitle": "Echtzeit-Eco-Coaching",
   "hapticEcoCoachSettingSubtitle": "Sanftes Vibrieren + Hinweis am Bildschirm, wenn du beim Cruisen aufs Pedal trittst",
   "hapticEcoCoachSnackBarMessage": "Locker vom Pedal — Ausrollen spart mehr",
+  "highwayViaExit": "über Ausfahrt {ref} · +{km} km",
+  "@highwayViaExit": {
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
+  },
   "semanticsNavigateTo": "Zu {name} navigieren",
   "semanticsRemoveFromFavorites": "{name} aus den Favoriten entfernen",
   "showOnMapSemanticLabel": "Tankstellen auf Karte anzeigen",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5113,6 +5113,18 @@
   "@hapticEcoCoachSnackBarMessage": {
     "description": "SnackBar copy shown on the trip-recording screen when the eco-coach heuristic fires (#1273). Co-located with the haptic; same toggle gates both surfaces."
   },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "description": "Highway mode v2 (#3633): sub-line on a radar station card naming the motorway exit that serves an off-highway station and the straight-line detour from that exit. {ref} is the signposted exit number/name from OSM, {km} the detour with one decimal.",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
+  },
   "semanticsNavigateTo": "Navigate to {name}",
   "@semanticsNavigateTo": {
     "placeholders": {

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1718,6 +1718,7 @@
   "hapticEcoCoachSettingTitle": "⟦Řéáł-ŧîɱé éçó çóáçĥîñǧ ·········⟧",
   "hapticEcoCoachSettingSubtitle": "⟦Ǧéñŧłé ĥáƥŧîç + óñ-šçřééñ ŧîƥ ŵĥéñ ýóú ƒłóóř îŧ đúřîñǧ çřúîšé ······················⟧",
   "hapticEcoCoachSnackBarMessage": "⟦Éášý óñ ŧĥé ŧĥřóŧŧłé — çóášŧîñǧ šáṽéš ɱóřé ···············⟧",
+  "highwayViaExit": "⟦ṽîá éẋîŧ {ref} · +{km} ķɱ ····⟧",
   "semanticsNavigateTo": "⟦Ñáṽîǧáŧé ŧó {name} ·····⟧",
   "semanticsRemoveFromFavorites": "⟦Řéɱóṽé {name} ƒřóɱ ƒáṽóřîŧéš ·········⟧",
   "showOnMapSemanticLabel": "⟦Šĥóŵ šŧáŧîóñš óñ ɱáƥ ········⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5573,5 +5573,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10488,6 +10488,12 @@ abstract class AppLocalizations {
   /// **'Easy on the throttle — coasting saves more'**
   String get hapticEcoCoachSnackBarMessage;
 
+  /// Highway mode v2 (#3633): sub-line on a radar station card naming the motorway exit that serves an off-highway station and the straight-line detour from that exit. {ref} is the signposted exit number/name from OSM, {km} the detour with one decimal.
+  ///
+  /// In en, this message translates to:
+  /// **'via exit {ref} · +{km} km'**
+  String highwayViaExit(String ref, String km);
+
   /// No description provided for @semanticsNavigateTo.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6033,6 +6033,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'По-леко с педала — инерцията спестява повече';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Навигация до $name';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5994,6 +5994,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get hapticEcoCoachSnackBarMessage => 'Mírnit plyn — výběh šetří více';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigovat na $name';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -5981,6 +5981,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Let på speederen — kystning sparer mere';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Naviger til $name';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6022,6 +6022,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Locker vom Pedal — Ausrollen spart mehr';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'über Ausfahrt $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Zu $name navigieren';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -6032,6 +6032,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ελαφρύτερο γκάζι — η αδράνεια εξοικονομεί περισσότερα';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Πλοήγηση προς $name';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5954,6 +5954,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Easy on the throttle — coasting saves more';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigate to $name';
   }
@@ -14445,6 +14450,11 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get hapticEcoCoachSnackBarMessage =>
       '⟦Éášý óñ ŧĥé ŧĥřóŧŧłé — çóášŧîñǧ šáṽéš ɱóřé ···············⟧';
+
+  @override
+  String highwayViaExit(String ref, String km) {
+    return '⟦ṽîá éẋîŧ $ref · +$km ķɱ ····⟧';
+  }
 
   @override
   String semanticsNavigateTo(String name) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6025,6 +6025,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Suave con el acelerador: dejarse llevar ahorra más';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navegar a $name';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -5982,6 +5982,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kerge gaasiga — libisemine säästab rohkem';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigeeri sihtkohta $name';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -5983,6 +5983,11 @@ class AppLocalizationsFi extends AppLocalizations {
       'Pehmeästi kaasulla — liuku säästää enemmän';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigoi kohteeseen $name';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6038,6 +6038,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Doucement sur l\'accélérateur — la roue libre économise plus';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Naviguer vers $name';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6001,6 +6001,11 @@ class AppLocalizationsHr extends AppLocalizations {
       'Polako s gasom — klizanje više štedi';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigiraj do $name';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -6024,6 +6024,11 @@ class AppLocalizationsHu extends AppLocalizations {
       'Kíméletes gáz — a gurulás több üzemanyagot takarít meg';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigálás ide: $name';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6013,6 +6013,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Giù l\'acceleratore — il rilascio del gas fa risparmiare di più';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Naviga verso $name';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -6016,6 +6016,11 @@ class AppLocalizationsLt extends AppLocalizations {
       'Atsargiau su akseleratoriumi — inercinė eiga taupo daugiau';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Nuvykti į $name';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -6019,6 +6019,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'Uzmanīgi ar gāzi — skriešana ietaupa vairāk';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigēt uz $name';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -5982,6 +5982,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Slipp opp for gassen – frihjuling sparer mer';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Naviger til $name';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6003,6 +6003,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Rustig aan het gas — uitrollen bespaart meer';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigeer naar $name';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6007,6 +6007,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Łagodniej z gazem — wybieg oszczędza więcej';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Nawiguj do $name';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6023,6 +6023,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Devagar no acelerador — deslizar poupa mais';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navegar até $name';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6023,6 +6023,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Ușor cu acceleratorul — inerția economisește mai mult';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navighează către $name';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -6010,6 +6010,11 @@ class AppLocalizationsSk extends AppLocalizations {
       'Šetrite plynom — voľný beh šetrí viac';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigovať na $name';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -5994,6 +5994,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'Nežno s plinom — drsenje prihrani več';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigiraj do $name';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -5980,6 +5980,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Varsamt med gasen – frihjul sparar mer';
 
   @override
+  String highwayViaExit(String ref, String km) {
+    return 'via exit $ref · +$km km';
+  }
+
+  @override
   String semanticsNavigateTo(String name) {
     return 'Navigera till $name';
   }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5700,5 +5700,18 @@
   "@obd2ResetConnectionNoLink": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "highwayViaExit": "via exit {ref} · +{km} km",
+  "@highwayViaExit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "ref": {
+        "type": "String"
+      },
+      "km": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/test/core/services/radar/motorway_exits_provider_test.dart
+++ b/test/core/services/radar/motorway_exits_provider_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits_provider.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits_service.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3633 — [MotorwayExits.ensureLoaded] is fire-and-forget by contract:
+/// a failing service must never throw into the caller (the radar's
+/// poll loop) and the state stays the empty v1 list. Fault-injected per
+/// the never-throws contract (#2349).
+class _OfflineAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? body,
+          Future<void>? cancelFuture) =>
+      throw DioException.connectionError(
+          requestOptions: options, reason: 'offline');
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  test('ensureLoaded with a failing service returns normally and leaves '
+      'the empty v1 state', () async {
+    final container = ProviderContainer(overrides: [
+      motorwayExitsServiceProvider.overrideWithValue(
+        MotorwayExitsService(dio: Dio()..httpClientAdapter = _OfflineAdapter()),
+      ),
+    ]);
+    addTearDown(container.dispose);
+
+    expect(
+      () => container.read(motorwayExitsProvider.notifier).ensureLoaded('FR'),
+      returnsNormally,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(motorwayExitsProvider), isEmpty);
+  });
+
+  test('the annotation side-channel publishes and clears', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(highwayExitInfoMapProvider.notifier);
+    expect(container.read(highwayExitInfoMapProvider), isEmpty);
+    notifier.clear(); // idempotent on empty
+    expect(container.read(highwayExitInfoMapProvider), isEmpty);
+  });
+}

--- a/test/core/services/radar/motorway_exits_service_test.dart
+++ b/test/core/services/radar/motorway_exits_service_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits_service.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #3633 — [MotorwayExitsService.exitsFor] never throws: any failure
+/// (network down, hostile body) degrades to the last-known copy or an
+/// empty list, so highway mode falls back to exit-less v1. Fault-
+/// injected per the never-throws contract (#2349).
+class _ThrowingAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? body,
+          Future<void>? cancelFuture) =>
+      throw DioException.connectionError(
+          requestOptions: options, reason: 'offline');
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+
+  @override
+  Future<void> put(String key, Map<String, dynamic> data,
+      {required Duration ttl, required ServiceSource source}) async {
+    _store[key] = CacheEntry(
+        payload: data,
+        // #3660 — pinned instant, not the wall clock.
+        storedAt: DateTime(2026, 3, 11, 14, 30),
+        originalSource: source,
+        ttl: ttl);
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) => _store[key];
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  test('a dead network completes with an empty list — never throws', () async {
+    final dio = Dio()..httpClientAdapter = _ThrowingAdapter();
+    final service = MotorwayExitsService(dio: dio, cache: _MemCache());
+
+    await expectLater(service.exitsFor('FR'), completes);
+    expect(await service.exitsFor('FR'), isEmpty,
+        reason: 'no copy anywhere → the exit-less v1 degradation');
+  });
+
+  test('no cache wired (isolated harness) still completes', () async {
+    final dio = Dio()..httpClientAdapter = _ThrowingAdapter();
+    final service = MotorwayExitsService(dio: dio);
+    await expectLater(service.exitsFor('DE'), completes);
+  });
+}

--- a/test/core/services/radar/motorway_exits_test.dart
+++ b/test/core/services/radar/motorway_exits_test.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/domain/station.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits.dart';
+
+/// #3633 — pure unit tests for the exit-aware v2 layer.
+///
+/// Geometry: the driver sits at (43.30, 3.40) heading due EAST (90°).
+/// At this latitude 0.01° of longitude ≈ 0.81 km east; 0.01° of
+/// latitude ≈ 1.11 km north. Assertions use generous tolerances so the
+/// spherical math never fights the flat-earth approximations here.
+void main() {
+  const lat = 43.30, lng = 3.40, heading = 90.0;
+
+  Station station(String id, double la, double lo) => Station(
+        id: id,
+        name: 'S$id',
+        brand: 'B',
+        street: '',
+        place: '',
+        postCode: '',
+        lat: la,
+        lng: lo,
+        dist: 0,
+        isOpen: true,
+      );
+
+  MotorwayExit exit(double la, double lo, {String? ref, String? name}) =>
+      MotorwayExit(lat: la, lng: lo, ref: ref, name: name);
+
+  group('parse', () {
+    test('compact asset parses; malformed entries are skipped', () {
+      final exits = parseMotorwayExits({
+        'v': 1,
+        'exits': [
+          {'la': 43.31, 'lo': 3.41, 'r': '36', 'n': 'Saint-Thibéry'},
+          {'la': 'garbage', 'lo': 3.5},
+          {'lo': 3.6},
+          {'la': 43.32, 'lo': 3.42},
+        ],
+      });
+      expect(exits, hasLength(2));
+      expect(exits.first.ref, '36');
+      expect(exits.first.label, '36');
+      expect(exits.last.label, isNull, reason: 'no ref, no name');
+    });
+
+    test('a hostile payload NEVER throws — skip, do not fail (the cache '
+        'layer contract)', () {
+      expect(
+        () => parseMotorwayExits({'exits': 'not-a-list'}),
+        returnsNormally,
+      );
+      expect(parseMotorwayExits({'exits': 'not-a-list'}), isEmpty);
+      expect(() => parseMotorwayExits(const {}), returnsNormally);
+    });
+
+    test('a ref-less named exit labels by name', () {
+      expect(exit(1, 2, name: 'Pézenas').label, 'Pézenas');
+    });
+  });
+
+  group('annotateStationsViaExits (#3633)', () {
+    test('an off-axis station is annotated with the LAST exit before its '
+        'along-track position, with the straight-line detour', () {
+      // Exit 36 is 4 km ahead ON the road; the station sits 8 km ahead
+      // and ~1.1 km off to the north (off-axis).
+      final exits = [
+        exit(43.30, 3.449, ref: '36'), // ~4.0 km east
+        exit(43.30, 3.548, ref: '38'), // ~12 km east — BEYOND the station
+      ];
+      final stations = [station('a', 43.31, 3.499)]; // ~8 km east, 1.1 km north
+
+      final ann = annotateStationsViaExits(
+        stations: stations,
+        exits: exits,
+        lat: lat,
+        lng: lng,
+        headingDegrees: heading,
+      );
+
+      final info = ann.infoByStationId['a'];
+      expect(info, isNotNull);
+      expect(info!.exitLabel, '36',
+          reason: 'exit 38 lies beyond the station — you take 36');
+      // Exit→station straight line: ~4 km east + ~1.1 km north ≈ 4.2 km.
+      expect(info.detourKm, closeTo(4.2, 0.5));
+      expect(info.alongKm, closeTo(8.0, 0.5));
+    });
+
+    test('an ON-ROAD service area gets NO exit annotation but still '
+        'drives the along-track sort', () {
+      final exits = [exit(43.30, 3.449, ref: '36')];
+      final stations = [
+        station('services', 43.30, 3.474), // ~6 km dead ahead, on-road
+        station('near-off', 43.31, 3.437), // ~3 km east, 1.1 km north
+      ];
+      final ann = annotateStationsViaExits(
+        stations: stations,
+        exits: exits,
+        lat: lat,
+        lng: lng,
+        headingDegrees: heading,
+      );
+      expect(ann.infoByStationId.containsKey('services'), isFalse,
+          reason: 'reachable without exiting — no "via exit" line');
+      // Sort is along-track: the off-axis 3 km station precedes the 6 km
+      // services.
+      expect(ann.stations.map((s) => s.id).toList(),
+          ['near-off', 'services']);
+    });
+
+    test('a station BEFORE the first labeled exit gets no annotation '
+        '(you cannot reach it without an exit that exists)', () {
+      final exits = [exit(43.30, 3.523, ref: '40')]; // ~10 km ahead
+      final stations = [station('x', 43.31, 3.437)]; // ~3 km ahead, off-axis
+      final ann = annotateStationsViaExits(
+        stations: stations,
+        exits: exits,
+        lat: lat,
+        lng: lng,
+        headingDegrees: heading,
+      );
+      expect(ann.infoByStationId, isEmpty);
+    });
+
+    test('exits BEHIND the driver are ignored', () {
+      final exits = [exit(43.30, 3.351, ref: '34')]; // ~4 km WEST (behind)
+      final stations = [station('x', 43.31, 3.499)];
+      final ann = annotateStationsViaExits(
+        stations: stations,
+        exits: exits,
+        lat: lat,
+        lng: lng,
+        headingDegrees: heading,
+      );
+      expect(ann.infoByStationId, isEmpty);
+    });
+
+    test('unlabeled exits never annotate (nothing to signpost)', () {
+      final exits = [exit(43.30, 3.449)]; // no ref, no name
+      final stations = [station('x', 43.31, 3.499)];
+      final ann = annotateStationsViaExits(
+        stations: stations,
+        exits: exits,
+        lat: lat,
+        lng: lng,
+        headingDegrees: heading,
+      );
+      expect(ann.infoByStationId, isEmpty);
+    });
+
+    test('degenerate inputs preserve order with an empty map — the v1 '
+        'degradation contract', () {
+      final stations = [station('b', 43.31, 3.499), station('a', 43.30, 3.42)];
+      for (final ann in [
+        annotateStationsViaExits(
+            stations: stations,
+            exits: const [],
+            lat: lat,
+            lng: lng,
+            headingDegrees: heading),
+        annotateStationsViaExits(
+            stations: stations,
+            exits: [exit(43.30, 3.449, ref: '36')],
+            lat: lat,
+            lng: lng,
+            headingDegrees: double.nan),
+      ]) {
+        expect(ann.infoByStationId, isEmpty);
+        expect(ann.stations.map((s) => s.id).toList(), ['b', 'a'],
+            reason: 'input order untouched — v1 behaviour verbatim');
+      }
+    });
+  });
+}

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -4,6 +4,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits.dart';
+import 'package:tankstellen/core/services/radar/motorway_exits_provider.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
@@ -1446,5 +1448,45 @@ void main() {
         closeTo(0.38, 1e-9),
       );
     });
+    testWidgets('highway mode v2 (#3633): silent without an exit '
+        'annotation', (tester) async {
+      await pumpApp(
+        tester,
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
+      );
+      expect(find.byIcon(Icons.fork_right), findsNothing);
+    });
+
+    testWidgets('highway mode v2 (#3633): renders "via exit {ref} · +km" '
+        'from the side-channel annotation', (tester) async {
+      await pumpApp(
+        tester,
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
+        overrides: <Object>[
+          highwayExitInfoMapProvider.overrideWith(
+            () => _FixedExitInfoMap({
+              testStation.id: const HighwayExitInfo(
+                exitLabel: '36',
+                detourKm: 1.24,
+                alongKm: 4.2,
+              ),
+            }),
+          ),
+        ],
+      );
+      expect(find.byIcon(Icons.fork_right), findsOneWidget);
+      expect(find.textContaining('via exit 36'), findsOneWidget);
+      expect(find.textContaining('+1.2 km'), findsOneWidget);
+    });
+
   });
 }
+
+class _FixedExitInfoMap extends HighwayExitInfoMap {
+  _FixedExitInfoMap(this._value);
+  final Map<String, HighwayExitInfo> _value;
+
+  @override
+  Map<String, HighwayExitInfo> build() => _value;
+}
+

--- a/tool/motorway_exits/publish_motorway_exits.py
+++ b/tool/motorway_exits/publish_motorway_exits.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+"""#3633 — extract motorway exits per supported country from OpenStreetMap.
+
+One Overpass query per country pulls every `highway=motorway_junction`
+node (position + `ref` exit number + optional `name`) and writes a
+compact JSON per country:
+
+    {"v": 1, "cc": "FR", "generatedAt": "…", "exits":
+      [{"la": 48.85123, "lo": 2.35456, "r": "36", "n": "Saint-Thibéry"}, …]}
+
+Coordinates are rounded to 5 decimals (~1.1 m) — far below the app's
+lateral thresholds — which roughly halves the payload. Exits change on
+the timescale of years, so the publish cadence is monthly.
+
+Usage: python3 publish_motorway_exits.py <out-dir> [CC …]
+(default: every supported country).
+
+Rate-limit etiquette: Overpass is donated infrastructure. One query per
+country, a courtesy sleep between queries, bounded retries with backoff
+across the public mirror pool, and a descriptive User-Agent.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# The app's supported countries (lib/core/country/country_config_data*).
+# KR/AU/CL/MX/AR are served too — motorway_junction tagging is global.
+COUNTRIES = [
+    "AR", "AT", "AU", "CL", "DE", "DK", "ES", "FR", "GB",
+    "GR", "IT", "KR", "LU", "MX", "PT", "RO", "SI",
+]
+
+MIRRORS = [
+    "https://overpass-api.de/api/interpreter",
+    "https://overpass.kumi.systems/api/interpreter",
+]
+
+USER_AGENT = (
+    "tankstellen-motorway-exits/1.0 "
+    "(+https://github.com/fdittgen-png/tankstellen; monthly batch)"
+)
+
+QUERY = """
+[out:json][timeout:180];
+area["ISO3166-1"="{cc}"][admin_level=2]->.c;
+node["highway"="motorway_junction"](area.c);
+out;
+"""
+
+
+def fetch(cc: str) -> dict:
+    data = urllib.parse.urlencode({"data": QUERY.format(cc=cc)}).encode()
+    last: Exception | None = None
+    for attempt in range(4):
+        mirror = MIRRORS[attempt % len(MIRRORS)]
+        req = urllib.request.Request(
+            mirror, data=data, headers={"User-Agent": USER_AGENT}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=240) as resp:
+                return json.load(resp)
+        except Exception as e:  # noqa: BLE001 — retried, surfaced on exhaust
+            last = e
+            wait = 20 * (attempt + 1)
+            print(f"  {cc}: attempt {attempt + 1} failed ({e}); "
+                  f"retrying in {wait}s", flush=True)
+            time.sleep(wait)
+    raise RuntimeError(f"{cc}: Overpass exhausted: {last}")
+
+
+def compact(cc: str, raw: dict) -> dict:
+    exits = []
+    for el in raw.get("elements", []):
+        if el.get("type") != "node":
+            continue
+        tags = el.get("tags", {})
+        entry = {
+            "la": round(el["lat"], 5),
+            "lo": round(el["lon"], 5),
+        }
+        ref = tags.get("ref")
+        if ref:
+            entry["r"] = ref
+        name = tags.get("name")
+        if name:
+            entry["n"] = name
+        exits.append(entry)
+    exits.sort(key=lambda e: (e["la"], e["lo"]))
+    return {
+        "v": 1,
+        "cc": cc,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "exits": exits,
+    }
+
+
+def main() -> int:
+    out_dir = Path(sys.argv[1])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    countries = sys.argv[2:] or COUNTRIES
+    failures = []
+    for cc in countries:
+        print(f"{cc}: querying Overpass …", flush=True)
+        try:
+            payload = compact(cc, fetch(cc))
+        except Exception as e:  # noqa: BLE001 — collected, run continues
+            print(f"  {cc}: FAILED — {e}", flush=True)
+            failures.append(cc)
+            continue
+        out = out_dir / f"exits_{cc.lower()}.json"
+        out.write_text(json.dumps(payload, separators=(",", ":"),
+                                  ensure_ascii=False))
+        print(f"  {cc}: {len(payload['exits'])} exits → {out.name} "
+              f"({out.stat().st_size} bytes)", flush=True)
+        time.sleep(10)  # courtesy gap between country queries
+    if failures:
+        # Partial publishes are fine (each country is its own asset and
+        # the app keeps its previous cached copy) — but the run must go
+        # red so the gap is visible and the next run retries.
+        print(f"FAILED countries: {', '.join(failures)}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What (highway mode v2, follow-up to #3631)

With real exit knowledge from OSM, the radar's highway suggestions become exit-aware: an off-highway station row now reads **« via sortie 36 · +1,2 km »**, and the list orders by **along-track distance** — what the driver can actually reach next — instead of crow-flies.

### Data pipeline (the proven fuel-gr rolling-release pattern)
`motorway-exits-publish.yml` (monthly + manual dispatch) runs one Overpass query per supported country (17), extracting every `highway=motorway_junction` node (position, `ref` exit number, name) into a compact per-country JSON (France ≈ tens of KB) published on the rolling **`motorway-exits`** release. Mirror pool, bounded retries, courtesy gaps, descriptive UA; a partial run publishes what succeeded and goes red. Data © OpenStreetMap contributors (ODbL). **First dispatch should be watched** to seed the assets.

### App side
- `MotorwayExitsService` — per-country keyed dataset (soft 30 d / hard 365 d; exits change on the timescale of years), disk-persisted, **never-throws** (fault-injected). A country that never fetched simply behaves as exit-less v1.
- Lazy load the first time highway mode engages; the ranking reads the loaded list synchronously per GPS poll. The fault test caught a post-dispose state write on the async load — fixed with a `ref.mounted` guard.
- Pure `annotateStationsViaExits`: the #3631 along/lateral projection; each off-axis station associates with the **last labeled exit at-or-before** its along-track position; detour = straight exit→station line (issue scope: no routing); on-road service areas need no exit; degenerate inputs preserve v1 order with an empty map.
- Wiring via `rankWithExitLayer` (`radar_exit_layer.dart` — the radar provider stays under the 400-line cap at 395); annotations flow through the #3634-style side-channel `highwayExitInfoMapProvider` into the station card.
- i18n: 1 key, en/de/fr + full fan-out.

### Tests
9 pure geometry/parse cases (incl. the never-throws fault), service dead-network degradation, provider fire-and-forget contract, card row (annotated + silent). Detached-worktree run: analyze clean, **15,527 passed**; failures were the Argentina live-API flake + three known combined-run isolation flakes that all pass standalone (re-verified).

Closes #3633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
