### PR TITLE
feat(ux): one shared delete confirmation, applied to every destructive action (#3682)

### DIFF
--- a/lib/core/widgets/confirm_delete_dialog.dart
+++ b/lib/core/widgets/confirm_delete_dialog.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+
+/// #3682 — THE one destructive-action confirmation for the whole app.
+///
+/// Every delete (and delete-like reset) routes through this function so
+/// the warning look, the button order, the barrier semantics and the
+/// error styling exist exactly once. Before it, the same AlertDialog
+/// scaffolding was copy-pasted six times and five swipe surfaces plus
+/// two sheet deletes had no confirmation at all.
+///
+/// Contract:
+///  * returns `true` ONLY on an explicit tap of the destructive action;
+///  * Cancel, barrier dismiss and system back all return `false` — a
+///    destructive action must never happen by accident;
+///  * [title] / [message] / [confirmLabel] default to the generic
+///    localized strings; sites with richer copy (the η_v reset's
+///    explainer, the vehicle delete naming the vehicle) pass their own;
+///  * [confirmKey] gives a surface a stable per-site test handle
+///    without duplicating the dialog.
+///
+/// The confirm button is error-styled AND icon-carrying so the
+/// destructive choice is signalled by more than colour (the same
+/// non-colour-alone rule the snackbars follow, #1692).
+Future<bool> confirmDestructiveAction(
+  BuildContext context, {
+  String? title,
+  String? message,
+  String? confirmLabel,
+  Key? confirmKey,
+}) async {
+  if (!context.mounted) return false;
+  final l = AppLocalizations.of(context);
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (ctx) {
+      final scheme = Theme.of(ctx).colorScheme;
+      return AlertDialog(
+        icon: Icon(Icons.warning_amber_rounded, color: scheme.error),
+        title: Text(title ?? l.confirmDeleteTitle),
+        content: Text(message ?? l.confirmDeleteBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l.cancel),
+          ),
+          FilledButton.tonalIcon(
+            key: confirmKey,
+            style: FilledButton.styleFrom(
+              backgroundColor: scheme.errorContainer,
+              foregroundColor: scheme.onErrorContainer,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            icon: const Icon(Icons.delete_outline, size: 18),
+            label: Text(confirmLabel ?? l.delete),
+          ),
+        ],
+      );
+    },
+  );
+  return confirmed ?? false;
+}

--- a/lib/core/widgets/swipe_to_delete.dart
+++ b/lib/core/widgets/swipe_to_delete.dart
@@ -4,21 +4,35 @@
 import 'package:flutter/material.dart';
 
 import '../theme/dark_mode_colors.dart';
+import 'confirm_delete_dialog.dart';
 
 /// Reusable swipe-to-delete wrapper with red background and delete icon.
 ///
-/// Replaces 2 identical Dismissible implementations in AlertsScreen
-/// and FavoritesScreen.
+/// Replaces the once-identical Dismissible implementations across the
+/// list surfaces (alerts, favorites, itineraries, fill-ups, charging
+/// logs). The `confirm_delete_lint_test` allowlists raw `Dismissible`
+/// usages, so every delete-swipe in the app goes through here.
+///
+/// #3682 — every swipe now asks the shared [confirmDestructiveAction]
+/// warning BEFORE dismissing, so an accidental flick can't destroy
+/// data; the surfaces' existing 10-second undo (#3664) stays as the
+/// second net for a confirmed-but-regretted delete. [confirmMessage]
+/// lets a list name the item ("Delete the alert for Total Sète?");
+/// null keeps the generic localized body.
 class SwipeToDelete extends StatelessWidget {
   final Key dismissKey;
   final VoidCallback onDismissed;
   final Widget child;
+
+  /// Optional item-specific message for the confirmation dialog.
+  final String? confirmMessage;
 
   const SwipeToDelete({
     super.key,
     required this.dismissKey,
     required this.onDismissed,
     required this.child,
+    this.confirmMessage,
   });
 
   @override
@@ -26,6 +40,8 @@ class SwipeToDelete extends StatelessWidget {
     return Dismissible(
       key: dismissKey,
       direction: DismissDirection.endToStart,
+      confirmDismiss: (_) =>
+          confirmDestructiveAction(context, message: confirmMessage),
       background: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/swipe_to_delete.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -231,16 +231,11 @@ class _AlertListTile extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Dismissible(
-      key: ValueKey(alert.id),
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 24),
-        color: DarkModeColors.error(context),
-        child: const Icon(Icons.delete, color: Colors.white),
-      ),
-      onDismissed: (_) {
+    // #3682 — the shared swipe-to-delete carries the app-wide delete
+    // confirmation.
+    return SwipeToDelete(
+      dismissKey: ValueKey(alert.id),
+      onDismissed: () {
         unawaited(ref.read(alertProvider.notifier).removeAlert(alert.id));
         SnackBarHelper.show(context, l10n.alertDeleted(alert.stationName));
       },
@@ -333,16 +328,11 @@ class _RadiusAlertListTile extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Dismissible(
-      key: ValueKey('radius-${alert.id}'),
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 24),
-        color: DarkModeColors.error(context),
-        child: const Icon(Icons.delete, color: Colors.white),
-      ),
-      onDismissed: (_) {
+    // #3682 — the shared swipe-to-delete carries the app-wide delete
+    // confirmation.
+    return SwipeToDelete(
+      dismissKey: ValueKey('radius-${alert.id}'),
+      onDismissed: () {
         // #2494 — mirror the per-station tile (:142): a past-tense
         // confirmation with an Undo that re-inserts the deleted alert,
         // rather than the old interrogative "Delete radius alert?" copy

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/sync/trip_shares_sync_enabled_provider.dart';
 import '../../../../core/sync/trips_sync.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
@@ -327,23 +328,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     WidgetRef ref,
     AppLocalizations l,
   ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l.trajetDetailDeleteConfirmTitle),
-        content: Text(l.trajetDetailDeleteConfirmBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l.trajetDetailDeleteConfirmCancel),
-          ),
-          TextButton(
-            key: const Key('trip_detail_delete_confirm'),
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l.trajetDetailDeleteConfirmConfirm),
-          ),
-        ],
-      ),
+    // #3682 — the ONE shared destructive-action dialog (the stable
+    // per-surface test key rides on the confirm button).
+    final confirmed = await confirmDestructiveAction(
+      context,
+      title: l.trajetDetailDeleteConfirmTitle,
+      message: l.trajetDetailDeleteConfirmBody,
+      confirmLabel: l.trajetDetailDeleteConfirmConfirm,
+      confirmKey: const Key('trip_detail_delete_confirm'),
     );
     if (confirmed != true || !context.mounted) return;
     // #3664 — capture-and-restore undo. The whole entry (summary +

--- a/lib/features/consumption/presentation/widgets/charging_tab.dart
+++ b/lib/features/consumption/presentation/widgets/charging_tab.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/swipe_to_delete.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/charging_log.dart';
@@ -64,16 +64,11 @@ class ChargingTab extends ConsumerWidget {
                 return const _ChargingChartsSection();
               }
               final log = ordered[index - 1];
-              return Dismissible(
-                key: ValueKey('charging-${log.id}'),
-                direction: DismissDirection.endToStart,
-                background: Container(
-                  alignment: Alignment.centerRight,
-                  padding: const EdgeInsets.only(right: 24),
-                  color: DarkModeColors.error(context),
-                  child: const Icon(Icons.delete, color: Colors.white),
-                ),
-                onDismissed: (_) {
+              // #3682 — the shared swipe-to-delete carries the app-wide
+              // delete confirmation.
+              return SwipeToDelete(
+                dismissKey: ValueKey('charging-${log.id}'),
+                onDismissed: () {
                   unawaited(
                     ref.read(chargingLogsProvider.notifier).remove(log.id),
                   );

--- a/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../core/utils/time_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/add_fill_up_validators.dart';
@@ -128,6 +129,9 @@ class _EditCorrectionFillUpSheetState
   }
 
   Future<void> _delete() async {
+    // #3682 — the app-wide delete confirmation.
+    if (!await confirmDestructiveAction(context)) return;
+    if (!mounted) return;
     // #3664 — capture the messenger + localized strings BEFORE the
     // await/pop (SnackBarHelper contract): the sheet's own context dies
     // with the pop, but the undo snackbar must outlive it.

--- a/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_virtual_trajet_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/trip_history_repository.dart';
 import '../../domain/add_fill_up_validators.dart';
@@ -80,6 +81,9 @@ class _EditVirtualTrajetSheetState
   }
 
   Future<void> _delete() async {
+    // #3682 — the app-wide delete confirmation.
+    if (!await confirmDestructiveAction(context)) return;
+    if (!mounted) return;
     // #3664 — capture the messenger + localized strings BEFORE the
     // await/pop: the sheet's context dies with the pop, but the undo
     // snackbar must outlive it. The whole entry (summary + embedded

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -10,11 +10,11 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/widgets/responsive_layout.dart';
 import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
-import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/swipe_to_delete.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../achievements/presentation/widgets/badge_shelf.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
@@ -85,16 +85,11 @@ class FuelTab extends ConsumerWidget {
 
     Widget buildFillUpRow(int index) {
       final fillUp = fillUps[index];
-      return Dismissible(
-        key: ValueKey(fillUp.id),
-        direction: DismissDirection.endToStart,
-        background: Container(
-          alignment: Alignment.centerRight,
-          padding: const EdgeInsets.only(right: 24),
-          color: DarkModeColors.error(context),
-          child: const Icon(Icons.delete, color: Colors.white),
-        ),
-        onDismissed: (_) {
+      // #3682 — the shared swipe-to-delete carries the app-wide delete
+      // confirmation; the #3664 undo stays as the second net.
+      return SwipeToDelete(
+        dismissKey: ValueKey(fillUp.id),
+        onDismissed: () {
           final notifier = ref.read(fillUpListProvider.notifier);
           unawaited(notifier.remove(fillUp.id));
           // #3664 — capture-and-restore undo: the swiped entity is held

--- a/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
+++ b/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/situation_classifier.dart';
 import '../../providers/vehicle_baseline_summary_provider.dart';
@@ -241,22 +242,12 @@ class _VehicleBaselineSectionState
     WidgetRef ref,
     AppLocalizations l,
   ) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l.vehicleBaselineResetConfirmTitle),
-        content: Text(l.vehicleBaselineResetConfirmBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l.vehicleBaselineReset),
-          ),
-        ],
-      ),
+    // #3682 — the ONE shared destructive-action dialog.
+    final confirm = await confirmDestructiveAction(
+      context,
+      title: l.vehicleBaselineResetConfirmTitle,
+      message: l.vehicleBaselineResetConfirmBody,
+      confirmLabel: l.vehicleBaselineReset,
     );
     // #3159 — guard before the post-dialog ref use: a dead WidgetRef throws
     // a StateError under Riverpod 3, and the read itself performs the reset

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
@@ -74,6 +75,9 @@ class AlertsTab extends StatelessWidget {
               return Dismissible(
                 key: ValueKey(alert.id),
                 direction: DismissDirection.endToStart,
+                // #3682 — the app-wide delete confirmation (allowlisted
+                // raw Dismissible: it keeps its labeled background).
+                confirmDismiss: (_) => confirmDestructiveAction(context),
                 background: Container(
                   alignment: Alignment.centerRight,
                   padding: const EdgeInsets.only(right: 24),

--- a/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
@@ -8,6 +8,7 @@ import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../core/domain/ev/charging_station.dart';
 import '../../providers/ev_favorites_provider.dart';
@@ -47,6 +48,9 @@ class EvFavoriteDismissible extends ConsumerWidget {
           );
           return false;
         }
+        // #3682 — the app-wide delete confirmation before the removal.
+        if (!await confirmDestructiveAction(context)) return false;
+        if (!context.mounted) return false;
         await favorites.remove(station.id);
         if (!context.mounted) return true;
         final l10nSnack = AppLocalizations.of(context);

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -11,6 +11,7 @@ import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../../core/domain/fuel_type.dart';
@@ -54,6 +55,9 @@ class FavoriteStationDismissible extends ConsumerWidget {
           );
           return false;
         }
+        // #3682 — the app-wide delete confirmation before the removal.
+        if (!await confirmDestructiveAction(context)) return false;
+        if (!context.mounted) return false;
         await favorites.remove(station.id);
         if (!context.mounted) return true;
         final l10nSnack = AppLocalizations.of(context);

--- a/lib/features/loyalty/presentation/loyalty_settings_screen.dart
+++ b/lib/features/loyalty/presentation/loyalty_settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/widgets/page_scaffold.dart';
+import '../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../l10n/app_localizations.dart';
 import '../domain/entities/loyalty_card.dart';
 import '../providers/loyalty_provider.dart';
@@ -87,24 +88,13 @@ class LoyaltySettingsScreen extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     // #3159 — capture before the dialog await; see _openAddSheet.
     final cards = ref.read(loyaltyCardsProvider.notifier);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(l.loyaltyDeleteConfirmTitle),
-        content: Text(l.loyaltyDeleteConfirmBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l.delete),
-          ),
-        ],
-      ),
+    // #3682 — the ONE shared destructive-action dialog.
+    final confirmed = await confirmDestructiveAction(
+      context,
+      title: l.loyaltyDeleteConfirmTitle,
+      message: l.loyaltyDeleteConfirmBody,
     );
-    if (confirmed == true) {
+    if (confirmed) {
       await cards.remove(card.id);
     }
   }

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -22,6 +22,7 @@ import '../../../../core/export/data_exporter.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/privacy_data_provider.dart';
 import '../widgets/config_verification_widget.dart';
@@ -339,31 +340,12 @@ class _PrivacyDashboardScreenState
 
   Future<bool?> _confirmDelete() {
     final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    return showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        icon: Icon(
-          Icons.warning_amber_rounded,
-          color: theme.colorScheme.error,
-          size: 48,
-        ),
-        title: Text(l.privacyDeleteTitle),
-        content: Text(l.privacyDeleteBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: theme.colorScheme.error,
-            ),
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l.privacyDeleteConfirm),
-          ),
-        ],
-      ),
+    // #3682 — the ONE shared destructive-action dialog.
+    return confirmDestructiveAction(
+      context,
+      title: l.privacyDeleteTitle,
+      message: l.privacyDeleteBody,
+      confirmLabel: l.privacyDeleteConfirm,
     );
   }
 }

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -12,6 +12,7 @@ import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../favorites/providers/favorites_provider.dart';
 import '../../../route_search/data/cross_border_corridor.dart'
@@ -216,6 +217,9 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
           );
           return false;
         } else {
+          // #3682 — the app-wide delete confirmation before hiding.
+          if (!await confirmDestructiveAction(context)) return false;
+          if (!context.mounted) return false;
           await ignored.add(item.id);
           if (context.mounted) {
             final stationLabel = item.station.brand.isNotEmpty

--- a/lib/features/search/presentation/widgets/swipeable_station_card.dart
+++ b/lib/features/search/presentation/widgets/swipeable_station_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_tier.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../loyalty/providers/loyalty_provider.dart';
 import '../../../../core/domain/fuel_type.dart';
@@ -59,6 +60,8 @@ class SwipeableStationCard extends ConsumerWidget {
           onNavigate();
           return false; // Don't dismiss — just trigger navigation
         } else {
+          // #3682 — the app-wide delete confirmation before hiding.
+          if (!await confirmDestructiveAction(context)) return false;
           onIgnore();
           return true; // Dismiss — remove from list
         }

--- a/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
+++ b/lib/features/vehicle/presentation/screens/vehicle_list_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/navigation/app_routes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/vehicle_providers.dart';
 import '../widgets/vehicle_card.dart';
@@ -85,24 +86,13 @@ class VehicleListScreen extends ConsumerWidget {
     // element throws a StateError under Riverpod 3, and the screen can be
     // popped out from underneath the open dialog.
     final vehicles = ref.read(vehicleProfileListProvider.notifier);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l.vehicleDeleteTitle),
-        content: Text(l.vehicleDeleteMessage(name)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l.delete),
-          ),
-        ],
-      ),
+    // #3682 — the ONE shared destructive-action dialog.
+    final confirmed = await confirmDestructiveAction(
+      context,
+      title: l.vehicleDeleteTitle,
+      message: l.vehicleDeleteMessage(name),
     );
-    if (confirmed == true) {
+    if (confirmed) {
       await vehicles.remove(id);
     }
   }

--- a/lib/features/vehicle/presentation/widgets/catalog_reset_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reset_confirm_dialog.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Confirmation dialog for the reset-from-vehicle-database action
@@ -17,22 +18,12 @@ class CatalogResetConfirmDialog {
   /// reset action; cancel / barrier dismiss / back all return `null`.
   static Future<bool?> show(BuildContext context, String vehicleLabel) {
     final l = AppLocalizations.of(context);
-    return showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(l.catalogResetConfirmTitle),
-        content: Text(l.catalogResetConfirmBody(vehicleLabel)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l.cancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l.catalogResetAction),
-          ),
-        ],
-      ),
+    // #3682 — delegates to the ONE shared destructive-action dialog.
+    return confirmDestructiveAction(
+      context,
+      title: l.catalogResetConfirmTitle,
+      message: l.catalogResetConfirmBody(vehicleLabel),
+      confirmLabel: l.catalogResetAction,
     );
   }
 }

--- a/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
+++ b/lib/features/vehicle/presentation/widgets/ve_reset_confirm_dialog.dart
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
+import '../../../../core/widgets/confirm_delete_dialog.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Destructive-action confirmation dialog for the η_v calibration
@@ -16,22 +17,13 @@ class VeResetConfirmDialog {
   /// `null`, which callers should treat as "do nothing".
   static Future<bool?> show(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(l.veResetConfirmTitle),
-        content: Text(l.veResetConfirmBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(l.cancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: Text(l.veResetAction),
-          ),
-        ],
-      ),
+    // #3682 — delegates to the ONE shared destructive-action dialog;
+    // this class stays as the call-site-stable named entry point.
+    return confirmDestructiveAction(
+      context,
+      title: l.veResetConfirmTitle,
+      message: l.veResetConfirmBody,
+      confirmLabel: l.veResetAction,
     );
   }
 }

--- a/lib/l10n/_fragments/confirm_delete_de.arb
+++ b/lib/l10n/_fragments/confirm_delete_de.arb
@@ -1,0 +1,4 @@
+{
+  "confirmDeleteTitle": "Löschen?",
+  "confirmDeleteBody": "Soll dieser Eintrag wirklich gelöscht werden?"
+}

--- a/lib/l10n/_fragments/confirm_delete_en.arb
+++ b/lib/l10n/_fragments/confirm_delete_en.arb
@@ -1,0 +1,10 @@
+{
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "description": "Title of the shared destructive-action confirmation dialog (#3682) shown before EVERY delete in the app."
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "description": "Generic body of the shared delete confirmation (#3682), used when a surface passes no item-specific message."
+  }
+}

--- a/lib/l10n/_fragments/confirm_delete_fr.arb
+++ b/lib/l10n/_fragments/confirm_delete_fr.arb
@@ -1,0 +1,4 @@
+{
+  "confirmDeleteTitle": "Supprimer ?",
+  "confirmDeleteBody": "Voulez-vous vraiment supprimer cet élément ?"
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1893,6 +1893,8 @@
   "chargingEfficiencyTitle": "Effizienz (kWh/100 km)",
   "chargingChartsEmpty": "Noch nicht genügend Daten",
   "chargingChartsMonthAxis": "Monat",
+  "confirmDeleteTitle": "Löschen?",
+  "confirmDeleteBody": "Soll dieser Eintrag wirklich gelöscht werden?",
   "consoFeatureGroupTitle": "Verbrauch",
   "consoFeatureGroupDescription": "Verfolgen Sie Ihren Verbrauch — manuelle Tankvorgänge oder automatische OBD2-Fahrtaufzeichnung.",
   "consoModeOff": "Aus",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2859,6 +2859,14 @@
   "@chargingChartsMonthAxis": {
     "description": "Axis label for the X axis (month) on the charging charts (#582 phase 3)."
   },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "description": "Title of the shared destructive-action confirmation dialog (#3682) shown before EVERY delete in the app."
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "description": "Generic body of the shared delete confirmation (#3682), used when a surface passes no item-specific message."
+  },
   "consoFeatureGroupTitle": "Consumption",
   "consoFeatureGroupDescription": "Track your consumption — manual fill-ups, or automatic OBD2 trip recording.",
   "consoModeOff": "Off",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1243,6 +1243,8 @@
   "chargingEfficiencyTitle": "⟦Éƒƒîçîéñçý (ķŴĥ/100 ķɱ) ·······⟧",
   "chargingChartsEmpty": "⟦Ñóŧ éñóúǧĥ đáŧá ýéŧ ·······⟧",
   "chargingChartsMonthAxis": "⟦Ṁóñŧĥ ··⟧",
+  "confirmDeleteTitle": "⟦Đéłéŧé? ···⟧",
+  "confirmDeleteBody": "⟦Đó ýóú řéáłłý ŵáñŧ ŧó đéłéŧé ŧĥîš? ············⟧",
   "consoFeatureGroupTitle": "⟦Çóñšúɱƥŧîóñ ·····⟧",
   "consoFeatureGroupDescription": "⟦Ŧřáçķ ýóúř çóñšúɱƥŧîóñ — ɱáñúáł ƒîłł-úƥš, óř áúŧóɱáŧîç ÓƁĐ2 ŧřîƥ řéçóřđîñǧ. ···························⟧",
   "consoModeOff": "⟦Óƒƒ ·⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5586,5 +5586,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7634,6 +7634,18 @@ abstract class AppLocalizations {
   /// **'Month'**
   String get chargingChartsMonthAxis;
 
+  /// Title of the shared destructive-action confirmation dialog (#3682) shown before EVERY delete in the app.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete?'**
+  String get confirmDeleteTitle;
+
+  /// Generic body of the shared delete confirmation (#3682), used when a surface passes no item-specific message.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you really want to delete this?'**
+  String get confirmDeleteBody;
+
   /// No description provided for @consoFeatureGroupTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4275,6 +4275,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Месец';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Разход';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Měsíc';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Spotřeba';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4245,6 +4245,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Måned';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Forbrug';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4271,6 +4271,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Monat';
 
   @override
+  String get confirmDeleteTitle => 'Löschen?';
+
+  @override
+  String get confirmDeleteBody =>
+      'Soll dieser Eintrag wirklich gelöscht werden?';
+
+  @override
   String get consoFeatureGroupTitle => 'Verbrauch';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4276,6 +4276,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Μήνας';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Κατανάλωση';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4226,6 +4226,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Month';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Consumption';
 
   @override
@@ -12671,6 +12677,13 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get chargingChartsMonthAxis => '⟦Ṁóñŧĥ ··⟧';
+
+  @override
+  String get confirmDeleteTitle => '⟦Đéłéŧé? ···⟧';
+
+  @override
+  String get confirmDeleteBody =>
+      '⟦Đó ýóú řéáłłý ŵáñŧ ŧó đéłéŧé ŧĥîš? ············⟧';
 
   @override
   String get consoFeatureGroupTitle => '⟦Çóñšúɱƥŧîóñ ·····⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4270,6 +4270,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mes';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Consumo';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4244,6 +4244,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Kuu';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Kulu';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4246,6 +4246,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Kuukausi';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Kulutus';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4284,6 +4284,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mois';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Conso';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4255,6 +4255,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mjesec';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Conso';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4275,6 +4275,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Hónap';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Fogyasztás';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4263,6 +4263,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mese';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Conso';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4268,6 +4268,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mėnuo';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Suvartojimas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4272,6 +4272,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mēnesis';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Patēriņš';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4244,6 +4244,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Måned';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Forbruk';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4261,6 +4261,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Maand';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Verbruik';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4257,6 +4257,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Miesiąc';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Zużycie';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4272,6 +4272,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mês';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Conso';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4272,6 +4272,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Luna';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Conso';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4262,6 +4262,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mesiac';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Spotreba';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4248,6 +4248,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Mesec';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Poraba';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4245,6 +4245,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chargingChartsMonthAxis => 'Månad';
 
   @override
+  String get confirmDeleteTitle => 'Delete?';
+
+  @override
+  String get confirmDeleteBody => 'Do you really want to delete this?';
+
+  @override
   String get consoFeatureGroupTitle => 'Förbrukning';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5713,5 +5713,15 @@
         "type": "String"
       }
     }
+  },
+  "confirmDeleteTitle": "Delete?",
+  "@confirmDeleteTitle": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
+  },
+  "confirmDeleteBody": "Do you really want to delete this?",
+  "@confirmDeleteBody": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/widgets/confirm_delete_dialog_test.dart
+++ b/test/core/widgets/confirm_delete_dialog_test.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/confirm_delete_dialog.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #3682 — the ONE destructive-action confirmation. Pins the contract
+/// every delete surface in the app relies on: true only on the explicit
+/// destructive tap; cancel/barrier/back are false; defaults localize;
+/// overrides + the per-surface test key ride through.
+void main() {
+  Future<void> pumpHost(
+    WidgetTester tester, {
+    String? title,
+    String? message,
+    String? confirmLabel,
+    Key? confirmKey,
+    required void Function(Future<bool>) onShow,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                key: const Key('open'),
+                onPressed: () => onShow(confirmDestructiveAction(
+                  context,
+                  title: title,
+                  message: message,
+                  confirmLabel: confirmLabel,
+                  confirmKey: confirmKey,
+                )),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('defaults: localized title/body, warning icon, Delete label',
+      (tester) async {
+    late Future<bool> result;
+    await pumpHost(tester, onShow: (f) => result = f);
+
+    expect(find.text('Delete?'), findsOneWidget);
+    expect(find.text('Do you really want to delete this?'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+    expect(await result, isTrue);
+  });
+
+  testWidgets('cancel and barrier both return FALSE — a destructive action '
+      'never happens by accident', (tester) async {
+    final results = <Future<bool>>[];
+    await pumpHost(tester, onShow: results.add);
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(await results.single, isFalse);
+
+    // Re-open, dismiss via the barrier: the null result maps to false.
+    await tester.tap(find.byKey(const Key('open')));
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(await results.last, isFalse);
+  });
+
+  testWidgets('overrides + per-surface confirmKey ride through',
+      (tester) async {
+    late Future<bool> result;
+    await pumpHost(
+      tester,
+      title: 'Delete this vehicle?',
+      message: 'Golf and its history will be gone.',
+      confirmLabel: 'Delete vehicle',
+      confirmKey: const Key('surface_confirm'),
+      onShow: (f) => result = f,
+    );
+    expect(find.text('Delete this vehicle?'), findsOneWidget);
+    expect(find.text('Golf and its history will be gone.'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('surface_confirm')));
+    await tester.pumpAndSettle();
+    expect(await result, isTrue);
+  });
+}

--- a/test/core/widgets/swipe_to_delete_test.dart
+++ b/test/core/widgets/swipe_to_delete_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/widgets/swipe_to_delete.dart';
 
 import '../../helpers/pump_app.dart';
+import '../../helpers/confirm_delete.dart';
 
 void main() {
   group('SwipeToDelete', () {
@@ -46,10 +47,32 @@ void main() {
         ),
       );
 
-      // Swipe right to left
+      // Swipe right to left — #3682: the shared confirmation gates it.
       await tester.drag(find.text('Swipe me'), const Offset(-500, 0));
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester);
       expect(dismissed, true);
+    });
+
+    testWidgets('cancelling the confirmation keeps the row (#3682)',
+        (tester) async {
+      var dismissed = false;
+      await pumpApp(
+        tester,
+        SwipeToDelete(
+          dismissKey: const ValueKey('test-cancel'),
+          onDismissed: () => dismissed = true,
+          child: const SizedBox(width: 200, height: 50, child: Text('Keep me')),
+        ),
+      );
+
+      await tester.drag(find.text('Keep me'), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(dismissed, isFalse);
+      expect(find.text('Keep me'), findsOneWidget,
+          reason: 'a cancelled confirmation restores the row');
     });
 
     testWidgets('shows red background with delete icon on swipe', (tester) async {

--- a/test/features/alerts/presentation/screens/alerts_screen_radius_section_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_radius_section_test.dart
@@ -13,6 +13,7 @@ import 'package:tankstellen/features/alerts/providers/radius_alerts_provider.dar
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 
 void main() {
   group('AlertsScreen radius section (#578 phase 2)', () {
@@ -97,7 +98,7 @@ void main() {
         find.text('Home diesel'),
         const Offset(-600, 0),
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       expect(fake.removedIds, ['r1']);
     });
@@ -126,7 +127,7 @@ void main() {
       );
 
       await tester.drag(find.text('Home diesel'), const Offset(-600, 0));
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       // Past-tense deletion copy with the alert's label.
       expect(find.text('Radius alert "Home diesel" deleted'), findsOneWidget);
@@ -157,7 +158,7 @@ void main() {
       );
 
       await tester.drag(find.text('Home diesel'), const Offset(-600, 0));
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       expect(fake.removedIds, ['r1']);
       expect(fake.addedAlerts, isEmpty);

--- a/test/features/consumption/presentation/widgets/edit_correction_fill_up_sheet_test.dart
+++ b/test/features/consumption/presentation/widgets/edit_correction_fill_up_sheet_test.dart
@@ -13,6 +13,8 @@ import 'package:tankstellen/features/consumption/providers/consumption_providers
 import 'package:tankstellen/core/domain/fuel_type.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
+import '../../../../helpers/confirm_delete.dart';
+
 /// #1361 phase 2b — widget tests for [EditCorrectionFillUpSheet].
 ///
 /// Mirrors the Riverpod-test pattern from
@@ -201,7 +203,7 @@ void main() {
     await tester.tap(
       find.widgetWithText(OutlinedButton, 'Delete correction'),
     );
-    await tester.pump();
+    await confirmPendingDelete(tester); // #3682
     await tester.pump(const Duration(milliseconds: 50));
 
     final all = container.read(fillUpListProvider);

--- a/test/features/consumption/presentation/widgets/fuel_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/fuel_tab_test.dart
@@ -19,6 +19,7 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Widget tests for the gamification opt-out gate on [FuelTab] (#1194).
@@ -196,7 +197,7 @@ void main() {
       expect(container.read(fillUpListProvider), hasLength(1));
 
       await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       // Deleted from the provider; the undo affordance is up.
       expect(container.read(fillUpListProvider), isEmpty);

--- a/test/features/favorites/presentation/widgets/alerts_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/alerts_tab_test.dart
@@ -16,6 +16,7 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 
 PriceAlert _alert({
   String id = 'alert-1',
@@ -179,7 +180,7 @@ void main() {
         find.byType(Dismissible),
         const Offset(-600, 0),
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       expect(notifier.removeCalls, ['alert-99']);
       // SnackBar text uses l10n alertDeleted with the station name.

--- a/test/features/favorites/presentation/widgets/ev_favorite_dismissible_test.dart
+++ b/test/features/favorites/presentation/widgets/ev_favorite_dismissible_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_
 import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
 
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 
 /// Regression tests for #1958 — EV-charger favorites must be swipeable
 /// like fuel-station favorites (`FavoriteStationDismissible`).
@@ -69,7 +70,7 @@ void main() {
         const Offset(-500, 0),
         1000,
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       // Removal routed to the EV favorites notifier — not the fuel one.
       expect(recording.removeCalls, ['ev-charger-7']);
@@ -96,7 +97,7 @@ void main() {
         const Offset(-500, 0),
         1000,
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
       await tester.tap(find.text('Undo'));
       await tester.pumpAndSettle();
 

--- a/test/features/favorites/presentation/widgets/favorite_station_dismissible_test.dart
+++ b/test/features/favorites/presentation/widgets/favorite_station_dismissible_test.dart
@@ -25,6 +25,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 import '../../../../mocks/mocks.dart';
 
 /// One reusable station — kept tiny so test bodies focus on the swipe
@@ -299,7 +300,7 @@ void main() {
         const Offset(-500, 0),
         1000,
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       expect(favorites.removeCalls, [_station.id]);
 
@@ -332,7 +333,7 @@ void main() {
         const Offset(-500, 0),
         1000,
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       // Press the undo action. Tapping the SnackBarAction triggers the
       // notifier's add() with both id and the original Station entity.

--- a/test/features/search/presentation/widgets/swipeable_station_card_test.dart
+++ b/test/features/search/presentation/widgets/swipeable_station_card_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/search/presentation/widgets/swipeable_stati
 import '../../../../fixtures/stations.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/confirm_delete.dart';
 
 void main() {
   group('SwipeableStationCard', () {
@@ -108,7 +109,7 @@ void main() {
         find.byType(Dismissible),
         const Offset(-500, 0),
       );
-      await tester.pumpAndSettle();
+      await confirmPendingDelete(tester); // #3682
 
       expect(ignoreCalled, isTrue);
     });

--- a/test/features/vehicle/presentation/widgets/catalog_reset_confirm_dialog_test.dart
+++ b/test/features/vehicle/presentation/widgets/catalog_reset_confirm_dialog_test.dart
@@ -68,7 +68,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(AlertDialog), findsNothing);
-      expect(await result, isNull);
+      // #3682 — the shared dialog maps barrier dismiss to FALSE (still
+      // "do nothing" for every caller; the tri-state null is gone).
+      expect(await result, isFalse);
     });
   });
 }

--- a/test/features/vehicle/presentation/widgets/ve_reset_confirm_dialog_test.dart
+++ b/test/features/vehicle/presentation/widgets/ve_reset_confirm_dialog_test.dart
@@ -47,11 +47,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Both actions are TextButtons inside the AlertDialog.
-      final actions = find.descendant(
+      // #3682 — Cancel is a TextButton; the destructive action is the
+      // shared error-styled FilledButton.
+      final cancels = find.descendant(
         of: find.byType(AlertDialog),
         matching: find.byType(TextButton),
       );
-      expect(actions, findsNWidgets(2));
+      expect(cancels, findsOneWidget);
       expect(
         find.descendant(
           of: find.byType(AlertDialog),
@@ -121,7 +123,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(AlertDialog), findsNothing);
-      expect(await result, isNull);
+      // #3682 — barrier now maps to FALSE (see shared dialog).
+      expect(await result, isFalse);
     });
   });
 }

--- a/test/helpers/confirm_delete.dart
+++ b/test/helpers/confirm_delete.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #3682 — taps the shared destructive-action dialog's confirm button.
+/// The ONE helper the swipe/delete tests use after triggering a delete,
+/// so the tests stay as copy-free as the production dialog.
+Future<void> confirmPendingDelete(WidgetTester tester) async {
+  await tester.pumpAndSettle();
+  final confirm = find.descendant(
+    of: find.byType(AlertDialog),
+    matching: find.byIcon(Icons.delete_outline),
+  );
+  expect(confirm, findsOneWidget,
+      reason: 'the shared delete confirmation (#3682) must be showing');
+  await tester.tap(confirm);
+  await tester.pumpAndSettle();
+}

--- a/test/lint/confirm_delete_lint_test.dart
+++ b/test/lint/confirm_delete_lint_test.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #3682 — every delete-swipe goes through the shared [SwipeToDelete]
+/// (which carries the app-wide delete confirmation), and every
+/// confirm-before-destroy dialog goes through
+/// [confirmDestructiveAction]. This lint keeps both from silently
+/// regressing into copy-paste:
+///
+///  1. A raw `Dismissible(` in lib/ is allowed only on the allowlist —
+///     the non-delete swipes (radar paging, notice dismissal) and the
+///     two-direction favorite rows whose DELETE branch calls the shared
+///     confirmation explicitly.
+///  2. No file outside the shared component builds the
+///     `showDialog&lt;bool&gt; … pop(true)` confirm shape together with a
+///     delete icon — the tell of a re-copied confirm dialog.
+void main() {
+  /// Raw `Dismissible(` usages that are legitimately NOT SwipeToDelete.
+  /// Shrink-only: converting one to SwipeToDelete removes its entry;
+  /// adding a new raw delete-swipe is forbidden — use SwipeToDelete.
+  const dismissibleAllowlist = <String, String>{
+    'lib/core/widgets/swipe_to_delete.dart': 'the shared component itself',
+    'lib/features/consumption/presentation/widgets/radar_swipe_wrapper.dart':
+        'radar paging — navigation, not deletion',
+    'lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart':
+        'two-direction (navigate|delete); the delete branch calls '
+            'confirmDestructiveAction explicitly',
+    'lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart':
+        'two-direction (navigate|delete); the delete branch calls '
+            'confirmDestructiveAction explicitly',
+    'lib/features/favorites/presentation/widgets/alerts_tab.dart':
+        'labeled background variant; confirmDismiss calls '
+            'confirmDestructiveAction explicitly',
+    'lib/features/loyalty/presentation/widgets/loyalty_card_tile.dart':
+        'delegates to the screen-side confirmation (which uses the shared '
+            'dialog) so a cancelled swipe restores the row visually',
+    'lib/features/search/presentation/widgets/route_results_view.dart':
+        'two-direction (navigate|hide); the hide branch calls '
+            'confirmDestructiveAction explicitly',
+    'lib/features/search/presentation/widgets/swipeable_station_card.dart':
+        'two-direction (navigate|hide); the hide branch calls '
+            'confirmDestructiveAction explicitly',
+  };
+
+  test('raw Dismissible usages in lib/ are allowlisted (#3682)', () {
+    final offenders = <String>[];
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.endsWith('.g.dart') ||
+          entity.path.endsWith('.freezed.dart')) {
+        continue;
+      }
+      final rel = entity.path.replaceAll(r'\', '/');
+      if (dismissibleAllowlist.containsKey(rel)) continue;
+      // Word-boundary match: `FavoriteStationDismissible(` must not count.
+      if (RegExp(r'(?<![A-Za-z])Dismissible\(')
+          .hasMatch(entity.readAsStringSync())) {
+        offenders.add(rel);
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Raw Dismissible found outside the allowlist. Delete-swipes '
+          'use the shared SwipeToDelete (core/widgets/swipe_to_delete.dart) '
+          'which carries the app-wide delete confirmation; genuinely '
+          'non-delete swipes get an allowlist entry with a reason:\n'
+          '${offenders.map((f) => '  - $f').join('\n')}',
+    );
+  });
+
+  test('allowlisted files still exist and still contain a Dismissible '
+      '(stale entries are removed)', () {
+    for (final entry in dismissibleAllowlist.keys) {
+      if (entry == 'lib/core/widgets/swipe_to_delete.dart') continue;
+      final f = File(entry);
+      expect(f.existsSync(), isTrue, reason: '$entry vanished — drop it');
+      expect(
+          RegExp(r'(?<![A-Za-z])Dismissible\(')
+              .hasMatch(f.readAsStringSync()),
+          isTrue,
+          reason: '$entry no longer swipes — drop it from the allowlist');
+    }
+  });
+
+  test('the two-direction dismissibles DO call the shared confirmation '
+      'in their delete branch', () {
+    for (final f in [
+      'lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart',
+      'lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart',
+      'lib/features/favorites/presentation/widgets/alerts_tab.dart',
+      'lib/features/search/presentation/widgets/route_results_view.dart',
+      'lib/features/search/presentation/widgets/swipeable_station_card.dart',
+    ]) {
+      expect(
+        File(f).readAsStringSync(),
+        contains('confirmDestructiveAction('),
+        reason: '$f is allowlisted BECAUSE its delete branch confirms — '
+            'that call must stay',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## What

Every destructive action in the app now warns first — implemented **once**, reused everywhere, with a lint that keeps it that way.

### The component
`confirmDestructiveAction(context, {title, message, confirmLabel, confirmKey})` — one warning dialog (warning icon, error-styled Delete button with a non-colour signal, Cancel). Returns `true` only on the explicit destructive tap; Cancel, barrier and system back are all `false`.

### Applied everywhere
- **`SwipeToDelete` confirms** via `confirmDismiss` — and the raw delete-Dismissibles were converted onto it (fill-up swipe, charging logs, alerts screen ×2, itineraries already used it). A cancelled confirmation restores the row.
- **Two-direction swipes** (favorites ×2, EV alerts, route-corridor hide, search-card hide) call the shared confirmation in their delete/hide branch — the navigate direction is untouched.
- **Six bespoke bool-dialogs consolidated** (vehicle delete, privacy wipe, baseline reset, η_v reset, catalog reset, trip delete, loyalty delete) — their specific ARB copy and test keys ride through as parameters; the duplicated AlertDialog scaffolding is gone.
- **Two deletes that had NO confirmation at all** (correction fill-up sheet, virtual trajet sheet) gained it.
- The #3664 **10-second undo stays** — confirm prevents the accident, undo repairs the slip-through.

### Enforcement
`test/lint/confirm_delete_lint_test.dart`: a raw `Dismissible(` in lib/ must be on the reasoned allowlist (non-delete swipes + the two-direction rows, whose confirm call is itself asserted); a new raw delete-swipe fails CI. Tests use one shared `confirmPendingDelete` helper — the test side is as copy-free as the production side.

### Contract note
The delegating VeReset/CatalogReset dialogs now map barrier dismiss to `false` instead of `null` (both were "do nothing" for every caller).

## Verification
Detached-worktree run: analyze clean, **15,537 passed**; sole failure the recurring Argentina live-API flake. 2 new generic ARB keys (en/de/fr + full 24-locale fan-out).

Closes #3682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
