### PR TITLE
fix: JNI global-ref overflow crashes — background FlutterEngine leak gate + cache.hive compaction-race self-heal (#3688, #3689)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/BackgroundScanEnqueuer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/BackgroundScanEnqueuer.kt
@@ -5,6 +5,7 @@ package de.tankstellen.tankstellen
 
 import android.content.Context
 import android.util.Log
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
@@ -26,6 +27,25 @@ import dev.fluttercommunity.workmanager.SharedPreferenceHelper
  * alert. Without it, there is nothing to scan and polling would be
  * unconsented.
  *
+ * ## Handle-freshness gate (#3688)
+ *
+ * The persisted callback handle encodes an offset into the Dart snapshot of
+ * the build that persisted it. After an app UPDATE it is stale until the
+ * next foreground launch re-persists it — and a stale handle makes
+ * [BackgroundWorker] fail `FlutterCallbackInformation.lookupCallbackInformation`
+ * AFTER creating its FlutterEngine, which that failure path never destroys.
+ * Field tombstones showed 43 live leaked engines (each with a bound
+ * TextToSpeech) killing the process with a JNI global-reference-table
+ * overflow. The Dart side stamps the build number that persisted the handle
+ * (`flutter.bg_handle_build`); we refuse to enqueue when it does not match
+ * the installed build. Fail-safe direction: a missing/mismatched stamp only
+ * skips an opportunistic scan until the user next opens the app.
+ *
+ * A 60-min cooldown additionally caps the periodic widget wake (#3688):
+ * even a healthy engine run leaves a small permanent JNI residue, so the
+ * 30-min `updatePeriodMillis` churn is halved. User-initiated refreshes
+ * bypass the cooldown but never the freshness gate.
+ *
  * The cross-trigger cooldown in `BackgroundAlertScanCoordinator` (#2415)
  * dedups these one-offs against the WorkManager periodic tasks, so an
  * opportunistic widget wake seconds after a periodic scan is a cheap no-op.
@@ -33,16 +53,55 @@ import dev.fluttercommunity.workmanager.SharedPreferenceHelper
 object BackgroundScanEnqueuer {
     private const val TAG = "BackgroundScanEnqueuer"
 
+    /** Written by the Dart shared_preferences plugin (flutter.-prefixed). */
+    private const val FLUTTER_PREFS = "FlutterSharedPreferences"
+
+    /** Build number stamped right after `Workmanager().initialize` (#3688). */
+    const val HANDLE_BUILD_KEY = "flutter.bg_handle_build"
+
+    private const val GATE_PREFS = "bg_scan_gate"
+    private const val LAST_ENQUEUE_KEY = "last_enqueue_ms"
+    private const val COOLDOWN_MS = 60L * 60L * 1000L
+
     /**
      * Enqueue [dartTask] as a unique CONNECTED-network one-off. [uniqueName]
      * keeps the OS from stacking duplicates when the trigger fires rapidly
      * (e.g. several widgets refreshing at once) — REPLACE collapses them
      * into one pending task, and the coordinator's cooldown handles the rest.
+     *
+     * Returns whether the task was actually enqueued, so callers with
+     * visible feedback (the widget refresh glyph) only show progress for a
+     * scan that will really run. [respectCooldown] is set by the periodic
+     * widget wake; user-initiated triggers pass false.
      */
-    fun enqueue(context: Context, dartTask: String, uniqueName: String) {
+    fun enqueue(
+        context: Context,
+        dartTask: String,
+        uniqueName: String,
+        respectCooldown: Boolean = false,
+    ): Boolean {
         if (SharedPreferenceHelper.getCallbackHandle(context) == -1L) {
             Log.d(TAG, "$dartTask: no persisted WorkManager callback — skipping")
-            return
+            return false
+        }
+
+        if (!handleIsFresh(context)) {
+            Log.d(
+                TAG,
+                "$dartTask: callback handle predates this build — skipping " +
+                    "until the next app launch re-persists it (#3688)",
+            )
+            return false
+        }
+
+        val gate = context.getSharedPreferences(GATE_PREFS, Context.MODE_PRIVATE)
+        val now = System.currentTimeMillis()
+        if (respectCooldown) {
+            val last = gate.getLong(LAST_ENQUEUE_KEY, 0L)
+            if (now - last < COOLDOWN_MS) {
+                Log.d(TAG, "$dartTask: within scan cooldown — skipping")
+                return false
+            }
         }
 
         val input = Data.Builder()
@@ -63,6 +122,24 @@ object BackgroundScanEnqueuer {
             ExistingWorkPolicy.REPLACE,
             request,
         )
+        gate.edit().putLong(LAST_ENQUEUE_KEY, now).apply()
         Log.d(TAG, "enqueued one-off scan task: $dartTask")
+        return true
+    }
+
+    /**
+     * True when the Dart-side stamp says the persisted callback handle was
+     * written by the currently installed build. Absent stamp = stale (the
+     * update that ships the stamp, or any update before the first launch).
+     */
+    private fun handleIsFresh(context: Context): Boolean {
+        val stamped = context
+            .getSharedPreferences(FLUTTER_PREFS, Context.MODE_PRIVATE)
+            .getString(HANDLE_BUILD_KEY, null)
+            ?: return false
+        val installed = PackageInfoCompat.getLongVersionCode(
+            context.packageManager.getPackageInfo(context.packageName, 0),
+        ).toString()
+        return stamped == installed
     }
 }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/BootReceiver.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/BootReceiver.kt
@@ -43,7 +43,13 @@ class BootReceiver : BroadcastReceiver() {
 
         // Re-arm only when WorkManager was previously initialized from Dart;
         // the shared enqueuer guards on the persisted callback handle so a
-        // fresh install with no alerts re-arms nothing.
+        // fresh install with no alerts re-arms nothing. #3688 — the
+        // enqueuer's freshness gate also refuses when the handle predates
+        // the installed build: on MY_PACKAGE_REPLACED the handle is ALWAYS
+        // stale (the update just invalidated it), and enqueueing anyway
+        // leaked one live FlutterEngine per app update. The periodic
+        // schedule survives in WorkManager's DB regardless; the next
+        // foreground launch re-persists the handle and re-arms.
         Log.d(TAG, "boot: re-arming background-scan registration")
         BackgroundScanEnqueuer.enqueue(
             context,

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
@@ -30,10 +30,13 @@ class FuelPriceWidgetProvider : AppWidgetProvider() {
         // the WorkManager periodic tasks, NOT a reliability guarantee. The
         // coordinator's cross-trigger cooldown (#2415) dedups this against a
         // concurrent periodic scan, so it is a cheap no-op when one just ran.
+        // #3688 — respectCooldown: the 30-min OS wake churns one background
+        // FlutterEngine per enqueue; the native 60-min cooldown halves that.
         BackgroundScanEnqueuer.enqueue(
             context,
             dartTask = WIDGET_SCAN_TASK,
             uniqueName = WIDGET_SCAN_UNIQUE_NAME,
+            respectCooldown = true,
         )
     }
 
@@ -70,18 +73,22 @@ class FuelPriceWidgetProvider : AppWidgetProvider() {
             // The coordinator's cross-trigger cooldown (#2415) dedups this
             // against a concurrent periodic scan, so a rapid tap is cheap.
             StationWidgetRenderer.ACTION_REFRESH -> {
-                val id = intent.getIntExtra(
-                    StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
-                    AppWidgetManager.INVALID_APPWIDGET_ID,
-                )
-                if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
-                    StationWidgetRenderer.setRefreshing(context, id)
-                }
-                BackgroundScanEnqueuer.enqueue(
+                // #3688 — enqueue FIRST: the freshness gate may refuse (stale
+                // callback handle after an update), and the glyph must only
+                // dim for a scan that will actually run — otherwise the
+                // widget shows "refreshing" forever.
+                val enqueued = BackgroundScanEnqueuer.enqueue(
                     context,
                     dartTask = WIDGET_SCAN_TASK,
                     uniqueName = WIDGET_SCAN_UNIQUE_NAME,
                 )
+                val id = intent.getIntExtra(
+                    StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
+                    AppWidgetManager.INVALID_APPWIDGET_ID,
+                )
+                if (enqueued && id != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                    StationWidgetRenderer.setRefreshing(context, id)
+                }
             }
         }
     }

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import 'hive_cipher_loader.dart';
+import 'hive_isolate_boxes.dart';
 import 'hive_isolate_ownership.dart';
 import 'hive_legacy_migration.dart';
 import 'hive_schema_migration.dart';
@@ -289,52 +290,15 @@ class HiveBoxes {
   }
 
   /// Initialize Hive in a background isolate with proper encryption.
-  static Future<void> initInIsolate() async {
-    await Hive.initFlutter();
-    final cipher = await HiveCipherLoader.loadGuarded();
-    await Hive.openBox<dynamic>(settings, encryptionCipher: cipher);
-    await Hive.openBox<dynamic>(favorites, encryptionCipher: cipher);
-    await Hive.openBox<dynamic>(profiles, encryptionCipher: cipher); // #2205 BG widget
-    await Hive.openBox<dynamic>(alerts, encryptionCipher: cipher);
-    await Hive.openBox<dynamic>(cache, encryptionCipher: cipher);
-    await Hive.openBox<dynamic>(priceHistory, encryptionCipher: cipher);
-    // #579 — velocity detector reads/writes snapshots from the BG
-    // isolate, mirroring the main-isolate open above.
-    await Hive.openBox<String>(priceSnapshots);
-    // #1105 — isolate error spool: background-isolate errors written
-    // here while Riverpod is unavailable, drained by the foreground
-    // initialiser into TraceRecorder.
-    await Hive.openBox<String>(isolateErrorSpool);
-    // #2866 — feature flags (uncipher'd, mirroring the foreground open) so the
-    // background scan can read the developer-mode flag to dev-gate the #2824
-    // data-access trace export. Best-effort; the scan no-ops the trace if this
-    // is unavailable.
-    await Hive.openBox<dynamic>(featureFlags);
-  }
+  /// #3689 — lives in [HiveIsolateBoxes]: background opens pin a
+  /// never-compact strategy so a BG isolate can't rename box files under
+  /// the foreground's open handles.
+  static Future<void> initInIsolate() => HiveIsolateBoxes.initInIsolate();
 
-  /// Close the Hive boxes opened by [initInIsolate] at the end of a
-  /// background task to release file handles.
-  ///
-  /// #2670 — boxes [HiveIsolateOwnership] records as main-isolate-owned (from
-  /// [init] / [initDeferred] / [initForTest]) are **skipped**: when the scan
-  /// ran inside the foreground isolate these are the live, shared global
-  /// handles the rest of the app still uses, and closing them produced the
-  /// `FileSystemException: File closed, path='…/cache.hive'` field crash. A
-  /// true spawned `dart:isolate` worker never ran [init], so its registry is
-  /// empty and every [initInIsolate] handle is still closed.
-  static Future<void> closeIsolateBoxes() async {
-    final boxNames = [settings, favorites, alerts, cache, priceHistory, priceSnapshots, isolateErrorSpool, featureFlags];
-    for (final name in boxNames) {
-      if (HiveIsolateOwnership.isOwned(name)) continue;
-      try {
-        if (Hive.isBoxOpen(name)) {
-          await Hive.box<dynamic>(name).close();
-        }
-      } catch (e, st) {
-        debugPrint('HiveBoxes: failed to close box "$name": $e\n$st');
-      }
-    }
-  }
+  /// Close the Hive boxes opened by [initInIsolate] (#2670 ownership guard
+  /// applies — see [HiveIsolateBoxes.closeIsolateBoxes]).
+  static Future<void> closeIsolateBoxes() =>
+      HiveIsolateBoxes.closeIsolateBoxes();
 
   @visibleForTesting
   static Future<void> initForTest() async {

--- a/lib/core/storage/hive_cache_recovery.dart
+++ b/lib/core/storage/hive_cache_recovery.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../logging/error_logger.dart';
+import 'hive_boxes.dart';
+import 'hive_cipher_loader.dart';
+import 'hive_isolate_ownership.dart';
+
+/// #3689 — self-heal for a foreground `cache` box whose file handle died
+/// mid-flight.
+///
+/// Field failure mode: a background isolate's compaction (or any concurrent
+/// file-level interference) invalidates the foreground's open handle; the
+/// box still reads as open (`Hive.isBoxOpen` is registry state, and regular
+/// box READS are memory-only), but every WRITE throws
+/// `FileSystemException: File closed` until app restart — the cache went
+/// silently read-only for 46+ minutes in the 2026-08-09 log.
+///
+/// [recover] closes the broken handle and reopens the box with the same
+/// cipher — the data-preserving path. Only when the file is damaged beyond
+/// reopen (at which point Hive's own crash recovery would truncate it
+/// anyway) is the box deleted from disk and reopened empty: the box is
+/// TTL'd API responses plus itineraries — the latter re-sync from TankSync
+/// where enabled, and staying write-dead until restart loses strictly more.
+/// #1686's never-delete rule still stands for the real user-data boxes
+/// (favorites, profiles, trips …), which this recovery must never be
+/// pointed at. Concurrent failing writers share one recovery via the
+/// single-flight future.
+class HiveCacheRecovery {
+  HiveCacheRecovery._();
+
+  static Future<bool>? _inFlight;
+
+  /// Recover the `cache` box after a write-path [FileSystemException].
+  /// Returns true when the box is open and writable again.
+  static Future<bool> recover() => _inFlight ??= _recover().whenComplete(() {
+        _inFlight = null;
+      });
+
+  static Future<bool> _recover() async {
+    try {
+      // Drop the broken handle. close() on a dead file may itself throw —
+      // that still unregisters the box from Hive's registry.
+      if (Hive.isBoxOpen(HiveBoxes.cache)) {
+        try {
+          await Hive.box<dynamic>(HiveBoxes.cache).close();
+        } catch (_) {
+          // ignore: silent_catch — the handle is already broken; closing is best-effort cleanup
+        }
+      }
+      final cipher = await HiveCipherLoader.loadGuarded();
+      try {
+        await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+      } catch (e, st) {
+        // The on-disk file is damaged beyond reopen (e.g. a half-finished
+        // foreign compaction). The cache is disposable: start fresh rather
+        // than staying write-dead until restart.
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+          'where': 'HiveCacheRecovery: reopen failed — resetting cache box',
+        }));
+        await Hive.deleteBoxFromDisk(HiveBoxes.cache);
+        await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+      }
+      // The recovered handle belongs to the main isolate again (#2670).
+      HiveIsolateOwnership.markOwned(const [HiveBoxes.cache]);
+      debugPrint('HiveCacheRecovery: cache box recovered');
+      return true;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'HiveCacheRecovery: recovery failed',
+      }));
+      return false;
+    }
+  }
+}

--- a/lib/core/storage/hive_isolate_boxes.dart
+++ b/lib/core/storage/hive_isolate_boxes.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'hive_boxes.dart';
+import 'hive_cipher_loader.dart';
+import 'hive_isolate_ownership.dart';
+
+/// Background-isolate box lifecycle, split out of [HiveBoxes] (#3689).
+///
+/// A WorkManager scan runs in its own isolate with its own Hive registry,
+/// but on the SAME box files the foreground holds open. Hive forbids that
+/// (one file, one isolate); [HiveIsolateLock] serialises the background
+/// acquirers against each other, yet the foreground keeps its handles open
+/// throughout. The one file-level mutation a background open could still
+/// perform is COMPACTION: Hive auto-compacts on write/delete thresholds and
+/// renames `<box>.hivec` over `<box>.hive` — yanking the file out from
+/// under the foreground's open handle. Field log 2026-08-09: a
+/// `PathNotFoundException: cannot rename …cache.hivec` followed by a dead
+/// foreground cache box (`FileSystemException: File closed` on every put
+/// until restart). Every background open therefore pins
+/// [_neverCompact] — a background isolate reads and writes, but NEVER
+/// rewrites the file. The foreground (sole long-lived owner) keeps Hive's
+/// default compaction.
+class HiveIsolateBoxes {
+  HiveIsolateBoxes._();
+
+  /// #3689 — background isolates must never rename box files. See class doc.
+  static bool _neverCompact(int entries, int deletedEntries) => false;
+
+  /// Initialize Hive in a background isolate with proper encryption.
+  static Future<void> initInIsolate() async {
+    await Hive.initFlutter();
+    final cipher = await HiveCipherLoader.loadGuarded();
+    Future<Box<T>> open<T>(String name, {HiveAesCipher? boxCipher}) =>
+        Hive.openBox<T>(name,
+            encryptionCipher: boxCipher, compactionStrategy: _neverCompact);
+    await open<dynamic>(HiveBoxes.settings, boxCipher: cipher);
+    await open<dynamic>(HiveBoxes.favorites, boxCipher: cipher);
+    // #2205 — BG widget reads the profile.
+    await open<dynamic>(HiveBoxes.profiles, boxCipher: cipher);
+    await open<dynamic>(HiveBoxes.alerts, boxCipher: cipher);
+    await open<dynamic>(HiveBoxes.cache, boxCipher: cipher);
+    await open<dynamic>(HiveBoxes.priceHistory, boxCipher: cipher);
+    // #579 — velocity detector reads/writes snapshots from the BG
+    // isolate, mirroring the main-isolate open above.
+    await open<String>(HiveBoxes.priceSnapshots);
+    // #1105 — isolate error spool: background-isolate errors written
+    // here while Riverpod is unavailable, drained by the foreground
+    // initialiser into TraceRecorder.
+    await open<String>(HiveBoxes.isolateErrorSpool);
+    // #2866 — feature flags (uncipher'd, mirroring the foreground open) so the
+    // background scan can read the developer-mode flag to dev-gate the #2824
+    // data-access trace export. Best-effort; the scan no-ops the trace if this
+    // is unavailable.
+    await open<dynamic>(HiveBoxes.featureFlags);
+  }
+
+  /// Close the Hive boxes opened by [initInIsolate] at the end of a
+  /// background task to release file handles.
+  ///
+  /// #2670 — boxes [HiveIsolateOwnership] records as main-isolate-owned (from
+  /// `HiveBoxes.init` / `initDeferred` / `initForTest`) are **skipped**: when
+  /// the scan ran inside the foreground isolate these are the live, shared
+  /// global handles the rest of the app still uses, and closing them produced
+  /// the `FileSystemException: File closed, path='…/cache.hive'` field crash.
+  /// A true spawned `dart:isolate` worker never ran `init`, so its registry
+  /// is empty and every [initInIsolate] handle is still closed.
+  static Future<void> closeIsolateBoxes() async {
+    final boxNames = [
+      HiveBoxes.settings,
+      HiveBoxes.favorites,
+      HiveBoxes.alerts,
+      HiveBoxes.cache,
+      HiveBoxes.priceHistory,
+      HiveBoxes.priceSnapshots,
+      HiveBoxes.isolateErrorSpool,
+      HiveBoxes.featureFlags,
+    ];
+    for (final name in boxNames) {
+      if (HiveIsolateOwnership.isOwned(name)) continue;
+      try {
+        if (Hive.isBoxOpen(name)) {
+          await Hive.box<dynamic>(name).close();
+        }
+      } catch (e, st) {
+        debugPrint('HiveIsolateBoxes: failed to close box "$name": $e\n$st');
+      }
+    }
+  }
+}

--- a/lib/core/storage/stores/cache_hive_store.dart
+++ b/lib/core/storage/stores/cache_hive_store.dart
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:meta/meta.dart';
 
 import '../../data/storage_repository.dart';
 import '../../logging/error_logger.dart';
 import '../hive_boxes.dart';
+import '../hive_cache_recovery.dart';
 
 /// Hive-backed implementation of [CacheStorage] and [ItineraryStorage].
 ///
@@ -24,6 +27,35 @@ import '../hive_boxes.dart';
 /// `VelocityAlertCooldown`). The root close-site is fixed in
 /// [HiveBoxes.closeIsolateBoxes]; this is the belt-and-braces reader guard.
 class CacheHiveStore implements CacheStorage, ItineraryStorage {
+  /// Recovery hook — [HiveCacheRecovery.recover] in production, a fake in
+  /// tests (the dead-handle state can't be produced via Hive's public API).
+  CacheHiveStore({@visibleForTesting Future<bool> Function()? recover})
+      : _recover = recover ?? HiveCacheRecovery.recover;
+
+  final Future<bool> Function() _recover;
+
+  /// #3689 — write-path self-heal. A box whose FILE handle died (foreign
+  /// compaction, #3689) still passes [_boxOrNull] (`isBoxOpen` is registry
+  /// state) but throws `FileSystemException: File closed` on every write.
+  /// Recover the box once and retry; on a second failure rethrow so the
+  /// caller's storage-layer logging ([CacheManager.put]'s catch) records it.
+  /// Public-for-testing: the dead-handle throw can't be produced through
+  /// Hive's public API, so tests drive [op] directly with a throwing fake.
+  @visibleForTesting
+  Future<void> writeWithRecovery(
+      Future<void> Function(Box<dynamic> box) op) async {
+    final box = _boxOrNull();
+    if (box == null) return;
+    try {
+      await op(box);
+    } on FileSystemException {
+      if (!await _recover()) rethrow;
+      final reopened = _boxOrNull();
+      if (reopened == null) return;
+      await op(reopened);
+    }
+  }
+
   Box<dynamic>? _boxOrNull() {
     try {
       if (!Hive.isBoxOpen(HiveBoxes.cache)) return null;
@@ -37,14 +69,11 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
 
   // Cache
   @override
-  Future<void> cacheData(String key, dynamic data) async {
-    final box = _boxOrNull();
-    if (box == null) return;
-    await box.put(key, {
-      'data': data,
-      'timestamp': DateTime.now().millisecondsSinceEpoch,
-    });
-  }
+  Future<void> cacheData(String key, dynamic data) =>
+      writeWithRecovery((box) => box.put(key, {
+            'data': data,
+            'timestamp': DateTime.now().millisecondsSinceEpoch,
+          }));
 
   @override
   Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
@@ -69,19 +98,14 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
   }
 
   @override
-  Future<void> clearCache() async {
-    final box = _boxOrNull();
-    if (box != null) await box.clear();
-  }
+  Future<void> clearCache() => writeWithRecovery((box) => box.clear());
 
   @override
   Iterable<dynamic> get cacheKeys => _boxOrNull()?.keys ?? const [];
 
   @override
-  Future<void> deleteCacheEntry(String key) async {
-    final box = _boxOrNull();
-    if (box != null) await box.delete(key);
-  }
+  Future<void> deleteCacheEntry(String key) =>
+      writeWithRecovery((box) => box.delete(key));
 
   @override
   int get cacheEntryCount => _boxOrNull()?.length ?? 0;
@@ -100,10 +124,8 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
   }
 
   @override
-  Future<void> saveItineraries(List<Map<String, dynamic>> itineraries) async {
-    final box = _boxOrNull();
-    if (box != null) await box.put('itineraries', itineraries);
-  }
+  Future<void> saveItineraries(List<Map<String, dynamic>> itineraries) =>
+      writeWithRecovery((box) => box.put('itineraries', itineraries));
 
   @override
   Future<void> addItinerary(Map<String, dynamic> itinerary) async {

--- a/lib/features/alerts/background/android_background_price_fetcher.dart
+++ b/lib/features/alerts/background/android_background_price_fetcher.dart
@@ -1,9 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
 import '../../../core/background/background_price_fetcher.dart';
+import '../../../core/logging/error_logger.dart';
 import 'background_service.dart';
 
 /// Android implementation of [BackgroundPriceFetcher] using WorkManager.
@@ -29,9 +34,14 @@ class AndroidBackgroundPriceFetcher implements BackgroundPriceFetcher {
   AndroidBackgroundPriceFetcher({Workmanager? workmanager})
       : _workmanager = workmanager ?? Workmanager();
 
+  /// #3688 — key read natively by `BackgroundScanEnqueuer.handleIsFresh`
+  /// (shared_preferences persists it as `flutter.bg_handle_build`).
+  static const handleBuildKey = 'bg_handle_build';
+
   @override
   Future<void> init() async {
     await _workmanager.initialize(callbackDispatcher);
+    await _stampHandleBuild();
 
     // #2300 — register with ExistingPeriodicWorkPolicy.update so a repeated
     // init() (every app launch) is idempotent: it refreshes the existing task
@@ -56,6 +66,30 @@ class AndroidBackgroundPriceFetcher implements BackgroundPriceFetcher {
   @override
   Future<void> cancelAll() async {
     await _workmanager.cancelAll();
+  }
+
+  /// #3688 — record WHICH build just persisted the WorkManager callback
+  /// handle. The native `BackgroundScanEnqueuer` refuses to enqueue when
+  /// this stamp doesn't match the installed build: a handle persisted by a
+  /// previous build resolves to nothing in the new Dart snapshot, and the
+  /// workmanager `BackgroundWorker` failure path leaks its freshly created
+  /// FlutterEngine alive (43 live engines in the field tombstone). The
+  /// stamp is also refreshed by the boot re-arm's background `init()`, so
+  /// the gate reopens as soon as ANY isolate re-persists the handle.
+  ///
+  /// Best-effort: on failure the stamp stays stale, which only suppresses
+  /// opportunistic widget scans until the next successful launch — the
+  /// fail-safe direction.
+  Future<void> _stampHandleBuild() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(handleBuildKey, info.buildNumber);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.background, e, st, context: const {
+        'where': 'AndroidBackgroundPriceFetcher: stamp handle build (#3688)',
+      }));
+    }
   }
 
   /// #3169 — deliberate no-op on Android. The twice-daily WorkManager

--- a/test/core/storage/cache_hive_store_recovery_test.dart
+++ b/test/core/storage/cache_hive_store_recovery_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/stores/cache_hive_store.dart';
+
+/// #3689 — write-path self-heal contract of [CacheHiveStore].
+///
+/// The field failure (a cache box whose FILE handle died under a foreign
+/// compaction while `isBoxOpen` still reports true) cannot be produced
+/// through Hive's public API, so these tests drive [writeWithRecovery]
+/// with an op that throws the same `FileSystemException: File closed`
+/// and assert the recovery orchestration around it.
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('cache_recovery_test');
+    Hive.init(tmp.path);
+    await Hive.openBox<dynamic>(HiveBoxes.cache);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await tmp.delete(recursive: true);
+  });
+
+  test('a FileSystemException write triggers ONE recovery and a retry '
+      'that lands', () async {
+    var recoveries = 0;
+    var attempts = 0;
+    final store = CacheHiveStore(recover: () async {
+      recoveries++;
+      return true;
+    });
+
+    await store.writeWithRecovery((box) async {
+      attempts++;
+      if (attempts == 1) {
+        throw const FileSystemException('File closed', 'cache.hive');
+      }
+      await box.put('healed', true);
+    });
+
+    expect(recoveries, 1);
+    expect(attempts, 2);
+    expect(Hive.box<dynamic>(HiveBoxes.cache).get('healed'), isTrue);
+  });
+
+  test('failed recovery rethrows so CacheManager\'s storage-layer catch '
+      'records it', () async {
+    final store = CacheHiveStore(recover: () async => false);
+
+    await expectLater(
+      store.writeWithRecovery(
+          (_) async => throw const FileSystemException('File closed')),
+      throwsA(isA<FileSystemException>()),
+    );
+  });
+
+  test('a healthy write never invokes recovery', () async {
+    var recoveries = 0;
+    final store = CacheHiveStore(recover: () async {
+      recoveries++;
+      return true;
+    });
+
+    await store.cacheData('key', {'value': 1});
+
+    expect(recoveries, 0);
+    expect(store.getCachedData('key'), {'value': 1});
+  });
+
+  test('a closed box stays the #2670 no-op — no recovery attempt', () async {
+    await Hive.box<dynamic>(HiveBoxes.cache).close();
+    var recoveries = 0;
+    final store = CacheHiveStore(recover: () async {
+      recoveries++;
+      return true;
+    });
+
+    await store.cacheData('key', {'value': 1});
+
+    expect(recoveries, 0);
+  });
+}

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -63,28 +63,43 @@ void main() {
           );
         }
 
-        // Extract initInIsolate() method body
+        // #3689 — initInIsolate moved to HiveIsolateBoxes; its opens route
+        // through the local `open` helper so every background open pins the
+        // never-compact strategy. The six PII boxes must pass the cipher.
+        final isolateSource =
+            File('lib/core/storage/hive_isolate_boxes.dart').readAsStringSync();
         final isolateMatch = RegExp(
           r'static Future<void> initInIsolate\(\) async \{(.*?)\n  \}',
           dotAll: true,
-        ).firstMatch(source);
+        ).firstMatch(isolateSource);
         expect(isolateMatch, isNotNull,
-            reason: 'initInIsolate() method must exist');
+            reason: 'initInIsolate() method must exist in HiveIsolateBoxes');
         final isolateBody = isolateMatch!.group(1)!;
 
-        // All Hive.openBox calls in initInIsolate() must use encryptionCipher
-        final isolateOpenBoxCalls = RegExp(r'Hive\.openBox\([^)]+\)')
-            .allMatches(isolateBody)
-            .map((m) => m.group(0)!)
-            .toList();
-        for (final call in isolateOpenBoxCalls) {
+        for (final boxName in [
+          'settings',
+          'favorites',
+          'profiles',
+          'alerts',
+          'cache',
+          'priceHistory',
+        ]) {
           expect(
-            call.contains('encryptionCipher'),
+            isolateBody
+                .contains('open<dynamic>(HiveBoxes.$boxName, boxCipher: '),
             isTrue,
-            reason: 'All Hive.openBox calls in initInIsolate() must use '
-                'encryptionCipher: found "$call" without it',
+            reason: 'initInIsolate must open the encrypted $boxName box '
+                'with the cipher',
           );
         }
+        // The helper is the single Hive.openBox site — it must carry both
+        // the cipher pass-through and the #3689 never-compact strategy.
+        expect(
+          isolateSource.contains('compactionStrategy: _neverCompact'),
+          isTrue,
+          reason: 'background opens must never compact (#3689) — a BG '
+              'compaction renames box files under the foreground handles',
+        );
       });
 
       test('all six domain boxes are in the encrypted set', () {
@@ -149,8 +164,9 @@ void main() {
       });
 
       test('initInIsolate() opens the six background boxes', () {
+        // #3689 — the isolate box lifecycle lives in HiveIsolateBoxes.
         final source =
-            File('lib/core/storage/hive_boxes.dart').readAsStringSync();
+            File('lib/core/storage/hive_isolate_boxes.dart').readAsStringSync();
 
         final isolateMatch = RegExp(
           r'static Future<void> initInIsolate\(\) async \{(.*?)\n  \}',

--- a/test/core/storage/hive_cache_recovery_test.dart
+++ b/test/core/storage/hive_cache_recovery_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/hive_cache_recovery.dart';
+import 'package:tankstellen/core/storage/hive_cipher_loader.dart';
+
+/// #3689 — [HiveCacheRecovery] reopens the cache box after its handle died.
+void main() {
+  late Directory tmp;
+  final cipher = HiveAesCipher(List<int>.filled(32, 7));
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('hive_cache_recovery_test');
+    Hive.init(tmp.path);
+    HiveCipherLoader.cipherLoader = () async => cipher;
+  });
+
+  tearDown(() async {
+    HiveCipherLoader.resetCipherLoaderForTest();
+    await Hive.deleteFromDisk();
+    await tmp.delete(recursive: true);
+  });
+
+  test('recover reopens the box with the cipher — data intact', () async {
+    final box =
+        await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+    await box.put('kept', 42);
+
+    expect(await HiveCacheRecovery.recover(), isTrue);
+
+    final reopened = Hive.box<dynamic>(HiveBoxes.cache);
+    expect(reopened.isOpen, isTrue);
+    expect(reopened.get('kept'), 42);
+    await reopened.put('writable', true); // the point of the recovery
+  });
+
+  test('recover also works when the box is fully closed', () async {
+    final box =
+        await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+    await box.put('kept', 1);
+    await box.close();
+
+    expect(await HiveCacheRecovery.recover(), isTrue);
+    expect(Hive.box<dynamic>(HiveBoxes.cache).get('kept'), 1);
+  });
+
+  test('a file damaged beyond reopen is reset to an EMPTY writable box '
+      '(the cache is refetchable; write-dead-until-restart loses more)',
+      () async {
+    final box =
+        await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+    await box.put('doomed', 1);
+    await box.close();
+    // Overwrite the box file with garbage the cipher can't decode.
+    File('${tmp.path}/${HiveBoxes.cache}.hive')
+        .writeAsBytesSync(List<int>.generate(64, (i) => 255 - i));
+
+    expect(await HiveCacheRecovery.recover(), isTrue);
+
+    final fresh = Hive.box<dynamic>(HiveBoxes.cache);
+    expect(fresh.isEmpty, isTrue);
+    await fresh.put('alive', true);
+    expect(fresh.get('alive'), isTrue);
+  });
+
+  test('concurrent recoveries share one flight', () async {
+    await Hive.openBox<dynamic>(HiveBoxes.cache, encryptionCipher: cipher);
+
+    final a = HiveCacheRecovery.recover();
+    final b = HiveCacheRecovery.recover();
+    expect(identical(a, b), isTrue);
+    expect(await a, isTrue);
+    // After completion a NEW recovery starts a fresh flight.
+    expect(await HiveCacheRecovery.recover(), isTrue);
+  });
+}

--- a/test/features/alerts/background/background_price_fetcher_test.dart
+++ b/test/features/alerts/background/background_price_fetcher_test.dart
@@ -4,6 +4,8 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tankstellen/features/alerts/background/android_background_price_fetcher.dart';
 import 'package:tankstellen/core/background/background_price_fetcher.dart';
 import 'package:tankstellen/features/alerts/background/background_service.dart';
@@ -268,6 +270,78 @@ void main() {
     test('cancelAll method exists and is callable', () {
       final fetcher = AndroidBackgroundPriceFetcher();
       expect(fetcher.cancelAll, isA<Function>());
+    });
+
+    // #3688 — the handle-freshness stamp is a Dart↔Kotlin contract: Dart
+    // persists WHICH build persisted the WorkManager callback handle;
+    // the native BackgroundScanEnqueuer refuses to enqueue on mismatch
+    // (a stale handle leaks a live FlutterEngine per background wake).
+    test('init stamps the build number the callback handle belongs to '
+        '(#3688)', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({});
+      PackageInfo.setMockInitialValues(
+        appName: 'tankstellen',
+        packageName: 'de.tankstellen.fuelprices',
+        version: '6.0.5',
+        buildNumber: '51383',
+        buildSignature: '',
+      );
+      final wm = _RecordingWorkmanager();
+
+      await AndroidBackgroundPriceFetcher(workmanager: wm).init();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString(AndroidBackgroundPriceFetcher.handleBuildKey),
+        '51383',
+        reason: 'the stamp must record the build that ran '
+            'Workmanager().initialize',
+      );
+    });
+
+    test('the stamp key matches the native gate\'s SharedPreferences key '
+        '(#3688)', () {
+      // shared_preferences persists Dart keys with a `flutter.` prefix in
+      // the FlutterSharedPreferences XML the Kotlin side reads.
+      expect(AndroidBackgroundPriceFetcher.handleBuildKey, 'bg_handle_build');
+      final kotlin = File(
+        'android/app/src/main/kotlin/de/tankstellen/tankstellen/'
+        'BackgroundScanEnqueuer.kt',
+      ).readAsStringSync();
+      expect(
+        kotlin.contains('"flutter.bg_handle_build"'),
+        isTrue,
+        reason: 'BackgroundScanEnqueuer must read the flutter.-prefixed '
+            'stamp key',
+      );
+      expect(
+        kotlin.contains('"FlutterSharedPreferences"'),
+        isTrue,
+        reason: 'the stamp lives in the shared_preferences XML file',
+      );
+    });
+
+    test('the widget periodic wake respects the native cooldown; the '
+        'boot re-arm and refresh tap do not (#3688)', () {
+      final widgetProvider = File(
+        'android/app/src/main/kotlin/de/tankstellen/tankstellen/'
+        'FuelPriceWidgetProvider.kt',
+      ).readAsStringSync();
+      expect(
+        widgetProvider.contains('respectCooldown = true'),
+        isTrue,
+        reason: 'the 30-min OS wake must ride the 60-min engine-churn '
+            'cooldown',
+      );
+      // The refresh tap only dims the glyph when a scan was enqueued —
+      // otherwise a gated tap leaves the widget "refreshing" forever.
+      expect(
+        widgetProvider.contains('val enqueued = BackgroundScanEnqueuer'),
+        isTrue,
+        reason: 'ACTION_REFRESH must branch its glyph feedback on the '
+            'enqueue result',
+      );
     });
 
     test('uses the BackgroundService periodic task name constant', () {


### PR DESCRIPTION
## Summary

The 2026-08-08→09 error log's native tombstones (harvested by #3580) refute the #3590 pairip attribution: the same `JNI ERROR: global reference table overflow (max=51200)` fires on pairip-free builds. The histogram pins the real cause — **43 live, never-destroyed background FlutterEngines** (43 bound TextToSpeech connections, ~3 receivers + ~6 ContentObservers each, ~8.4k global refs to the one Application object).

**One root cause, four symptom classes**: 3× crash_native, 20× low_memory_kill (rss up to 342 MB), 8× EXCESSIVE-CPU kills + 5 bg-CPU-watchdog traces (leaked receivers dispatching on main for every system broadcast), and the cache.hive corruption.

### #3688 — engine-leak gate + cooldown
- The 30-min widget `updatePeriodMillis` wake enqueues a workmanager `BackgroundWorker`; its `callbackInfo == null` failure path (stale persisted Dart callback handle — every post-update window until the next app launch, i.e. every nightly beta) creates a FlutterEngine it never destroys.
- Dart now stamps `bg_handle_build` right after `Workmanager().initialize`; `BackgroundScanEnqueuer` refuses to enqueue when the stamp ≠ installed `longVersionCode`. Covers the widget periodic wake, the refresh tap, and the boot re-arm (`MY_PACKAGE_REPLACED` was a guaranteed one-leak-per-update).
- 60-min native cooldown on the periodic widget wake (healthy runs still leave ~44 permanent JNI refs each); refresh tap + boot re-arm skip the cooldown but honor the gate; the refresh glyph only dims when a scan was actually enqueued.

### #3689 — cache.hive multi-isolate compaction race
- Background isolates opened the same box files with default compaction — a BG auto-compaction renamed `cache.hivec → cache.hive` under the foreground's open handle → foreground cache box write-dead until restart (46+ min in the field).
- `HiveIsolateBoxes` (split from `hive_boxes.dart` for the file-length norm) pins a never-compact strategy on every background open.
- `HiveCacheRecovery`: single-flight foreground self-heal — close + reopen with cipher (data-preserving); only a file damaged beyond reopen is reset empty (cache is refetchable; itineraries re-sync via TankSync). #1686's never-delete rule untouched for user-data boxes.

## Test plan
- New: `hive_cache_recovery_test.dart` (reopen preserves data, corrupt-file reset, single-flight), `cache_hive_store_recovery_test.dart` (recover-and-retry, rethrow on failed recovery, no recovery on healthy/closed box), Dart↔Kotlin contract tests for the stamp key + cooldown wiring.
- Full suite green in a detached worktree at the committed state (15548 tests; single red = known `test_selector` long-run flake, green standalone). `flutter analyze` clean; `compilePlayDebugKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
