### PR TITLE
fix: OBD2 hands-free connect at engine start + error-log flood + E85 false alarm (#3699, #3700, #3701)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BackgroundAdapterChannel.kt
@@ -72,6 +72,9 @@ object BackgroundAdapterChannel {
     fun registerWith(flutterEngine: FlutterEngine, context: Context) {
         appContext = context.applicationContext
 
+        // #3699 — ACL engine-start hints ride this channel's event stream.
+        BtAclEngineStartReceiver.register(context)
+
         val method = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
         method.setMethodCallHandler { call, result -> handle(call, result) }
 

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BtAclEngineStartReceiver.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/autorecord/BtAclEngineStartReceiver.kt
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.autorecord
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.SystemClock
+import android.util.Log
+
+/**
+ * #3699 — engine-start hint from Bluetooth ACL connections.
+ *
+ * The vLinker-class OBD2 adapter sleeps at ~3 mA while the ignition is
+ * off (its Bluetooth presence lingers, but RFCOMM connects time out) and
+ * wakes on bus activity the instant the ignition turns on. The reconnect
+ * supervisor's stand-down holds are therefore CORRECT while parked but
+ * blind at engine start: with the phone pocketed, nothing used to break
+ * the hold until the app came to the foreground (2026-08-11 field log —
+ * hourly 23 s misses escalating the hold past an hour, morning drives
+ * connecting only after the app was opened).
+ *
+ * The one broadcast that fires at exactly the right moment is
+ * [BluetoothDevice.ACTION_ACL_CONNECTED]: when driving starts, the phone
+ * links to the car's audio system (and/or the adapter itself). We
+ * forward it as an `aclConnected` event on the existing auto_record
+ * events channel; the Dart side calls `Obd2LinkSupervisor.wake()`, which
+ * resets the stand-down and dials immediately (a no-op in every state
+ * where waking is meaningless).
+ *
+ * Deliberately UNFILTERED by device: the car-audio MAC is unknown to the
+ * app, and a false hint (headphones at home) costs at most one fast
+ * dial ladder before the stand-down re-arms. A [COOLDOWN_MS] gate keeps
+ * accessory churn from re-triggering that repeatedly.
+ *
+ * Context-registered on the application context (process lifetime — no
+ * manifest registration, so a dead process is never revived into a
+ * fresh FlutterEngine; see the #3688 engine-churn lesson).
+ */
+object BtAclEngineStartReceiver {
+    private const val TAG = "BtAclEngineStart"
+    private const val COOLDOWN_MS = 5L * 60L * 1000L
+
+    @Volatile
+    private var registered = false
+
+    @Volatile
+    private var lastHintElapsedMs = -COOLDOWN_MS
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != BluetoothDevice.ACTION_ACL_CONNECTED) return
+            val nowElapsed = SystemClock.elapsedRealtime()
+            if (nowElapsed - lastHintElapsedMs < COOLDOWN_MS) return
+            lastHintElapsedMs = nowElapsed
+            val device: BluetoothDevice? =
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(
+                        BluetoothDevice.EXTRA_DEVICE,
+                        BluetoothDevice::class.java,
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+                }
+            val mac = device?.address ?: ""
+            Log.d(TAG, "ACL connected ($mac) — forwarding engine-start hint")
+            BackgroundAdapterChannel.post(
+                mapOf(
+                    "type" to "aclConnected",
+                    "mac" to mac,
+                    "atMillis" to System.currentTimeMillis(),
+                ),
+            )
+        }
+    }
+
+    /** Idempotent; safe to call on every engine configure. */
+    fun register(context: Context) {
+        if (registered) return
+        synchronized(this) {
+            if (registered) return
+            context.applicationContext.registerReceiver(
+                receiver,
+                IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED),
+            )
+            registered = true
+            Log.d(TAG, "registered for ACTION_ACL_CONNECTED")
+        }
+    }
+}

--- a/lib/app/startup/provider_warmup_phase.dart
+++ b/lib/app/startup/provider_warmup_phase.dart
@@ -13,6 +13,7 @@ import '../../features/obd2/data/ios_state_restoration_provider.dart';
 import '../../features/consumption/providers/auto_record_orchestrator.dart';
 import '../../features/obd2/providers/obd2_comm_diagnostics_gate_provider.dart';
 import '../../features/obd2/providers/obd2_debug_logging_provider.dart';
+import '../../features/obd2/providers/obd2_engine_start_hint_provider.dart';
 import '../../features/consumption/providers/trip_ve_recompute_provider.dart';
 import '../../features/vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../../features/vehicle/data/repositories/vehicle_profile_repository.dart';
@@ -156,6 +157,15 @@ class ProviderWarmupPhase {
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.background, e, st,
           context: {'where': 'autoRecordOrchestrator init'}));
+    }
+    // #3699 — ACL engine-start hints wake the reconnect supervisor so a
+    // pocketed phone connects at ignition-on instead of waiting out a
+    // parked stand-down hold.
+    try {
+      container.read(engineStartHintWakeProvider);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.background, e, st,
+          context: {'where': 'engineStartHintWake init'}));
     }
   }
 

--- a/lib/core/telemetry/crash_forensics_harvester.dart
+++ b/lib/core/telemetry/crash_forensics_harvester.dart
@@ -81,26 +81,76 @@ class CrashForensicsHarvester {
       ));
     }
 
+    // #3700 — group non-crash exits by reason: a phone under memory
+    // pressure produces DOZENS of routine background reclaims between two
+    // launches, and one 50-slot log trace per exit evicted the actually
+    // diagnostic traces (the 2026-08-14 export spent 24 slots on
+    // individual process deaths). One trace per reason keeps every fact
+    // (count, rss range, individual timestamps) in a single slot.
+    // crash_native stays one-trace-per-exit: each carries its own
+    // tombstone, and that stream is what solved #3688.
+    final grouped = <String, List<Map<dynamic, dynamic>>>{};
     for (final entry in (decoded['exits'] as List? ?? const [])) {
       if (entry is! Map) continue;
       final reason = entry['reason']?.toString() ?? 'unknown';
       if (_routineReasons.contains(reason)) continue;
       final stamp = _stamp(entry['timestampMs']);
       final trace = entry['trace']?.toString() ?? '';
+      if (reason == 'crash_native') {
+        unawaited(errorLogger.log(
+          ErrorLayer.background,
+          PreviousProcessDeath(
+            'process died: $reason '
+            '(${entry['importance']}, $stamp, '
+            'pss=${entry['pssKb']}kB rss=${entry['rssKb']}kB) '
+            '${entry['description'] ?? ''}',
+          ),
+          trace.isEmpty ? StackTrace.current : StackTrace.fromString(trace),
+          context: {
+            'where': 'crash forensics: ApplicationExitInfo (#3580)',
+            'reason': reason,
+            'importance': entry['importance']?.toString() ?? '',
+            'crashedAt': stamp,
+            'lastBreadcrumbs': breadcrumbs,
+          },
+        ));
+      } else {
+        grouped.putIfAbsent(reason, () => []).add(entry);
+      }
+    }
+
+    for (final MapEntry(key: reason, value: entries) in grouped.entries) {
+      final stamps = [for (final e in entries) _stamp(e['timestampMs'])];
+      final rss = [
+        for (final e in entries)
+          if (e['rssKb'] is num) (e['rssKb'] as num).toInt()
+      ]..sort();
+      final rssRange = rss.isEmpty
+          ? 'rss=?'
+          : rss.length == 1
+              ? 'rss=${rss.single}kB'
+              : 'rss=${rss.first}-${rss.last}kB';
+      final importances =
+          {for (final e in entries) e['importance']?.toString() ?? ''}
+              .join('/');
+      // The most recent exit's description + trace represent the group;
+      // full per-exit timestamps ride in context.
+      final last = entries.last;
+      final trace = last['trace']?.toString() ?? '';
       unawaited(errorLogger.log(
         ErrorLayer.background,
         PreviousProcessDeath(
-          'process died: $reason '
-          '(${entry['importance']}, $stamp, '
-          'pss=${entry['pssKb']}kB rss=${entry['rssKb']}kB) '
-          '${entry['description'] ?? ''}',
+          'process died: $reason x${entries.length} '
+          '($importances, $rssRange, ${stamps.first} -> ${stamps.last}) '
+          '${last['description'] ?? ''}',
         ),
         trace.isEmpty ? StackTrace.current : StackTrace.fromString(trace),
         context: {
-          'where': 'crash forensics: ApplicationExitInfo (#3580)',
+          'where': 'crash forensics: ApplicationExitInfo (#3580, '
+              'coalesced #3700)',
           'reason': reason,
-          'importance': entry['importance']?.toString() ?? '',
-          'crashedAt': stamp,
+          'count': entries.length.toString(),
+          'crashedAt': stamps.join(', '),
           'lastBreadcrumbs': breadcrumbs,
         },
       ));

--- a/lib/features/consumption/data/lessons/rules/combustion_health_rule.dart
+++ b/lib/features/consumption/data/lessons/rules/combustion_health_rule.dart
@@ -150,10 +150,40 @@ class CombustionHealthRule implements DrivingLessonRule {
   @override
   String get id => combustionHealthLessonId;
 
+  /// #3701 — extra fuel an ethanol blend legitimately demands, as trim
+  /// percent per unit ethanol volume fraction: E100 stoich (9.0:1) vs
+  /// gasoline (14.7:1) means pure ethanol needs ~+34 % fuel mass, so an
+  /// E85 tank explains LTFT around +29 %.
+  static const double _trimPctPerEthanolFraction = 34.0;
+
+  /// Tolerance on top of the fuel-explained trim before a lean signal is
+  /// considered a real fault again (sensor scatter + blend uncertainty).
+  static const double _ethanolExplainedTolerancePct = 8.0;
+
   @override
   DrivingLesson? evaluate(LessonContext context, AppLocalizations l) {
     final signal = combustionHealthSignal(context.samples);
     if (!signal.fired) return null;
+
+    // #3701 — an E85-heavy tank makes sustained positive trims the
+    // CORRECT operating point, not a P0171-style defect: firing "lean
+    // mixture — possible inefficiency" on every trip of an E85
+    // conversion was a false alarm (2026-08-14 field exports, +25 %
+    // LTFT on every drive). Suppress the lean signal when the tank-mix
+    // model explains the magnitude; a genuinely excessive trim (beyond
+    // fuel + tolerance) still fires, as do rich-side signals.
+    // Only a genuinely ethanol-heavy tank (≥ ~E15 equivalent) changes the
+    // expected trim band — ordinary E5/E10 tanks keep the stock rule so a
+    // real vacuum-leak lean condition is never masked by trace ethanol.
+    final ethanol = context.expectedEthanolShare;
+    if (signal.kind == CombustionHealthKind.leanCompensation &&
+        ethanol != null &&
+        ethanol >= 0.15 &&
+        signal.magnitudePct <=
+            ethanol * _trimPctPerEthanolFraction +
+                _ethanolExplainedTolerancePct) {
+      return null;
+    }
 
     final pct = formatLessonPercent(signal.magnitudePct);
     final (String title, String advice) = switch (signal.kind!) {

--- a/lib/features/consumption/domain/lessons/driving_lesson_rule.dart
+++ b/lib/features/consumption/domain/lessons/driving_lesson_rule.dart
@@ -45,11 +45,20 @@ class LessonContext {
   /// found nothing in (the empty-state path).
   final List<DrivingInsight> insights;
 
+  /// #3701 — expected ethanol volume fraction (0..1) of the tank content
+  /// at trip time, from the tank-mix model (#3652). Null when unknown
+  /// (no mix data, single-fuel vehicle, or a caller without provider
+  /// access — e.g. the bare GPX export path). Lets fuel-aware rules
+  /// (combustion health) distinguish "the ECU is fighting a fault" from
+  /// "the ECU is correctly trimming for E85".
+  final double? expectedEthanolShare;
+
   const LessonContext({
     required this.summary,
     required this.samples,
     required this.score,
     required this.insights,
+    this.expectedEthanolShare,
   });
 
   /// The cost line with the given [labelKey], or null when the analyzer

--- a/lib/features/consumption/domain/services/tank_mix_estimator.dart
+++ b/lib/features/consumption/domain/services/tank_mix_estimator.dart
@@ -45,6 +45,27 @@ class TankMixEstimate {
   /// only a trace of a second grade) reads as single-fuel.
   bool isBlend({double minShare = 0.01}) =>
       shares.where((s) => s.share >= minShare).length >= 2;
+
+  /// #3701 — share-weighted ethanol volume fraction of the tank content
+  /// (0..1), from the nominal ethanol content of each grade (E85 ≈ 85 %,
+  /// E10 = 10 %, E5/E98 = 5 %). Drives the combustion-health lesson's
+  /// fuel-explains-the-trims gate: an ECU running an E85-heavy tank
+  /// legitimately holds LTFT around +20‥30 % (stoich 9.8:1 vs 14.7:1) —
+  /// that is the fuel, not a P0171-style fault.
+  double get ethanolVolumeFraction {
+    var fraction = 0.0;
+    for (final s in shares) {
+      fraction += s.share * _nominalEthanolContent(s.fuel);
+    }
+    return fraction.clamp(0.0, 1.0);
+  }
+
+  static double _nominalEthanolContent(FuelType fuel) {
+    if (fuel == FuelType.e85) return 0.85;
+    if (fuel == FuelType.e10) return 0.10;
+    if (fuel == FuelType.e5 || fuel == FuelType.e98) return 0.05;
+    return 0.0;
+  }
 }
 
 /// Estimate the fuel mix of the current tank content from the fill-up

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -8,6 +8,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
 import '../../../../core/domain/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
+import 'trip_detail_lessons.dart';
 import '../../data/driving_insights_analyzer.dart';
 import '../../data/driving_score_calculator.dart';
 import '../../data/lessons/driving_lesson_registry.dart';
@@ -18,7 +19,6 @@ import '../../domain/fuel_event_attribution.dart';
 import '../../domain/gps_coverage_report.dart';
 import '../../domain/gps_driving_features.dart';
 import '../../domain/lessons/driving_lesson.dart';
-import '../../domain/lessons/driving_lesson_rule.dart';
 import '../../domain/services/throttle_rpm_histogram_calculator.dart';
 import '../../domain/trip_recorder.dart';
 import 'driving_analysis_trace_card.dart';
@@ -246,25 +246,22 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // toggling back on instantly restores the score without a re-render.
     final showGamification = ref.watch(gamificationEnabledProvider);
 
-    // Post-trip lessons (#2251) — resolved here because the localized
-    // titles depend on the active locale, but built off the cached
-    // [_insights] / [_score] (and the stored summary) so the O(n)
-    // analyzer / score passes don't re-run on a theme / locale rebuild.
+    // Post-trip lessons (#2251/#3701) — see [buildTripDetailLessons].
     // Empty for EV / empty trips on the same gating rule as the card
     // below, and the registry returns [] when no rule fires (the
     // empty-state path).
     final List<DrivingLesson> lessons = (widget.isEv || widget.samples.isEmpty)
         ? const []
-        : _lessonRegistry.evaluateContext(
-            LessonContext(
-              summary: widget.entry.summary,
-              samples: widget.samples
-                  .map(tripDetailToTripSample)
-                  .toList(growable: false),
-              score: _score,
-              insights: _insights,
-            ),
-            l,
+        : buildTripDetailLessons(
+            ref: ref,
+            registry: _lessonRegistry,
+            entry: widget.entry,
+            samples: widget.samples
+                .map(tripDetailToTripSample)
+                .toList(growable: false),
+            score: _score,
+            insights: _insights,
+            l: l,
           );
 
     // Wrap the report content in a [RepaintBoundary] so the Share

--- a/lib/features/consumption/presentation/widgets/trip_detail_lessons.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_lessons.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../data/lessons/driving_lesson_registry.dart';
+import '../../data/trip_history_entry.dart';
+import '../../domain/driving_insight.dart';
+import '../../domain/driving_score.dart';
+import '../../domain/lessons/driving_lesson.dart';
+import '../../domain/lessons/driving_lesson_rule.dart';
+import '../../domain/trip_sample.dart';
+import '../../providers/tank_mix_provider.dart';
+
+/// Post-trip lesson resolution for the trip-detail body (#2251), split
+/// out of `trip_detail_body.dart` for the file-length norm.
+///
+/// Resolved per build because the localized titles depend on the active
+/// locale, but built off the caller's CACHED insights / score (and the
+/// stored summary) so the O(n) analyzer / score passes don't re-run on a
+/// theme / locale rebuild.
+///
+/// #3701 — the tank-mix ethanol share (from the #3652 mix model) rides
+/// into [LessonContext] so the combustion-health rule can tell "the ECU
+/// is trimming for E85" from "the ECU is fighting a fault". Null
+/// (unknown vehicle / single-fuel) keeps every rule stock.
+List<DrivingLesson> buildTripDetailLessons({
+  required WidgetRef ref,
+  required DrivingLessonRegistry registry,
+  required TripHistoryEntry entry,
+  required List<TripSample> samples,
+  required DrivingScore score,
+  required List<DrivingInsight> insights,
+  required AppLocalizations l,
+}) {
+  final vehicleId = entry.vehicleId;
+  return registry.evaluateContext(
+    LessonContext(
+      summary: entry.summary,
+      samples: samples,
+      score: score,
+      insights: insights,
+      expectedEthanolShare: vehicleId == null
+          ? null
+          : ref.watch(tankMixProvider(vehicleId))?.ethanolVolumeFraction,
+    ),
+    l,
+  );
+}

--- a/lib/features/obd2/data/android_background_adapter_listener.dart
+++ b/lib/features/obd2/data/android_background_adapter_listener.dart
@@ -73,6 +73,21 @@ class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
   @override
   Stream<BackgroundAdapterEvent> get events => _controller.stream;
 
+  /// #3699 — engine-start hints from the native `BtAclEngineStartReceiver`
+  /// (`{"type": "aclConnected"}` payloads on the same events channel).
+  /// STATIC: the hint is a process-wide signal (the phone linked to SOME
+  /// Bluetooth device — in the car, that's the audio system at ignition
+  /// on), not a per-adapter transition, so it deliberately bypasses the
+  /// sealed [BackgroundAdapterEvent] hierarchy and the per-coordinator
+  /// MAC filter. Emits the native event timestamp; the consumer
+  /// ([engineStartHintWake]) applies the staleness gate — the native
+  /// ring buffer can replay minutes-old hints on (re)subscribe.
+  static final StreamController<DateTime> _hintController =
+      StreamController<DateTime>.broadcast();
+
+  /// Broadcast stream of ACL engine-start hint timestamps (#3699).
+  static Stream<DateTime> get engineStartHints => _hintController.stream;
+
   /// #3505 — localized notification title/body handed to the native FGS at
   /// arm time (null keeps the built-in English fallback). Settable fields
   /// (not `start` params) so the [BackgroundAdapterListener] interface and
@@ -193,6 +208,11 @@ class AndroidBackgroundAdapterListener implements BackgroundAdapterListener {
         return AdapterConnected(mac: mac, at: at);
       case 'disconnect':
         return AdapterDisconnected(mac: mac, at: at);
+      // #3699 — process-wide engine-start hint, not an adapter event:
+      // routed to the static hint stream, never to the coordinator.
+      case 'aclConnected':
+        _hintController.add(at);
+        return null;
       default:
         debugPrint(
           'AndroidBackgroundAdapterListener: dropping event with '

--- a/lib/features/obd2/data/obd2_reconnect_stand_down.dart
+++ b/lib/features/obd2/data/obd2_reconnect_stand_down.dart
@@ -122,13 +122,22 @@ class ReconnectBackoff {
 
   /// #3642 — each consecutive storm-cadence advance means the previous
   /// held attempt STILL failed identically, so the hold lengthens:
-  /// storm ×1 → ×3 → ×12 (5 → 15 → 60 min at the default). A parked car
-  /// (adapter powered, ignition off, permanently in range) otherwise
-  /// keeps a ~18% duty cycle of doomed ~67 s Bluetooth ladders running
-  /// all day — the field shape behind the 2026-07-29 `[EXCESSIVE CPU
-  /// USAGE]` process kill. Any positive signal ([reset], or a healthy
-  /// ladder advance) restores the fast cadence.
-  static const List<int> stormEscalation = [1, 3, 12];
+  /// storm ×1 → ×3, capped at ×3 (5 → 15 → 15 min at the default). A
+  /// parked car (adapter powered, ignition off, permanently in range)
+  /// otherwise keeps a ~18% duty cycle of doomed ~67 s Bluetooth
+  /// ladders running all day — the field shape behind the 2026-07-29
+  /// `[EXCESSIVE CPU USAGE]` process kill. Any positive signal
+  /// ([reset], or a healthy ladder advance) restores the fast cadence.
+  ///
+  /// #3699 — the cap came DOWN from ×12 (60 min): overnight-parked
+  /// misses escalated the hold past an hour, and an engine start
+  /// mid-hold left hands-free connect blind for the whole drive
+  /// (2026-08-11 field log: holds of 927→3693→3982 s while the user's
+  /// morning drives connected only after opening the app). A ≤15-min
+  /// probe cadence is ~2% Bluetooth duty — cheap since the #3671 dial
+  /// budget bounds each probe — and the ACL engine-start hint (#3699)
+  /// usually breaks the hold the moment the ignition turns on anyway.
+  static const List<int> stormEscalation = [1, 3, 3];
 
   int get currentMs => _current.inMilliseconds;
   bool get atCap => _current >= max;

--- a/lib/features/obd2/providers/obd2_engine_start_hint_provider.dart
+++ b/lib/features/obd2/providers/obd2_engine_start_hint_provider.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../../../core/time/app_clock.dart';
+import '../data/android_background_adapter_listener.dart';
+// The wake() action lives in the supervisor library's part extension —
+// importing the library brings it into scope.
+import '../data/obd2_link_supervisor.dart';
+import 'obd2_reconnect_provider.dart';
+
+part 'obd2_engine_start_hint_provider.g.dart';
+
+/// #3699 — turn Bluetooth ACL connects into reconnect wakes.
+///
+/// The stand-down escalation is correct while the car is parked (the
+/// adapter sleeps; every probe is a doomed 23 s timeout), but before
+/// this wiring NOTHING broke the hold at engine start with the phone
+/// pocketed: `wake()` fired only on app resume and on GPS movement
+/// during an already-running recording. Field shape (2026-08-11):
+/// overnight misses escalated the hold past an hour and the morning
+/// drive got no hands-free connect until the app was opened.
+///
+/// The phone linking to ANY Bluetooth device — in the car, the audio
+/// system, at exactly ignition-on when the vLinker wakes from its 3 mA
+/// sleep — is the cheapest engine-start signal Android offers without
+/// new permissions. The native receiver already rate-limits to one hint
+/// per 5 min; here we drop hints older than [staleness] (the native
+/// ring can replay buffered hints on resubscribe) and nudge `wake()`,
+/// which is a no-op in every state where waking is meaningless and an
+/// immediate dial in `engineOff` / held-`reconnecting`.
+@Riverpod(keepAlive: true)
+void engineStartHintWake(Ref ref) {
+  const staleness = Duration(minutes: 2);
+  final sub = AndroidBackgroundAdapterListener.engineStartHints.listen((at) {
+    final now = ref.read(appClockProvider).now();
+    if (now.difference(at) > staleness) return;
+    BreadcrumbCollector.add(
+      'OBD2 engine-start hint',
+      detail: 'BT ACL connect — waking reconnect',
+    );
+    ref.read(obd2ReconnectProvider.notifier).supervisor.wake();
+  });
+  ref.onDispose(sub.cancel);
+}

--- a/lib/features/obd2/providers/obd2_engine_start_hint_provider.g.dart
+++ b/lib/features/obd2/providers/obd2_engine_start_hint_provider.g.dart
@@ -1,0 +1,107 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'obd2_engine_start_hint_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// #3699 — turn Bluetooth ACL connects into reconnect wakes.
+///
+/// The stand-down escalation is correct while the car is parked (the
+/// adapter sleeps; every probe is a doomed 23 s timeout), but before
+/// this wiring NOTHING broke the hold at engine start with the phone
+/// pocketed: `wake()` fired only on app resume and on GPS movement
+/// during an already-running recording. Field shape (2026-08-11):
+/// overnight misses escalated the hold past an hour and the morning
+/// drive got no hands-free connect until the app was opened.
+///
+/// The phone linking to ANY Bluetooth device — in the car, the audio
+/// system, at exactly ignition-on when the vLinker wakes from its 3 mA
+/// sleep — is the cheapest engine-start signal Android offers without
+/// new permissions. The native receiver already rate-limits to one hint
+/// per 5 min; here we drop hints older than [staleness] (the native
+/// ring can replay buffered hints on resubscribe) and nudge `wake()`,
+/// which is a no-op in every state where waking is meaningless and an
+/// immediate dial in `engineOff` / held-`reconnecting`.
+
+@ProviderFor(engineStartHintWake)
+final engineStartHintWakeProvider = EngineStartHintWakeProvider._();
+
+/// #3699 — turn Bluetooth ACL connects into reconnect wakes.
+///
+/// The stand-down escalation is correct while the car is parked (the
+/// adapter sleeps; every probe is a doomed 23 s timeout), but before
+/// this wiring NOTHING broke the hold at engine start with the phone
+/// pocketed: `wake()` fired only on app resume and on GPS movement
+/// during an already-running recording. Field shape (2026-08-11):
+/// overnight misses escalated the hold past an hour and the morning
+/// drive got no hands-free connect until the app was opened.
+///
+/// The phone linking to ANY Bluetooth device — in the car, the audio
+/// system, at exactly ignition-on when the vLinker wakes from its 3 mA
+/// sleep — is the cheapest engine-start signal Android offers without
+/// new permissions. The native receiver already rate-limits to one hint
+/// per 5 min; here we drop hints older than [staleness] (the native
+/// ring can replay buffered hints on resubscribe) and nudge `wake()`,
+/// which is a no-op in every state where waking is meaningless and an
+/// immediate dial in `engineOff` / held-`reconnecting`.
+
+final class EngineStartHintWakeProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// #3699 — turn Bluetooth ACL connects into reconnect wakes.
+  ///
+  /// The stand-down escalation is correct while the car is parked (the
+  /// adapter sleeps; every probe is a doomed 23 s timeout), but before
+  /// this wiring NOTHING broke the hold at engine start with the phone
+  /// pocketed: `wake()` fired only on app resume and on GPS movement
+  /// during an already-running recording. Field shape (2026-08-11):
+  /// overnight misses escalated the hold past an hour and the morning
+  /// drive got no hands-free connect until the app was opened.
+  ///
+  /// The phone linking to ANY Bluetooth device — in the car, the audio
+  /// system, at exactly ignition-on when the vLinker wakes from its 3 mA
+  /// sleep — is the cheapest engine-start signal Android offers without
+  /// new permissions. The native receiver already rate-limits to one hint
+  /// per 5 min; here we drop hints older than [staleness] (the native
+  /// ring can replay buffered hints on resubscribe) and nudge `wake()`,
+  /// which is a no-op in every state where waking is meaningless and an
+  /// immediate dial in `engineOff` / held-`reconnecting`.
+  EngineStartHintWakeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'engineStartHintWakeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$engineStartHintWakeHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return engineStartHintWake(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$engineStartHintWakeHash() =>
+    r'c571dee3267a3c0ef80e46c23ea6048d5ecc51d6';

--- a/test/core/telemetry/crash_forensics_harvester_test.dart
+++ b/test/core/telemetry/crash_forensics_harvester_test.dart
@@ -97,6 +97,59 @@ void main() {
       expect(recorder.errors[1].toString(), contains('background'));
     });
 
+    test('#3700 same-reason exits COALESCE into one trace (count + rss '
+        'range + all timestamps); crash_native stays one-per-exit because '
+        'each carries its own tombstone', () async {
+      mockHarvest({
+        'exits': [
+          for (final (ts, rss) in [
+            (1783990100000, 62020),
+            (1783990200000, 57856),
+            (1783990300000, 61424),
+          ])
+            {
+              'timestampMs': ts,
+              'reason': 'low_memory_kill',
+              'importance': 'background',
+              'description': '',
+              'pssKb': 0,
+              'rssKb': rss,
+              'trace': '',
+            },
+          for (final ts in [1783990400000, 1783990500000])
+            {
+              'timestampMs': ts,
+              'reason': 'crash_native',
+              'importance': 'foreground',
+              'description': 'SIGABRT',
+              'pssKb': 100000,
+              'rssKb': 342000,
+              'trace': 'tombstone-$ts',
+            },
+        ],
+      });
+
+      await CrashForensicsHarvester.harvestAndLog();
+      await Future<void>.delayed(Duration.zero);
+
+      // 2 individual crash_native + 1 coalesced low_memory_kill = 3 slots
+      // instead of 5.
+      expect(recorder.errors, hasLength(3));
+      final natives = recorder.errors
+          .where((e) => e.toString().contains('crash_native'))
+          .toList();
+      expect(natives, hasLength(2),
+          reason: 'each native crash keeps its own tombstone trace');
+      expect(recorder.stacks.map((s) => s.toString()),
+          containsAll(['tombstone-1783990400000', 'tombstone-1783990500000']));
+
+      final coalesced = recorder.errors
+          .singleWhere((e) => e.toString().contains('low_memory_kill'))
+          .toString();
+      expect(coalesced, contains('x3'));
+      expect(coalesced, contains('rss=57856-62020kB'));
+    });
+
     test('routine freezer exits are skipped; a missing channel is a no-op',
         () async {
       mockHarvest({

--- a/test/features/consumption/data/lessons/combustion_health_rule_test.dart
+++ b/test/features/consumption/data/lessons/combustion_health_rule_test.dart
@@ -226,6 +226,57 @@ void main() {
       expect(lesson.impact, lessThan(0.01));
     });
 
+    // #3701 — E85 tanks legitimately hold LTFT +20‥30 %: stoich 9.8:1 vs
+    // 14.7:1. The 2026-08-14 field exports fired "lean mixture +25% —
+    // possible inefficiency" on EVERY trip of an E85 conversion.
+    group('#3701 tank-mix ethanol gate', () {
+      LessonContext ethanolCtx(List<TripSample> samples, double? share) =>
+          LessonContext(
+            summary: summary(),
+            samples: samples,
+            score: DrivingScore.perfect,
+            insights: const <DrivingInsight>[],
+            expectedEthanolShare: share,
+          );
+
+      test('an E85-heavy tank (75% ethanol) SUPPRESSES a +25% lean trim — '
+          'that is the fuel, not a fault', () {
+        final lesson = rule.evaluate(
+            ethanolCtx(warmSamples(count: 14, stft: 5, ltft: 25), 0.75), l);
+        expect(lesson, isNull,
+            reason: '25% <= 0.75*34 + 8 tolerance — fully fuel-explained');
+      });
+
+      test('the same trims WITHOUT mix data still fire (null keeps the '
+          'stock rule)', () {
+        final lesson = rule.evaluate(
+            ethanolCtx(warmSamples(count: 14, stft: 5, ltft: 25), null), l);
+        expect(lesson, isNotNull);
+      });
+
+      test('a trim BEYOND what the ethanol explains still fires — a real '
+          'fault is never masked', () {
+        // 0.20 ethanol explains ~6.8% + 8 tolerance = 14.8%; 25% exceeds it.
+        final lesson = rule.evaluate(
+            ethanolCtx(warmSamples(count: 14, stft: 5, ltft: 25), 0.20), l);
+        expect(lesson, isNotNull);
+      });
+
+      test('trace ethanol (E10 tank, 10%) never gates — below the 15% '
+          'flex threshold', () {
+        final lesson = rule.evaluate(
+            ethanolCtx(warmSamples(count: 14, stft: 6, ltft: 16), 0.10), l);
+        expect(lesson, isNotNull);
+      });
+
+      test('RICH compensation is never ethanol-gated (wrong direction '
+          'for a lean-running blend)', () {
+        final lesson = rule.evaluate(
+            ethanolCtx(warmSamples(count: 14, stft: -6, ltft: -16), 0.75), l);
+        expect(lesson, isNotNull);
+      });
+    });
+
     test('fires the rich-compensation lesson on sustained negative trim', () {
       final lesson =
           rule.evaluate(ctx(warmSamples(count: 14, stft: -6, ltft: -16)), l);

--- a/test/features/obd2/data/android_background_adapter_listener_test.dart
+++ b/test/features/obd2/data/android_background_adapter_listener_test.dart
@@ -137,6 +137,50 @@ void main() {
       await sub.cancel();
     });
 
+    test('#3699 aclConnected events feed the STATIC engine-start hint '
+        'stream and never reach the sealed adapter-event stream', () async {
+      messenger.setMockMethodCallHandler(
+        methodChannel,
+        (call) async => true,
+      );
+
+      late MockStreamHandlerEventSink sink;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (_, events) {
+            sink = events;
+          },
+        ),
+      );
+
+      final adapterEvents = <BackgroundAdapterEvent>[];
+      final hints = <DateTime>[];
+      final sub = listener.events.listen(adapterEvents.add);
+      final hintSub =
+          AndroidBackgroundAdapterListener.engineStartHints.listen(hints.add);
+
+      await listener.start(mac: 'AA:BB:CC:DD:EE:01');
+
+      sink.success(<String, Object?>{
+        'type': 'aclConnected',
+        'mac': '11:22:33:44:55:66', // the CAR AUDIO mac, not the adapter
+        'atMillis': 1700000000000,
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(adapterEvents, isEmpty,
+          reason: 'a process-wide hint must not impersonate an adapter '
+              'transition (the coordinator filters by MAC and would '
+              'misread it)');
+      expect(hints, hasLength(1));
+      expect(hints.single.millisecondsSinceEpoch, 1700000000000);
+
+      await sub.cancel();
+      await hintSub.cancel();
+    });
+
     test('malformed events are dropped (no crash, no sealed-event emission)',
         () async {
       messenger.setMockMethodCallHandler(

--- a/test/features/obd2/obd2_link_standdown_test.dart
+++ b/test/features/obd2/obd2_link_standdown_test.dart
@@ -209,8 +209,9 @@ void main() {
     });
   });
 
-  test('#3642 consecutive storm holds ESCALATE 5 → 15 → 60 min — a parked '
-      'car stops costing an all-day dial duty cycle', () {
+  test('#3642/#3699 consecutive storm holds ESCALATE 5 → 15 min and CAP '
+      'at 15 — a parked car stops hammering, but an engine start is never '
+      'more than one hold away', () {
     fakeAsync((async) {
       dialer.enqueue(TimeoutException('ladder budget'));
       final sup = build();
@@ -231,13 +232,15 @@ void main() {
       elapse(async, const Duration(minutes: 4));
       expect(dialer.calls, 5, reason: 'second storm hold is 15 min');
 
-      // Hold 3: storm ×12 (60 min + ≤7.5 min jitter), the cap.
-      elapse(async, const Duration(minutes: 55));
-      expect(dialer.calls, 5, reason: 'third hold escalated past 55 min');
+      // Hold 3: STILL ×3 — #3699 capped the ×12 (60 min) step: overnight
+      // holds past an hour left the morning drive without hands-free
+      // connect for the whole hold (2026-08-11 field log).
       elapse(async, const Duration(minutes: 13));
+      expect(dialer.calls, 5, reason: 'third hold escalated past 13 min');
+      elapse(async, const Duration(minutes: 4));
       expect(dialer.calls, 6,
           reason: 'the no-dead-end invariant survives the escalation — '
-              'the loop still dials, hourly');
+              'the loop still dials every ≤15 min (#3699 cap)');
 
       // A user connect resets the escalation back to the fast ladder.
       dialer.replaceAll(_liveService());

--- a/test/features/obd2/obd2_link_supervisor_test.dart
+++ b/test/features/obd2/obd2_link_supervisor_test.dart
@@ -92,27 +92,31 @@ void main() {
       async.flushMicrotasks();
       expect(sup.state.value, Obd2LinkState.reconnecting);
 
-      // #3603 / #3642 — three identical misses stand the loop down, and
-      // consecutive holds ESCALATE (5 → 15 → 60 min, capped), so the
-      // horizon is much longer; the INVARIANT under test is unchanged:
-      // no dead end, ever.
+      // #3603 / #3642 / #3699 — three identical misses stand the loop
+      // down, and consecutive holds ESCALATE (5 → 15 min, capped at 15
+      // since #3699: the 60-min cap blinded engine starts); the
+      // INVARIANT under test is unchanged: no dead end, ever.
+      // 40 min = ladder (~0) + 5-min hold + 15-min hold + a second
+      // 15-min hold (+ jitter) — 6 dials.
       async.elapse(const Duration(minutes: 40));
-      expect(dialer.calls, 5,
-          reason: 'fast ladder ×3, then the 5 min and 15 min holds');
+      expect(dialer.calls, 6,
+          reason: 'fast ladder ×3, then the 5 min hold and two capped '
+              '15 min holds');
       expect(sup.state.value, Obd2LinkState.reconnecting,
           reason: 'no dead end — still trying');
 
-      // The escalated cadence parks at hourly — steady, never terminal.
+      // The escalated cadence parks at ≤15-min periods — steady, never
+      // terminal.
       async.elapse(const Duration(minutes: 55));
-      expect(dialer.calls, 6,
-          reason: 'the capped 60-min hold still dials — the loop must '
+      expect(dialer.calls, greaterThanOrEqualTo(9),
+          reason: 'the capped 15-min hold keeps dialing — the loop must '
               'outlive the old terminalFailed cap');
 
       // And when the adapter finally reappears, the loop connects. The
       // queued miss still in front costs one more capped hold, so two
-      // full 60-min periods (+ jitter) must pass.
+      // full 15-min periods (+ jitter) must pass.
       dialer.enqueue(_liveService());
-      async.elapse(const Duration(minutes: 140));
+      async.elapse(const Duration(minutes: 40));
       expect(sup.state.value, Obd2LinkState.ready);
       unawaited(sup.dispose());
       async.flushMicrotasks();


### PR DESCRIPTION
## Summary

Field analysis of the 2026-08-11→14 error log + 11 driving exports: **recording works (10/11 trips at full OBD2 coverage) — the hands-free connect around drive start was the disaster.**

### #3699 — engine-start blindness
Overnight-parked probe misses (the vLinker sleeps at 3 mA; every RFCOMM probe is a doomed 23 s timeout) escalated the stand-down hold past an hour (927→3693→3982 s in the log). Nothing broke the hold at ignition-on with the phone pocketed — `wake()` fired only on app resume / GPS movement during an active recording. The log proves it: hands-free connects failed all night, while every app-open connected in 3–12 s.
- Storm escalation capped at **15 min** (`[1,3,12]` → `[1,3,3]`) — ~2% BT duty while parked, safe post-#3671/#3690.
- **`BtAclEngineStartReceiver`**: context-registered `ACTION_ACL_CONNECTED` (the phone linking to the car audio at ignition-on — exactly when the adapter wakes) → `aclConnected` event on the existing auto_record channel → static `engineStartHints` stream → `engineStartHintWake` provider (2-min staleness via AppClock) → `supervisor.wake()` = stand-down reset + immediate dial. 5-min native cooldown bounds accessory churn.

### #3700 — error-log flood
24 of 50 log slots were individual process-death traces, evicting OBD2 diagnostics. Non-crash `ApplicationExitInfo` exits now coalesce per reason (count + rss range + all timestamps in one trace); `crash_native` stays one-per-exit (each tombstone matters — that stream solved #3688).

### #3701 — E85 "lean mixture" false alarm
Every driving export fired "Mélange pauvre +25%". On an E85-heavy tank that trim is the correct operating point (stoich 9.8:1 vs 14.7:1). `LessonContext.expectedEthanolShare` (from the #3652 tank-mix model, threaded via the new `buildTripDetailLessons` helper — which also feeds the exported traces) gates the lean signal only when ethanol ≥ 15% AND the magnitude is fuel-explained + 8% tolerance. E10 tanks, rich signals, and beyond-blend trims still fire.

#3702 (IMU candidate flood) is filed separately.

## Test plan
- Updated stand-down escalation test (15-min cap), new bridge test (aclConnected → static hint stream, never the sealed adapter stream), harvester coalescing test (3 low_memory + 2 crash_native → 3 traces), 5 ethanol-gate tests.
- `flutter analyze` clean; `compilePlayDebugKotlin` clean; full suite in a detached worktree ×2 — only known load-flakes (different sets per run), all green standalone. Pre-push hook (lint/l10n/codegen) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
