### PR TITLE
fix: nightly-full SWR test race + IMU near-miss record flood (#3703, #3698, #3702)

### DIFF
--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 
 import '../persistent_dataset.dart';
 
@@ -188,10 +188,22 @@ mixin CachedDatasetMixin {
       _swallowBackground(refresh());
 
   void _swallowBackground(Future<Object?> pending) {
-    unawaited(pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
+    final tracked =
+        pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
       debugPrint('CachedDatasetMixin: background dataset refresh failed: $e');
-    }));
+    });
+    // #3703 — deterministic completion handle: the nightly full suite
+    // raced `pumpEventQueue()` against this chain (fetch → store →
+    // persist) on loaded runners and lost. Tests await the handle.
+    debugLastBackgroundRefresh = tracked;
+    unawaited(tracked);
   }
+
+  /// #3703 — the most recent fire-and-forget refresh chain, for tests to
+  /// await instead of pumping the event queue. Null until the first
+  /// background refresh of this instance.
+  @visibleForTesting
+  Future<void>? debugLastBackgroundRefresh;
 
   /// Completeness-gated variant of [loadPersistentDataset] (#2249).
   ///

--- a/lib/core/services/mixins/keyed_cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/keyed_cached_dataset_mixin.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 
 import '../persistent_dataset.dart';
 import 'cached_dataset_mixin.dart' show datasetStaleServeDeadline;
@@ -130,11 +130,21 @@ mixin KeyedCachedDatasetMixin {
 
   /// Keyed twin of the unkeyed mixin's background-swallow (#3668).
   void _swallowKeyedBackground(Future<Object?> pending) {
-    unawaited(pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
+    final tracked =
+        pending.then<void>((_) {}).catchError((Object e, StackTrace st) {
       debugPrint(
           'KeyedCachedDatasetMixin: background dataset refresh failed: $e');
-    }));
+    });
+    // #3703 — see the unkeyed twin: tests await this instead of racing
+    // pumpEventQueue against the chain.
+    debugLastKeyedBackgroundRefresh = tracked;
+    unawaited(tracked);
   }
+
+  /// #3703 — the most recent fire-and-forget keyed refresh chain, for
+  /// tests to await deterministically.
+  @visibleForTesting
+  Future<void>? debugLastKeyedBackgroundRefresh;
 
   /// Per-key twin of the unkeyed mixin's deduped fetch (#2313): collapses
   /// concurrent calls for the same [key] onto a single in-flight future,

--- a/lib/features/consumption/domain/imu_event_record.dart
+++ b/lib/features/consumption/domain/imu_event_record.dart
@@ -20,6 +20,15 @@ const int kImuEventRecordCap = 48;
 const double kImuMicroJoltMaxDuration = 0.15;
 const double kImuMicroJoltMaxPeak = 4.5;
 
+/// #3702 — per-trip cap on UNCONFIRMED records (tooShort / ambiguous /
+/// cornerGeometry near-misses). The 2026-08-14 field exports carried up
+/// to 48 stored tooShort blips (and 23,926 dropped) per trip: the noise
+/// filled [kImuEventRecordCap] and — worse — CONFIRMED harsh events
+/// finalized after slot 48 were silently dropped from the calibration
+/// export. Near-misses only need a representative sample for threshold
+/// calibration; confirmed events keep the remaining slots guaranteed.
+const int kImuUnconfirmedRecordCap = 16;
+
 /// One strong-manoeuvre stretch as the IMU detector saw it (#3589) —
 /// confirmed events AND rejected near-misses, so the accel/brake
 /// thresholds can be calibrated against labeled magnitude distributions
@@ -101,6 +110,7 @@ class ImuStretchTracker {
   double _lastNetDeltaKmh = 0;
   bool _sawCornerGeometry = false;
   String? _confirmedOutcome;
+  int _unconfirmedCount = 0; // #3702 — see [kImuUnconfirmedRecordCap]
 
   /// Records finalized so far (open stretch not included — call
   /// [finish] first at harvest time).
@@ -176,10 +186,19 @@ class ImuStretchTracker {
             : _sawCornerGeometry && _peakYaw >= kSharpCornerYawRateRadPerSec
                 ? 'cornerGeometry'
                 : 'ambiguous');
+    // #3702 — near-misses stop at their own cap so noise can never crowd
+    // confirmed events out of the export (a 48-slot list full of
+    // tooShort blips used to drop every later confirmed harsh event).
+    if (_confirmedOutcome == null &&
+        _unconfirmedCount >= kImuUnconfirmedRecordCap) {
+      _dropped++;
+      return;
+    }
     if (_records.length >= kImuEventRecordCap) {
       _dropped++;
       return;
     }
+    if (_confirmedOutcome == null) _unconfirmedCount++;
     _records.add(ImuEventRecord(
       outcome: outcome,
       peakMps2: _peakMps2,

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -455,7 +455,9 @@ void main() {
       expect(fetchCalls, 1, reason: 'the background refresh must start');
 
       gate.complete();
-      await pumpEventQueue();
+      // #3703 — await the chain handle, not pumpEventQueue: loaded CI
+      // runners lost that race two nightlies in a row.
+      await cached.debugLastBackgroundRefresh;
       expect(persistent.read()?.value, [9],
           reason: 'the background refresh must persist its result');
       expect(cached.isDatasetFresh(const Duration(minutes: 5)), isTrue,
@@ -483,7 +485,7 @@ void main() {
 
       expect(result, const [5]);
       gate.complete();
-      await pumpEventQueue();
+      await cached.debugLastBackgroundRefresh; // #3703 — deterministic
       expect(persistent.read()?.value, [9]);
     });
 
@@ -510,7 +512,7 @@ void main() {
       expect(result, [1, 2],
           reason: 'past the deadline, an ancient copy beats a skeleton');
       gate.complete();
-      await pumpEventQueue();
+      await cached.debugLastBackgroundRefresh; // #3703 — deterministic
       expect(persistent.read()?.value, [9]);
     });
 
@@ -548,8 +550,9 @@ void main() {
         completes,
       );
       // Let the background failure settle — it must be swallowed (logged),
-      // never thrown into the zone.
-      await pumpEventQueue();
+      // never thrown into the zone. #3703 — the handle completes normally
+      // BECAUSE the swallow caught the error; awaiting it IS the assertion.
+      await cached.debugLastBackgroundRefresh;
     });
 
     test('keyed variant: soft-stale disk copy serves immediately with a '
@@ -575,7 +578,7 @@ void main() {
 
       expect(result, [1, 2]);
       gate.complete();
-      await pumpEventQueue();
+      await keyed.debugLastKeyedBackgroundRefresh; // #3703 — deterministic
       expect(persistent.read()?.value, [9]);
     });
   });

--- a/test/features/consumption/domain/services/imu_event_detector_test.dart
+++ b/test/features/consumption/domain/services/imu_event_detector_test.dart
@@ -319,7 +319,8 @@ void main() {
           reason: 'high peak clears the micro-jolt floor');
     });
 
-    test('records past the cap are counted, not stored', () {
+    test('#3702 UNCONFIRMED records stop at their own cap — the tooShort '
+        'flood is bounded', () {
       final det = ImuEventDetector();
       var t = t0;
       for (var i = 0; i < kImuEventRecordCap + 5; i++) {
@@ -330,8 +331,42 @@ void main() {
             startSpeedKmh: 40);
         t = feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 40);
       }
-      expect(det.eventRecords, hasLength(kImuEventRecordCap));
-      expect(det.droppedEventRecords, 5);
+      expect(det.eventRecords, hasLength(kImuUnconfirmedRecordCap),
+          reason: 'near-misses keep only a representative calibration '
+              'sample (field trips stored 48 tooShort blips, #3702)');
+      expect(det.droppedEventRecords,
+          kImuEventRecordCap + 5 - kImuUnconfirmedRecordCap);
+    });
+
+    test('#3702 CONFIRMED events are stored even after the tooShort flood '
+        'exhausted the near-miss cap', () {
+      final det = ImuEventDetector();
+      var t = t0;
+      // Flood: 20 tooShort bursts (cap is 16).
+      for (var i = 0; i < 20; i++) {
+        t = feed(det,
+            start: t, count: 10, mag: 5.0, startSpeedKmh: 40);
+        t = feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 40);
+      }
+      // Then a REAL sustained hard accel (>= 1 s strong + rising speed).
+      t = feed(det,
+          start: t,
+          count: 45,
+          mag: 5.0,
+          startSpeedKmh: 30,
+          speedStepKmh: 0.5);
+      feed(det, start: t, count: 5, mag: 0.2, startSpeedKmh: 55);
+
+      final confirmed =
+          det.eventRecords.where((r) => r.outcome == 'accel').toList();
+      expect(confirmed, hasLength(1),
+          reason: 'a confirmed harsh event must NEVER be crowded out by '
+              'near-miss noise (#3702 — the old shared cap dropped it)');
+      expect(
+          det.eventRecords
+              .where((r) => r.outcome == 'tooShort')
+              .length,
+          kImuUnconfirmedRecordCap);
     });
   });
 }


### PR DESCRIPTION
## Summary

### #3703 + #3698 — both nightly-full failures, one root cause
The 2026-08-13 and 2026-08-14 nightlies failed ONLY in `cached_dataset_mixin_test.dart` (#3668 stale-first tests), different subtests per run, same shape: `gate.complete(); await pumpEventQueue();` raced the fire-and-forget refresh chain (fetch → store → persist) and lost on loaded runners (`Expected [9], Actual [1,2]` / `null`).

Both mixins now expose the tracked chain as a `@visibleForTesting` handle (`debugLastBackgroundRefresh` / `debugLastKeyedBackgroundRefresh`); the five racing tests await it deterministically. The swallow-failure test awaits it too — the handle completing normally IS the swallow assertion. Verified 5× standalone at concurrency 1.

### #3702 — IMU near-miss record flood
Field exports carried up to 48 stored `tooShort` blips (+23,926 dropped counters) per trip. The real defect: near-miss noise filled the shared 48-slot `kImuEventRecordCap`, after which even CONFIRMED harsh events were silently dropped from the calibration export. Unconfirmed stretches now stop at their own `kImuUnconfirmedRecordCap` (16 — a representative calibration sample); confirmed events keep the remaining slots guaranteed. New regression test: a confirmed hard-accel after a 20-blip flood is stored.

## Test plan
- Mixin tests green 5× at `--concurrency=1`; IMU detector tests updated + new crowd-out regression test.
- `flutter analyze` clean; full suite in a detached worktree — only the known load-flakes (always_run_bucket/test_selector), green standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
