### PR TITLE
chore(release): v6.0.5 — 81 commits of fixes for F-Droid + stores (#3684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ About-screen build number always maps back to a commit.
 
 ## [Unreleased]
 
+## [6.0.5] - 2026-08-10 (Build 5138)
+
+### Added
+
+- Tank level v2: a full fill anchors 100 %, the OBD2 sensor tracks between
+  fills, and the E85/E10 tank mix is computed per fill-up (#3645-#3652).
+- Reference-catalog tank capacities, auto-filled on add / via OBD2, with a
+  "reset from vehicle database" action (#3651).
+- Highway mode v2: exit-aware suggestions ("via exit 36 - +1.2 km") ordered
+  by reachable-first along-track distance, from monthly OSM exit datasets
+  (#3633).
+- OBD2 "Reset connection" on the vehicle screen and the recording page -
+  ATZ chip reset + full link recycle (#3676, #3678).
+- Every delete asks first (one shared confirmation) and stays undoable for
+  10 seconds (#3682, #3664).
+
+### Fixed
+
+- Startup no longer waits on the network: last-known stations paint within
+  ~2 s and refresh in the background; last results survive long absences
+  (#3668).
+- Stopping a recording never hangs on a slow/unreachable sync server -
+  "Saving to history" is local-only (#3670).
+- Background reconnect can no longer burn CPU for minutes (whole-dial
+  budget + no background scans) - the OS process kills are gone (#3671).
+
 ## [6.0.4] - 2026-07-06 (Build 5137)
 
 ### Changed

--- a/fastlane/metadata/android/de-DE/changelogs/5138.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Schnellerer Start: letzte Ergebnisse sofort, Preise aktualisieren im Hintergrund
+• Tankstand v2: Vollbetankung = 100 %, OBD2 verfolgt dazwischen, E85/E10-Mix wird berücksichtigt
+• Autobahnmodus: Sortierung nach Erreichbarkeit, mit „über Ausfahrt“-Hinweisen
+• OBD2: Reset-Knopf, sparsamere Wiederverbindung, Speichern hängt nie mehr am Netz
+• Löschen fragt jetzt nach und ist 10 Sekunden rückgängig machbar
+• Fahrzeugdatenbank füllt die Tankgröße automatisch

--- a/fastlane/metadata/android/de-DE/changelogs/51381.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Schnellerer Start: letzte Ergebnisse sofort, Preise aktualisieren im Hintergrund
+• Tankstand v2: Vollbetankung = 100 %, OBD2 verfolgt dazwischen, E85/E10-Mix wird berücksichtigt
+• Autobahnmodus: Sortierung nach Erreichbarkeit, mit „über Ausfahrt“-Hinweisen
+• OBD2: Reset-Knopf, sparsamere Wiederverbindung, Speichern hängt nie mehr am Netz
+• Löschen fragt jetzt nach und ist 10 Sekunden rückgängig machbar
+• Fahrzeugdatenbank füllt die Tankgröße automatisch

--- a/fastlane/metadata/android/de-DE/changelogs/51382.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Schnellerer Start: letzte Ergebnisse sofort, Preise aktualisieren im Hintergrund
+• Tankstand v2: Vollbetankung = 100 %, OBD2 verfolgt dazwischen, E85/E10-Mix wird berücksichtigt
+• Autobahnmodus: Sortierung nach Erreichbarkeit, mit „über Ausfahrt“-Hinweisen
+• OBD2: Reset-Knopf, sparsamere Wiederverbindung, Speichern hängt nie mehr am Netz
+• Löschen fragt jetzt nach und ist 10 Sekunden rückgängig machbar
+• Fahrzeugdatenbank füllt die Tankgröße automatisch

--- a/fastlane/metadata/android/de-DE/changelogs/51383.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Schnellerer Start: letzte Ergebnisse sofort, Preise aktualisieren im Hintergrund
+• Tankstand v2: Vollbetankung = 100 %, OBD2 verfolgt dazwischen, E85/E10-Mix wird berücksichtigt
+• Autobahnmodus: Sortierung nach Erreichbarkeit, mit „über Ausfahrt“-Hinweisen
+• OBD2: Reset-Knopf, sparsamere Wiederverbindung, Speichern hängt nie mehr am Netz
+• Löschen fragt jetzt nach und ist 10 Sekunden rückgängig machbar
+• Fahrzeugdatenbank füllt die Tankgröße automatisch

--- a/fastlane/metadata/android/en-US/changelogs/5138.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Faster start: your last results appear instantly, prices refresh in the background
+• Tank level v2: a full fill sets 100%, OBD2 tracks in between, E85/E10 mix is accounted for
+• Highway mode: stations sorted by what you can reach, with "via exit" hints
+• OBD2: reset button, smarter reconnects (less battery), trip saving never hangs on bad network
+• Deletes now ask first and can be undone for 10 seconds
+• Vehicle database fills your tank capacity automatically

--- a/fastlane/metadata/android/en-US/changelogs/51381.txt
+++ b/fastlane/metadata/android/en-US/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Faster start: your last results appear instantly, prices refresh in the background
+• Tank level v2: a full fill sets 100%, OBD2 tracks in between, E85/E10 mix is accounted for
+• Highway mode: stations sorted by what you can reach, with "via exit" hints
+• OBD2: reset button, smarter reconnects (less battery), trip saving never hangs on bad network
+• Deletes now ask first and can be undone for 10 seconds
+• Vehicle database fills your tank capacity automatically

--- a/fastlane/metadata/android/en-US/changelogs/51382.txt
+++ b/fastlane/metadata/android/en-US/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Faster start: your last results appear instantly, prices refresh in the background
+• Tank level v2: a full fill sets 100%, OBD2 tracks in between, E85/E10 mix is accounted for
+• Highway mode: stations sorted by what you can reach, with "via exit" hints
+• OBD2: reset button, smarter reconnects (less battery), trip saving never hangs on bad network
+• Deletes now ask first and can be undone for 10 seconds
+• Vehicle database fills your tank capacity automatically

--- a/fastlane/metadata/android/en-US/changelogs/51383.txt
+++ b/fastlane/metadata/android/en-US/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Faster start: your last results appear instantly, prices refresh in the background
+• Tank level v2: a full fill sets 100%, OBD2 tracks in between, E85/E10 mix is accounted for
+• Highway mode: stations sorted by what you can reach, with "via exit" hints
+• OBD2: reset button, smarter reconnects (less battery), trip saving never hangs on bad network
+• Deletes now ask first and can be undone for 10 seconds
+• Vehicle database fills your tank capacity automatically

--- a/fastlane/metadata/android/es-ES/changelogs/5138.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Inicio más rápido: los últimos resultados aparecen al instante, precios en segundo plano
+• Depósito v2: llenado completo = 100 %, seguimiento OBD2, mezcla E85/E10 tenida en cuenta
+• Modo autopista: orden por accesibilidad real, con indicaciones «vía salida»
+• OBD2: botón de reinicio, reconexión más eficiente, el guardado ya no se bloquea sin red
+• Borrar pide confirmación y se puede deshacer durante 10 s
+• La base de vehículos rellena la capacidad del depósito

--- a/fastlane/metadata/android/es-ES/changelogs/51381.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Inicio más rápido: los últimos resultados aparecen al instante, precios en segundo plano
+• Depósito v2: llenado completo = 100 %, seguimiento OBD2, mezcla E85/E10 tenida en cuenta
+• Modo autopista: orden por accesibilidad real, con indicaciones «vía salida»
+• OBD2: botón de reinicio, reconexión más eficiente, el guardado ya no se bloquea sin red
+• Borrar pide confirmación y se puede deshacer durante 10 s
+• La base de vehículos rellena la capacidad del depósito

--- a/fastlane/metadata/android/es-ES/changelogs/51382.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Inicio más rápido: los últimos resultados aparecen al instante, precios en segundo plano
+• Depósito v2: llenado completo = 100 %, seguimiento OBD2, mezcla E85/E10 tenida en cuenta
+• Modo autopista: orden por accesibilidad real, con indicaciones «vía salida»
+• OBD2: botón de reinicio, reconexión más eficiente, el guardado ya no se bloquea sin red
+• Borrar pide confirmación y se puede deshacer durante 10 s
+• La base de vehículos rellena la capacidad del depósito

--- a/fastlane/metadata/android/es-ES/changelogs/51383.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Inicio más rápido: los últimos resultados aparecen al instante, precios en segundo plano
+• Depósito v2: llenado completo = 100 %, seguimiento OBD2, mezcla E85/E10 tenida en cuenta
+• Modo autopista: orden por accesibilidad real, con indicaciones «vía salida»
+• OBD2: botón de reinicio, reconexión más eficiente, el guardado ya no se bloquea sin red
+• Borrar pide confirmación y se puede deshacer durante 10 s
+• La base de vehículos rellena la capacidad del depósito

--- a/fastlane/metadata/android/fr-FR/changelogs/5138.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Démarrage plus rapide : derniers résultats affichés aussitôt, prix actualisés en arrière-plan
+• Réservoir v2 : plein = 100 %, suivi OBD2 entre les pleins, mélange E85/E10 pris en compte
+• Mode autoroute : tri par accessibilité réelle, repères « via sortie »
+• OBD2 : bouton de réinitialisation, reconnexion plus sobre, enregistrement jamais bloqué par le réseau
+• Les suppressions demandent confirmation, annulables pendant 10 s
+• La base véhicules remplit la capacité du réservoir

--- a/fastlane/metadata/android/fr-FR/changelogs/51381.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Démarrage plus rapide : derniers résultats affichés aussitôt, prix actualisés en arrière-plan
+• Réservoir v2 : plein = 100 %, suivi OBD2 entre les pleins, mélange E85/E10 pris en compte
+• Mode autoroute : tri par accessibilité réelle, repères « via sortie »
+• OBD2 : bouton de réinitialisation, reconnexion plus sobre, enregistrement jamais bloqué par le réseau
+• Les suppressions demandent confirmation, annulables pendant 10 s
+• La base véhicules remplit la capacité du réservoir

--- a/fastlane/metadata/android/fr-FR/changelogs/51382.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Démarrage plus rapide : derniers résultats affichés aussitôt, prix actualisés en arrière-plan
+• Réservoir v2 : plein = 100 %, suivi OBD2 entre les pleins, mélange E85/E10 pris en compte
+• Mode autoroute : tri par accessibilité réelle, repères « via sortie »
+• OBD2 : bouton de réinitialisation, reconnexion plus sobre, enregistrement jamais bloqué par le réseau
+• Les suppressions demandent confirmation, annulables pendant 10 s
+• La base véhicules remplit la capacité du réservoir

--- a/fastlane/metadata/android/fr-FR/changelogs/51383.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Démarrage plus rapide : derniers résultats affichés aussitôt, prix actualisés en arrière-plan
+• Réservoir v2 : plein = 100 %, suivi OBD2 entre les pleins, mélange E85/E10 pris en compte
+• Mode autoroute : tri par accessibilité réelle, repères « via sortie »
+• OBD2 : bouton de réinitialisation, reconnexion plus sobre, enregistrement jamais bloqué par le réseau
+• Les suppressions demandent confirmation, annulables pendant 10 s
+• La base véhicules remplit la capacité du réservoir

--- a/fastlane/metadata/android/it-IT/changelogs/5138.txt
+++ b/fastlane/metadata/android/it-IT/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Avvio più rapido: gli ultimi risultati appaiono subito, i prezzi si aggiornano in background
+• Serbatoio v2: pieno = 100%, monitoraggio OBD2, miscela E85/E10 considerata
+• Modalità autostrada: ordinamento per raggiungibilità, con indicazioni «via uscita»
+• OBD2: pulsante di reset, riconnessione più efficiente, salvataggio mai bloccato dalla rete
+• L'eliminazione chiede conferma ed è annullabile per 10 s
+• Il database veicoli compila la capacità del serbatoio

--- a/fastlane/metadata/android/it-IT/changelogs/51381.txt
+++ b/fastlane/metadata/android/it-IT/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Avvio più rapido: gli ultimi risultati appaiono subito, i prezzi si aggiornano in background
+• Serbatoio v2: pieno = 100%, monitoraggio OBD2, miscela E85/E10 considerata
+• Modalità autostrada: ordinamento per raggiungibilità, con indicazioni «via uscita»
+• OBD2: pulsante di reset, riconnessione più efficiente, salvataggio mai bloccato dalla rete
+• L'eliminazione chiede conferma ed è annullabile per 10 s
+• Il database veicoli compila la capacità del serbatoio

--- a/fastlane/metadata/android/it-IT/changelogs/51382.txt
+++ b/fastlane/metadata/android/it-IT/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Avvio più rapido: gli ultimi risultati appaiono subito, i prezzi si aggiornano in background
+• Serbatoio v2: pieno = 100%, monitoraggio OBD2, miscela E85/E10 considerata
+• Modalità autostrada: ordinamento per raggiungibilità, con indicazioni «via uscita»
+• OBD2: pulsante di reset, riconnessione più efficiente, salvataggio mai bloccato dalla rete
+• L'eliminazione chiede conferma ed è annullabile per 10 s
+• Il database veicoli compila la capacità del serbatoio

--- a/fastlane/metadata/android/it-IT/changelogs/51383.txt
+++ b/fastlane/metadata/android/it-IT/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Avvio più rapido: gli ultimi risultati appaiono subito, i prezzi si aggiornano in background
+• Serbatoio v2: pieno = 100%, monitoraggio OBD2, miscela E85/E10 considerata
+• Modalità autostrada: ordinamento per raggiungibilità, con indicazioni «via uscita»
+• OBD2: pulsante di reset, riconnessione più efficiente, salvataggio mai bloccato dalla rete
+• L'eliminazione chiede conferma ed è annullabile per 10 s
+• Il database veicoli compila la capacità del serbatoio

--- a/fastlane/metadata/android/pt-PT/changelogs/5138.txt
+++ b/fastlane/metadata/android/pt-PT/changelogs/5138.txt
@@ -1,0 +1,6 @@
+• Arranque mais rápido: últimos resultados aparecem de imediato, preços atualizam em segundo plano
+• Depósito v2: atesto completo = 100%, monitorização OBD2, mistura E85/E10 considerada
+• Modo autoestrada: ordenação por acessibilidade real, com indicações «via saída»
+• OBD2: botão de reinício, reconexão mais eficiente, gravação nunca bloqueia sem rede
+• Eliminar pede confirmação e pode ser anulado durante 10 s
+• A base de veículos preenche a capacidade do depósito

--- a/fastlane/metadata/android/pt-PT/changelogs/51381.txt
+++ b/fastlane/metadata/android/pt-PT/changelogs/51381.txt
@@ -1,0 +1,6 @@
+• Arranque mais rápido: últimos resultados aparecem de imediato, preços atualizam em segundo plano
+• Depósito v2: atesto completo = 100%, monitorização OBD2, mistura E85/E10 considerada
+• Modo autoestrada: ordenação por acessibilidade real, com indicações «via saída»
+• OBD2: botão de reinício, reconexão mais eficiente, gravação nunca bloqueia sem rede
+• Eliminar pede confirmação e pode ser anulado durante 10 s
+• A base de veículos preenche a capacidade do depósito

--- a/fastlane/metadata/android/pt-PT/changelogs/51382.txt
+++ b/fastlane/metadata/android/pt-PT/changelogs/51382.txt
@@ -1,0 +1,6 @@
+• Arranque mais rápido: últimos resultados aparecem de imediato, preços atualizam em segundo plano
+• Depósito v2: atesto completo = 100%, monitorização OBD2, mistura E85/E10 considerada
+• Modo autoestrada: ordenação por acessibilidade real, com indicações «via saída»
+• OBD2: botão de reinício, reconexão mais eficiente, gravação nunca bloqueia sem rede
+• Eliminar pede confirmação e pode ser anulado durante 10 s
+• A base de veículos preenche a capacidade do depósito

--- a/fastlane/metadata/android/pt-PT/changelogs/51383.txt
+++ b/fastlane/metadata/android/pt-PT/changelogs/51383.txt
@@ -1,0 +1,6 @@
+• Arranque mais rápido: últimos resultados aparecem de imediato, preços atualizam em segundo plano
+• Depósito v2: atesto completo = 100%, monitorização OBD2, mistura E85/E10 considerada
+• Modo autoestrada: ordenação por acessibilidade real, com indicações «via saída»
+• OBD2: botão de reinício, reconexão mais eficiente, gravação nunca bloqueia sem rede
+• Eliminar pede confirmação e pode ser anulado durante 10 s
+• A base de veículos preenche a capacidade do depósito

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 17 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 6.0.4+5137
+version: 6.0.5+5138
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Release cut approved by the maintainer (2026-08-10): pubspec → 6.0.5+5138, per-ABI What's New (5138 + 51381–3, six locales), CHANGELOG entry. After the squash-merge, `v6.0.5` is tagged on the merge commit and the fdroiddata MR !42093 metadata update is prepared from that hash (linsui's standing obligation).

Closes #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM