### PR TITLE
fix(trajets): whole-page scroll (3706)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -103,34 +103,35 @@ class TrajetsTab extends ConsumerWidget {
     // Stack double-counted it).
     const bottomInset = kFabScrollClearance;
 
+    Widget rowFor(BuildContext context, TripHistoryEntry entry) {
+      final vehicle = entry.vehicleId == null
+          ? activeVehicle
+          : vehicles.where((v) => v.id == entry.vehicleId).firstOrNull ??
+                activeVehicle;
+      return TrajetRow(
+        entry: entry,
+        vehicle: vehicle,
+        l: l,
+        theme: theme,
+        // #2444 — a virtual reconciliation trajet opens the
+        // dedicated edit sheet (it has no recorded path / samples
+        // to show on the trip-detail screen); a real trip routes
+        // to its detail page as before.
+        onTap: entry.summary.isVirtual
+            ? () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => EditVirtualTrajetSheet(entry: entry),
+                )
+            : () => TripDetailRoute(entry.id).push<void>(context),
+      );
+    }
+
     final trajetsList = ListView.builder(
       key: const Key('trajets_list'),
       padding: const EdgeInsets.only(top: 4, bottom: bottomInset),
       itemCount: filtered.length,
-      itemBuilder: (context, index) {
-        final entry = filtered[index];
-        final vehicle = entry.vehicleId == null
-            ? activeVehicle
-            : vehicles.where((v) => v.id == entry.vehicleId).firstOrNull ??
-                  activeVehicle;
-        return TrajetRow(
-          entry: entry,
-          vehicle: vehicle,
-          l: l,
-          theme: theme,
-          // #2444 — a virtual reconciliation trajet opens the
-          // dedicated edit sheet (it has no recorded path / samples
-          // to show on the trip-detail screen); a real trip routes
-          // to its detail page as before.
-          onTap: entry.summary.isVirtual
-              ? () => showModalBottomSheet<void>(
-                    context: context,
-                    isScrollControlled: true,
-                    builder: (_) => EditVirtualTrajetSheet(entry: entry),
-                  )
-              : () => TripDetailRoute(entry.id).push<void>(context),
-        );
-      },
+      itemBuilder: (context, index) => rowFor(context, filtered[index]),
     );
 
     // #2018 — landscape / tablet split: left = monthly-insights
@@ -161,16 +162,29 @@ class TrajetsTab extends ConsumerWidget {
         detail: trajetsList,
       );
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        MonthlyInsightsCard(summary: monthlySummary),
-        // #3648 — see the wide branch above.
-        const TankReportCard(),
-        const MaintenanceSuggestionList(),
-        const SharedTripsSection(),
-        Expanded(child: trajetsList),
-      ],
+    // Field report: the pinned cards left only a sliver of the screen
+    // scrolling. ONE scroll view now carries cards AND rows — the same
+    // whole-page scroll every other tab has (the wide split already
+    // scrolls both panes).
+    return ListView.builder(
+      key: const Key('trajets_list'),
+      padding: const EdgeInsets.only(top: 4, bottom: bottomInset),
+      itemCount: filtered.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MonthlyInsightsCard(summary: monthlySummary),
+              // #3648 — see the wide branch above.
+              const TankReportCard(),
+              const MaintenanceSuggestionList(),
+              const SharedTripsSection(),
+            ],
+          );
+        }
+        return rowFor(context, filtered[index - 1]);
+      },
     );
   }
 }

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -383,6 +383,61 @@ void main() {
       // summary, not a crashed widget that bailed before the title.
       expect(find.text('This month vs last month'), findsOneWidget);
     });
+
+    testWidgets(
+      'narrow layout: cards and rows share ONE scroll view — the cards '
+      'scroll away with the list (field report: only a sliver scrolled)',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final trips = [
+          for (var i = 0; i < 20; i++)
+            _entry(
+              id: 'trip-$i',
+              vehicleId: 'v1',
+              startedAt: DateTime(2026, 4, 22, 9).add(Duration(hours: i)),
+              endedAt: DateTime(
+                2026,
+                4,
+                22,
+                9,
+                30,
+              ).add(Duration(hours: i)),
+              distanceKm: 12.0,
+            ),
+        ];
+
+        await _pumpTab(
+          tester,
+          vehicleId: null,
+          trips: trips,
+          vehicles: [combustionVehicle],
+          activeVehicle: combustionVehicle,
+        );
+
+        // The insights card lives INSIDE the trajets scroll view…
+        final list = find.byKey(const Key('trajets_list'));
+        expect(
+          find.descendant(
+            of: list,
+            matching: find.byKey(const ValueKey('monthly_insights_card')),
+          ),
+          findsOneWidget,
+        );
+
+        // …so scrolling the page moves it off-screen instead of
+        // pinning it over a tiny list strip.
+        await tester.drag(list, const Offset(0, -600));
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('monthly_insights_card')),
+          findsNothing,
+        );
+      },
+    );
   });
 
   group('TrajetsTab — populated list', () {


### PR DESCRIPTION
Closes #3706.

Narrow branch = ONE `ListView` (`trajets_list` key + FAB-clearance padding kept): item 0 = the four cards, then the rows via the shared `rowFor`. Regression test pins the insights card INSIDE the scroll view and scrolling it off-screen. Consumption + lint suites green (3300 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wBFVA5FZSPr7icDAi5zvR