### PR TITLE
chore(ci): gate the beta tag step on skip_upload too (#3695 follow-up)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -207,6 +207,9 @@ jobs:
         run: rm -f "$PLAY_KEY_PATH"
 
       - name: Tag the shipped build (vX.Y.Z+BUILD)
+        # #3695 — nothing shipped on skip_upload runs; tagging would also
+        # fail from a non-master dispatch ref.
+        if: github.event.inputs.skip_upload != 'true'
         # #3177 — every CI-minted versionCode must map back to a commit
         # (the About-screen build number is the documented first triage
         # step). Annotated tag pushed with the default GITHUB_TOKEN:


### PR DESCRIPTION
The artifact-only dispatch path skipped upload but still tried to tag —
nothing shipped, and the step fails from a branch dispatch. Same gate as
the upload steps.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
