### PR TITLE
feat(build): R8 optimized resource shrinking — release AAB -22% (#3718)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,3 +11,11 @@ org.gradle.caching=true
 # warning — the documented Kotlin-Gradle escape hatch. Version-
 # independent: fixes both ci.yml and the Daily Open-Testing Build.
 kotlin.jvm.target.validation.mode=warning
+
+# #3718 — R8-integrated ("optimized") resource shrinking: minify +
+# shrinkResources were already on, but the R8-integrated pass (AGP 8.6+,
+# default from AGP 9) shrinks resources precisely alongside code and is
+# what the Play Console "technical quality" panel checks for. Validated
+# with a full local release-AAB build before landing (dynamic resource
+# lookups are the classic breakage; the beta channel is the runtime net).
+android.r8.optimizedResourceShrinking=true


### PR DESCRIPTION
Play Console 'technical quality' flagged it: minify + shrinkResources
were already on, but the R8-integrated resource pass (AGP 8.6+, default
from AGP 9) was not. Enabling android.r8.optimizedResourceShrinking
cuts the play-flavor release AAB from ~150 MB to 116.3 MB (-22%),
validated with a full local release build. The beta channel is the
runtime net for over-aggressive removal of dynamically-referenced
resources.

The panel's other item (AGP 9.0) is deliberately deferred: it needs
Gradle 9 + the built-in-Kotlin migration, unsupported by the pinned
Flutter 3.41.9 toolchain — revisit with the next Flutter upgrade. The
Android-15 edge-to-edge notice needs no action (EdgeToEdge.enable()
has been wired at init all along).

Closes #3718

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
