### PR TITLE
feat: Android live recording tile + Argentina live-probe hardening (#3722, #3717)

### DIFF
--- a/lib/features/consumption/data/android_live_activity_notifier.dart
+++ b/lib/features/consumption/data/android_live_activity_notifier.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../domain/live_activity_content.dart';
+
+/// #3722 — the ANDROID twin of the iOS Live Activity (#3170): an ongoing
+/// chronometer notification on the lock screen / notification shade
+/// while a trip records (Samsung surfaces it in the "dynamic content"
+/// card area, like a media tile).
+///
+/// The elapsed readout ticks NATIVELY: `usesChronometer` + `when =
+/// startedAtEpochMs` make the OS render "recording since / for" without
+/// any update traffic — exactly the ActivityKit `Text(timerInterval:)`
+/// trick the Swift widget uses. Distance / consumption refresh rides the
+/// [LiveActivityCoordinator]'s existing update cadence with
+/// `onlyAlertOnce`, so updates are silent in-place redraws.
+///
+/// Same never-throw contract as [LiveActivityController]: any platform
+/// failure degrades to "no tile", never to a crashed recorder.
+class AndroidLiveActivityNotifier {
+  /// [plugin] is injectable for tests; the default constructor talks to
+  /// the same platform facade [LocalNotificationService] initialized at
+  /// startup (tap callback + permission flow live there).
+  AndroidLiveActivityNotifier({FlutterLocalNotificationsPlugin? plugin})
+      : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  /// Fixed id — at most one live-trip tile exists (mirrors the
+  /// single-activity invariant of the iOS side). 3170 = the epic number.
+  static const int notificationId = 3170;
+
+  static const String _channelId = 'trip_live';
+  // Channel name/description surface only in the SYSTEM settings UI —
+  // same English-literal convention as LocalNotificationService's
+  // channels.
+  static const String _channelName = 'Trip recording status';
+  static const String _channelDescription =
+      'Ongoing tile while a trip records: elapsed time, distance and '
+      'consumption';
+
+  bool _channelCreated = false;
+
+  Future<void> _ensureChannel() async {
+    if (_channelCreated) return;
+    final android = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    await android?.createNotificationChannel(const AndroidNotificationChannel(
+      _channelId,
+      _channelName,
+      description: _channelDescription,
+      // Low: visible on the shade + lock screen, never a heads-up
+      // banner or a sound while driving.
+      importance: Importance.low,
+      playSound: false,
+      enableVibration: false,
+    ));
+    _channelCreated = true;
+  }
+
+  /// Show (or restyle in place) the live tile for [content]. Returns
+  /// false when the platform refused — the coordinator then stays quiet
+  /// for this trip, mirroring the iOS contract.
+  Future<bool> show(LiveActivityContent content) async {
+    try {
+      await _ensureChannel();
+      final render = buildAndroidLiveActivityRender(content);
+      await _plugin.show(
+        id: notificationId,
+        title: render.title,
+        body: render.body,
+        notificationDetails: NotificationDetails(
+          android: AndroidNotificationDetails(
+            _channelId,
+            _channelName,
+            channelDescription: _channelDescription,
+            importance: Importance.low,
+            priority: Priority.low,
+            category: AndroidNotificationCategory.stopwatch,
+            visibility: NotificationVisibility.public,
+            ongoing: true,
+            autoCancel: false,
+            onlyAlertOnce: true,
+            playSound: false,
+            enableVibration: false,
+            showWhen: true,
+            when: content.startedAtEpochMs,
+            usesChronometer: render.chronometerTicking,
+          ),
+        ),
+      );
+      return true;
+    } catch (e, st) {
+      // Best-effort by contract — a notification failure must never
+      // reach the recorder.
+      debugPrint('AndroidLiveActivityNotifier: show failed: $e\n$st');
+      return false;
+    }
+  }
+
+  /// Remove the tile (trip stopped, or a stale tile from a dead
+  /// process on next launch).
+  Future<void> end() async {
+    try {
+      await _plugin.cancel(id: notificationId);
+    } catch (e, st) {
+      debugPrint('AndroidLiveActivityNotifier: cancel failed: $e\n$st');
+    }
+  }
+}
+
+/// What the tile shows for one content snapshot — pure and separately
+/// testable (the plugin call itself is a thin pass-through).
+@immutable
+class AndroidLiveActivityRender {
+  const AndroidLiveActivityRender({
+    required this.title,
+    required this.body,
+    required this.chronometerTicking,
+  });
+
+  final String title;
+  final String body;
+
+  /// Paused trips freeze the elapsed readout (the `when` timestamp still
+  /// anchors "started at HH:MM" via `showWhen`).
+  final bool chronometerTicking;
+}
+
+/// Render precedence mirrors the PiP tile / Live Activity exactly:
+/// approach mode leads with the station + price, recording mode with the
+/// consumption hero; the paused label replaces the title while paused.
+AndroidLiveActivityRender buildAndroidLiveActivityRender(
+    LiveActivityContent c) {
+  final title = c.paused ? c.pausedLabel : c.recordingLabel;
+  final parts = <String>[
+    if (c.mode == LiveActivityMode.approach) ...[
+      if (c.stationName != null && c.stationName!.isNotEmpty) c.stationName!,
+      if (c.priceText != null) '${c.priceText} ${c.fuelLabel ?? ''}'.trim(),
+      if (c.stationDistanceText != null) c.stationDistanceText!,
+    ] else ...[
+      '${c.bigFigure} ${c.bigCaption}',
+      if (c.distanceText != null) c.distanceText!,
+    ],
+  ];
+  return AndroidLiveActivityRender(
+    title: title,
+    body: parts.join(' · '),
+    chronometerTicking: !c.paused,
+  );
+}

--- a/lib/features/consumption/data/live_activity_controller.dart
+++ b/lib/features/consumption/data/live_activity_controller.dart
@@ -4,6 +4,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../domain/live_activity_content.dart';
+import 'android_live_activity_notifier.dart';
+
 /// Dart binding for the app-internal iOS Live Activity channel
 /// `tankstellen/live_activity` (#3170). The Swift side lives in
 /// `ios/Runner/LiveActivityBridge.swift` and mirrors the same channel
@@ -11,10 +14,14 @@ import 'package:flutter/services.dart';
 ///
 /// Live Activities (Dynamic Island / lock-screen surface) are the
 /// iOS-native answer to the Android PiP driving tile — iOS PiP is
-/// video-only by OS policy ([PipController]). On every other platform
-/// every method here is an inert no-op and [isSupported] is false, so
-/// call sites need no platform branching of their own (the plugin-seam
-/// rule: no `Platform.isIOS` forks in shared code).
+/// video-only by OS policy ([PipController]).
+///
+/// #3722 — ANDROID renders the same content as an ongoing chronometer
+/// notification ([AndroidLiveActivityNotifier]): lock-screen/shade tile
+/// with a natively ticking elapsed readout. Any other platform stays an
+/// inert no-op with [isSupported] false, so call sites need no platform
+/// branching of their own (the plugin-seam rule: no `Platform.isIOS`
+/// forks in shared code).
 ///
 /// None of the methods ever throw — a missing handler (unit-test
 /// engine), a user who disabled Live Activities, or any platform error
@@ -22,25 +29,49 @@ import 'package:flutter/services.dart';
 class LiveActivityController {
   /// [channel] is injectable so unit tests can supply a mock without a
   /// live platform binding.
-  LiveActivityController({MethodChannel? channel})
-      : _channel = channel ?? const MethodChannel('tankstellen/live_activity');
+  /// The Android notifier is wired automatically on Android (#3722) —
+  /// this class is the sanctioned platform-dispatch seam (#3163), so the
+  /// provider stays platform-free. Tests inject a fake (or construct on
+  /// a non-Android override for the inert path).
+  LiveActivityController({
+    MethodChannel? channel,
+    AndroidLiveActivityNotifier? androidNotifier,
+  })  : _channel = channel ?? const MethodChannel('tankstellen/live_activity'),
+        _android = androidNotifier ??
+            (defaultTargetPlatform == TargetPlatform.android
+                ? AndroidLiveActivityNotifier()
+                : null);
 
   final MethodChannel _channel;
 
-  /// Whether the running platform can host a Live Activity at all.
-  /// iOS-only; the OS-level gate (iOS ≥ 16.1 + the user's per-app
-  /// Live Activities toggle) is checked natively by [startActivity].
-  bool get isSupported => defaultTargetPlatform == TargetPlatform.iOS;
+  /// #3722 — non-null on Android (wired by the provider); null keeps the
+  /// platform an inert no-op (tests, desktop).
+  final AndroidLiveActivityNotifier? _android;
+
+  bool get _isIos => defaultTargetPlatform == TargetPlatform.iOS;
+  bool get _isAndroid =>
+      defaultTargetPlatform == TargetPlatform.android && _android != null;
+
+  /// Whether the running platform can host a live trip surface at all.
+  /// iOS Live Activity or the Android ongoing tile (#3722); the OS-level
+  /// gates (iOS 16.1+/user toggle, Android 13+ notification permission)
+  /// are enforced by the respective platform paths.
+  bool get isSupported => _isIos || _isAndroid;
 
   /// Request a new Live Activity rendering [content] (the
   /// `LiveActivityContent.toChannelMap()` payload). Returns false when
   /// the activity could not be started (unsupported platform, the user
   /// disabled Live Activities, or ActivityKit rejected the request) —
   /// callers treat false as "stay quiet for this trip".
-  Future<bool> startActivity(Map<String, Object?> content) async {
-    if (!isSupported) return false;
+  Future<bool> startActivity(LiveActivityContent content) async {
+    if (_isAndroid) return _android!.show(content);
+    if (!_isIos) return false;
     try {
-      return await _channel.invokeMethod<bool>('start', content) ?? false;
+      return await _channel.invokeMethod<bool>(
+            'start',
+            content.toChannelMap(),
+          ) ??
+          false;
     } on PlatformException {
       return false;
     } on MissingPluginException {
@@ -51,10 +82,14 @@ class LiveActivityController {
   /// Push fresh [content] onto the running activity. Best-effort: a
   /// failure (no running activity, platform error) is silently dropped —
   /// the next update or the trip end will reconcile.
-  Future<void> updateActivity(Map<String, Object?> content) async {
-    if (!isSupported) return;
+  Future<void> updateActivity(LiveActivityContent content) async {
+    if (_isAndroid) {
+      await _android!.show(content); // in-place restyle (onlyAlertOnce)
+      return;
+    }
+    if (!_isIos) return;
     try {
-      await _channel.invokeMethod<void>('update', content);
+      await _channel.invokeMethod<void>('update', content.toChannelMap());
     } on PlatformException {
       // Best-effort: a failed update just leaves stale content briefly.
     } on MissingPluginException {
@@ -66,7 +101,11 @@ class LiveActivityController {
   /// any activity left over from a previous process so a crash can't
   /// strand a stale surface on the lock screen.
   Future<void> endActivity() async {
-    if (!isSupported) return;
+    if (_isAndroid) {
+      await _android!.end();
+      return;
+    }
+    if (!_isIos) return;
     try {
       await _channel.invokeMethod<void>('end');
     } on PlatformException {

--- a/lib/features/consumption/data/live_activity_coordinator.dart
+++ b/lib/features/consumption/data/live_activity_coordinator.dart
@@ -107,7 +107,7 @@ class LiveActivityCoordinator {
 
     final now = _clock();
     if (!_active) {
-      final started = await _controller.startActivity(content.toChannelMap());
+      final started = await _controller.startActivity(content);
       if (started) {
         _active = true;
         _lastSent = content;
@@ -133,6 +133,6 @@ class LiveActivityCoordinator {
 
     _lastSent = content;
     _lastSentAt = now;
-    await _controller.updateActivity(content.toChannelMap());
+    await _controller.updateActivity(content);
   }
 }

--- a/lib/features/consumption/domain/live_activity_content.dart
+++ b/lib/features/consumption/domain/live_activity_content.dart
@@ -63,6 +63,13 @@ class LiveActivityContent {
   /// [RadarCloseness.fillFor] scale. Null collapses the bar.
   final double? progress;
 
+  /// #3722 — localized "Recording trip" label for the ANDROID ongoing
+  /// notification title. Deliberately NOT part of [toChannelMap]: the
+  /// iOS bridge decodes the map into a strict `ContentState`, and the
+  /// Swift widget carries its own title strings — adding keys there
+  /// would break the documented lock-step.
+  final String recordingLabel;
+
   const LiveActivityContent({
     required this.mode,
     required this.paused,
@@ -72,6 +79,7 @@ class LiveActivityContent {
     required this.isEstimate,
     required this.distanceText,
     required this.pausedLabel,
+    required this.recordingLabel,
     this.stationName,
     this.priceText,
     this.fuelLabel,
@@ -110,6 +118,7 @@ class LiveActivityContent {
       other.isEstimate == isEstimate &&
       other.distanceText == distanceText &&
       other.pausedLabel == pausedLabel &&
+      other.recordingLabel == recordingLabel &&
       other.stationName == stationName &&
       other.priceText == priceText &&
       other.fuelLabel == fuelLabel &&
@@ -126,6 +135,7 @@ class LiveActivityContent {
     isEstimate,
     distanceText,
     pausedLabel,
+    recordingLabel,
     stationName,
     priceText,
     fuelLabel,
@@ -167,6 +177,7 @@ LiveActivityContent? buildLiveActivityContent({
           1000) *
       1000;
   final pausedLabel = l.tripBannerPaused;
+  final recordingLabel = l.tripBannerRecording; // #3722 — Android tile title
   final distance = live?.distanceKmSoFar;
   final distanceText = (distance != null && distance >= 0.1)
       ? '${distance.toStringAsFixed(1)} km'
@@ -215,6 +226,7 @@ LiveActivityContent? buildLiveActivityContent({
       isEstimate: isEstimate,
       distanceText: distanceText,
       pausedLabel: pausedLabel,
+      recordingLabel: recordingLabel,
       stationName: station.name.isNotEmpty ? station.name : station.brand,
       priceText: price != null ? PriceFormatter.formatPrice(price) : '--',
       fuelLabel: fuel.displayName,
@@ -251,5 +263,6 @@ LiveActivityContent? buildLiveActivityContent({
     isEstimate: isEstimate,
     distanceText: distanceText,
     pausedLabel: pausedLabel,
+    recordingLabel: recordingLabel,
   );
 }

--- a/lib/features/consumption/providers/live_activity_provider.dart
+++ b/lib/features/consumption/providers/live_activity_provider.dart
@@ -27,6 +27,8 @@ part 'live_activity_provider.g.dart';
 /// the [PipController] singleton convention.
 @Riverpod(keepAlive: true)
 LiveActivityController liveActivityController(Ref ref) =>
+    // #3722 — the controller wires its own Android notifier internally
+    // (it is the sanctioned platform-dispatch seam, #3163).
     LiveActivityController();
 
 /// The single app-wide [LiveActivityCoordinator] — keepAlive so its

--- a/test/features/consumption/data/android_live_activity_notifier_test.dart
+++ b/test/features/consumption/data/android_live_activity_notifier_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/android_live_activity_notifier.dart';
+import 'package:tankstellen/features/consumption/data/live_activity_controller.dart';
+import 'package:tankstellen/features/consumption/domain/live_activity_content.dart';
+
+/// #3722 — the Android ongoing-tile twin of the iOS Live Activity.
+LiveActivityContent _content({
+  LiveActivityMode mode = LiveActivityMode.recording,
+  bool paused = false,
+  String? distanceText = '12.3 km',
+  String? stationName,
+  String? priceText,
+  String? fuelLabel,
+  String? stationDistanceText,
+}) =>
+    LiveActivityContent(
+      mode: mode,
+      paused: paused,
+      startedAtEpochMs: 1723700000000,
+      bigFigure: '5.8',
+      bigCaption: 'L/100 km',
+      isEstimate: false,
+      distanceText: distanceText,
+      pausedLabel: 'Trip paused',
+      recordingLabel: 'Recording trip',
+      stationName: stationName,
+      priceText: priceText,
+      fuelLabel: fuelLabel,
+      stationDistanceText: stationDistanceText,
+    );
+
+void main() {
+  group('buildAndroidLiveActivityRender (#3722)', () {
+    test('recording mode: localized title, consumption hero + distance, '
+        'ticking chronometer', () {
+      final r = buildAndroidLiveActivityRender(_content());
+      expect(r.title, 'Recording trip');
+      expect(r.body, '5.8 L/100 km · 12.3 km');
+      expect(r.chronometerTicking, isTrue);
+    });
+
+    test('paused: the localized paused label replaces the title and the '
+        'chronometer freezes', () {
+      final r = buildAndroidLiveActivityRender(_content(paused: true));
+      expect(r.title, 'Trip paused');
+      expect(r.chronometerTicking, isFalse);
+    });
+
+    test('approach mode leads with station + price + distance, mirroring '
+        'the PiP precedence', () {
+      final r = buildAndroidLiveActivityRender(_content(
+        mode: LiveActivityMode.approach,
+        stationName: 'Total Sète',
+        priceText: '0,899 €',
+        fuelLabel: 'E85',
+        stationDistanceText: '2,5 km',
+      ));
+      expect(r.title, 'Recording trip');
+      expect(r.body, 'Total Sète · 0,899 € E85 · 2,5 km');
+    });
+
+    test('warm-up recording with no distance keeps a clean single-part '
+        'body', () {
+      final r = buildAndroidLiveActivityRender(_content(distanceText: null));
+      expect(r.body, '5.8 L/100 km');
+    });
+  });
+
+  group('LiveActivityController Android dispatch (#3722)', () {
+    test('start/update/end route to the notifier on Android and report '
+        'its result', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      final notifier = _RecordingNotifier();
+      final controller = LiveActivityController(androidNotifier: notifier);
+
+      expect(controller.isSupported, isTrue);
+      expect(await controller.startActivity(_content()), isTrue);
+      await controller.updateActivity(_content(paused: true));
+      await controller.endActivity();
+      expect(notifier.calls, ['show', 'show', 'end']);
+      expect(notifier.lastContent?.paused, isTrue);
+    });
+
+    test('a non-Android, non-iOS platform stays the documented inert '
+        'no-op', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      final controller = LiveActivityController();
+      expect(controller.isSupported, isFalse);
+      expect(await controller.startActivity(_content()), isFalse);
+    });
+  });
+
+  group('never-throws contract (#3722 fault injection)', () {
+    test('a throwing plugin is swallowed — show returns false, end '
+        'completes normally', () async {
+      final notifier =
+          AndroidLiveActivityNotifier(plugin: _ThrowingPlugin());
+      await expectLater(notifier.show(_content()), completes);
+      expect(await notifier.show(_content()), isFalse,
+          reason: 'a notification failure must never reach the recorder');
+      await expectLater(notifier.end(), completes);
+    });
+  });
+
+  test('recordingLabel is NOT part of the iOS channel map — the Swift '
+      'ContentState lock-step stays untouched (#3722)', () {
+    expect(_content().toChannelMap().containsKey('recordingLabel'), isFalse);
+  });
+}
+
+/// Every plugin call throws — drives the never-throw boundary.
+class _ThrowingPlugin implements FlutterLocalNotificationsPlugin {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('injected plugin fault');
+}
+
+class _RecordingNotifier extends AndroidLiveActivityNotifier {
+  final List<String> calls = [];
+  LiveActivityContent? lastContent;
+
+  @override
+  Future<bool> show(LiveActivityContent content) async {
+    calls.add('show');
+    lastContent = content;
+    return true;
+  }
+
+  @override
+  Future<void> end() async {
+    calls.add('end');
+  }
+}

--- a/test/features/consumption/data/live_activity_controller_test.dart
+++ b/test/features/consumption/data/live_activity_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/live_activity_controller.dart';
+import 'package:tankstellen/features/consumption/domain/live_activity_content.dart';
 
 /// Unit coverage for [LiveActivityController] — the Dart side of the
 /// `tankstellen/live_activity` channel (#3170). The Live Activity render
@@ -12,6 +13,19 @@ import 'package:tankstellen/features/consumption/data/live_activity_controller.d
 /// method names, payload pass-through, the iOS-only guard, and the
 /// never-throws degradation on platform errors (the fault-injection
 /// sibling for the class's never-throw doccontract).
+
+LiveActivityContent _content({bool paused = false}) => LiveActivityContent(
+      mode: LiveActivityMode.recording,
+      paused: paused,
+      startedAtEpochMs: 1000000,
+      bigFigure: '5.8',
+      bigCaption: 'L/100 km',
+      isEstimate: false,
+      distanceText: null,
+      pausedLabel: 'Paused',
+      recordingLabel: 'Recording trip',
+    );
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -41,7 +55,7 @@ void main() {
 
       final controller = LiveActivityController();
       final ok = await controller
-          .startActivity(<String, Object?>{'mode': 'recording', 'paused': false});
+          .startActivity(_content());
 
       expect(ok, isTrue);
       expect(calls.single.method, 'start');
@@ -55,7 +69,7 @@ void main() {
         () async {
       messenger.setMockMethodCallHandler(channel, (call) async => false);
       expect(
-        await LiveActivityController().startActivity(const {}),
+        await LiveActivityController().startActivity(_content()),
         isFalse,
       );
     });
@@ -66,7 +80,7 @@ void main() {
         throw PlatformException(code: 'activitykit');
       });
       expect(
-        await LiveActivityController().startActivity(const {}),
+        await LiveActivityController().startActivity(_content()),
         isFalse,
       );
     });
@@ -81,9 +95,9 @@ void main() {
       });
 
       final controller = LiveActivityController();
-      await controller.updateActivity(<String, Object?>{'bigFigure': '5.8'});
+      await controller.updateActivity(_content());
       // Second call hits the injected fault — must not throw.
-      await controller.updateActivity(<String, Object?>{'bigFigure': '6.0'});
+      await controller.updateActivity(_content());
 
       expect(calls.map((c) => c.method), everyElement('update'));
       expect(calls.first.arguments, containsPair('bigFigure', '5.8'));
@@ -104,14 +118,16 @@ void main() {
         '(MissingPluginException fault)', () async {
       // No mock handler installed → MissingPluginException path.
       final controller = LiveActivityController();
-      expect(await controller.startActivity(const {}), isFalse);
-      await controller.updateActivity(const {});
+      expect(await controller.startActivity(_content()), isFalse);
+      await controller.updateActivity(_content());
       await controller.endActivity();
     });
   });
 
   group('LiveActivityController off iOS', () {
-    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
+    // #3722 — Android is now a SUPPORTED platform (ongoing-tile twin);
+    // fuchsia stands in for "no live surface exists here".
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia);
 
     test('isSupported is false and calls are inert no-ops', () async {
       var invoked = false;
@@ -122,8 +138,8 @@ void main() {
 
       final controller = LiveActivityController();
       expect(controller.isSupported, isFalse);
-      expect(await controller.startActivity(const {}), isFalse);
-      await controller.updateActivity(const {});
+      expect(await controller.startActivity(_content()), isFalse);
+      await controller.updateActivity(_content());
       await controller.endActivity();
       expect(invoked, isFalse,
           reason: 'no channel traffic on a platform without Live Activities');

--- a/test/features/consumption/data/live_activity_coordinator_test.dart
+++ b/test/features/consumption/data/live_activity_coordinator_test.dart
@@ -45,6 +45,7 @@ void main() {
         isEstimate: false,
         distanceText: distanceText,
         pausedLabel: 'Paused',
+        recordingLabel: 'Recording trip',
         stationName: stationName,
         priceText: priceText,
       );
@@ -101,10 +102,7 @@ void main() {
       await coordinator.apply(content(distanceText: '1.2 km'));
 
       expect(controller.calls, ['start', 'update']);
-      expect(
-        controller.lastUpdatePayload,
-        containsPair('distanceText', '1.2 km'),
-      );
+      expect(controller.lastUpdatePayload?.distanceText, '1.2 km');
     });
 
     test('the throttle window restarts from the last SENT update', () async {
@@ -140,7 +138,7 @@ void main() {
       ));
 
       expect(controller.calls, ['start', 'update']);
-      expect(controller.lastUpdatePayload, containsPair('mode', 'approach'));
+      expect(controller.lastUpdatePayload?.mode, LiveActivityMode.approach);
     });
 
     test('a station change within approach mode is a transition', () async {
@@ -229,7 +227,7 @@ class _FakeLiveActivityController extends LiveActivityController {
 
   final bool supported;
   final List<String> calls = [];
-  Map<String, Object?>? lastUpdatePayload;
+  LiveActivityContent? lastUpdatePayload;
   bool startResult = true;
   String? throwOn;
 
@@ -237,14 +235,14 @@ class _FakeLiveActivityController extends LiveActivityController {
   bool get isSupported => supported;
 
   @override
-  Future<bool> startActivity(Map<String, Object?> content) async {
+  Future<bool> startActivity(LiveActivityContent content) async {
     if (throwOn == 'start') throw StateError('injected start fault');
     calls.add('start');
     return startResult;
   }
 
   @override
-  Future<void> updateActivity(Map<String, Object?> content) async {
+  Future<void> updateActivity(LiveActivityContent content) async {
     if (throwOn == 'update') throw StateError('injected update fault');
     calls.add('update');
     lastUpdatePayload = content;

--- a/test/features/station_services/argentina/argentina_station_service_test.dart
+++ b/test/features/station_services/argentina/argentina_station_service_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
@@ -316,7 +318,10 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
     // `network` so CI's --exclude-tags=network skips it; the deterministic
     // error-path coverage lives in the withDio cert/connection tests below.
     test('searchStations throws ApiException on network failure',
-        tags: 'network', () async {
+        tags: 'network',
+        // #3717 — the live CSV is tens of MB; a slow runner needs more
+        // than the 30 s default before OUR 90 s bound below kicks in.
+        timeout: const Timeout(Duration(minutes: 3)), () async {
       const params = SearchParams(
         lat: -34.6, lng: -58.4, radiusKm: 10.0,
       );
@@ -324,30 +329,42 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
       // network error (ApiException) or the specific cert-expired path
       // (#837 — UpstreamCertificateException) is acceptable here, since the
       // real upstream cert is currently expired and the test harness has no
-      // network.
+      // network. #3717 — a SLOW live endpoint is also a network-failure
+      // shape: bound the call ourselves so the nightly-flaky runner never
+      // dies on the framework timeout mid-download.
       try {
-        await service.searchStations(params);
+        await service
+            .searchStations(params)
+            .timeout(const Duration(seconds: 90));
         // If it somehow succeeds (cached data), just verify the result
       } on ApiException catch (e) {
         expect(e.message, isNotEmpty);
       } on UpstreamCertificateException catch (e) {
         expect(e.host, 'datos.energia.gob.ar');
+      } on TimeoutException {
+        // Accepted: the live endpoint is reachable but too slow — exactly
+        // the nondeterminism this network-tagged probe tolerates (#3717).
       }
     });
 
     test('searchStations returns valid ServiceResult type',
-        tags: 'network', () async {
+        tags: 'network',
+        timeout: const Timeout(Duration(minutes: 3)), () async {
       const params = SearchParams(
         lat: -34.6, lng: -58.4, radiusKm: 10.0,
       );
       try {
-        final result = await service.searchStations(params);
+        final result = await service
+            .searchStations(params)
+            .timeout(const Duration(seconds: 90));
         expect(result.source, ServiceSource.argentinaApi);
         expect(result.data, isA<List<Station>>());
       } on ApiException catch (_) {
         // Expected if no network
       } on UpstreamCertificateException catch (_) {
         // Expected if the live cert is expired (#837)
+      } on TimeoutException {
+        // Accepted: reachable-but-slow endpoint (#3717).
       }
     });
   });


### PR DESCRIPTION
## Summary

### #3722 — Android live recording tile
While recording, the trip status is now visible outside the app — lock screen + shade (Samsung dynamic-content card area on Android 16): localized "Recording trip" title, **natively ticking elapsed duration** (`usesChronometer` + `when = trip start`), distance + consumption body, station·price·distance when the approach radar leads, paused label with frozen chronometer, cancel on stop.

Rides the #3170 iOS Live Activity pipeline unchanged. The controller — the sanctioned #3163 platform-dispatch seam — wires its own `AndroidLiveActivityNotifier` on Android; the provider stays platform-free. `recordingLabel` uses the existing ARB key (no new strings) and is excluded from the iOS channel map (Swift ContentState lock-step pinned by test). Never-throw boundary fault-injected via a throwing plugin fake.

### #3717 — nightly-flaky: Argentina live-CSV probes
3-min test timeout + 90 s client-side bound; `TimeoutException` counts as the accepted reachable-but-slow outcome, so the framework timeout can no longer kill the suite mid-download.

## Test plan
- New render/dispatch/fault tests; existing controller/coordinator/content tests adapted (off-platform case now uses fuchsia since Android is supported). All lint ratchets green (platform-seam + never-throws both enforced their patterns on this very PR). Full suite in a detached worktree — known load-flakes only, green standalone. Pre-push hook (lint/l10n/clean-codegen) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UmqZiNgtozs3vXJEmiwVM
