### PR TITLE
feat(ci): Release Train — unified per-channel deploy with fault-isolated legs + failure notify/email (#3720)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -19,6 +19,24 @@ name: Daily Open-Testing Build
 on:
   schedule:
     - cron: '0 16 * * *'
+  # #3720 — callable from the Release Train orchestrator.
+  workflow_call:
+    inputs:
+      track:
+        required: false
+        type: string
+        default: beta
+      release_notes:
+        required: false
+        type: string
+      fgs_bundle:
+        required: false
+        type: boolean
+        default: false
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       track:
@@ -145,7 +163,7 @@ jobs:
         # run (mints the #3436 declaration-surfacing bundle) without
         # flipping the global variable, which would 403 the next scheduled
         # upload.
-        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }} ${{ (vars.FGS_FORM_APPROVED == 'true' || github.event.inputs.fgs_bundle == 'true') && '--dart-define=FGS_FORM_APPROVED=true' || '' }}
+        run: flutter build appbundle --release --flavor play --build-number=${{ steps.bn.outputs.build_number }} ${{ (vars.FGS_FORM_APPROVED == 'true' || inputs.fgs_bundle == true) && '--dart-define=FGS_FORM_APPROVED=true' || '' }}
 
       # #3661 — size visible on every build; fails on an implausibly
       # small artifact (llmwiki page 25).
@@ -175,10 +193,10 @@ jobs:
       - name: Resolve upload gate
         id: gate
         run: |
-          if [ "${{ github.event.inputs.skip_upload }}" = "true" ]; then
+          if [ "${{ inputs.skip_upload }}" = "true" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::notice::skip_upload — AAB available as workflow artifact"
-          elif [ "${{ github.event.inputs.fgs_bundle }}" = "true" ] && [ "${{ vars.FGS_FORM_APPROVED }}" != "true" ]; then
+          elif [ "${{ inputs.fgs_bundle }}" = "true" ] && [ "${{ vars.FGS_FORM_APPROVED }}" != "true" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::notice::fgs_bundle without an approved FGS declaration — Play upload auto-skipped (#3708). Download the AAB artifact and upload it manually per docs/guides/play-fgs-declaration.md"
           else
@@ -217,8 +235,8 @@ jobs:
           python tools/upload_to_play.py \
             --aab build/app/outputs/bundle/playRelease/app-play-release.aab \
             --key "$PLAY_KEY_PATH" \
-            --track "${{ github.event.inputs.track || 'beta' }}" \
-            ${{ github.event.inputs.release_notes && format('--release-notes "{0}"', github.event.inputs.release_notes) || '' }}
+            --track "${{ inputs.track || 'beta' }}" \
+            ${{ inputs.release_notes && format('--release-notes "{0}"', inputs.release_notes) || '' }}
 
       - name: Clean up service-account key
         if: always() && steps.gate.outputs.skip != 'true'
@@ -249,7 +267,7 @@ jobs:
           TAG="v${VERSION}+${{ steps.bn.outputs.build_number }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Beta build ${{ steps.bn.outputs.build_number }} (track: ${{ github.event.inputs.track || 'beta' }}) — $GITHUB_SHA"
+          git tag -a "$TAG" -m "Beta build ${{ steps.bn.outputs.build_number }} (track: ${{ inputs.track || 'beta' }}) — $GITHUB_SHA"
           if ! git push origin "$TAG"; then
             echo "::warning::Tag push rejected (workflow-file race, #3710). The build IS shipped. Push the tag manually: SKIP_PREPUSH=1 git tag -a '$TAG' $GITHUB_SHA -m 'Beta build ${{ steps.bn.outputs.build_number }}' && SKIP_PREPUSH=1 git push origin '$TAG'"
             exit 1
@@ -262,5 +280,5 @@ jobs:
           echo "## Daily Open-Testing Release" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Build number:** ${{ steps.bn.outputs.build_number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Track:** ${{ github.event.inputs.track || 'beta' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Track:** ${{ inputs.track || 'beta' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Trigger:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -18,6 +18,8 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  # #3720 — callable from the Release Train orchestrator.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -14,6 +14,21 @@ name: iOS TestFlight Build
 # external 'extern' TestFlight group; plain manual runs stay internal-only.
 
 on:
+  # #3720 — callable from the Release Train orchestrator.
+  workflow_call:
+    inputs:
+      release_notes:
+        required: false
+        type: string
+        default: 'Daily build.'
+      distribute:
+        required: false
+        type: boolean
+        default: false
+      sync_certs:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       release_notes:
@@ -148,7 +163,7 @@ jobs:
           # ASC_API_KEY_FILEPATH was exported by the decode step above so the
           # Fastfile's `asc_api_key` helper picks up the on-disk .p8.
           IOS_BUILD_NUMBER: ${{ steps.bn.outputs.build_number }}
-          TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.release_notes || 'Daily build.' }}
+          TESTFLIGHT_CHANGELOG: ${{ inputs.release_notes || 'Daily build.' }}
           # Scheduled runs always distribute externally; manual runs only when
           # the distribute input is checked.
           DISTRIBUTE: ${{ github.event_name == 'schedule' || inputs.distribute }}
@@ -217,5 +232,5 @@ jobs:
             echo "- **Build number:** ${{ steps.bn.outputs.build_number }}"
             echo "- **Bundle ID:** de.tankstellen.tankstellen"
             echo "- **Trigger:** ${{ github.event_name }}"
-            echo "- **Changelog:** ${{ github.event.inputs.release_notes || 'Daily build.' }}"
+            echo "- **Changelog:** ${{ inputs.release_notes || 'Daily build.' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -15,6 +15,21 @@ name: Promote Release
 # waits in the publishing overview for the final publish click.
 
 on:
+  # #3720 — callable from the Release Train orchestrator.
+  workflow_call:
+    inputs:
+      from_track:
+        required: false
+        type: string
+        default: beta
+      to_track:
+        required: false
+        type: string
+        default: production
+      dry_run:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       from_track:
@@ -67,10 +82,10 @@ jobs:
       - name: Promote at 100%
         run: |
           python tools/promote_release.py \
-            --from-track "${{ github.event.inputs.from_track }}" \
-            --to-track "${{ github.event.inputs.to_track }}" \
+            --from-track "${{ inputs.from_track }}" \
+            --to-track "${{ inputs.to_track }}" \
             --key "$PLAY_KEY_PATH" \
-            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}
 
       - name: Clean up service-account key
         if: always()
@@ -80,6 +95,6 @@ jobs:
         if: always()
         run: |
           echo "## Promote Release" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **${{ github.event.inputs.from_track }} → ${{ github.event.inputs.to_track }}** at 100% (status: completed)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Dry run: ${{ github.event.inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **${{ inputs.from_track }} → ${{ inputs.to_track }}** at 100% (status: completed)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Managed publishing: check the publishing overview after review for the final publish click." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: Release Train
+
+# #3720 — ONE dispatch that ships every distribution surface for a channel,
+# with fault-isolated legs: one platform failing never cancels the others,
+# and the always-running notify job reports exactly which legs failed and
+# why — as a run summary, a GitHub issue (= GitHub notification + email to
+# the owner, zero extra secrets), and optionally a direct SMTP email when
+# the MAIL_SMTP_SERVER / MAIL_USERNAME / MAIL_PASSWORD / MAIL_TO secrets
+# are configured (e.g. GMX free SMTP: mail.gmx.net:587).
+#
+# Channel mapping:
+#   beta:        Play beta upload (daily-beta.yml)
+#                iOS TestFlight incl. external Beta App Review
+#                  (ios-testflight.yml, distribute=true)
+#                F-Droid: SKIPPED by design — the self-hosted repo serves
+#                  the stable stream only.
+#   production:  Play promote beta -> production at 100% (promote-release.yml)
+#                F-Droid self-hosted repo publish (fdroid-publish.yml)
+#                iOS: reported as MANUAL — App Store submission needs the
+#                  #3537 demo video + review notes; no automated lane yet.
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Release channel'
+        required: true
+        type: choice
+        options: [beta, production]
+        default: beta
+      release_notes:
+        description: 'Release notes (Play + TestFlight; per-version changelogs used when empty)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pages: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: release-train
+  cancel-in-progress: false
+
+jobs:
+  android-beta:
+    if: inputs.channel == 'beta'
+    uses: ./.github/workflows/daily-beta.yml
+    with:
+      track: beta
+      release_notes: ${{ inputs.release_notes }}
+    secrets: inherit
+
+  android-production:
+    if: inputs.channel == 'production'
+    uses: ./.github/workflows/promote-release.yml
+    with:
+      from_track: beta
+      to_track: production
+    secrets: inherit
+
+  ios-testflight:
+    if: inputs.channel == 'beta'
+    uses: ./.github/workflows/ios-testflight.yml
+    with:
+      release_notes: ${{ inputs.release_notes || 'Release train build.' }}
+      distribute: true
+    secrets: inherit
+
+  fdroid:
+    if: inputs.channel == 'production'
+    uses: ./.github/workflows/fdroid-publish.yml
+    secrets: inherit
+
+  notify:
+    # The whole point: runs NO MATTER WHAT, so partial failures are
+    # reported instead of silently truncating the train.
+    if: always()
+    needs: [android-beta, android-production, ios-testflight, fdroid]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect leg results
+        id: legs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          R_AB: ${{ needs.android-beta.result }}
+          R_AP: ${{ needs.android-production.result }}
+          R_IOS: ${{ needs.ios-testflight.result }}
+          R_FD: ${{ needs.fdroid.result }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          declare -A LEGS
+          if [ "$CHANNEL" = "beta" ]; then
+            LEGS["Android (Play beta)"]="$R_AB"
+            LEGS["iOS (TestFlight + Beta App Review)"]="$R_IOS"
+            LEGS["F-Droid"]="skipped-by-design (stable stream only)"
+          else
+            LEGS["Android (Play production, promote 100%)"]="$R_AP"
+            LEGS["F-Droid (self-hosted repo)"]="$R_FD"
+            LEGS["iOS (App Store)"]="manual (needs #3537 demo video; no automated lane)"
+          fi
+
+          FAILED=0
+          {
+            echo "## Release Train — channel: $CHANNEL"
+            echo ""
+            echo "| Leg | Result |"
+            echo "|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for leg in "${!LEGS[@]}"; do
+            r="${LEGS[$leg]}"
+            icon="✅"
+            case "$r" in
+              failure) icon="❌"; FAILED=$((FAILED+1));;
+              cancelled) icon="🚫"; FAILED=$((FAILED+1));;
+              skipped*|manual*) icon="⏭️";;
+            esac
+            echo "| $leg | $icon $r |" >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+
+          # Error excerpts for every failed job of THIS run (the failed
+          # legs' logs are complete by the time notify runs).
+          if [ "$FAILED" -gt 0 ]; then
+            gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed 2>/dev/null \
+              | grep -viE "^\s*$" | tail -n 120 > failed-excerpt.txt || true
+            if [ ! -s failed-excerpt.txt ]; then
+              echo "(no log excerpt available yet — open the run for details)" > failed-excerpt.txt
+            fi
+          fi
+
+      - name: Open failure issue (GitHub notification + email to owner)
+        if: steps.legs.outputs.failed != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL: ${{ inputs.channel }}
+          R_AB: ${{ needs.android-beta.result }}
+          R_AP: ${{ needs.android-production.result }}
+          R_IOS: ${{ needs.ios-testflight.result }}
+          R_FD: ${{ needs.fdroid.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Release Train (**$CHANNEL**) finished with failed leg(s). Every other leg was still attempted and deployed if it worked."
+            echo ""
+            echo "| Leg | Result |"
+            echo "|---|---|"
+            if [ "$CHANNEL" = "beta" ]; then
+              echo "| Android (Play beta) | $R_AB |"
+              echo "| iOS (TestFlight) | $R_IOS |"
+            else
+              echo "| Android (Play production) | $R_AP |"
+              echo "| F-Droid | $R_FD |"
+            fi
+            echo ""
+            echo "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo ""
+            echo "<details><summary>Error excerpt (last 120 log lines of the failed jobs)</summary>"
+            echo ""
+            echo '```'
+            cat failed-excerpt.txt
+            echo '```'
+            echo "</details>"
+          } > issue-body.md
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "release-train ($CHANNEL) — ${{ steps.legs.outputs.failed }} leg(s) failed ($(date -u +%Y-%m-%d))" \
+            --label "type/bug" --label "area/ci" \
+            --body-file issue-body.md
+
+      - name: Direct email (optional — needs MAIL_* secrets)
+        if: steps.legs.outputs.failed != '0'
+        env:
+          MAIL_SMTP_SERVER: ${{ secrets.MAIL_SMTP_SERVER }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_TO: ${{ secrets.MAIL_TO }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MAIL_SMTP_SERVER" ] || [ -z "$MAIL_USERNAME" ] || [ -z "$MAIL_PASSWORD" ] || [ -z "$MAIL_TO" ]; then
+            echo "MAIL_* secrets not configured — the GitHub issue above already emails the owner via GitHub notifications. To enable direct SMTP mail set MAIL_SMTP_SERVER (e.g. mail.gmx.net), MAIL_USERNAME, MAIL_PASSWORD, MAIL_TO."
+            exit 0
+          fi
+          {
+            echo "Subject: [Sparkilo] Release Train ($CHANNEL) - ${{ steps.legs.outputs.failed }} leg(s) failed"
+            echo "To: $MAIL_TO"
+            echo "From: $MAIL_USERNAME"
+            echo ""
+            echo "Release Train ($CHANNEL) finished with failures. Working legs were still deployed."
+            echo "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo ""
+            echo "--- error excerpt ---"
+            cat failed-excerpt.txt
+          } > mail.txt
+          curl --ssl-reqd --url "smtp://$MAIL_SMTP_SERVER:587" \
+            --mail-from "$MAIL_USERNAME" --mail-rcpt "$MAIL_TO" \
+            --user "$MAIL_USERNAME:$MAIL_PASSWORD" \
+            --upload-file mail.txt


### PR DESCRIPTION
One workflow_dispatch (channel = beta | production) orchestrating every
distribution surface via reusable workflows. Legs run independently —
one platform failing never cancels the others — and the always-running
notify job writes a per-leg result table to the run summary, opens a
GitHub issue carrying the failed jobs' log excerpt (= GitHub
notification + email to the owner with zero new secrets), and sends a
direct SMTP email when the optional MAIL_SMTP_SERVER / MAIL_USERNAME /
MAIL_PASSWORD / MAIL_TO secrets are configured (GMX free SMTP works).

Channel mapping: beta = Play beta upload + TestFlight (external Beta
App Review); F-Droid skipped by design (stable-only repo). production =
Play promote beta->production at 100% + F-Droid repo publish; iOS
reported as manual (App Store submission needs the #3537 demo video —
no automated lane yet).

Enablers: daily-beta.yml, promote-release.yml, ios-testflight.yml and
fdroid-publish.yml gain workflow_call triggers; input references
normalized from github.event.inputs.* to the inputs context (identical
behavior under dispatch, required under call).

Closes #3720

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
